### PR TITLE
test: add strict privacy regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ More install paths: [Install Guide](docs/install.md).
 
 ## Platform Support
 
-The core app is not macOS-only. The CLI, SQLite index, dashboard generator, and localhost server are Python-based and CI-tested on Ubuntu for Python 3.10-3.13. It defaults to `~/.codex` for local Codex logs and `~/.codex-usage-tracker` for tracker data; pass `--codex-home` or `--db` when your local layout differs. Codex plugin discovery depends on Codex's local plugin directories on your machine, so run `codex-usage-tracker doctor` after setup if plugin registration does not appear in Codex.
+The core app is not macOS-only. The CLI, SQLite index, dashboard generator, and localhost server are Python-based and CI-tested on Ubuntu for Python 3.10-3.13. Python 3.14 support is a near-term roadmap item, but it is not an official target until CI, package classifiers, docs, and installed-package smoke coverage pass. It defaults to `~/.codex` for local Codex logs and `~/.codex-usage-tracker` for tracker data; pass `--codex-home` or `--db` when your local layout differs. Codex plugin discovery depends on Codex's local plugin directories on your machine, so run `codex-usage-tracker doctor` after setup if plugin registration does not appear in Codex.
 
 ## Dashboard Preview
 
@@ -224,6 +224,7 @@ This is optional. The normal shell install above is the fastest trusted path for
 
 ## Roadmap
 
+- Add official Python 3.14 support once CI, package metadata, docs, and installed-package smoke tests are green ([tracking issue #12](https://github.com/douglasmonsky/codex-usage-tracker/issues/12)).
 - Improve the `Set limits` flow with a paste/import experience for 5-hour and weekly allowance snapshots.
 - Track allowance snapshot history so local Codex credits can be compared against visible remaining-usage changes over time.
 - Clarify top-card token accounting by showing output tokens and reasoning output as a subset instead of implying all token cards add together.

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,6 +32,8 @@ Restart Codex after plugin registration if you want Codex to discover the MCP to
 
 The CLI, SQLite index, dashboard generator, and localhost server are Python-based and are not macOS-only. CI runs the package on Ubuntu with Python 3.10, 3.11, 3.12, and 3.13.
 
+Python 3.14 is planned soon, but it is not an official support target yet. The package may install on 3.14 because metadata allows Python 3.10+, but the project will only document 3.14 as supported after CI, package classifiers, docs, and installed-package smoke coverage pass.
+
 By default the tracker looks for Codex JSONL logs under `~/.codex`, stores its own database/config under `~/.codex-usage-tracker`, and writes the local plugin wrapper under `~/plugins/codex-usage-tracker`. Override paths with `--codex-home`, `--db`, `--plugin-dir`, or `--marketplace` if your platform or Codex installation uses a different layout.
 
 Windows support should work for the core dashboard/CLI when Codex writes readable JSONL logs, but plugin discovery is tied to Codex's local plugin directory behavior. Run `codex-usage-tracker doctor --suggest-repair` after setup if Codex does not show the plugin.

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -29,7 +29,7 @@ Not guaranteed:
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
 - [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version <version>`.
 - [ ] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
-- [ ] Add Python 3.14 as an official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Track this in issue #12.
+- [ ] Add Python 3.14 as a near-term official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Track this in issue #12.
 
 ## 2. Upgrade And Migration
 
@@ -89,12 +89,12 @@ Not guaranteed:
 
 ## 9. Privacy And Sharing Safety
 
-- [ ] Verify dashboard payloads in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
-- [ ] Verify query JSON in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
-- [ ] Verify session JSON in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
-- [ ] Verify CSV export in redacted and strict modes: `python -m pytest tests/test_privacy.py`.
-- [ ] Verify strict mode does not leak raw cwd, source paths, branch, remote labels, project tags, or synthetic private project names: `python -m pytest tests/test_privacy.py`.
-- [ ] Verify raw context fields never appear in SQLite, CSV, dashboard payloads, support bundles, docs, screenshots, or synthetic fixtures: `python -m pytest tests/test_privacy.py scripts/check_release.py`.
+- [x] Verify dashboard payloads in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
+- [x] Verify query JSON in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
+- [x] Verify session JSON in normal, redacted, and strict modes: `python -m pytest tests/test_privacy.py`.
+- [x] Verify CSV export in redacted and strict modes: `python -m pytest tests/test_privacy.py`.
+- [x] Verify strict mode does not leak raw cwd, source paths, branch, remote labels, project tags, or synthetic private project names: `python -m pytest tests/test_privacy.py`.
+- [x] Verify raw context fields never appear in SQLite, CSV, dashboard payloads, support bundles, generated static HTML, docs, or screenshots: `python -m pytest tests/test_privacy.py scripts/check_release.py`.
 
 ## 10. Support-Bundle Safety
 

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import csv
+import json
+import threading
+import urllib.error
+import urllib.request
+from functools import partial
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+from codex_usage_tracker.api_payloads import session_payload
+from codex_usage_tracker.context import load_call_context
+from codex_usage_tracker.dashboard import dashboard_payload, generate_dashboard
+from codex_usage_tracker.projects import (
+    apply_project_privacy_to_rows,
+    project_identity_for_cwd,
+)
+from codex_usage_tracker.reports import build_query_report
+from codex_usage_tracker.store import (
+    export_usage_csv,
+    query_dashboard_events,
+    query_session_usage,
+    refresh_usage_index,
+)
+from codex_usage_tracker.support import build_support_bundle
+
+SESSION_ID = "019e383a-2a4d-7a1e-bf9d-b8775626f6a4"
+PROMPT_SENTINEL = "RAW_PROMPT_SENTINEL_DO_NOT_PERSIST"
+ASSISTANT_SENTINEL = "RAW_ASSISTANT_SENTINEL_DO_NOT_PERSIST"
+TOOL_OUTPUT_SENTINEL = "RAW_TOOL_OUTPUT_SENTINEL_DO_NOT_PERSIST"
+OPENAI_SECRET = "sk" + "-proj-abcdefghijklmnopqrstuvwxyz123456"
+AWS_SECRET = "AKIA" + "IOSFODNN7EXAMPLE"
+BEARER_SECRET = "Authorization: " + "Bearer abc.def.ghi123456789"
+PRIVATE_BRANCH = "private-client-branch"
+PRIVATE_TAG = "private-client-tag"
+RAW_SENTINELS = (
+    PROMPT_SENTINEL,
+    ASSISTANT_SENTINEL,
+    TOOL_OUTPUT_SENTINEL,
+    OPENAI_SECRET,
+    AWS_SECRET,
+    BEARER_SECRET,
+)
+
+
+def test_aggregate_outputs_exclude_raw_transcript_content(tmp_path: Path) -> None:
+    fixture = _make_privacy_fixture(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    csv_path = tmp_path / "usage.csv"
+    dashboard_path = tmp_path / "dashboard.html"
+    support_path = tmp_path / "support.json"
+
+    refresh_usage_index(codex_home=fixture.codex_home, db_path=db_path)
+    raw_rows = query_dashboard_events(db_path=db_path, limit=0)
+    strict_payload = dashboard_payload(
+        db_path=db_path,
+        limit=0,
+        projects_path=fixture.projects_path,
+        privacy_mode="strict",
+    )
+    generate_dashboard(
+        db_path=db_path,
+        output_path=dashboard_path,
+        limit=0,
+        projects_path=fixture.projects_path,
+        privacy_mode="strict",
+    )
+    export_usage_csv(csv_path, db_path=db_path, privacy_mode="strict")
+    build_support_bundle(
+        output_path=support_path,
+        codex_home=fixture.codex_home,
+        db_path=db_path,
+        projects_path=fixture.projects_path,
+        privacy_mode="strict",
+    )
+
+    aggregate_outputs = [
+        db_path.read_bytes().decode("utf-8", errors="ignore"),
+        json.dumps(raw_rows),
+        json.dumps(strict_payload),
+        dashboard_path.read_text(encoding="utf-8"),
+        csv_path.read_text(encoding="utf-8"),
+        support_path.read_text(encoding="utf-8"),
+    ]
+    for sentinel in RAW_SENTINELS:
+        for output in aggregate_outputs:
+            assert sentinel not in output
+
+    strict_row = strict_payload["rows"][0]
+    csv_rows = list(csv.DictReader(csv_path.open(encoding="utf-8", newline="")))
+    assert strict_payload["privacy_mode"] == "strict"
+    assert strict_row["cwd"].startswith("[redacted cwd:")
+    assert strict_row["source_file"].startswith("[redacted source:")
+    assert strict_row["project_name"].startswith("Project ")
+    assert strict_row["project_relative_cwd"] is None
+    assert strict_row["git_branch"] is None
+    assert strict_row["git_remote_label"] is None
+    assert strict_row["project_tags"] == []
+    assert csv_rows[0]["cwd"].startswith("[redacted cwd:")
+    assert PRIVATE_BRANCH not in json.dumps(strict_payload)
+    assert PRIVATE_TAG not in json.dumps(strict_payload)
+    assert PRIVATE_BRANCH not in csv_path.read_text(encoding="utf-8")
+    assert PRIVATE_TAG not in csv_path.read_text(encoding="utf-8")
+
+
+def test_privacy_modes_cover_dashboard_query_session_and_csv(tmp_path: Path) -> None:
+    fixture = _make_privacy_fixture(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=fixture.codex_home, db_path=db_path)
+
+    dashboard_by_mode = {
+        mode: dashboard_payload(
+            db_path=db_path,
+            limit=0,
+            projects_path=fixture.projects_path,
+            privacy_mode=mode,
+        )
+        for mode in ("normal", "redacted", "strict")
+    }
+    query_by_mode = {
+        mode: build_query_report(
+            db_path=db_path,
+            pricing_path=tmp_path / "pricing.json",
+            allowance_path=tmp_path / "allowance.json",
+            projects_path=fixture.projects_path,
+            limit=0,
+            privacy_mode=mode,
+        ).payload
+        for mode in ("normal", "redacted", "strict")
+    }
+    session_rows = query_session_usage(db_path=db_path, session_id=SESSION_ID)
+    session_by_mode = {
+        mode: session_payload(
+            apply_project_privacy_to_rows(session_rows, privacy_mode=mode),
+            requested_session_id=SESSION_ID,
+            limit=200,
+            privacy_mode=mode,
+        )
+        for mode in ("normal", "redacted", "strict")
+    }
+    redacted_csv = tmp_path / "usage-redacted.csv"
+    strict_csv = tmp_path / "usage-strict.csv"
+    export_usage_csv(redacted_csv, db_path=db_path, privacy_mode="redacted")
+    export_usage_csv(strict_csv, db_path=db_path, privacy_mode="strict")
+
+    assert str(fixture.cwd) in json.dumps(dashboard_by_mode["normal"])
+    assert str(fixture.cwd) in json.dumps(query_by_mode["normal"])
+    assert str(fixture.cwd) in json.dumps(session_by_mode["normal"])
+    for payload in (
+        dashboard_by_mode["redacted"],
+        dashboard_by_mode["strict"],
+        query_by_mode["redacted"],
+        query_by_mode["strict"],
+        session_by_mode["redacted"],
+        session_by_mode["strict"],
+    ):
+        text = json.dumps(payload)
+        assert str(fixture.cwd) not in text
+        assert "[redacted cwd:" in text
+    assert query_by_mode["redacted"]["rows"][0]["project_relative_cwd"] == "private/workflow"
+    assert query_by_mode["redacted"]["rows"][0]["git_branch"] == PRIVATE_BRANCH
+    assert query_by_mode["redacted"]["rows"][0]["project_tags"] == [PRIVATE_TAG]
+    assert query_by_mode["strict"]["rows"][0]["project_relative_cwd"] is None
+    assert query_by_mode["strict"]["rows"][0]["git_branch"] is None
+    assert query_by_mode["strict"]["rows"][0]["git_remote_label"] is None
+    assert query_by_mode["strict"]["rows"][0]["project_tags"] == []
+    assert str(fixture.cwd) not in redacted_csv.read_text(encoding="utf-8")
+    assert str(fixture.cwd) not in strict_csv.read_text(encoding="utf-8")
+
+
+def test_context_loading_is_explicit_redacted_and_not_static_html(tmp_path: Path) -> None:
+    fixture = _make_privacy_fixture(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    dashboard_path = tmp_path / "dashboard.html"
+    refresh_usage_index(codex_home=fixture.codex_home, db_path=db_path)
+    record_id = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]["record_id"]
+
+    generate_dashboard(
+        db_path=db_path,
+        output_path=dashboard_path,
+        context_api_enabled=True,
+        api_token="test-token",
+    )
+    static_html = dashboard_path.read_text(encoding="utf-8")
+    default_context = load_call_context(record_id, db_path=db_path)
+    default_context_text = json.dumps(default_context)
+    tool_context = load_call_context(record_id, db_path=db_path, include_tool_output=True)
+    tool_context_text = json.dumps(tool_context)
+
+    for sentinel in RAW_SENTINELS:
+        assert sentinel not in static_html
+    assert default_context["loaded_on_demand"] is True
+    assert default_context["raw_context_persisted"] is False
+    assert PROMPT_SENTINEL in default_context_text
+    assert ASSISTANT_SENTINEL in default_context_text
+    assert TOOL_OUTPUT_SENTINEL not in default_context_text
+    assert "Tool output omitted by default" in default_context_text
+    assert TOOL_OUTPUT_SENTINEL in tool_context_text
+    for secret in (OPENAI_SECRET, AWS_SECRET, BEARER_SECRET):
+        assert secret not in default_context_text
+        assert secret not in tool_context_text
+    assert "[REDACTED_OPENAI_KEY]" in default_context_text
+    assert "[REDACTED_AWS_ACCESS_KEY]" in default_context_text
+    assert "Authorization: Bearer [REDACTED_BEARER_TOKEN]" in tool_context_text
+
+
+def test_context_server_requires_loopback_origin_token_and_enablement(tmp_path: Path) -> None:
+    from codex_usage_tracker.server import _ContextApiState, _UsageDashboardHandler
+
+    fixture = _make_privacy_fixture(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=fixture.codex_home, db_path=db_path)
+    record_id = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]["record_id"]
+    context_api_state = _ContextApiState(False)
+    handler = partial(
+        _UsageDashboardHandler,
+        directory=str(tmp_path),
+        db_path=db_path,
+        pricing_path=tmp_path / "pricing.json",
+        allowance_path=tmp_path / "allowance.json",
+        thresholds_path=tmp_path / "thresholds.json",
+        projects_path=fixture.projects_path,
+        limit=5000,
+        since=None,
+        codex_home=fixture.codex_home,
+        include_archived=False,
+        dashboard_name="dashboard.html",
+        context_chars=2000,
+        api_token="test-token",
+        context_api_state=context_api_state,
+        refresh_lock=threading.Lock(),
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}"
+        disabled_error = _http_error_json(
+            f"{base_url}/api/context?record_id={record_id}",
+            headers={"X-Codex-Usage-Token": "test-token"},
+        )
+        foreign_origin_error = _http_error_json(
+            f"{base_url}/api/context-settings?enabled=1",
+            headers={
+                "Origin": "http://example.test",
+                "X-Codex-Usage-Token": "test-token",
+            },
+        )
+        missing_token_error = _http_error_json(f"{base_url}/api/context-settings?enabled=1")
+        with urllib.request.urlopen(  # noqa: S310 - local test server only
+            urllib.request.Request(
+                f"{base_url}/api/context-settings?enabled=1",
+                headers={"X-Codex-Usage-Token": "test-token"},
+            ),
+            timeout=5,
+        ) as response:
+            settings_payload = json.loads(response.read().decode("utf-8"))
+        with urllib.request.urlopen(  # noqa: S310 - local test server only
+            urllib.request.Request(
+                f"{base_url}/api/context?record_id={record_id}",
+                headers={"X-Codex-Usage-Token": "test-token"},
+            ),
+            timeout=5,
+        ) as response:
+            context_payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert disabled_error["status"] == 403
+    assert disabled_error["payload"]["context_api_enabled"] is False
+    assert foreign_origin_error["status"] == 403
+    assert missing_token_error["status"] == 403
+    assert settings_payload["schema"] == "codex-usage-tracker-context-settings-v1"
+    assert settings_payload["context_api_enabled"] is True
+    assert settings_payload["raw_context_persisted"] is False
+    assert context_payload["loaded_on_demand"] is True
+    assert context_payload["raw_context_persisted"] is False
+
+
+class _PrivacyFixture:
+    def __init__(self, *, codex_home: Path, projects_path: Path, cwd: Path) -> None:
+        self.codex_home = codex_home
+        self.projects_path = projects_path
+        self.cwd = cwd
+
+
+def _make_privacy_fixture(tmp_path: Path) -> _PrivacyFixture:
+    codex_home = tmp_path / ".codex"
+    project_root = tmp_path / "private-client-project"
+    cwd = project_root / "private" / "workflow"
+    git_dir = project_root / ".git"
+    cwd.mkdir(parents=True)
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text(f"ref: refs/heads/{PRIVATE_BRANCH}\n", encoding="utf-8")
+    (git_dir / "config").write_text(
+        '[remote "origin"]\n\turl = git@github.com:secret-owner/secret-repo.git\n',
+        encoding="utf-8",
+    )
+    project_key = project_identity_for_cwd(str(cwd))["project_key"]
+    projects_path = tmp_path / "projects.json"
+    projects_path.write_text(
+        json.dumps({"tags": {project_key: [PRIVATE_TAG]}}),
+        encoding="utf-8",
+    )
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "17"
+        / f"rollout-2026-05-17T18-58-27-{SESSION_ID}.jsonl"
+    )
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [
+            {
+                "id": SESSION_ID,
+                "thread_name": "Synthetic privacy thread",
+                "updated_at": "2026-05-17T19:00:00Z",
+            }
+        ],
+    )
+    _write_jsonl(
+        log_path,
+        [
+            _entry("session_meta", {"id": SESSION_ID}),
+            _entry(
+                "turn_context",
+                {
+                    "turn_id": "turn-a",
+                    "model": "gpt-5.5",
+                    "effort": "high",
+                    "cwd": str(cwd),
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": f"{PROMPT_SENTINEL} {OPENAI_SECRET} {AWS_SECRET}",
+                        }
+                    ],
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": ASSISTANT_SENTINEL}],
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "function_call_output",
+                    "name": "shell",
+                    "output": f"{TOOL_OUTPUT_SENTINEL} {BEARER_SECRET}",
+                },
+            ),
+            _token_event(250, 250),
+        ],
+    )
+    return _PrivacyFixture(codex_home=codex_home, projects_path=projects_path, cwd=cwd)
+
+
+def _token_event(cumulative_total: int, last_total: int) -> dict[str, object]:
+    return _entry(
+        "event_msg",
+        {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": cumulative_total - 30,
+                    "cached_input_tokens": 80,
+                    "output_tokens": 30,
+                    "reasoning_output_tokens": 10,
+                    "total_tokens": cumulative_total,
+                },
+                "last_token_usage": {
+                    "input_tokens": last_total - 30,
+                    "cached_input_tokens": 20,
+                    "output_tokens": 30,
+                    "reasoning_output_tokens": 10,
+                    "total_tokens": last_total,
+                },
+                "model_context_window": 258400,
+            },
+        },
+    )
+
+
+def _entry(entry_type: str, payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "timestamp": "2026-05-17T18:58:27.000Z",
+        "type": entry_type,
+        "payload": payload,
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _http_error_json(url: str, headers: dict[str, str] | None = None) -> dict[str, object]:
+    request = urllib.request.Request(url, headers=headers or {})
+    try:
+        urllib.request.urlopen(request, timeout=5)  # noqa: S310 - local test server only
+    except urllib.error.HTTPError as exc:
+        return {
+            "status": exc.code,
+            "payload": json.loads(exc.read().decode("utf-8")),
+        }
+    raise AssertionError("expected HTTPError")


### PR DESCRIPTION
Closes #5.

## Summary
- Add strict privacy regression tests covering aggregate outputs, dashboard/query/session JSON privacy modes, CSV exports, support bundles, on-demand context loading, and context API enablement guards.
- Mark privacy readiness checklist items complete.
- Document Python 3.14 as a near-term planned support target without changing the official 3.10-3.13 support claim.

## Checks
- `.venv/bin/python -m pytest tests/test_privacy.py -q`
- `.venv/bin/python -m pytest tests/test_privacy.py tests/test_store_dashboard_mcp.py tests/test_projects.py tests/test_cli_lifecycle.py -q`
- `.venv/bin/python -m ruff check tests/test_privacy.py`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- `.venv/bin/python -m build`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/python scripts/check_release.py --dist`
- `git diff --check`
- `git diff --cached --check`