### PR TITLE
chore: skip existing package versions on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,53 @@ jobs:
         with:
           name: python-dist
           path: dist
+      - name: Check target package version
+        id: package-version
+        env:
+          PACKAGE_INDEX_JSON_URL: https://test.pypi.org/pypi/codex-usage-tracking/json
+          PACKAGE_INDEX_NAME: TestPyPI
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          versions = set()
+          for path in Path("dist").iterdir():
+              name = path.name
+              if name.endswith(".tar.gz") and name.startswith("codex_usage_tracking-"):
+                  versions.add(name.removeprefix("codex_usage_tracking-").removesuffix(".tar.gz"))
+              elif name.endswith(".whl") and name.startswith("codex_usage_tracking-"):
+                  versions.add(name.split("-")[1])
+          if len(versions) != 1:
+              raise SystemExit(f"expected one distribution version, found {sorted(versions)}")
+          version = versions.pop()
+
+          url = os.environ["PACKAGE_INDEX_JSON_URL"]
+          index_name = os.environ["PACKAGE_INDEX_NAME"]
+          try:
+              with urllib.request.urlopen(url, timeout=30) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  exists = False
+              else:
+                  raise
+          else:
+              exists = version in payload.get("releases", {})
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"version={version}\n")
+              output.write(f"exists={str(exists).lower()}\n")
+          if exists:
+              print(f"codex-usage-tracking {version} already exists on {index_name}; skipping upload.")
+          else:
+              print(f"codex-usage-tracking {version} is not present on {index_name}; upload will run.")
+          PY
       - name: Publish package distributions to TestPyPI
+        if: steps.package-version.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -143,7 +189,53 @@ jobs:
         with:
           name: python-dist
           path: dist
+      - name: Check target package version
+        id: package-version
+        env:
+          PACKAGE_INDEX_JSON_URL: https://pypi.org/pypi/codex-usage-tracking/json
+          PACKAGE_INDEX_NAME: PyPI
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          versions = set()
+          for path in Path("dist").iterdir():
+              name = path.name
+              if name.endswith(".tar.gz") and name.startswith("codex_usage_tracking-"):
+                  versions.add(name.removeprefix("codex_usage_tracking-").removesuffix(".tar.gz"))
+              elif name.endswith(".whl") and name.startswith("codex_usage_tracking-"):
+                  versions.add(name.split("-")[1])
+          if len(versions) != 1:
+              raise SystemExit(f"expected one distribution version, found {sorted(versions)}")
+          version = versions.pop()
+
+          url = os.environ["PACKAGE_INDEX_JSON_URL"]
+          index_name = os.environ["PACKAGE_INDEX_NAME"]
+          try:
+              with urllib.request.urlopen(url, timeout=30) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  exists = False
+              else:
+                  raise
+          else:
+              exists = version in payload.get("releases", {})
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"version={version}\n")
+              output.write(f"exists={str(exists).lower()}\n")
+          if exists:
+              print(f"codex-usage-tracking {version} already exists on {index_name}; skipping upload.")
+          else:
+              print(f"codex-usage-tracking {version} is not present on {index_name}; upload will run.")
+          PY
       - name: Publish package distributions to PyPI
+        if: steps.package-version.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.4.1 - 2026-06-09
 
 - Harden the production PyPI workflow so manual publishing must run from `main` or a tag ref before artifacts are downloaded and uploaded.
+- Skip TestPyPI/PyPI uploads when the exact distribution version already exists on the target index, allowing a GitHub Release to be reconciled after a workflow-dispatch publish.
 - Strengthen `scripts/check_release.py` so it validates the publish-ref preflight inside both the TestPyPI and PyPI jobs.
 - Check off completed 1.0 readiness items with evidence for migration coverage, localhost dashboard smoke testing, and the protected GitHub `pypi` environment.
 - Pin the marketplace MCP runtime launcher to the exact `codex-usage-tracking==0.4.1` package.

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -322,6 +322,8 @@ def _check_publish_workflow() -> list[str]:
         "name: pypi",
         "https://test.pypi.org/project/codex-usage-tracking/",
         "https://pypi.org/project/codex-usage-tracking/",
+        "steps.package-version.outputs.exists != 'true'",
+        "codex-usage-tracking {version} already exists on {index_name}; skipping upload.",
     ]:
         if required not in workflow:
             failures.append(f"publish workflow is missing required Trusted Publishing text: {required}")
@@ -343,6 +345,11 @@ def _check_publish_workflow() -> list[str]:
             "echo \"sha=$GITHUB_SHA\"",
             "refs/heads/main|refs/tags/*",
             "Manual PyPI publishing must run from main or a tag ref.",
+            "Check target package version",
+            "id: package-version",
+            "PACKAGE_INDEX_JSON_URL",
+            "PACKAGE_INDEX_NAME",
+            "steps.package-version.outputs.exists != 'true'",
         ]:
             if required not in job_block:
                 failures.append(f"publish workflow {job_name} job is missing preflight: {required}")


### PR DESCRIPTION
## Summary
- add TestPyPI/PyPI version existence checks before package upload
- skip upload when the exact dist version already exists on the target index
- enforce the guard from scripts/check_release.py

## Checks
- python scripts/check_release.py
- python -m pytest tests/test_cli_release.py
- git diff --check