### PR TITLE
fix: ignore known non-token parser events

### DIFF
--- a/src/codex_usage_tracker/parser.py
+++ b/src/codex_usage_tracker/parser.py
@@ -40,7 +40,19 @@ PARSER_DIAGNOSTIC_KEYS = (
 )
 
 KNOWN_NON_TOKEN_EVENT_MSG_TYPES = frozenset({
+    "agent_message",
     "context_compacted",
+    "image_generation_end",
+    "item_completed",
+    "mcp_tool_call_end",
+    "patch_apply_end",
+    "task_complete",
+    "task_started",
+    "thread_goal_updated",
+    "thread_rolled_back",
+    "turn_aborted",
+    "user_message",
+    "web_search_end",
 })
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -167,6 +167,38 @@ def test_parser_ignores_known_non_token_context_compaction_event(tmp_path: Path)
     assert "SECRET COMPACTION TEXT" not in json.dumps([event.to_row() for event in events])
 
 
+def test_parser_ignores_known_non_token_event_messages(tmp_path: Path) -> None:
+    log_path = tmp_path / f"rollout-2026-05-17T14-58-23-{SESSION_ID}.jsonl"
+    known_event_types = [
+        "agent_message",
+        "image_generation_end",
+        "item_completed",
+        "mcp_tool_call_end",
+        "patch_apply_end",
+        "task_complete",
+        "task_started",
+        "thread_goal_updated",
+        "thread_rolled_back",
+        "turn_aborted",
+        "user_message",
+        "web_search_end",
+    ]
+    _write_jsonl(
+        log_path,
+        [
+            _entry("session_meta", {"id": SESSION_ID}),
+            *[_entry("event_msg", {"type": event_type}) for event_type in known_event_types],
+            _token_event(100, 100),
+        ],
+    )
+
+    stats: dict[str, int] = {}
+    events = parse_usage_events_from_file(log_path, stats=stats)
+
+    assert len(events) == 1
+    assert stats.get("unknown_event_shape", 0) == 0
+
+
 def test_parser_persists_call_origin_from_metadata_segments(tmp_path: Path) -> None:
     log_path = tmp_path / f"rollout-2026-05-17T14-58-23-{SESSION_ID}.jsonl"
     _write_jsonl(


### PR DESCRIPTION
## Summary
- Treat current normal Codex non-token `event_msg` payload types as known parser events instead of schema drift.
- Add a parser regression test covering those known non-token event types.
- Rebuilt the local aggregate index after setup; `doctor` now reports PASS with no parser drift warnings.

## Validation
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing`
- `.venv/bin/python -m compileall src`
- `for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file"; done`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
- `.venv/bin/python -m build`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/python scripts/check_release.py --dist`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/codex-usage-tracker setup`
- `.venv/bin/codex-usage-tracker rebuild-index`
- `.venv/bin/codex-usage-tracker doctor --suggest-repair`
