### PR TITLE
packaging: add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,24 +22,24 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
       - uses: actions/setup-node@v4
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         with:
           node-version: "22"
       - name: Ruff
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         run: python -m ruff check .
       - name: Type check
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         run: python -m mypy
       - name: Test
         run: python -m pytest
       - name: Coverage
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         run: python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
       - name: Compile
         run: python -m compileall src
       - name: Dashboard JavaScript syntax
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14'
         run: |
           node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js
           node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Local-first dashboard, Codex plugin, and companion skill for understanding where
 
 [![CI](https://github.com/douglasmonsky/codex-usage-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/douglasmonsky/codex-usage-tracker/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/codex-usage-tracking.svg)](https://pypi.org/project/codex-usage-tracking/)
-![Python 3.10-3.13](https://img.shields.io/badge/python-3.10--3.13-blue)
+![Python 3.10-3.14](https://img.shields.io/badge/python-3.10--3.14-blue)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 > **Unofficial project:** Codex Usage Tracker is an independent open-source project. It is not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. OpenAI and Codex are trademarks of OpenAI; this project only reads local log files from your machine.
@@ -63,7 +63,7 @@ More install paths: [Install Guide](docs/install.md).
 
 ## Platform Support
 
-The core app is not macOS-only. The CLI, SQLite index, dashboard generator, and localhost server are Python-based and CI-tested on Ubuntu for Python 3.10-3.13. Python 3.14 support is a near-term roadmap item, but it is not an official target until CI, package classifiers, docs, and installed-package smoke coverage pass. It defaults to `~/.codex` for local Codex logs and `~/.codex-usage-tracker` for tracker data; pass `--codex-home` or `--db` when your local layout differs. Codex plugin discovery depends on Codex's local plugin directories on your machine, so run `codex-usage-tracker doctor` after setup if plugin registration does not appear in Codex.
+The core app is not macOS-only. The CLI, SQLite index, dashboard generator, and localhost server are Python-based and CI-tested on Ubuntu for Python 3.10-3.14. The installed-package Docker smoke path uses `python:3.14-slim` by default so packaged resources and CLI entry points are exercised on the newest supported runtime. It defaults to `~/.codex` for local Codex logs and `~/.codex-usage-tracker` for tracker data; pass `--codex-home` or `--db` when your local layout differs. Codex plugin discovery depends on Codex's local plugin directories on your machine, so run `codex-usage-tracker doctor` after setup if plugin registration does not appear in Codex.
 
 ## Dashboard Preview
 
@@ -224,7 +224,7 @@ This is optional. The normal shell install above is the fastest trusted path for
 
 ## Roadmap
 
-- Add official Python 3.14 support soon once CI, package metadata, docs, and installed-package smoke tests are green, including Docker smoke coverage for the packaged app ([tracking issue #12](https://github.com/douglasmonsky/codex-usage-tracker/issues/12)).
+- Keep Python runtime support validated with CI matrix coverage, package classifiers, release docs, and installed-package smoke tests.
 - Improve the `Set limits` flow with a paste/import experience for 5-hour and weekly allowance snapshots.
 - Track allowance snapshot history so local Codex credits can be compared against visible remaining-usage changes over time.
 - Clarify top-card token accounting by showing output tokens and reasoning output as a subset instead of implying all token cards add together.

--- a/docs/development.md
+++ b/docs/development.md
@@ -255,6 +255,8 @@ python scripts/smoke_installed_package.py
 python scripts/smoke_installed_package.py --docker
 ```
 
+The Docker smoke uses `python:3.14-slim` by default so release prep verifies installed-package behavior on the newest supported runtime.
+
 The release checker verifies version alignment, required public docs, packaged plugin assets, wheel contents, and obvious tracked secret patterns. It does not publish anything.
 
 After the release branch merges, tag from updated `main`, not from an unreviewed branch:

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,9 +30,9 @@ Restart Codex after plugin registration if you want Codex to discover the MCP to
 
 ## Platform Support
 
-The CLI, SQLite index, dashboard generator, and localhost server are Python-based and are not macOS-only. CI runs the package on Ubuntu with Python 3.10, 3.11, 3.12, and 3.13.
+The CLI, SQLite index, dashboard generator, and localhost server are Python-based and are not macOS-only. CI runs the package on Ubuntu with Python 3.10, 3.11, 3.12, 3.13, and 3.14.
 
-Python 3.14 is planned soon, but it is not an official support target yet. The package may install on 3.14 because metadata allows Python 3.10+, but the project will only document 3.14 as supported after CI, package classifiers, docs, and installed-package smoke coverage pass, including Docker smoke coverage for the packaged app.
+The installed-package Docker smoke path uses `python:3.14-slim` by default, which exercises the built wheel, package data, CLI entry point, and plugin installer on the newest supported runtime.
 
 By default the tracker looks for Codex JSONL logs under `~/.codex`, stores its own database/config under `~/.codex-usage-tracker`, and writes the local plugin wrapper under `~/plugins/codex-usage-tracker`. Override paths with `--codex-home`, `--db`, `--plugin-dir`, or `--marketplace` if your platform or Codex installation uses a different layout.
 

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -29,7 +29,7 @@ Not guaranteed:
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
 - [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version <version>`.
 - [ ] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
-- [ ] Add Python 3.14 as a near-term official support target only after CI, package classifiers, docs, and installed-package smoke coverage pass. Include Docker smoke coverage for the packaged app before updating support badges or classifiers. Track this in issue #12.
+- [x] Add Python 3.14 as an official support target after CI, package classifiers, docs, and installed-package smoke coverage were added. Docker smoke coverage uses `python:3.14-slim` by default. Track this in issue #12.
 
 ## 2. Upgrade And Migration
 
@@ -128,4 +128,3 @@ Not guaranteed:
 - [ ] Document that live account allowance cannot be read automatically by this local tracker.
 - [ ] Document that cost and credit estimates are not guaranteed to match exact billing.
 - [ ] Document platform/plugin discovery limitations separately from the core Python CLI/dashboard support.
-- [ ] Document that Python 3.14 may install because package metadata allows `>=3.10`, but it is not officially supported until issue #12 is complete.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: System :: Monitoring",
 ]

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -22,6 +22,7 @@ DISTRIBUTION_NAME = "codex-usage-tracking"
 DIST_FILE_STEM = "codex_usage_tracking"
 IMPORT_PACKAGE = "codex_usage_tracker"
 CONSOLE_SCRIPT = "codex-usage-tracker"
+SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 SECRET_PATTERNS = {
     "OpenAI API key": re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}"),
     "GitHub token": re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{20,}"),
@@ -221,7 +222,39 @@ def _check_packaging_metadata() -> list[str]:
         failures.append("MCP runtime launcher must check the codex-usage-tracking distribution")
     if "PACKAGE_SPEC_MARKER" not in launcher:
         failures.append("MCP runtime launcher should invalidate cached runtimes when package spec changes")
+    failures.extend(_check_python_support_metadata(project))
     failures.extend(_check_publish_workflow())
+    return failures
+
+
+def _check_python_support_metadata(project: dict[str, object]) -> list[str]:
+    failures: list[str] = []
+    classifiers = set(project.get("classifiers", []))
+    for version in SUPPORTED_PYTHON_VERSIONS:
+        classifier = f"Programming Language :: Python :: {version}"
+        if classifier not in classifiers:
+            failures.append(f"pyproject.toml is missing Python classifier: {classifier}")
+
+    ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    for version in SUPPORTED_PYTHON_VERSIONS:
+        if f'"{version}"' not in ci_workflow:
+            failures.append(f"CI workflow test matrix is missing Python {version}")
+
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    if "python-3.10--3.14" not in readme:
+        failures.append("README.md Python badge should advertise Python 3.10-3.14")
+    if "Python 3.10-3.14" not in readme:
+        failures.append("README.md platform support should document Python 3.10-3.14")
+
+    install_doc = (REPO_ROOT / "docs" / "install.md").read_text(encoding="utf-8")
+    if "Python 3.10, 3.11, 3.12, 3.13, and 3.14" not in install_doc:
+        failures.append("docs/install.md should document CI support through Python 3.14")
+
+    smoke_script = (REPO_ROOT / "scripts" / "smoke_installed_package.py").read_text(
+        encoding="utf-8"
+    )
+    if 'DEFAULT_DOCKER_IMAGE = "python:3.14-slim"' not in smoke_script:
+        failures.append("installed-package Docker smoke default should use python:3.14-slim")
     return failures
 
 

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -32,7 +32,7 @@ DISTRIBUTION_NAME = "codex-usage-tracking"
 WHEEL_STEM = "codex_usage_tracking"
 IMPORT_PACKAGE = "codex_usage_tracker"
 CONSOLE_SCRIPT = "codex-usage-tracker"
-DEFAULT_DOCKER_IMAGE = "python:3.13-slim"
+DEFAULT_DOCKER_IMAGE = "python:3.14-slim"
 
 RESOURCE_PATHS = [
     "assets/icon.svg",


### PR DESCRIPTION
## Summary
- add Python 3.14 to the CI test matrix and package classifier
- move primary CI/package/publish build runtime checks to Python 3.14
- update README badge, platform/install docs, and 1.0-readiness tracking to include Python 3.14
- make installed-package Docker smoke default to python:3.14-slim
- add release-readiness guards so CI matrix, classifiers, docs, and Docker smoke runtime stay in sync

Closes #12.

## Local checks
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy
- .venv/bin/python -m pytest
- .venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
- .venv/bin/python -m compileall src
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js
- .venv/bin/python scripts/check_release.py
- git diff --check
- rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist
- .venv/bin/python scripts/smoke_installed_package.py
- .venv/bin/python scripts/smoke_installed_package.py --docker
- .venv/bin/python scripts/smoke_installed_package.py --docker --from-pypi --version 0.3.2