### PR TITLE
test: enforce release state consistency

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -151,6 +151,8 @@ python scripts/smoke_installed_package.py --from-pypi --version 0.4.1
 python scripts/smoke_installed_package.py --docker --from-pypi --version 0.4.1
 ```
 
+`scripts/check_release.py` treats these public-package smoke commands as release-state claims. Keep their `--version` and `codex-usage-tracking==...` values aligned with `pyproject.toml`; the release gate fails when the docs claim a different public version. It also checks that install docs point at the real PyPI distribution, `codex-usage-tracking`, and keep the warning that `codex-usage-tracker` is a different PyPI package.
+
 Docker avoids local toolchain side effects during install testing. Keep one local `pipx` smoke for platform-specific PATH and plugin-discovery behavior, but use Docker for repeatable Linux package verification.
 
 For documentation-only branches, at minimum run:

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -23,6 +23,21 @@ DIST_FILE_STEM = "codex_usage_tracking"
 IMPORT_PACKAGE = "codex_usage_tracker"
 CONSOLE_SCRIPT = "codex-usage-tracker"
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+OLD_PYPI_DISTRIBUTION_NAME = "codex-usage-tracker"
+PUBLIC_RELEASE_DOCS = [
+    "docs/one-dot-oh-readiness.md",
+    "docs/development.md",
+]
+PACKAGE_NAMING_DOCS = [
+    "README.md",
+    "docs/install.md",
+    "docs/development.md",
+]
+PUBLIC_VERSION_PATTERNS = [
+    re.compile(r"codex-usage-tracking==([0-9]+(?:\.[0-9]+){2})"),
+    re.compile(r"--from-pypi --version ([0-9]+(?:\.[0-9]+){2})"),
+    re.compile(r"visible as `([0-9]+(?:\.[0-9]+){2})`"),
+]
 SECRET_PATTERNS = {
     "OpenAI API key": re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}"),
     "GitHub token": re.compile(r"\b(?:ghp|github_pat)_[A-Za-z0-9_]{20,}"),
@@ -156,6 +171,7 @@ def _check_versions() -> list[str]:
         failures.append(".codex-plugin/plugin.json version does not match pyproject.toml")
     if f"## {package_version}" not in changelog:
         failures.append("CHANGELOG.md does not contain an entry for the package version")
+    failures.extend(_check_public_release_doc_versions(package_version))
     return failures
 
 
@@ -164,6 +180,7 @@ def _check_docs() -> list[str]:
     failures: list[str] = []
     for required in [
         "pipx install",
+        "codex-usage-tracking",
         "codex-usage-tracker install-plugin",
         "codex-usage-tracker doctor",
         "Data Privacy",
@@ -171,6 +188,57 @@ def _check_docs() -> list[str]:
     ]:
         if required not in readme:
             failures.append(f"README.md is missing required install/privacy text: {required}")
+    failures.extend(_check_package_naming_docs())
+    return failures
+
+
+def _check_public_release_doc_versions(package_version: str) -> list[str]:
+    failures: list[str] = []
+    for relative_path in PUBLIC_RELEASE_DOCS:
+        path = REPO_ROOT / relative_path
+        text = path.read_text(encoding="utf-8")
+        for pattern in PUBLIC_VERSION_PATTERNS:
+            for match in pattern.finditer(text):
+                if match.group(1) != package_version:
+                    failures.append(
+                        f"{relative_path} public release version {match.group(1)} "
+                        f"does not match pyproject.toml {package_version}"
+                    )
+    return failures
+
+
+def _check_package_naming_docs() -> list[str]:
+    failures: list[str] = []
+    old_name_warning = f"The `{OLD_PYPI_DISTRIBUTION_NAME}` PyPI name is not this project"
+    for relative_path in PACKAGE_NAMING_DOCS:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        if DISTRIBUTION_NAME not in text:
+            failures.append(f"{relative_path} must name the public PyPI package {DISTRIBUTION_NAME}")
+        if relative_path in {"README.md", "docs/install.md"} and old_name_warning not in text:
+            failures.append(
+                f"{relative_path} must warn that {OLD_PYPI_DISTRIBUTION_NAME} "
+                "is a different PyPI package"
+            )
+        failures.extend(_check_doc_install_lines(relative_path, text))
+    return failures
+
+
+def _check_doc_install_lines(relative_path: str, text: str) -> list[str]:
+    failures: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        normalized = line.strip().strip("`")
+        if not normalized:
+            continue
+        if not re.search(r"\b(?:pipx|pip|python(?:3)? -m pip)\s+install\b", normalized):
+            continue
+        if OLD_PYPI_DISTRIBUTION_NAME not in normalized:
+            continue
+        if DISTRIBUTION_NAME in normalized or "git+" in normalized or "github.com" in normalized:
+            continue
+        failures.append(
+            f"{relative_path}:{line_number} installs {OLD_PYPI_DISTRIBUTION_NAME}; "
+            f"use {DISTRIBUTION_NAME}"
+        )
     return failures
 
 
@@ -364,23 +432,6 @@ def _workflow_job_block(workflow: str, job_name: str) -> str | None:
     if not match:
         return None
     return match.group("body")
-
-
-def _check_ci_workflow() -> list[str]:
-    workflow_path = REPO_ROOT / ".github" / "workflows" / "ci.yml"
-    if not workflow_path.exists():
-        return ["missing CI workflow: .github/workflows/ci.yml"]
-    workflow = workflow_path.read_text(encoding="utf-8")
-    failures: list[str] = []
-    for required in [
-        "name: Build package",
-        "python -m build",
-        "python -m twine check dist/*",
-        "python scripts/check_release.py --dist",
-    ]:
-        if required not in workflow:
-            failures.append(f"CI package job is missing required build check: {required}")
-    return failures
 
 
 def _check_ci_workflow() -> list[str]:

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -89,6 +89,64 @@ def test_release_check_script_passes() -> None:
     assert "Release readiness checks passed." in result.stdout
 
 
+def test_release_check_rejects_stale_public_package_version_claims(tmp_path: Path) -> None:
+    module = _load_release_check_module()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "one-dot-oh-readiness.md").write_text(
+        "Verify public install: codex-usage-tracking==0.4.0\n"
+        "Smoke Docker: --from-pypi --version 0.4.0\n"
+        "Verify visible as `0.4.0`.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "development.md").write_text(
+        "python scripts/smoke_installed_package.py --from-pypi --version 0.4.0\n",
+        encoding="utf-8",
+    )
+
+    original_root = module.REPO_ROOT
+    module.REPO_ROOT = tmp_path
+    try:
+        failures = module._check_public_release_doc_versions("0.4.1")
+    finally:
+        module.REPO_ROOT = original_root
+
+    assert len(failures) == 4
+    assert all("does not match pyproject.toml 0.4.1" in failure for failure in failures)
+
+
+def test_release_check_rejects_old_pypi_package_install_docs(tmp_path: Path) -> None:
+    module = _load_release_check_module()
+    readme = tmp_path / "README.md"
+    install_doc = tmp_path / "docs" / "install.md"
+    development_doc = tmp_path / "docs" / "development.md"
+    install_doc.parent.mkdir()
+    readme.write_text(
+        "Package naming: the PyPI distribution is `codex-usage-tracking`. "
+        "The `codex-usage-tracker` PyPI name is not this project.\n"
+        "pipx install codex-usage-tracker\n",
+        encoding="utf-8",
+    )
+    install_doc.write_text(
+        "Package naming: the public PyPI distribution is `codex-usage-tracking`. "
+        "The `codex-usage-tracker` PyPI name is not this project.\n"
+        "python -m pip install codex-usage-tracker\n",
+        encoding="utf-8",
+    )
+    development_doc.write_text("Distribution: codex-usage-tracking\n", encoding="utf-8")
+
+    original_root = module.REPO_ROOT
+    module.REPO_ROOT = tmp_path
+    try:
+        failures = module._check_package_naming_docs()
+    finally:
+        module.REPO_ROOT = original_root
+
+    assert {
+        "README.md:2 installs codex-usage-tracker; use codex-usage-tracking",
+        "docs/install.md:2 installs codex-usage-tracker; use codex-usage-tracking",
+    } <= set(failures)
+
+
 def test_readme_codex_usage_tracker_commands_reference_known_subcommands() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     readme = repo_root / "README.md"
@@ -340,6 +398,17 @@ def _subprocess_env() -> dict[str, str]:
         else src_path
     )
     return env
+
+
+def _load_release_check_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "check_release.py"
+    spec = importlib.util.spec_from_file_location("check_release", script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load check_release.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _documented_cli_commands(path: Path) -> tuple[set[str], list[str]]:

--- a/tests/test_store_dashboard_mcp.py
+++ b/tests/test_store_dashboard_mcp.py
@@ -93,7 +93,7 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
 def test_refresh_reports_skipped_corrupt_token_events(tmp_path: Path) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
-    log_path = next((codex_home / "sessions").glob("**/*.jsonl"))
+    log_path = next(path for path in (codex_home / "sessions").glob("**/*.jsonl") if SESSION_ID in path.name)
     corrupt = _token_event(600, 300)
     corrupt["payload"]["info"]["last_token_usage"]["total_tokens"] = "bad-total"  # type: ignore[index]
     valid = _token_event(650, 50)


### PR DESCRIPTION
## Summary
- fail release checks when public-package version claims in readiness/development docs drift from pyproject.toml
- fail release checks when install docs point at the old codex-usage-tracker PyPI package name
- add regression tests for stale public version claims and wrong package install docs
- document the release-state guard in development docs

## Verification
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy
- .venv/bin/python -m pytest
- .venv/bin/python -m compileall src
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_format.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_data.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
- node --check src/codex_usage_tracker/plugin_data/dashboard/dashboard_state.js
- .venv/bin/python scripts/check_release.py
- git diff --check
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- .venv/bin/python scripts/check_release.py --dist