### PR TITLE
docs: clarify Python 3.14 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This is optional. The normal shell install above is the fastest trusted path for
 
 ## Roadmap
 
-- Add official Python 3.14 support once CI, package metadata, docs, and installed-package smoke tests are green ([tracking issue #12](https://github.com/douglasmonsky/codex-usage-tracker/issues/12)).
+- Add official Python 3.14 support soon once CI, package metadata, docs, and installed-package smoke tests are green, including Docker smoke coverage for the packaged app ([tracking issue #12](https://github.com/douglasmonsky/codex-usage-tracker/issues/12)).
 - Improve the `Set limits` flow with a paste/import experience for 5-hour and weekly allowance snapshots.
 - Track allowance snapshot history so local Codex credits can be compared against visible remaining-usage changes over time.
 - Clarify top-card token accounting by showing output tokens and reasoning output as a subset instead of implying all token cards add together.

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@ Restart Codex after plugin registration if you want Codex to discover the MCP to
 
 The CLI, SQLite index, dashboard generator, and localhost server are Python-based and are not macOS-only. CI runs the package on Ubuntu with Python 3.10, 3.11, 3.12, and 3.13.
 
-Python 3.14 is planned soon, but it is not an official support target yet. The package may install on 3.14 because metadata allows Python 3.10+, but the project will only document 3.14 as supported after CI, package classifiers, docs, and installed-package smoke coverage pass.
+Python 3.14 is planned soon, but it is not an official support target yet. The package may install on 3.14 because metadata allows Python 3.10+, but the project will only document 3.14 as supported after CI, package classifiers, docs, and installed-package smoke coverage pass, including Docker smoke coverage for the packaged app.
 
 By default the tracker looks for Codex JSONL logs under `~/.codex`, stores its own database/config under `~/.codex-usage-tracker`, and writes the local plugin wrapper under `~/plugins/codex-usage-tracker`. Override paths with `--codex-home`, `--db`, `--plugin-dir`, or `--marketplace` if your platform or Codex installation uses a different layout.
 

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -29,7 +29,7 @@ Not guaranteed:
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
 - [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version <version>`.
 - [ ] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
-- [ ] Add Python 3.14 as a near-term official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Track this in issue #12.
+- [ ] Add Python 3.14 as a near-term official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Include Docker smoke coverage for the packaged app before updating support badges or classifiers. Track this in issue #12.
 
 ## 2. Upgrade And Migration
 


### PR DESCRIPTION
## Summary
- clarify that Python 3.14 support is planned soon but not official yet
- add Docker packaged-app smoke coverage to the acceptance bar before badges/classifiers change
- keep install/readiness docs aligned with the README roadmap

## Checks
- .venv/bin/python scripts/check_release.py
- git diff --check