### PR TITLE
docs: document protected main workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+-
+
+## Why This Change
+
+-
+
+## User-Visible Behavior
+
+-
+
+## Privacy Impact
+
+-
+
+## Packaging Or Release Impact
+
+-
+
+## Commands Run
+
+-
+
+## Screenshots
+
+-
+
+## Follow-Up
+
+-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,94 @@ python -m pip install ".[dev]" twine
 codex-usage-tracker install-plugin --python .venv/bin/python
 ```
 
+## Branch And PR Workflow
+
+This project is now a published PyPI package with user-facing docs, JSON/MCP contracts, a release workflow, and privacy guarantees. Treat `main` as always releasable.
+
+- Do not commit directly to `main`.
+- Start each coherent task from current `main` with a short-lived branch.
+- Use branch prefixes `feature/`, `fix/`, `docs/`, `chore/`, `test/`, `release/`, or `hotfix/`.
+- Keep each branch focused on one issue, one reviewable task, or one release.
+- Do not create a long-lived `develop` branch.
+- Do not mix release prep with unrelated feature work.
+- Push task branches and open a PR for all changes headed to `main`.
+- Prefer squash merge for ordinary task PRs so `main` stays readable.
+- Use the PR as the review artifact even when there is only one maintainer.
+
+Recommended branch names:
+
+```text
+feature/<issue-number>-short-description
+fix/<issue-number>-short-description
+docs/<issue-number>-short-description
+chore/<issue-number>-short-description
+test/<issue-number>-short-description
+release/0.4.0
+hotfix/0.3.3
+```
+
+Before starting a task branch:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c docs/123-short-description
+```
+
+## Agent Boundaries
+
+Codex may create task branches, write tests, update docs, run local gates, prepare PR summaries, prepare release branches, and prepare changelog/version changes.
+
+Codex must not do these without explicit maintainer approval:
+
+- Push directly to `main`.
+- Create or push release tags.
+- Publish to TestPyPI or PyPI.
+- Add PyPI or TestPyPI API tokens.
+- Publish from a local machine.
+- Change privacy semantics.
+- Rename the PyPI distribution, import package, CLI command, plugin name, MCP tools, schema IDs, or stable JSON contracts.
+- Delete branches.
+- Force-push shared branches.
+
+Publishing must happen only through the approved GitHub Actions Trusted Publishing workflow and protected `testpypi`/`pypi` environments.
+
+## Issue And Milestone Workflow
+
+Use GitHub issues as the normal unit of work once the task is non-trivial. A branch should usually map to one issue and close it from the PR.
+
+Recommended labels:
+
+```text
+bug
+docs
+packaging
+release
+privacy
+security
+performance
+dashboard
+cli
+mcp
+parser-compat
+good-first-issue
+blocked
+1.0-blocker
+```
+
+Recommended milestones:
+
+```text
+0.4.0
+1.0-readiness
+1.0.0
+```
+
+Use patch releases for public blockers such as broken PyPI installs, missing package data, broken CLI entry points, privacy leaks, bad plugin installs, or bad runtime pins. Put planned stabilization work into the next minor release instead of bundling it into a patch.
+
 ## Validation
 
-Run the local CI gate before pushing to `main`:
+Run focused tests first, then broader checks. Run the full local CI gate before opening or updating PRs that touch release, packaging, CLI contracts, MCP behavior, dashboard behavior, privacy behavior, schemas, generated docs/assets, or bundled plugin/skill files.
 
 ```bash
 python -m ruff check .
@@ -93,6 +178,65 @@ codex-usage-tracker support-bundle --output /tmp/codex-usage-support.json
 codex-usage-tracker pricing-coverage
 codex-usage-tracker summary --preset by-subagent-role
 codex-usage-tracker expensive --limit 5
+```
+
+For documentation-only branches, at minimum run:
+
+```bash
+python scripts/check_release.py
+git diff --check
+```
+
+## Release Branches
+
+Use release branches only for version/changelog/pinning/publish prep, for example `release/0.4.0` or `hotfix/0.3.3`.
+
+Release branches may include:
+
+- Version bumps.
+- `CHANGELOG.md` updates.
+- Install/version wording updates.
+- Runtime package pins.
+- Publish workflow tweaks.
+- Release notes.
+- Final smoke-test fixes directly tied to release readiness.
+
+Release branches must not include unrelated features.
+
+Recommended release sequence:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c release/0.4.0
+# version/changelog/release edits
+python -m ruff check .
+python -m mypy
+python -m pytest
+python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
+python -m compileall src
+node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js
+node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js
+node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
+node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js
+python scripts/check_release.py
+git diff --check
+rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info
+python -m build
+python -m twine check dist/*
+python scripts/check_release.py --dist
+git add .
+git commit -m "Prepare 0.4.0 release"
+git push -u origin release/0.4.0
+```
+
+Open a PR to `main` and merge only after CI passes. After merge, tag from updated `main`, not from an unreviewed release branch, and only after explicit maintainer approval:
+
+```bash
+git switch main
+git pull --ff-only
+git tag -a v0.4.0 -m "codex-usage-tracker 0.4.0"
+git push origin v0.4.0
 ```
 
 ## Privacy Rules

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,9 +24,91 @@ The public PyPI distribution is [`codex-usage-tracking`](https://pypi.org/projec
 - `scripts/check_release.py`: release-readiness checks for docs, versions, packaging, wheel contents, and tracked secret patterns.
 - `scripts/benchmark_synthetic_history.py`: synthetic benchmark for large aggregate histories.
 
+## Branch And PR Model
+
+This repository uses trunk-based development with protected `main`, short-lived task branches, and release branches only when preparing a release. Do not use a permanent `develop` branch.
+
+`main` should always be releasable: tests pass, package builds, dashboard assets are valid, docs are coherent, and any tag from `main` would be publishable.
+
+Use one branch per coherent task or issue:
+
+```text
+feature/<issue-number>-short-description
+fix/<issue-number>-short-description
+docs/<issue-number>-short-description
+chore/<issue-number>-short-description
+test/<issue-number>-short-description
+release/0.4.0
+hotfix/0.3.3
+```
+
+Start work from current `main`:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c fix/125-wheel-package-data
+```
+
+Keep each branch focused. Do not mix release prep with unrelated features, and do not push directly to `main`. Push the branch, open a PR, use the PR template, and merge only after required checks pass.
+
+For solo-maintainer work, the PR itself is still the review artifact. Prefer squash merge for ordinary task PRs so `main` remains readable.
+
+Recommended `main` protection:
+
+- Require pull request before merging.
+- Require status checks before merging.
+- Require branches to be up to date before merging.
+- Require conversation resolution.
+- Require linear history if it fits the current workflow.
+- Disable force pushes.
+- Disable branch deletion.
+- Keep production PyPI publication behind the protected `pypi` GitHub environment.
+
+## Issue And Milestone Model
+
+Use issues for non-trivial work so Codex sessions stay focused.
+
+Recommended labels:
+
+```text
+bug
+docs
+packaging
+release
+privacy
+security
+performance
+dashboard
+cli
+mcp
+parser-compat
+good-first-issue
+blocked
+1.0-blocker
+```
+
+Recommended milestones:
+
+```text
+0.4.0
+1.0-readiness
+1.0.0
+```
+
+Suggested 1.0-readiness issues:
+
+- Installed-package smoke script.
+- Strict privacy regression tests.
+- Upgrade and migration tests.
+- JSON contract documentation parity.
+- Benchmark thresholds.
+- Support-bundle safety tests.
+- Release recovery docs.
+
 ## Local CI Gate
 
-Run the local CI gate before pushing to `main`:
+Run focused tests first, then broader checks. Run the full local CI gate before opening or updating PRs that touch release, packaging, CLI contracts, MCP behavior, dashboard behavior, privacy behavior, schemas, generated docs/assets, or bundled plugin/skill files:
 
 ```bash
 python -m ruff check .
@@ -44,6 +126,13 @@ rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-
 python -m build
 python -m twine check dist/*
 python scripts/check_release.py --dist
+```
+
+For documentation-only branches, at minimum run:
+
+```bash
+python scripts/check_release.py
+git diff --check
 ```
 
 ## Additional Smoke Checks
@@ -85,7 +174,9 @@ The script creates synthetic aggregate-only SQLite databases and times common fi
 
 ## Release Checklist
 
-Before publishing a package:
+Use a release branch only for version/changelog/pinning/publish prep. It should include release-specific changes such as version bumps, `CHANGELOG.md`, install/version wording, runtime package pins, publish workflow tweaks, release notes, and final smoke-test fixes. It should not include unrelated features.
+
+Before opening a release PR:
 
 ```bash
 python -m ruff check .
@@ -114,6 +205,17 @@ codex-usage-tracker install-plugin --plugin-dir /tmp/codex-usage-tracker-plugin-
 ```
 
 The release checker verifies version alignment, required public docs, packaged plugin assets, wheel contents, and obvious tracked secret patterns. It does not publish anything.
+
+After the release branch merges, tag from updated `main`, not from an unreviewed branch:
+
+```bash
+git switch main
+git pull --ff-only
+git tag -a v0.4.0 -m "codex-usage-tracker 0.4.0"
+git push origin v0.4.0
+```
+
+Do not create or push release tags without maintainer approval.
 
 ## Publishing
 


### PR DESCRIPTION
## Summary
- Adds repo-local AGENTS guidance for protected main, short-lived task branches, PRs, release branches, and agent approval boundaries.
- Expands development docs with branch protection recommendations, issue/milestone model, release branch sequencing, and tagging rules.
- Adds a PR template covering summary, user-visible behavior, privacy impact, packaging/release impact, checks, screenshots, and follow-up.

## Why This Change
- The package is now published on PyPI, so main should remain releasable and future changes should go through short-lived branches and PRs.

## User-Visible Behavior
- Documentation/process only. No runtime behavior changes.

## Privacy Impact
- No privacy behavior changes. The new instructions explicitly require approval before changing privacy semantics.

## Packaging Or Release Impact
- No package contents or release workflow changes. The docs clarify that publish/tag actions require maintainer approval and Trusted Publishing.

## Commands Run
- .venv/bin/python scripts/check_release.py
- git diff --check

## Screenshots
- Not applicable.

## Follow-Up
- Configure GitHub main branch protection/ruleset.
- Add issue labels and milestones for 0.4.0 and 1.0-readiness.