### PR TITLE
test: add aggregate schema migration coverage

### DIFF
--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -29,16 +29,17 @@ Not guaranteed:
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
 - [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version <version>`.
 - [ ] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
+- [ ] Add Python 3.14 as an official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Track this in issue #12.
 
 ## 2. Upgrade And Migration
 
-- [ ] Add synthetic v0.2-style SQLite fixture test proving `init_db` upgrades without data loss: `python -m pytest tests/test_store_migrations.py`.
+- [x] Add synthetic legacy SQLite fixture test proving `init_db` upgrades without data loss: `python -m pytest tests/test_store_migrations.py`.
 - [ ] Add synthetic v0.3-style SQLite fixture if schema drift requires it: `python -m pytest tests/test_store_migrations.py`.
-- [ ] Verify `schema_state` reports expected version and checksum after migration: `python -m pytest tests/test_store_migrations.py`.
-- [ ] Verify `rebuild-index` clears only tracker-owned aggregate tables: `python -m pytest tests/test_cli_lifecycle.py`.
-- [ ] Verify `reset-db` does not touch raw Codex logs: `python -m pytest tests/test_cli_lifecycle.py`.
-- [ ] Verify refresh metadata and parser diagnostics survive migration: `python -m pytest tests/test_store_migrations.py tests/test_parser.py`.
-- [ ] Verify CSV export columns after migration: `python -m pytest tests/test_cli_lifecycle.py`.
+- [x] Verify `schema_state` reports expected version and checksum after migration: `python -m pytest tests/test_store_migrations.py`.
+- [x] Verify `rebuild-index` clears only tracker-owned aggregate tables: `python -m pytest tests/test_store_dashboard_mcp.py`.
+- [x] Verify `reset-db` does not touch raw Codex logs: `python -m pytest tests/test_cli_lifecycle.py`.
+- [x] Verify refresh metadata and parser diagnostics survive migration: `python -m pytest tests/test_store_migrations.py tests/test_parser.py`.
+- [x] Verify CSV export columns after migration: `python -m pytest tests/test_store_migrations.py`.
 
 ## 3. CLI Compatibility
 
@@ -127,3 +128,4 @@ Not guaranteed:
 - [ ] Document that live account allowance cannot be read automatically by this local tracker.
 - [ ] Document that cost and credit estimates are not guaranteed to match exact billing.
 - [ ] Document platform/plugin discovery limitations separately from the core Python CLI/dashboard support.
+- [ ] Document that Python 3.14 may install because package metadata allows `>=3.10`, but it is not officially supported until issue #12 is complete.

--- a/src/codex_usage_tracker/diagnostics.py
+++ b/src/codex_usage_tracker/diagnostics.py
@@ -20,7 +20,7 @@ from codex_usage_tracker.paths import (
     DEFAULT_PRICING_PATH,
 )
 from codex_usage_tracker.pricing import load_pricing_config
-from codex_usage_tracker.store import refresh_metadata, schema_state
+from codex_usage_tracker.store import SchemaMigrationError, refresh_metadata, schema_state
 
 PLUGIN_NAME = "codex-usage-tracker"
 
@@ -165,7 +165,15 @@ def _check_database(db_path: Path) -> DoctorCheck:
 
 
 def _check_database_schema(db_path: Path) -> DoctorCheck:
-    state = schema_state(db_path)
+    try:
+        state = schema_state(db_path)
+    except SchemaMigrationError as exc:
+        return DoctorCheck(
+            "Database schema",
+            "fail",
+            str(exc),
+            "Run: codex-usage-tracker rebuild-index after confirming your local aggregate index can be regenerated.",
+        )
     if not state["exists"]:
         return DoctorCheck(
             "Database schema",
@@ -197,7 +205,15 @@ def _check_database_schema(db_path: Path) -> DoctorCheck:
 
 
 def _check_parser_diagnostics(db_path: Path) -> DoctorCheck:
-    metadata = refresh_metadata(db_path)
+    try:
+        metadata = refresh_metadata(db_path)
+    except SchemaMigrationError as exc:
+        return DoctorCheck(
+            "Parser diagnostics",
+            "fail",
+            f"Parser diagnostics are unavailable because database migration failed: {exc}",
+            "Run: codex-usage-tracker rebuild-index after resolving the database schema warning.",
+        )
     if not metadata:
         return DoctorCheck(
             "Parser diagnostics",

--- a/src/codex_usage_tracker/store.py
+++ b/src/codex_usage_tracker/store.py
@@ -42,6 +42,10 @@ _ARCHIVED_SOURCE_PATTERNS = (
 )
 
 
+class SchemaMigrationError(RuntimeError):
+    """Raised when a persisted aggregate schema cannot be repaired safely."""
+
+
 def refresh_usage_index(
     codex_home: Path = DEFAULT_CODEX_HOME,
     db_path: Path = DEFAULT_DB_PATH,
@@ -137,6 +141,7 @@ def init_db(conn: sqlite3.Connection) -> None:
     else:
         _migrate_v2(conn)
         _record_migration_if_missing(conn, 2)
+    _validate_usage_events_schema(conn)
     conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
 
@@ -305,6 +310,22 @@ def _ensure_columns(conn: sqlite3.Connection, columns: dict[str, str]) -> None:
             except sqlite3.OperationalError as exc:
                 if "duplicate column name" not in str(exc).lower():
                     raise
+
+
+def _validate_usage_events_schema(conn: sqlite3.Connection) -> None:
+    existing = {
+        str(row["name"])
+        for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
+    }
+    missing = [column for column in EVENT_COLUMNS if column not in existing]
+    if missing:
+        missing_text = ", ".join(missing)
+        raise SchemaMigrationError(
+            "usage_events schema is missing required columns: "
+            f"{missing_text}. Run codex-usage-tracker rebuild-index after confirming your "
+            "local aggregate index can be regenerated; raw Codex logs are not touched by "
+            "rebuild-index."
+        )
 
 
 def upsert_usage_events(

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -84,11 +84,13 @@ def test_setup_support_bundle_and_reset_db_cli(tmp_path: Path) -> None:
         "reset-db",
         "--yes",
     )
+    raw_log_path = next((codex_home / "sessions").glob("**/*.jsonl"))
 
     assert reset_without_confirm.returncode == 1
     assert "Re-run with --yes" in reset_without_confirm.stderr
     assert reset.returncode == 0
     assert "Raw Codex logs were not touched" in reset.stdout
+    assert "SECRET RAW PROMPT" in raw_log_path.read_text(encoding="utf-8")
 
 
 def test_rate_card_allowance_and_pricing_snapshot_cli(tmp_path: Path) -> None:

--- a/tests/test_store_migrations.py
+++ b/tests/test_store_migrations.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.diagnostics import run_doctor
+from codex_usage_tracker.store import (
+    EVENT_COLUMNS,
+    SchemaMigrationError,
+    connect,
+    export_usage_csv,
+    init_db,
+    query_dashboard_event_count,
+    query_session_usage,
+    refresh_metadata,
+    refresh_usage_index,
+    schema_state,
+)
+
+LEGACY_SESSION_ID = "019e3810-78be-7f32-a7d7-884d9bdba1fd"
+NEW_SESSION_ID = "019e3811-5715-7018-a7bb-2232b46a5671"
+
+
+def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    _write_legacy_usage_database(db_path)
+
+    with connect(db_path) as conn:
+        init_db(conn)
+
+    rows = query_session_usage(db_path=db_path, session_id=LEGACY_SESSION_ID)
+    state = schema_state(db_path)
+    metadata = refresh_metadata(db_path)
+
+    assert len(rows) == 1
+    assert rows[0]["record_id"] == "legacy-record"
+    assert rows[0]["source_file"] == "/tmp/synthetic-session.jsonl"
+    assert rows[0]["thread_source"] is None
+    assert rows[0]["parent_thread_name"] is None
+    assert rows[0]["model_context_window"] is None
+    assert metadata["parsed_events"] == "legacy"
+    assert metadata["parser_invalid_integer"] == "2"
+    assert state["schema_version"] == 2
+    assert state["checksum_matches"] is True
+    assert [row["version"] for row in state["migrations"]] == [1, 2]
+
+
+def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    codex_home = _make_codex_home(tmp_path)
+    _write_legacy_usage_database(db_path)
+
+    first = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    first_count = query_dashboard_event_count(db_path=db_path)
+    second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    second_count = query_dashboard_event_count(db_path=db_path)
+    legacy_rows = query_session_usage(db_path=db_path, session_id=LEGACY_SESSION_ID)
+    new_rows = query_session_usage(db_path=db_path, session_id=NEW_SESSION_ID)
+    metadata = refresh_metadata(db_path)
+
+    assert first.parsed_events == 1
+    assert second.parsed_events == 1
+    assert first_count == 2
+    assert second_count == 2
+    assert legacy_rows[0]["record_id"] == "legacy-record"
+    assert new_rows[0]["thread_name"] == "Synthetic migration thread"
+    assert metadata["schema_version"] == "2"
+    assert metadata["parsed_events"] == "1"
+    assert metadata["inserted_or_updated_events"] == "1"
+
+
+def test_csv_export_keeps_current_columns_after_legacy_migration(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    csv_path = tmp_path / "usage.csv"
+    _write_legacy_usage_database(db_path)
+
+    exported = export_usage_csv(csv_path, db_path=db_path)
+
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert exported == 1
+    assert rows[0]["record_id"] == "legacy-record"
+    assert list(rows[0]) == EVENT_COLUMNS
+
+
+def test_malformed_legacy_schema_reports_actionable_error_without_data_loss(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    _write_legacy_usage_database(db_path, omit_source_file=True)
+
+    with pytest.raises(SchemaMigrationError, match="missing required columns: source_file"), connect(
+        db_path
+    ) as conn:
+        init_db(conn)
+
+    raw = sqlite3.connect(db_path)
+    try:
+        row_count = raw.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0]
+        user_version = raw.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        raw.close()
+
+    assert row_count == 1
+    assert user_version == 1
+
+
+def test_doctor_reports_malformed_legacy_schema_without_traceback(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    _write_legacy_usage_database(db_path, omit_source_file=True)
+
+    report = run_doctor(codex_home=tmp_path / ".codex", db_path=db_path)
+    schema_check = _check_named(report, "Database schema")
+    parser_check = _check_named(report, "Parser diagnostics")
+
+    assert report["status"] == "fail"
+    assert schema_check["status"] == "fail"
+    assert "source_file" in schema_check["detail"]
+    assert "rebuild-index" in str(schema_check["remediation"])
+    assert parser_check["status"] == "fail"
+    assert "database migration failed" in parser_check["detail"]
+
+
+def _write_legacy_usage_database(db_path: Path, *, omit_source_file: bool = False) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    columns = [
+        ("record_id", "TEXT PRIMARY KEY"),
+        ("session_id", "TEXT NOT NULL"),
+        ("event_timestamp", "TEXT NOT NULL"),
+        ("source_file", "TEXT NOT NULL"),
+        ("line_number", "INTEGER NOT NULL"),
+        ("input_tokens", "INTEGER NOT NULL"),
+        ("cached_input_tokens", "INTEGER NOT NULL"),
+        ("output_tokens", "INTEGER NOT NULL"),
+        ("reasoning_output_tokens", "INTEGER NOT NULL"),
+        ("total_tokens", "INTEGER NOT NULL"),
+        ("cumulative_input_tokens", "INTEGER NOT NULL"),
+        ("cumulative_cached_input_tokens", "INTEGER NOT NULL"),
+        ("cumulative_output_tokens", "INTEGER NOT NULL"),
+        ("cumulative_reasoning_output_tokens", "INTEGER NOT NULL"),
+        ("cumulative_total_tokens", "INTEGER NOT NULL"),
+        ("uncached_input_tokens", "INTEGER NOT NULL"),
+        ("cache_ratio", "REAL NOT NULL"),
+        ("reasoning_output_ratio", "REAL NOT NULL"),
+        ("context_window_percent", "REAL NOT NULL"),
+    ]
+    if omit_source_file:
+        columns = [column for column in columns if column[0] != "source_file"]
+    column_names = [name for name, _declaration in columns]
+    values = {
+        "record_id": "legacy-record",
+        "session_id": LEGACY_SESSION_ID,
+        "event_timestamp": "2026-05-17T18:58:27.000Z",
+        "source_file": "/tmp/synthetic-session.jsonl",
+        "line_number": 12,
+        "input_tokens": 90,
+        "cached_input_tokens": 20,
+        "output_tokens": 10,
+        "reasoning_output_tokens": 5,
+        "total_tokens": 100,
+        "cumulative_input_tokens": 90,
+        "cumulative_cached_input_tokens": 20,
+        "cumulative_output_tokens": 10,
+        "cumulative_reasoning_output_tokens": 5,
+        "cumulative_total_tokens": 100,
+        "uncached_input_tokens": 70,
+        "cache_ratio": 20 / 90,
+        "reasoning_output_ratio": 0.5,
+        "context_window_percent": 0.0,
+    }
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute(f"CREATE TABLE usage_events ({_columns_sql(columns)})")
+        raw.execute("CREATE TABLE refresh_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        raw.executemany(
+            "INSERT INTO refresh_meta (key, value) VALUES (?, ?)",
+            [
+                ("parsed_events", "legacy"),
+                ("parser_invalid_integer", "2"),
+            ],
+        )
+        placeholders = ", ".join("?" for _name in column_names)
+        raw.execute(
+            f"INSERT INTO usage_events ({', '.join(column_names)}) VALUES ({placeholders})",
+            [values[name] for name in column_names],
+        )
+        raw.execute("PRAGMA user_version = 1")
+        raw.commit()
+    finally:
+        raw.close()
+
+
+def _columns_sql(columns: list[tuple[str, str]]) -> str:
+    return ", ".join(f"{name} {declaration}" for name, declaration in columns)
+
+
+def _check_named(report: dict[str, object], name: str) -> dict[str, object]:
+    checks = report["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check["name"] == name:
+            return check
+    raise AssertionError(f"missing doctor check: {name}")
+
+
+def _make_codex_home(tmp_path: Path) -> Path:
+    codex_home = tmp_path / ".codex"
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "17"
+        / f"rollout-2026-05-17T18-58-27-{NEW_SESSION_ID}.jsonl"
+    )
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [
+            {
+                "id": NEW_SESSION_ID,
+                "thread_name": "Synthetic migration thread",
+                "updated_at": "2026-05-17T19:00:00Z",
+            }
+        ],
+    )
+    _write_jsonl(
+        log_path,
+        [
+            _entry("session_meta", {"id": NEW_SESSION_ID}),
+            _entry("turn_context", {"turn_id": "turn-a", "model": "gpt-5.5"}),
+            _token_event(200, 200),
+        ],
+    )
+    return codex_home
+
+
+def _token_event(cumulative_total: int, last_total: int) -> dict[str, object]:
+    return _entry(
+        "event_msg",
+        {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": cumulative_total - 20,
+                    "cached_input_tokens": 40,
+                    "output_tokens": 20,
+                    "reasoning_output_tokens": 5,
+                    "total_tokens": cumulative_total,
+                },
+                "last_token_usage": {
+                    "input_tokens": last_total - 20,
+                    "cached_input_tokens": 10,
+                    "output_tokens": 20,
+                    "reasoning_output_tokens": 5,
+                    "total_tokens": last_total,
+                },
+                "model_context_window": 258400,
+            },
+        },
+    )
+
+
+def _entry(entry_type: str, payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "timestamp": "2026-05-17T18:58:27.000Z",
+        "type": entry_type,
+        "payload": payload,
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary
- add focused SQLite aggregate migration tests with synthetic legacy DB fixtures
- verify `init_db` preserves legacy aggregate rows, refresh remains idempotent after migration, and CSV export keeps current columns
- add `SchemaMigrationError` for malformed legacy aggregate schemas that cannot be safely repaired
- make `doctor` report migration failures as actionable diagnostics instead of tracebacks
- tighten `reset-db` CLI coverage to prove raw Codex logs are not touched
- add Python 3.14 support tracking to the 1.0 readiness checklist and created issue #12 for the actual support work

Closes #6

## Local checks
- `.venv/bin/python -m pytest tests/test_store_migrations.py -q`
- `.venv/bin/python -m pytest tests/test_store_migrations.py tests/test_cli_lifecycle.py tests/test_store_dashboard_mcp.py tests/test_schema.py -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- `.venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist`
- `git diff --check`
