### PR TITLE
release: prepare 0.4.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-usage-tracker",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
   "author": {
     "name": "Douglas Monsky"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-09
+
+- Add official Python 3.14 support across CI, package classifiers, README/install docs, and installed-package Docker smoke coverage.
+- Add a release recovery runbook for failed publish workflows, stale PyPI/TestPyPI pages, Trusted Publishing issues, bad artifacts, and patch-forward recovery.
+- Add synthetic large-history benchmark thresholds for active/all-history dashboard queries, date filtering, model/effort filtering, recommendations, pricing coverage, and project summaries.
+- Add stricter privacy regression coverage for generated dashboards, CSV exports, API payloads, and support bundles.
+- Redact sensitive strings and local diagnostic paths in support bundles, including nested doctor output in redacted and strict privacy modes.
+- Add aggregate schema migration, JSON contract parity, installed-package smoke, and protected-main workflow readiness coverage.
+- Pin the marketplace MCP runtime launcher to the exact `codex-usage-tracking==0.4.0` package.
+
 ## 0.3.2 - 2026-06-08
 
 - Make `open-dashboard` and `serve-dashboard` refresh active-session logs by default, with `--no-refresh` as the explicit cached-index mode.

--- a/docs/development.md
+++ b/docs/development.md
@@ -147,8 +147,8 @@ python scripts/smoke_installed_package.py --docker
 To verify the public PyPI package instead of the local checkout:
 
 ```bash
-python scripts/smoke_installed_package.py --from-pypi --version 0.3.2
-python scripts/smoke_installed_package.py --docker --from-pypi --version 0.3.2
+python scripts/smoke_installed_package.py --from-pypi --version 0.4.0
+python scripts/smoke_installed_package.py --docker --from-pypi --version 0.4.0
 ```
 
 Docker avoids local toolchain side effects during install testing. Keep one local `pipx` smoke for platform-specific PATH and plugin-discovery behavior, but use Docker for repeatable Linux package verification.
@@ -274,11 +274,12 @@ Do not create or push release tags without maintainer approval.
 
 Publishing uses GitHub Actions Trusted Publishing through `.github/workflows/publish.yml`; do not upload from a local machine and do not add PyPI or TestPyPI API tokens.
 
-The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading:
+The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading. Minor release `0.4.0` added Python 3.14 support, release recovery docs, stricter privacy/support-bundle regression coverage, and large-history benchmark thresholds:
 
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.0`
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.1`
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.2`
+- GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.4.0`
 - PyPI: `https://pypi.org/project/codex-usage-tracking/`
 - TestPyPI: `https://test.pypi.org/project/codex-usage-tracking/`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -18,11 +18,11 @@ codex-usage-tracker install-plugin --python .venv/bin/python
 
 Restart Codex after registration so it can discover the plugin.
 
-Marketplace installs use the bundled MCP launcher at `skills/codex-usage-tracker/scripts/run_mcp.py`. On first MCP startup it creates a cached runtime under `~/.cache/codex-usage-tracker/mcp-runtime/` and installs the Python package from a pinned GitHub source commit, so it does not require a `.venv` inside the plugin directory.
+Marketplace installs use the bundled MCP launcher at `skills/codex-usage-tracker/scripts/run_mcp.py`. On first MCP startup it creates a cached runtime under `~/.cache/codex-usage-tracker/mcp-runtime/` and installs the exact pinned Python package, so it does not require a `.venv` inside the plugin directory.
 
-This is intentional: normal user installs come from the PyPI distribution `codex-usage-tracking`, while the plugin bootstrapper pins a reviewed repository commit so MCP startup does not accidentally track `main`.
+This is intentional: normal user installs come from the PyPI distribution `codex-usage-tracking`, and the plugin bootstrapper pins an exact reviewed package version so MCP startup does not accidentally track `main`.
 
-The launcher stores the GitHub package spec used for that runtime and reinstalls when the bundled package pin changes. Set `CODEX_USAGE_TRACKER_PACKAGE_SPEC` to test a different Git ref or `CODEX_USAGE_TRACKER_RUNTIME_DIR` to use a separate cache while debugging plugin startup.
+The launcher stores the package spec used for that runtime and reinstalls when the bundled package pin changes. Set `CODEX_USAGE_TRACKER_PACKAGE_SPEC` to test a different package version or Git ref, or set `CODEX_USAGE_TRACKER_RUNTIME_DIR` to use a separate cache while debugging plugin startup.
 
 ## Companion Skills
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codex-usage-tracking"
-version = "0.3.2"
+version = "0.4.0"
 description = "Unofficial local Codex plugin and dashboard for investigating aggregate token usage, costs, caching, and thread patterns."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -213,11 +213,19 @@ def _check_packaging_metadata() -> list[str]:
     )
     if "codex-usage-tracker.git@main" in launcher:
         failures.append("MCP runtime launcher must pin the package spec instead of tracking main")
-    package_spec = re.search(r"codex-usage-tracker\.git@([0-9a-f]{40})", launcher)
-    if not package_spec:
-        failures.append("MCP runtime launcher must pin a 40-character GitHub commit SHA")
-    elif not _is_ancestor_when_available(package_spec.group(1), "HEAD"):
-        failures.append("MCP runtime launcher package pin is not reachable from HEAD")
+    git_package_spec = re.search(r"codex-usage-tracker\.git@([0-9a-f]{40})", launcher)
+    pypi_package_spec = re.search(r"codex-usage-tracking==([0-9]+(?:\.[0-9]+){2})", launcher)
+    if pypi_package_spec:
+        if pypi_package_spec.group(1) != str(project.get("version")):
+            failures.append("MCP runtime launcher PyPI pin does not match project.version")
+    elif git_package_spec:
+        if not _is_ancestor_when_available(git_package_spec.group(1), "HEAD"):
+            failures.append("MCP runtime launcher package pin is not reachable from HEAD")
+    else:
+        failures.append(
+            "MCP runtime launcher must pin an exact codex-usage-tracking version or a "
+            "40-character GitHub commit SHA"
+        )
     if "importlib.metadata.version('codex-usage-tracking')" not in launcher:
         failures.append("MCP runtime launcher must check the codex-usage-tracking distribution")
     if "PACKAGE_SPEC_MARKER" not in launcher:

--- a/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "git+https://github.com/douglasmonsky/codex-usage-tracker.git@262f51960747a3eb061602e92c929684f8490adb",
+    "codex-usage-tracking==0.4.0",
 )
-RUNTIME_VERSION = "0.3.2"
+RUNTIME_VERSION = "0.4.0"
 PACKAGE_SPEC_MARKER = ".codex-usage-tracker-package-spec"
 MODULE_CHECK = (
     "import importlib.metadata; "

--- a/src/codex_usage_tracker/__init__.py
+++ b/src/codex_usage_tracker/__init__.py
@@ -2,6 +2,6 @@
 
 from codex_usage_tracker.models import UsageEvent
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 __all__ = ["UsageEvent", "__version__"]

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -20,7 +20,7 @@ def test_module_cli_version() -> None:
         env=_subprocess_env(),
     )
 
-    assert "codex-usage-tracker 0.3.2" in result.stdout
+    assert "codex-usage-tracker 0.4.0" in result.stdout
 
 
 def test_release_check_script_passes() -> None:

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -34,7 +34,7 @@ def test_install_plugin_writes_generated_wrapper_and_marketplace(tmp_path: Path)
     assert result.replaced_existing is False
     assert second.replaced_existing is False
     assert manifest["name"] == "codex-usage-tracker"
-    assert manifest["version"] == "0.3.2"
+    assert manifest["version"] == "0.4.0"
     assert manifest["interface"]["defaultPrompt"][:3] == [
         "Open dashboard",
         "Heaviest thread?",


### PR DESCRIPTION
## Summary
- bump package, plugin, and module versions to 0.4.0
- add 0.4.0 changelog entries for Python 3.14 support, release recovery docs, privacy/support-bundle coverage, large-history benchmarks, and packaging gates
- pin the marketplace MCP runtime launcher to codex-usage-tracking==0.4.0
- update release docs and MCP docs for exact package runtime pinning
- allow release checks to validate exact PyPI runtime pins as well as reachable Git SHA pins

## Local release gate
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy
- .venv/bin/python -m pytest
- .venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
- .venv/bin/python -m compileall src
- node --check dashboard_format.js/dashboard_data.js/dashboard.js/dashboard_state.js
- .venv/bin/python scripts/check_release.py
- git diff --check
- rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist
- .venv/bin/python scripts/smoke_installed_package.py
- .venv/bin/python scripts/smoke_installed_package.py --docker

## Local dist hashes
- 5b17f940b0f3510d7a06bd49b906f48ba8c43bb35f771d8cdac21d4e0b2a69a7  dist/codex_usage_tracking-0.4.0-py3-none-any.whl
- 514ee4497dd85e12a2ea028331a58e5d7a3b156b5576db682726faeaac285cdf  dist/codex_usage_tracking-0.4.0.tar.gz