### PR TITLE
test: enforce JSON contract parity

### DIFF
--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -1,6 +1,6 @@
-# CLI and MCP JSON Schemas
+# CLI, MCP, and Dashboard JSON Schemas
 
-Codex Usage Tracker exposes aggregate-only JSON for automation through CLI `--json` flags and MCP tools. These payloads do not include prompts, assistant messages, tool output, or raw transcript snippets.
+Codex Usage Tracker exposes aggregate-only JSON for automation through CLI `--json` flags, MCP tools, and the local dashboard server API. These payloads do not include prompts, assistant messages, tool output, or raw transcript snippets.
 
 ## Companion Skill Usage
 
@@ -24,6 +24,13 @@ Use the global `--privacy-mode redacted` or `--privacy-mode strict` option, or t
 
 Stable payload contracts are tracked in `codex_usage_tracker.json_contracts` and covered by tests. Every stable payload includes a top-level `schema` string so agents can distinguish compatible responses from markdown, disabled-context responses, or future versions.
 
+Compatibility rules before 1.0:
+
+- Additive fields are allowed when they do not change documented field types or privacy semantics.
+- Removing a documented schema, removing a required field, changing a required field type, or changing privacy behavior requires either a new schema id or an explicit pre-1.0 migration note.
+- After 1.0, breaking payload changes require a new schema id.
+- Config-file schemas such as pricing, allowance, and rate-card JSON are tracked separately from runtime CLI/MCP/dashboard payload schemas.
+
 Tracked schema ids:
 
 | Schema | Surface |
@@ -42,6 +49,7 @@ Tracked schema ids:
 | `codex-usage-tracker-session-v1` | CLI `session --json`, MCP `session_usage(response_format="json")` |
 | `codex-usage-tracker-context-v1` | CLI `context`, MCP `usage_call_context` when raw context is explicitly enabled |
 | `codex-usage-tracker-context-disabled-v1` | MCP `usage_call_context` when raw context is disabled |
+| `codex-usage-tracker-context-settings-v1` | Dashboard server `/api/context-settings` response |
 | `codex-usage-tracker-dashboard-v1` | CLI `dashboard --json`, MCP `generate_usage_dashboard()` |
 | `codex-usage-tracker-open-dashboard-v1` | CLI `open-dashboard --json` |
 | `codex-usage-tracker-serve-dashboard-v1` | CLI `serve-dashboard --json` startup payload |

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -57,12 +57,12 @@ Not guaranteed:
 
 ## 5. JSON Contract Stability
 
-- [ ] Verify every documented `--json` command has a tracked schema: `python -m pytest tests/test_json_contracts.py`.
-- [ ] Verify every schema in `docs/cli-json-schemas.md` exists in `src/codex_usage_tracker/json_contracts.py`: `python -m pytest tests/test_cli_release.py`.
-- [ ] Verify every schema in `json_contracts.py` is documented: `python -m pytest tests/test_json_contracts.py`.
-- [ ] Verify known payload examples pass `validate_json_payload_contract`: `python -m pytest tests/test_json_contracts.py`.
-- [ ] Verify invalid or missing required fields fail contract validation: `python -m pytest tests/test_json_contracts.py`.
-- [ ] Cover query, recommendations, summary, session, doctor, pricing-coverage, dashboard, export, support-bundle, and plugin lifecycle JSON payloads: `python -m pytest tests/test_json_contracts.py`.
+- [x] Verify every documented `--json` command has a tracked schema: `python -m pytest tests/test_json_contracts.py`.
+- [x] Verify every schema in `docs/cli-json-schemas.md` exists in `src/codex_usage_tracker/json_contracts.py`: `python -m pytest tests/test_json_contracts.py`.
+- [x] Verify every schema in `json_contracts.py` is documented: `python -m pytest tests/test_json_contracts.py`.
+- [x] Verify known payload examples pass `validate_json_payload_contract`: `python -m pytest tests/test_json_contracts.py`.
+- [x] Verify invalid or missing required fields fail contract validation: `python -m pytest tests/test_json_contracts.py`.
+- [x] Cover query, recommendations, summary, session, doctor, pricing-coverage, dashboard, export, support-bundle, and plugin lifecycle JSON payload contracts: `python -m pytest tests/test_json_contracts.py`.
 
 ## 6. CSV Export Stability
 

--- a/src/codex_usage_tracker/json_contracts.py
+++ b/src/codex_usage_tracker/json_contracts.py
@@ -154,6 +154,12 @@ JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "record_id": str,
         }
     },
+    "codex-usage-tracker-context-settings-v1": {
+        "required": {
+            "context_api_enabled": bool,
+            "raw_context_persisted": bool,
+        }
+    },
     "codex-usage-tracker-dashboard-v1": {
         "required": {
             "dashboard_path": str,

--- a/tests/test_json_contracts.py
+++ b/tests/test_json_contracts.py
@@ -1,6 +1,27 @@
 from __future__ import annotations
 
-from codex_usage_tracker.json_contracts import validate_json_payload_contract
+import json
+import re
+from pathlib import Path
+
+from codex_usage_tracker.json_contracts import (
+    JSON_PAYLOAD_CONTRACTS,
+    known_json_schemas,
+    validate_json_payload_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATTERN = re.compile(r"codex-usage-tracker-[a-z0-9-]+-v1")
+RUNTIME_SCHEMA_SOURCE_PATHS = [
+    REPO_ROOT / "src" / "codex_usage_tracker" / "api_payloads.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "cli.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "context.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "costing.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "diagnostics.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "mcp_server.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "reports.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "server.py",
+]
 
 
 def test_json_contract_validation_accepts_nested_query_contract() -> None:
@@ -48,3 +69,88 @@ def test_json_contract_validation_reports_schema_and_type_errors() -> None:
 
     assert "codex-usage-tracker-query-v1.row_count must be int, got bool" in errors
     assert "codex-usage-tracker-query-v1.filters.since is required" in errors
+
+
+def test_documented_schema_table_matches_tracked_contracts() -> None:
+    documented = _documented_schema_ids()
+
+    assert documented == set(known_json_schemas())
+
+
+def test_runtime_schema_ids_emitted_by_code_are_tracked() -> None:
+    emitted: set[str] = set()
+    for path in RUNTIME_SCHEMA_SOURCE_PATHS:
+        emitted.update(SCHEMA_PATTERN.findall(path.read_text(encoding="utf-8")))
+
+    assert emitted <= set(known_json_schemas())
+
+
+def test_cli_json_schema_doc_examples_validate_against_contracts() -> None:
+    docs = _schema_docs()
+    examples = [
+        json.loads(match.group(1))
+        for match in re.finditer(r"```json\n(.*?)\n```", docs, flags=re.DOTALL)
+    ]
+
+    assert examples
+    for payload in examples:
+        assert validate_json_payload_contract(payload) == []
+
+
+def test_minimal_payload_for_every_tracked_contract_validates() -> None:
+    for schema, contract in JSON_PAYLOAD_CONTRACTS.items():
+        payload: dict[str, object] = {"schema": schema}
+        for field, expected in contract.get("required", {}).items():
+            payload[field] = _example_value(expected)
+        for field, nested in contract.get("nested", {}).items():
+            nested_payload = payload.setdefault(field, {})
+            assert isinstance(nested_payload, dict)
+            for nested_field, expected in nested.items():
+                nested_payload[nested_field] = _example_value(expected)
+
+        assert validate_json_payload_contract(payload) == []
+
+
+def _schema_docs() -> str:
+    return (REPO_ROOT / "docs" / "cli-json-schemas.md").read_text(encoding="utf-8")
+
+
+def _documented_schema_ids() -> set[str]:
+    docs = _schema_docs()
+    in_table = False
+    schemas: set[str] = set()
+    for line in docs.splitlines():
+        if line.strip() == "| Schema | Surface |":
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.startswith("|"):
+            break
+        if line.startswith("| ---"):
+            continue
+        match = SCHEMA_PATTERN.search(line)
+        if match:
+            schemas.add(match.group(0))
+    return schemas
+
+
+def _example_value(expected: object) -> object:
+    if isinstance(expected, tuple):
+        non_null = next((item for item in expected if item is not type(None)), expected[0])
+        return _example_value(non_null)
+    if expected is str:
+        return "value"
+    if expected is int:
+        return 1
+    if expected is float:
+        return 1.0
+    if expected is bool:
+        return False
+    if expected is dict:
+        return {}
+    if expected is list:
+        return []
+    if expected is type(None):
+        return None
+    raise AssertionError(f"unsupported contract type: {expected!r}")


### PR DESCRIPTION
## Summary
- add the dashboard `context-settings` runtime response to tracked JSON contracts
- document pre-1.0 JSON compatibility rules and clarify runtime payload schemas vs config-file schemas
- add strict docs/contract parity tests that parse the schema table, runtime schema ids emitted by code, and JSON examples
- add a minimal valid payload check for every tracked contract so plugin lifecycle, support bundle, setup, dashboard, CLI, and MCP schemas stay covered

Closes #7

## Local checks
- `.venv/bin/python -m pytest tests/test_json_contracts.py tests/test_cli_release.py tests/test_store_dashboard_mcp.py -q`
- `.venv/bin/python -m ruff check tests/test_json_contracts.py src/codex_usage_tracker/json_contracts.py`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- `.venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist`
- `git diff --check`
