### PR TITLE
test: add large history benchmark thresholds

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Codex Usage Tracker is a local sidecar app. It reads aggregate token counters fr
 - `plugin_data/dashboard/dashboard_format.js` owns dashboard formatting primitives. `dashboard_data.js` owns row payload and thread relationship helpers. `dashboard_state.js` owns URL, CSV, and download state utilities. `dashboard.js` owns DOM rendering, event handling, API refresh, and detail-panel behavior.
 - `context.py` is the only normal path that reads raw log context, and it does so only for one selected record on demand with redaction and size limits.
 - `plugin_installer.py`, `.mcp.json`, `skills/`, and `scripts/check_release.py` own install and packaging behavior.
-- `scripts/benchmark_synthetic_history.py` owns generated large-history query timing for 10k, 100k, and 500k aggregate-row fixtures. It must stay synthetic-only and must not read real Codex logs.
+- `scripts/benchmark_synthetic_history.py` owns generated large-history query timing and threshold enforcement for 10k, 100k, and 500k aggregate-row fixtures. It must stay synthetic-only and must not read real Codex logs.
 - `skills/codex-usage-tracker/` is the source copy for the operational Codex skill. It should stay focused on setup, dashboard, export, doctor, and direct MCP workflows.
 - `skills/codex-usage-api/` is the source copy for the conversational analyst skill. It should stay focused on aggregate-only API routing, interpretation, and limitations.
 - `src/codex_usage_tracker/plugin_data/skills/` contains the wheel-bundled copies installed by `codex-usage-tracker install-plugin`.
@@ -50,4 +50,4 @@ git diff --check
 
 Dashboard UI changes should also be opened in a browser and checked on desktop and mobile widths for overlap, stale state, and aggregate-only output.
 
-Run `python scripts/benchmark_synthetic_history.py --rows 10000 100000 500000` after changing SQLite filters, dashboard payload loading, or indexes.
+Run `python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds` after changing SQLite filters, dashboard payload loading, or indexes. Run the 500k benchmark before release work when practical.

--- a/docs/development.md
+++ b/docs/development.md
@@ -192,10 +192,37 @@ Do not use real session logs, real prompts, assistant text, tool output, secrets
 Use the synthetic benchmark script when changing SQLite filters, dashboard payload loading, or indexes:
 
 ```bash
-python scripts/benchmark_synthetic_history.py --rows 10000 100000 500000
+python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds
+python scripts/benchmark_synthetic_history.py --rows 500000 --json --enforce-thresholds
 ```
 
-The script creates synthetic aggregate-only SQLite databases and times common filtered dashboard query paths. It does not read real Codex logs.
+The script creates synthetic aggregate-only SQLite databases and times common release-sensitive paths. It does not read real Codex logs.
+
+Thresholds are regression sentinels, not universal performance guarantees. Each timed path uses:
+
+```text
+limit_seconds = base_seconds + per_10k_seconds * (rows / 10000)
+```
+
+Use `--threshold-scale <number>` when intentionally running on a slower local machine. Keep the default scale for release checks unless there is a documented reason to relax it.
+
+Tracked timings:
+
+| Timing key | Path covered |
+| --- | --- |
+| `populate_seconds` | Synthetic aggregate indexing/upsert path |
+| `active_dashboard_query_seconds` | Dashboard row query with archived sessions excluded |
+| `all_history_dashboard_query_seconds` | Dashboard row query with archived sessions included |
+| `since_until_query_seconds` | Date-window dashboard filtering |
+| `filtered_query_seconds` | Model + effort + min-token dashboard filtering |
+| `filtered_count_seconds` | Filtered dashboard count query |
+| `dashboard_payload_active_seconds` | Active-session dashboard payload assembly |
+| `thread_summary_seconds` | Thread summary report |
+| `recommendations_report_seconds` | Recommendation report and thread rollup |
+| `pricing_coverage_seconds` | Pricing coverage report |
+| `project_summary_seconds` | Project summary report |
+
+The normal CI smoke uses a tiny synthetic history with `--enforce-thresholds` so regressions in the benchmark contract are visible on pull requests. The 10k/100k runs are a practical local gate for performance-sensitive changes; the 500k run is the release-sized gate and can take about a minute on a modern laptop because recommendations and project summary intentionally scan all aggregate rows.
 
 ## Release Checklist
 

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -104,11 +104,11 @@ Not guaranteed:
 
 ## 11. Large-History Performance
 
-- [ ] Run synthetic 10k benchmark: `python scripts/benchmark_synthetic_history.py --rows 10000 --json`.
-- [ ] Run synthetic 100k benchmark: `python scripts/benchmark_synthetic_history.py --rows 100000 --json`.
-- [ ] Run synthetic 500k benchmark as a release gate when practical: `python scripts/benchmark_synthetic_history.py --rows 500000 --json`.
-- [ ] Define thresholds for active-only dashboard query, all-history dashboard query, since/until, model/effort, min_tokens, recommendations, pricing coverage, and project summary.
-- [ ] Add a smaller CI-safe benchmark if it can stay fast and deterministic.
+- [x] Run synthetic 10k benchmark: `python scripts/benchmark_synthetic_history.py --rows 10000 --json --enforce-thresholds`.
+- [x] Run synthetic 100k benchmark: `python scripts/benchmark_synthetic_history.py --rows 100000 --json --enforce-thresholds`.
+- [x] Run synthetic 500k benchmark as a release gate when practical: `python scripts/benchmark_synthetic_history.py --rows 500000 --json --enforce-thresholds`.
+- [x] Define thresholds for active-only dashboard query, all-history dashboard query, since/until, model/effort, min_tokens, recommendations, pricing coverage, and project summary.
+- [x] Add a smaller CI-safe benchmark if it can stay fast and deterministic.
 
 ## 12. Release Process
 

--- a/scripts/benchmark_synthetic_history.py
+++ b/scripts/benchmark_synthetic_history.py
@@ -9,16 +9,22 @@ import shutil
 import sys
 import tempfile
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
+from codex_usage_tracker.dashboard import dashboard_payload  # noqa: E402
 from codex_usage_tracker.models import UsageEvent  # noqa: E402
+from codex_usage_tracker.reports import (  # noqa: E402
+    build_pricing_coverage_report,
+    build_recommendations_report,
+    build_summary_report,
+)
 from codex_usage_tracker.store import (  # noqa: E402
     connect,
     init_db,
@@ -28,6 +34,20 @@ from codex_usage_tracker.store import (  # noqa: E402
 )
 
 DEFAULT_ROW_COUNTS = (10_000, 100_000, 500_000)
+BENCHMARK_THRESHOLDS: dict[str, dict[str, float]] = {
+    "populate_seconds": {"base_seconds": 1.0, "per_10k_seconds": 0.60},
+    "active_dashboard_query_seconds": {"base_seconds": 0.25, "per_10k_seconds": 0.05},
+    "all_history_dashboard_query_seconds": {"base_seconds": 0.25, "per_10k_seconds": 0.05},
+    "since_until_query_seconds": {"base_seconds": 0.25, "per_10k_seconds": 0.05},
+    "filtered_query_seconds": {"base_seconds": 0.25, "per_10k_seconds": 0.05},
+    "filtered_count_seconds": {"base_seconds": 0.25, "per_10k_seconds": 0.04},
+    "dashboard_payload_active_seconds": {"base_seconds": 0.75, "per_10k_seconds": 0.20},
+    "thread_summary_seconds": {"base_seconds": 0.75, "per_10k_seconds": 0.12},
+    "recommendations_report_seconds": {"base_seconds": 1.0, "per_10k_seconds": 0.65},
+    "pricing_coverage_seconds": {"base_seconds": 0.50, "per_10k_seconds": 0.06},
+    "project_summary_seconds": {"base_seconds": 1.0, "per_10k_seconds": 0.45},
+}
+T = TypeVar("T")
 
 
 def main() -> int:
@@ -43,12 +63,25 @@ def main() -> int:
     parser.add_argument("--db-dir", type=Path)
     parser.add_argument("--keep-dbs", action="store_true")
     parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--enforce-thresholds",
+        action="store_true",
+        help="Exit nonzero when any benchmark timing exceeds its documented threshold.",
+    )
+    parser.add_argument(
+        "--threshold-scale",
+        type=float,
+        default=1.0,
+        help="Multiplier for timing thresholds on slower local machines. Defaults to 1.0.",
+    )
     args = parser.parse_args()
 
     if any(count <= 0 for count in args.rows):
         parser.error("--rows values must be positive")
     if args.batch_size <= 0:
         parser.error("--batch-size must be positive")
+    if args.threshold_scale <= 0:
+        parser.error("--threshold-scale must be positive")
 
     temp_dir: Path | None = None
     if args.db_dir:
@@ -60,52 +93,139 @@ def main() -> int:
 
     try:
         results = [
-            benchmark_size(row_count, db_dir=db_dir, batch_size=args.batch_size)
+            benchmark_size(
+                row_count,
+                db_dir=db_dir,
+                batch_size=args.batch_size,
+                threshold_scale=args.threshold_scale,
+            )
             for row_count in args.rows
         ]
         if args.as_json:
-            print(json.dumps({"benchmarks": results}, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "threshold_scale": args.threshold_scale,
+                        "thresholds": BENCHMARK_THRESHOLDS,
+                        "benchmarks": results,
+                    },
+                    indent=2,
+                )
+            )
         else:
             for result in results:
                 print(
                     f"{result['rows']:,} rows: populate {result['populate_seconds']:.3f}s, "
-                    f"filtered query {result['filtered_query_seconds']:.4f}s "
-                    f"({result['filtered_rows']} rows), count {result['count_seconds']:.4f}s"
+                    f"active query {result['active_dashboard_query_seconds']:.4f}s, "
+                    f"all-history query {result['all_history_dashboard_query_seconds']:.4f}s, "
+                    f"dashboard payload {result['dashboard_payload_active_seconds']:.4f}s, "
+                    f"recommendations {result['recommendations_report_seconds']:.4f}s, "
+                    f"thresholds {result['threshold_status']}"
                 )
-        return 0
+                for failure in result["threshold_failures"]:
+                    print(f"  FAIL {failure}")
+        return 1 if args.enforce_thresholds and any(
+            result["threshold_failures"] for result in results
+        ) else 0
     finally:
         if temp_dir and not args.keep_dbs:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-def benchmark_size(row_count: int, *, db_dir: Path, batch_size: int) -> dict[str, Any]:
+def benchmark_size(
+    row_count: int,
+    *,
+    db_dir: Path,
+    batch_size: int,
+    threshold_scale: float = 1.0,
+) -> dict[str, Any]:
     db_path = db_dir / f"synthetic-{row_count}.sqlite3"
     if db_path.exists():
         db_path.unlink()
+    config = _write_benchmark_config(db_dir)
     populate_start = time.perf_counter()
     for start in range(0, row_count, batch_size):
         end = min(start + batch_size, row_count)
         upsert_usage_events(_synthetic_events(start, end), db_path=db_path)
     populate_seconds = time.perf_counter() - populate_start
 
-    query_start = time.perf_counter()
-    filtered = query_dashboard_events(
-        db_path=db_path,
-        limit=50,
-        model="gpt-5.5",
-        effort="high",
-        min_tokens=9_000,
+    active_rows, active_dashboard_query_seconds = _time_call(
+        lambda: query_dashboard_events(db_path=db_path, limit=500, include_archived=False)
     )
-    filtered_seconds = time.perf_counter() - query_start
-
-    count_start = time.perf_counter()
-    filtered_count = query_dashboard_event_count(
-        db_path=db_path,
-        model="gpt-5.5",
-        effort="high",
-        min_tokens=9_000,
+    all_history_rows, all_history_dashboard_query_seconds = _time_call(
+        lambda: query_dashboard_events(db_path=db_path, limit=500, include_archived=True)
     )
-    count_seconds = time.perf_counter() - count_start
+    since_until_rows, since_until_query_seconds = _time_call(
+        lambda: query_dashboard_events(
+            db_path=db_path,
+            limit=500,
+            since="2026-05-10",
+            until="2026-05-20T23:59:59Z",
+            include_archived=True,
+        )
+    )
+    filtered, filtered_seconds = _time_call(
+        lambda: query_dashboard_events(
+            db_path=db_path,
+            limit=50,
+            model="gpt-5.5",
+            effort="high",
+            min_tokens=9_000,
+        )
+    )
+    filtered_count, count_seconds = _time_call(
+        lambda: query_dashboard_event_count(
+            db_path=db_path,
+            model="gpt-5.5",
+            effort="high",
+            min_tokens=9_000,
+        )
+    )
+    active_payload, dashboard_payload_active_seconds = _time_call(
+        lambda: dashboard_payload(
+            db_path=db_path,
+            limit=500,
+            pricing_path=config["pricing_path"],
+            allowance_path=config["allowance_path"],
+            thresholds_path=config["thresholds_path"],
+            projects_path=config["projects_path"],
+            include_archived=False,
+        )
+    )
+    thread_summary, thread_summary_seconds = _time_call(
+        lambda: build_summary_report(
+            db_path=db_path,
+            pricing_path=config["pricing_path"],
+            group_by="thread",
+            limit=50,
+            projects_path=config["projects_path"],
+        )
+    )
+    recommendations, recommendations_report_seconds = _time_call(
+        lambda: build_recommendations_report(
+            db_path=db_path,
+            pricing_path=config["pricing_path"],
+            allowance_path=config["allowance_path"],
+            projects_path=config["projects_path"],
+            min_score=20,
+            limit=50,
+        )
+    )
+    pricing_coverage, pricing_coverage_seconds = _time_call(
+        lambda: build_pricing_coverage_report(
+            db_path=db_path,
+            pricing_path=config["pricing_path"],
+        )
+    )
+    project_summary, project_summary_seconds = _time_call(
+        lambda: build_summary_report(
+            db_path=db_path,
+            pricing_path=config["pricing_path"],
+            group_by="project",
+            limit=50,
+            projects_path=config["projects_path"],
+        )
+    )
 
     with connect(db_path) as conn:
         init_db(conn)
@@ -122,16 +242,135 @@ def benchmark_size(row_count: int, *, db_dir: Path, batch_size: int) -> dict[str
             )
         )
 
+    timings = {
+        "populate_seconds": round(populate_seconds, 6),
+        "active_dashboard_query_seconds": active_dashboard_query_seconds,
+        "all_history_dashboard_query_seconds": all_history_dashboard_query_seconds,
+        "since_until_query_seconds": since_until_query_seconds,
+        "filtered_query_seconds": filtered_seconds,
+        "filtered_count_seconds": count_seconds,
+        "dashboard_payload_active_seconds": dashboard_payload_active_seconds,
+        "thread_summary_seconds": thread_summary_seconds,
+        "recommendations_report_seconds": recommendations_report_seconds,
+        "pricing_coverage_seconds": pricing_coverage_seconds,
+        "project_summary_seconds": project_summary_seconds,
+    }
+    threshold_results, threshold_failures = _evaluate_thresholds(
+        timings,
+        row_count=row_count,
+        threshold_scale=threshold_scale,
+    )
     return {
         "rows": row_count,
         "db_path": str(db_path),
-        "populate_seconds": round(populate_seconds, 6),
-        "filtered_query_seconds": round(filtered_seconds, 6),
-        "count_seconds": round(count_seconds, 6),
+        "timings": timings,
+        "populate_seconds": timings["populate_seconds"],
+        "active_dashboard_query_seconds": timings["active_dashboard_query_seconds"],
+        "all_history_dashboard_query_seconds": timings["all_history_dashboard_query_seconds"],
+        "since_until_query_seconds": timings["since_until_query_seconds"],
+        "filtered_query_seconds": timings["filtered_query_seconds"],
+        "count_seconds": timings["filtered_count_seconds"],
+        "filtered_count_seconds": timings["filtered_count_seconds"],
+        "dashboard_payload_active_seconds": timings["dashboard_payload_active_seconds"],
+        "thread_summary_seconds": timings["thread_summary_seconds"],
+        "recommendations_report_seconds": timings["recommendations_report_seconds"],
+        "pricing_coverage_seconds": timings["pricing_coverage_seconds"],
+        "project_summary_seconds": timings["project_summary_seconds"],
+        "active_rows": len(active_rows),
+        "all_history_rows": len(all_history_rows),
+        "since_until_rows": len(since_until_rows),
         "filtered_rows": len(filtered),
         "filtered_count": filtered_count,
+        "dashboard_payload_rows": active_payload["loaded_row_count"],
+        "thread_summary_rows": len(thread_summary.rows),
+        "recommendations_rows": recommendations.payload["row_count"],
+        "pricing_coverage_rows": len(pricing_coverage.payload["rows"]),
+        "project_summary_rows": len(project_summary.rows),
+        "threshold_status": "fail" if threshold_failures else "pass",
+        "thresholds": threshold_results,
+        "threshold_failures": threshold_failures,
         "query_plan": plan,
     }
+
+
+def _write_benchmark_config(db_dir: Path) -> dict[str, Path]:
+    pricing_path = db_dir / "synthetic-pricing.json"
+    allowance_path = db_dir / "synthetic-allowance.json"
+    thresholds_path = db_dir / "synthetic-thresholds.json"
+    projects_path = db_dir / "synthetic-projects.json"
+    pricing_path.write_text(
+        json.dumps(
+            {
+                "_source": {
+                    "name": "Synthetic benchmark pricing",
+                    "fetched_at": "2026-06-08T00:00:00Z",
+                },
+                "models": {
+                    "gpt-5.5": {
+                        "input_per_million": 2.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 10.0,
+                    },
+                    "codex-auto-review": {
+                        "input_per_million": 2.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 10.0,
+                    },
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    allowance_path.write_text(json.dumps({"windows": []}) + "\n", encoding="utf-8")
+    thresholds_path.write_text(json.dumps({"low_cache_ratio": 0.30}) + "\n", encoding="utf-8")
+    projects_path.write_text(
+        json.dumps({"aliases": {}, "ignored_paths": [], "tags": {}}) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "pricing_path": pricing_path,
+        "allowance_path": allowance_path,
+        "thresholds_path": thresholds_path,
+        "projects_path": projects_path,
+    }
+
+
+def _time_call(action: Callable[[], T]) -> tuple[T, float]:
+    start = time.perf_counter()
+    value = action()
+    return value, round(time.perf_counter() - start, 6)
+
+
+def _evaluate_thresholds(
+    timings: dict[str, float],
+    *,
+    row_count: int,
+    threshold_scale: float,
+) -> tuple[dict[str, dict[str, float | str]], list[str]]:
+    results: dict[str, dict[str, float | str]] = {}
+    failures: list[str] = []
+    for name, seconds in timings.items():
+        threshold = BENCHMARK_THRESHOLDS.get(name)
+        if threshold is None:
+            continue
+        limit = round(
+            (
+                threshold["base_seconds"]
+                + threshold["per_10k_seconds"] * (row_count / 10_000)
+            )
+            * threshold_scale,
+            6,
+        )
+        status = "pass" if seconds <= limit else "fail"
+        results[name] = {
+            "seconds": seconds,
+            "limit_seconds": limit,
+            "status": status,
+        }
+        if status == "fail":
+            failures.append(f"{name} {seconds:.6f}s exceeded {limit:.6f}s")
+    return results, failures
 
 
 def _synthetic_events(start: int, end: int) -> Iterable[UsageEvent]:
@@ -147,13 +386,18 @@ def _synthetic_events(start: int, end: int) -> Iterable[UsageEvent]:
         reasoning_tokens = 10 + (index % 120)
         total_tokens = input_tokens + output_tokens
         session_id = f"session-{index % 2500:04d}"
+        source_file = (
+            f"/tmp/synthetic/archived_sessions/{index % 2500}.jsonl"
+            if index % 11 == 0
+            else f"/tmp/synthetic/{index % 2500}.jsonl"
+        )
         yield UsageEvent(
             record_id=f"record-{index:08d}",
             session_id=session_id,
             thread_name=f"Thread {index % 500}",
             session_updated_at=f"2026-05-{day:02d}T23:00:00Z",
             event_timestamp=f"2026-05-{day:02d}T12:{index % 60:02d}:00Z",
-            source_file=f"/tmp/synthetic/{index % 2500}.jsonl",
+            source_file=source_file,
             line_number=index + 1,
             turn_id=f"turn-{index:08d}",
             turn_timestamp=f"2026-05-{day:02d}T12:{index % 60:02d}:00Z",

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -136,6 +136,7 @@ def test_synthetic_history_benchmark_script_smoke(tmp_path: Path) -> None:
             "--db-dir",
             str(tmp_path),
             "--json",
+            "--enforce-thresholds",
         ],
         check=True,
         capture_output=True,
@@ -148,6 +149,21 @@ def test_synthetic_history_benchmark_script_smoke(tmp_path: Path) -> None:
     assert payload["benchmarks"][0]["rows"] == 100
     assert payload["benchmarks"][0]["filtered_rows"] <= 50
     assert "idx_usage_model_effort" in payload["benchmarks"][0]["query_plan"]
+    assert payload["benchmarks"][0]["threshold_status"] == "pass"
+    assert payload["benchmarks"][0]["threshold_failures"] == []
+    assert {
+        "populate_seconds",
+        "active_dashboard_query_seconds",
+        "all_history_dashboard_query_seconds",
+        "since_until_query_seconds",
+        "filtered_query_seconds",
+        "filtered_count_seconds",
+        "dashboard_payload_active_seconds",
+        "thread_summary_seconds",
+        "recommendations_report_seconds",
+        "pricing_coverage_seconds",
+        "project_summary_seconds",
+    } <= set(payload["benchmarks"][0]["timings"])
 
 
 def _subprocess_env() -> dict[str, str]:


### PR DESCRIPTION
Closes #8.

## Summary
- Extend the synthetic large-history benchmark to time thresholded release-sensitive paths: indexing/upsert, active/all-history dashboard queries, date-window filters, model/effort/min-token filters, counts, dashboard payload assembly, thread summary, recommendations, pricing coverage, and project summary.
- Add `--enforce-thresholds` and `--threshold-scale` with JSON pass/fail metadata while preserving legacy top-level timing fields.
- Add a CI-safe benchmark smoke that enforces thresholds on a small synthetic history.
- Document the threshold formula, tracked timing keys, and release-sized 500k benchmark guidance.

## Benchmark Runs
- `python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds` passed.
- Initial `500000` run showed `recommendations_report_seconds` threshold was too tight; threshold was adjusted from `0.50` to `0.65` seconds per 10k rows based on observed all-row recommendation behavior.
- `python scripts/benchmark_synthetic_history.py --rows 500000 --json --enforce-thresholds` passed after the threshold correction.

## Checks
- `.venv/bin/python -m pytest tests/test_cli_release.py::test_synthetic_history_benchmark_script_smoke -q`
- `.venv/bin/python -m ruff check scripts/benchmark_synthetic_history.py tests/test_cli_release.py`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds`
- `.venv/bin/python scripts/benchmark_synthetic_history.py --rows 500000 --json --enforce-thresholds`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `.venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js`
- `node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- `.venv/bin/python -m build`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/python scripts/check_release.py --dist`
- `git diff --check`
- `git diff --cached --check`