### PR TITLE
test: add support bundle safety coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     id: diagnostics
     attributes:
       label: Safe diagnostics
-      description: Paste relevant output from `codex-usage-tracker doctor --json` or `codex-usage-tracker --privacy-mode strict support-bundle --json`. Review it first.
+      description: Prefer a reviewed strict support bundle from `codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json`. If pasting JSON, paste only reviewed strict-mode bundle content or `doctor --json` output.
       render: json
   - type: input
     id: version

--- a/docs/install.md
+++ b/docs/install.md
@@ -145,7 +145,9 @@ codex-usage-tracker setup
 codex-usage-tracker upgrade-plugin
 codex-usage-tracker uninstall-plugin
 codex-usage-tracker reset-db --yes
-codex-usage-tracker support-bundle --output ~/.codex-usage-tracker/support-bundle.json
+codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json
 ```
 
-`support-bundle` writes package, Python, OS, doctor, database schema, parser diagnostics, pricing status, and allowance status. It does not include raw logs, prompts, assistant messages, tool output, or context text.
+`support-bundle` writes package, Python, OS/platform, doctor status, database schema, parser diagnostics, pricing status, allowance status, threshold status, project config status, and privacy metadata. It does not include raw logs, prompts, assistant messages, tool output, context text, or aggregate rows.
+
+Default `support-bundle` mode keeps local diagnostic paths because they can help troubleshoot setup on your machine. Use `--privacy-mode strict` before sharing: strict mode redacts local diagnostic path strings in the bundle and doctor details while preserving existence flags, counts, parser diagnostics, and status fields.

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -98,9 +98,9 @@ Not guaranteed:
 
 ## 10. Support-Bundle Safety
 
-- [ ] Verify support bundles include package version, Python version, OS/platform, doctor status, schema state, parser diagnostics, pricing status, allowance status, threshold status, project config status, and privacy metadata: `python -m pytest tests/test_support.py`.
-- [ ] Verify support bundles exclude raw logs, prompt text, assistant text, tool output, context text, and raw source paths in strict mode: `python -m pytest tests/test_support.py`.
-- [ ] Update issue templates to request only strict-mode support bundles: manual review of `.github/ISSUE_TEMPLATE/`.
+- [x] Verify support bundles include package version, Python version, OS/platform, doctor status, schema state, parser diagnostics, pricing status, allowance status, threshold status, project config status, and privacy metadata: `python -m pytest tests/test_support.py`.
+- [x] Verify support bundles exclude raw logs, prompt text, assistant text, tool output, context text, and raw source paths in strict mode: `python -m pytest tests/test_support.py`.
+- [x] Update issue templates to request only strict-mode support bundles: manual review of `.github/ISSUE_TEMPLATE/`.
 
 ## 11. Large-History Performance
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -73,6 +73,20 @@ codex-usage-tracker --privacy-mode strict query --since 2026-06-01
 
 Dashboard payloads and support bundles include the active mode so screenshots and support artifacts make their metadata posture visible.
 
+## Support Bundles
+
+Support bundles are designed for diagnostics without raw conversation content. They include package version, Python version, OS/platform, path existence checks, database schema state, refresh/parser diagnostics, pricing status, allowance status, threshold status, project config status, doctor results, and privacy metadata.
+
+They do not include raw logs, aggregate rows, prompts, assistant messages, tool output, on-demand context text, or pasted transcript content. Known secret-like patterns are redacted from string fields before the bundle is written.
+
+Default support bundles keep local diagnostic paths for troubleshooting. Before sharing a bundle publicly, generate it in strict mode:
+
+```bash
+codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json
+```
+
+Strict mode redacts local diagnostic path strings in the bundle and doctor details while keeping booleans, counts, statuses, and parser diagnostics available.
+
 ## Costs, Credits, And Allowance
 
 Cost estimates are calculated only from aggregate token fields and your local pricing config. They are omitted when no matching model price is configured. Pricing refreshes pull only OpenAI's public pricing markdown and do not send local usage data anywhere.
@@ -86,7 +100,8 @@ The optional allowance config is local and stores only the remaining percentages
 Before sharing a dashboard, CSV, JSON query result, or support bundle:
 
 1. Use `--privacy-mode redacted` or `--privacy-mode strict` if project names, directories, branches, or tags are sensitive.
-2. Do not share local raw JSONL logs.
-3. Do not enable or export on-demand context unless you have reviewed the content.
-4. Prefer synthetic screenshots for public docs and issues.
-5. Treat source paths and thread names as potentially sensitive even when raw messages are absent.
+2. Use `--privacy-mode strict support-bundle` for public issues unless a maintainer specifically asks for normal-mode local path diagnostics.
+3. Do not share local raw JSONL logs.
+4. Do not enable or export on-demand context unless you have reviewed the content.
+5. Prefer synthetic screenshots for public docs and issues.
+6. Treat source paths and thread names as potentially sensitive even when raw messages are absent.

--- a/src/codex_usage_tracker/context.py
+++ b/src/codex_usage_tracker/context.py
@@ -3,54 +3,15 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
 from codex_usage_tracker.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.redaction import redact_secrets
 from codex_usage_tracker.store import query_usage_record
 
 DEFAULT_CONTEXT_CHARS = 20_000
 DEFAULT_CONTEXT_ENTRIES = 80
-
-_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"sk-[A-Za-z0-9_-]{10,}"), "[REDACTED_OPENAI_KEY]"),
-    (re.compile(r"github" r"_pat_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
-    (re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
-    (re.compile(r"\bA(?:KI|SI)A[0-9A-Z]{16}\b"), "[REDACTED_AWS_ACCESS_KEY]"),
-    (
-        re.compile(r"(?i)\baws_secret_access_key\s*[:=]\s*(['\"]?)[A-Za-z0-9/+=]{30,}\1"),
-        "aws_secret_access_key=[REDACTED_AWS_SECRET]",
-    ),
-    (
-        re.compile(r"(?i)\bAuthorization\s*[:=]\s*Bearer\s+[A-Za-z0-9._~+/-]+=*"),
-        "Authorization: Bearer [REDACTED_BEARER_TOKEN]",
-    ),
-    (re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/-]+=*"), "Bearer [REDACTED_BEARER_TOKEN]"),
-    (
-        re.compile(r"\bxox(?:a|b|p|r|s)-[A-Za-z0-9-]{10,}\b"),
-        "[REDACTED_SLACK_TOKEN]",
-    ),
-    (re.compile(r"\bxapp-[A-Za-z0-9-]{10,}\b"), "[REDACTED_SLACK_TOKEN]"),
-    (
-        re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
-        "[REDACTED_JWT]",
-    ),
-    (
-        re.compile(
-            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
-            re.S,
-        ),
-        "[REDACTED_PRIVATE_KEY]",
-    ),
-    (
-        re.compile(
-            r"(?i)\b([A-Z0-9_ -]*(?:password|api[_-]?key|token|secret|credential|private[_-]?key)[A-Z0-9_ -]*)\s*[:=]\s*"
-            r"(['\"]?)[^'\"\s,;}]+\2"
-        ),
-        r"\1=[REDACTED_SECRET]",
-    ),
-)
 
 _OUTPUT_OMITTED = (
     "Tool output omitted by default. Reload with include_tool_output=true to inspect "
@@ -392,10 +353,7 @@ def _jsonish(value: object) -> str:
 
 
 def _redact(text: str) -> str:
-    redacted = text
-    for pattern, replacement in _SECRET_PATTERNS:
-        redacted = pattern.sub(replacement, redacted)
-    return redacted
+    return redact_secrets(text)
 
 
 def _positive_int(value: object) -> int | None:

--- a/src/codex_usage_tracker/redaction.py
+++ b/src/codex_usage_tracker/redaction.py
@@ -1,0 +1,53 @@
+"""Shared redaction helpers for local diagnostic text."""
+
+from __future__ import annotations
+
+import re
+
+SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"sk-[A-Za-z0-9_-]{10,}"), "[REDACTED_OPENAI_KEY]"),
+    (re.compile(r"github" r"_pat_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"\bA(?:KI|SI)A[0-9A-Z]{16}\b"), "[REDACTED_AWS_ACCESS_KEY]"),
+    (
+        re.compile(r"(?i)\baws_secret_access_key\s*[:=]\s*(['\"]?)[A-Za-z0-9/+=]{30,}\1"),
+        "aws_secret_access_key=[REDACTED_AWS_SECRET]",
+    ),
+    (
+        re.compile(r"(?i)\bAuthorization\s*[:=]\s*Bearer\s+[A-Za-z0-9._~+/-]+=*"),
+        "Authorization: Bearer [REDACTED_BEARER_TOKEN]",
+    ),
+    (re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/-]+=*"), "Bearer [REDACTED_BEARER_TOKEN]"),
+    (
+        re.compile(r"\bxox(?:a|b|p|r|s)-[A-Za-z0-9-]{10,}\b"),
+        "[REDACTED_SLACK_TOKEN]",
+    ),
+    (re.compile(r"\bxapp-[A-Za-z0-9-]{10,}\b"), "[REDACTED_SLACK_TOKEN]"),
+    (
+        re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+        "[REDACTED_JWT]",
+    ),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.S,
+        ),
+        "[REDACTED_PRIVATE_KEY]",
+    ),
+    (
+        re.compile(
+            r"(?i)\b([A-Z0-9_ -]*(?:password|api[_-]?key|token|secret|credential|private[_-]?key)[A-Z0-9_ -]*)\s*[:=]\s*"
+            r"(['\"]?)[^'\"\s,;}]+\2"
+        ),
+        r"\1=[REDACTED_SECRET]",
+    ),
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Redact common credential patterns from one text value."""
+
+    redacted = text
+    for pattern, replacement in SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted

--- a/src/codex_usage_tracker/support.py
+++ b/src/codex_usage_tracker/support.py
@@ -6,6 +6,7 @@ import json
 import platform
 import sys
 from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +16,10 @@ from codex_usage_tracker.diagnostics import run_doctor
 from codex_usage_tracker.paths import (
     DEFAULT_ALLOWANCE_PATH,
     DEFAULT_CODEX_HOME,
+    DEFAULT_DASHBOARD_PATH,
     DEFAULT_DB_PATH,
+    DEFAULT_MARKETPLACE_PATH,
+    DEFAULT_PLUGIN_LINK,
     DEFAULT_PRICING_PATH,
     DEFAULT_PROJECTS_PATH,
     DEFAULT_RATE_CARD_PATH,
@@ -28,6 +32,7 @@ from codex_usage_tracker.projects import (
     validate_privacy_mode,
 )
 from codex_usage_tracker.recommendations import load_threshold_config
+from codex_usage_tracker.redaction import redact_secrets
 from codex_usage_tracker.store import refresh_metadata, schema_state
 
 
@@ -75,11 +80,21 @@ def support_bundle_payload(
     """Return support diagnostics safe to attach to a GitHub issue."""
 
     privacy_mode = validate_privacy_mode(privacy_mode)
+    redact_paths = privacy_mode in {"redacted", "strict"}
+    path_replacements = _support_path_replacements(
+        codex_home=codex_home,
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        rate_card_path=rate_card_path,
+        thresholds_path=thresholds_path,
+        projects_path=projects_path,
+    )
     pricing = load_pricing_config(pricing_path)
     allowance = load_allowance_config(allowance_path, rate_card_path=rate_card_path)
     thresholds = load_threshold_config(thresholds_path)
     projects = load_project_config(projects_path)
-    return {
+    payload = {
         "bundle_version": 1,
         "generated_at": datetime.now(timezone.utc)
         .replace(microsecond=0)
@@ -90,6 +105,7 @@ def support_bundle_payload(
             "contains_prompts": False,
             "contains_assistant_messages": False,
             "contains_tool_output": False,
+            "diagnostic_paths_redacted": redact_paths,
             "project_metadata": project_privacy_metadata(privacy_mode),
         },
         "package": {
@@ -99,14 +115,15 @@ def support_bundle_payload(
             "platform": platform.platform(),
         },
         "paths": {
+            "codex_home": _support_path_value("codex_home", codex_home, privacy_mode),
             "codex_home_exists": codex_home.expanduser().exists(),
             "sessions_dir_exists": (codex_home.expanduser() / "sessions").exists(),
-            "db_path": str(db_path.expanduser()),
-            "pricing_path": str(pricing_path.expanduser()),
-            "allowance_path": str(allowance_path.expanduser()),
-            "rate_card_path": str(rate_card_path.expanduser()),
-            "thresholds_path": str(thresholds_path.expanduser()),
-            "projects_path": str(projects_path.expanduser()),
+            "db_path": _support_path_value("db_path", db_path, privacy_mode),
+            "pricing_path": _support_path_value("pricing_path", pricing_path, privacy_mode),
+            "allowance_path": _support_path_value("allowance_path", allowance_path, privacy_mode),
+            "rate_card_path": _support_path_value("rate_card_path", rate_card_path, privacy_mode),
+            "thresholds_path": _support_path_value("thresholds_path", thresholds_path, privacy_mode),
+            "projects_path": _support_path_value("projects_path", projects_path, privacy_mode),
         },
         "database": schema_state(db_path),
         "refresh": refresh_metadata(db_path),
@@ -145,3 +162,122 @@ def support_bundle_payload(
             suggest_repair=True,
         ),
     }
+    return _sanitize_support_payload(
+        payload,
+        redact_paths=redact_paths,
+        path_replacements=path_replacements,
+    )
+
+
+def _support_path_value(label: str, path: Path, privacy_mode: str) -> str:
+    expanded = _safe_path(path.expanduser())
+    if privacy_mode == "normal":
+        return str(expanded)
+    return _redacted_path_label(label, expanded)
+
+
+def _support_path_replacements(
+    *,
+    codex_home: Path,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+    rate_card_path: Path,
+    thresholds_path: Path,
+    projects_path: Path,
+) -> tuple[tuple[str, str], ...]:
+    raw_paths: list[tuple[str, Path]] = [
+        ("codex_sessions", codex_home.expanduser() / "sessions"),
+        ("codex_home", codex_home),
+        ("db_path", db_path),
+        ("pricing_path", pricing_path),
+        ("allowance_path", allowance_path),
+        ("rate_card_path", rate_card_path),
+        ("thresholds_path", thresholds_path),
+        ("projects_path", projects_path),
+        ("dashboard_path", DEFAULT_DASHBOARD_PATH),
+        ("plugin_path", DEFAULT_PLUGIN_LINK),
+        ("marketplace_path", DEFAULT_MARKETPLACE_PATH),
+        ("cwd", Path.cwd()),
+        ("home", Path.home()),
+    ]
+    replacements: dict[str, str] = {}
+    for label, path in raw_paths:
+        expanded = _safe_path(path.expanduser())
+        _add_path_replacement(replacements, label, expanded)
+        if label not in {"home", "cwd"}:
+            _add_path_replacement(replacements, f"{label}_dir", expanded.parent)
+    return tuple(sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True))
+
+
+def _add_path_replacement(replacements: dict[str, str], label: str, path: Path) -> None:
+    value = str(path)
+    if not value or value in {".", "/"} or value in replacements:
+        return
+    replacements[value] = _redacted_path_label(label, path)
+
+
+def _redacted_path_label(label: str, path: Path) -> str:
+    digest = sha256(str(path).encode("utf-8")).hexdigest()[:8]
+    safe_label = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in label)
+    return f"[redacted path:{safe_label}:{digest}]"
+
+
+def _sanitize_support_payload(
+    value: Any,
+    *,
+    redact_paths: bool,
+    path_replacements: tuple[tuple[str, str], ...],
+) -> Any:
+    if isinstance(value, str):
+        return _sanitize_support_text(
+            value,
+            redact_paths=redact_paths,
+            path_replacements=path_replacements,
+        )
+    if isinstance(value, list):
+        return [
+            _sanitize_support_payload(
+                item,
+                redact_paths=redact_paths,
+                path_replacements=path_replacements,
+            )
+            for item in value
+        ]
+    if isinstance(value, dict):
+        return {
+            _sanitize_support_payload(
+                key,
+                redact_paths=redact_paths,
+                path_replacements=path_replacements,
+            )
+            if isinstance(key, str)
+            else key: _sanitize_support_payload(
+                item,
+                redact_paths=redact_paths,
+                path_replacements=path_replacements,
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _sanitize_support_text(
+    text: str,
+    *,
+    redact_paths: bool,
+    path_replacements: tuple[tuple[str, str], ...],
+) -> str:
+    sanitized = redact_secrets(text)
+    if not redact_paths:
+        return sanitized
+    for raw_path, replacement in path_replacements:
+        sanitized = sanitized.replace(raw_path, replacement)
+    return sanitized
+
+
+def _safe_path(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except OSError:
+        return path.absolute()

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_usage_tracker.store import refresh_usage_index
+from codex_usage_tracker.support import build_support_bundle, support_bundle_payload
+
+SESSION_ID = "019e3915-5120-7f93-a30f-4bb23669b2a8"
+PROMPT_SENTINEL = "SUPPORT_RAW_PROMPT_SENTINEL"
+ASSISTANT_SENTINEL = "SUPPORT_RAW_ASSISTANT_SENTINEL"
+TOOL_OUTPUT_SENTINEL = "SUPPORT_RAW_TOOL_OUTPUT_SENTINEL"
+OPENAI_SECRET = "sk" + "-proj-supportbundleabcdefghijklmnopqrstuvwxyz"
+AWS_SECRET = "AKIA" + "IOSFODNN7EXAMPLE"
+BEARER_SECRET = "Authorization: " + "Bearer support.bundle.token123456"
+RAW_SENTINELS = (
+    PROMPT_SENTINEL,
+    ASSISTANT_SENTINEL,
+    TOOL_OUTPUT_SENTINEL,
+    OPENAI_SECRET,
+    AWS_SECRET,
+    BEARER_SECRET,
+)
+
+
+def test_support_bundle_default_mode_contract_and_secret_safety(tmp_path: Path) -> None:
+    fixture = _make_support_fixture(tmp_path)
+    output_path = tmp_path / "support.json"
+
+    refresh_usage_index(codex_home=fixture["codex_home"], db_path=fixture["db_path"])
+    build_support_bundle(
+        output_path=output_path,
+        codex_home=fixture["codex_home"],
+        db_path=fixture["db_path"],
+        pricing_path=fixture["pricing_path"],
+        allowance_path=fixture["allowance_path"],
+        rate_card_path=fixture["rate_card_path"],
+        thresholds_path=fixture["thresholds_path"],
+        projects_path=fixture["projects_path"],
+    )
+
+    bundle = json.loads(output_path.read_text(encoding="utf-8"))
+    bundle_text = json.dumps(bundle)
+
+    assert bundle["bundle_version"] == 1
+    assert bundle["privacy"]["contains_raw_logs"] is False
+    assert bundle["privacy"]["contains_prompts"] is False
+    assert bundle["privacy"]["contains_assistant_messages"] is False
+    assert bundle["privacy"]["contains_tool_output"] is False
+    assert bundle["privacy"]["project_metadata"]["mode"] == "normal"
+    assert bundle["privacy"]["diagnostic_paths_redacted"] is False
+    assert bundle["package"]["version"]
+    assert bundle["package"]["python"]
+    assert bundle["package"]["platform"]
+    assert bundle["paths"]["db_path"] == str(fixture["db_path"])
+    assert bundle["database"]["exists"] is True
+    assert bundle["refresh"]["parsed_events"] == "1"
+    assert bundle["pricing"]["loaded"] is True
+    assert bundle["allowance"]["window_count"] == 0
+    assert "low_cache_ratio" in bundle["thresholds"]["keys"]
+    assert bundle["projects"]["tag_group_count"] == 1
+    assert bundle["doctor"]["schema"] == "codex-usage-tracker-doctor-v1"
+    assert any(check["name"] == "Parser diagnostics" for check in bundle["doctor"]["checks"])
+
+    for sentinel in RAW_SENTINELS:
+        assert sentinel not in bundle_text
+    assert "[REDACTED_OPENAI_KEY]" in bundle_text
+    assert "[REDACTED_AWS_ACCESS_KEY]" in bundle_text
+    assert "Authorization: Bearer [REDACTED_BEARER_TOKEN]" in bundle_text
+
+
+def test_support_bundle_strict_mode_redacts_local_paths_and_doctor_text(
+    tmp_path: Path,
+) -> None:
+    fixture = _make_support_fixture(tmp_path)
+
+    refresh_usage_index(codex_home=fixture["codex_home"], db_path=fixture["db_path"])
+    bundle = support_bundle_payload(
+        codex_home=fixture["codex_home"],
+        db_path=fixture["db_path"],
+        pricing_path=fixture["pricing_path"],
+        allowance_path=fixture["allowance_path"],
+        rate_card_path=fixture["rate_card_path"],
+        thresholds_path=fixture["thresholds_path"],
+        projects_path=fixture["projects_path"],
+        privacy_mode="strict",
+    )
+    bundle_text = json.dumps(bundle)
+
+    assert bundle["privacy"]["project_metadata"]["mode"] == "strict"
+    assert bundle["privacy"]["project_metadata"]["relative_cwd_hidden"] is True
+    assert bundle["privacy"]["diagnostic_paths_redacted"] is True
+    assert bundle["paths"]["db_path"].startswith("[redacted path:db_path:")
+    assert bundle["paths"]["codex_home"].startswith("[redacted path:codex_home:")
+    assert "[redacted path:" in bundle_text
+
+    for sentinel in RAW_SENTINELS:
+        assert sentinel not in bundle_text
+    for raw_path in (
+        str(tmp_path),
+        str(Path.cwd()),
+        str(fixture["codex_home"]),
+        str(fixture["cwd"]),
+        str(fixture["db_path"]),
+        str(fixture["pricing_path"]),
+        str(fixture["projects_path"]),
+    ):
+        assert raw_path not in bundle_text
+
+
+def _make_support_fixture(tmp_path: Path) -> dict[str, Path]:
+    codex_home = tmp_path / ".codex"
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = tmp_path / "pricing.json"
+    allowance_path = tmp_path / "allowance.json"
+    rate_card_path = tmp_path / "rate-card.json"
+    thresholds_path = tmp_path / "thresholds.json"
+    projects_path = tmp_path / "projects.json"
+    cwd = tmp_path / "support-client-project" / "private" / "workflow"
+    cwd.mkdir(parents=True)
+
+    pricing_path.write_text(
+        json.dumps(
+            {
+                "_source": {
+                    "name": f"Synthetic {OPENAI_SECRET}",
+                    "url": f"https://example.test/{AWS_SECRET}",
+                    "fetched_at": BEARER_SECRET,
+                },
+                "models": {
+                    "gpt-5.5": {
+                        "input_per_million": 2.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 10.0,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    thresholds_path.write_text(json.dumps({"low_cache_ratio": 0.25}), encoding="utf-8")
+    projects_path.write_text(
+        json.dumps({"tags": {"support-project": ["private-tag"]}}),
+        encoding="utf-8",
+    )
+
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [
+            {
+                "id": SESSION_ID,
+                "thread_name": "Synthetic support thread",
+                "updated_at": "2026-05-17T19:00:00Z",
+            }
+        ],
+    )
+    _write_jsonl(
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "17"
+        / f"rollout-2026-05-17T19-00-00-{SESSION_ID}.jsonl",
+        [
+            _entry("session_meta", {"id": SESSION_ID}),
+            _entry(
+                "turn_context",
+                {
+                    "turn_id": "support-turn",
+                    "model": "gpt-5.5",
+                    "cwd": str(cwd),
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": f"{PROMPT_SENTINEL} {OPENAI_SECRET}",
+                        }
+                    ],
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": ASSISTANT_SENTINEL}],
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "function_call_output",
+                    "name": "shell",
+                    "output": f"{TOOL_OUTPUT_SENTINEL} {AWS_SECRET}",
+                },
+            ),
+            _entry(
+                "event_msg",
+                {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 90,
+                            "cached_input_tokens": 20,
+                            "output_tokens": 10,
+                            "reasoning_output_tokens": 5,
+                            "total_tokens": 100,
+                        },
+                        "last_token_usage": {
+                            "input_tokens": 90,
+                            "cached_input_tokens": 20,
+                            "output_tokens": 10,
+                            "reasoning_output_tokens": 5,
+                            "total_tokens": 100,
+                        },
+                    },
+                },
+            ),
+        ],
+    )
+    return {
+        "codex_home": codex_home,
+        "db_path": db_path,
+        "pricing_path": pricing_path,
+        "allowance_path": allowance_path,
+        "rate_card_path": rate_card_path,
+        "thresholds_path": thresholds_path,
+        "projects_path": projects_path,
+        "cwd": cwd,
+    }
+
+
+def _entry(entry_type: str, payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "timestamp": "2026-05-17T19:00:00.000Z",
+        "type": entry_type,
+        "payload": payload,
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
Closes #9.

## Summary
- Add support-bundle safety tests covering default and strict privacy modes.
- Add shared secret redaction helper reused by on-demand context and support bundle sanitization.
- Redact local diagnostic paths from strict/redacted support bundles, including nested doctor details, while preserving status/count diagnostics.
- Document support-bundle contents and strict-mode sharing guidance; update the bug template to request reviewed strict bundles.

## Checks
- `.venv/bin/python -m pytest tests/test_support.py -q`
- `.venv/bin/python -m ruff check src/codex_usage_tracker/redaction.py src/codex_usage_tracker/context.py src/codex_usage_tracker/support.py tests/test_support.py`
- `.venv/bin/python -m pytest tests/test_support.py tests/test_privacy.py tests/test_store_dashboard_mcp.py -q`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python -m pytest tests/test_support.py tests/test_privacy.py tests/test_cli_lifecycle.py tests/test_json_contracts.py -q`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `.venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- `.venv/bin/python -m build`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/python scripts/check_release.py --dist`
- `git diff --check`
- `git diff --cached --check`