### PR TITLE
Integrate live refresh with incremental refresh deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Make refresh delta-aware so no-op refreshes skip downstream adjacency and
+  thread-summary rebuild work, and append refreshes update only affected thread
+  read models.
+
 ## 0.6.1 - 2026-06-13
 
 - Polish the README landing screenshots with matched dashboard/investigator previews and an additional lower investigator evidence view.

--- a/src/codex_usage_tracker/api_payloads.py
+++ b/src/codex_usage_tracker/api_payloads.py
@@ -39,6 +39,13 @@ def refresh_result_payload(result: Any, *, schema: str) -> dict[str, Any]:
         "parsed_events": result.parsed_events,
         "skipped_events": result.skipped_events,
         "inserted_or_updated_events": result.inserted_or_updated_events,
+        "changed_source_files": result.changed_source_files,
+        "append_source_files": result.append_source_files,
+        "full_reparse_source_files": result.full_reparse_source_files,
+        "inserted_records": result.inserted_records,
+        "deleted_records": result.deleted_records,
+        "affected_threads": result.affected_threads,
+        "skipped_downstream_work": result.skipped_downstream_work,
         "db_path": result.db_path,
         "parser_diagnostics": result.parser_diagnostics,
     }

--- a/src/codex_usage_tracker/json_contracts.py
+++ b/src/codex_usage_tracker/json_contracts.py
@@ -14,6 +14,13 @@ REFRESH_RESULT_FIELDS = {
     "parsed_events": int,
     "skipped_events": int,
     "inserted_or_updated_events": int,
+    "changed_source_files": int,
+    "append_source_files": int,
+    "full_reparse_source_files": int,
+    "inserted_records": int,
+    "deleted_records": int,
+    "affected_threads": int,
+    "skipped_downstream_work": bool,
     "db_path": str,
     "parser_diagnostics": dict,
 }

--- a/src/codex_usage_tracker/models.py
+++ b/src/codex_usage_tracker/models.py
@@ -108,3 +108,10 @@ class RefreshResult:
     db_path: str
     skipped_events: int = 0
     parser_diagnostics: dict[str, int] = field(default_factory=dict)
+    changed_source_files: int = 0
+    append_source_files: int = 0
+    full_reparse_source_files: int = 0
+    inserted_records: int = 0
+    deleted_records: int = 0
+    affected_threads: int = 0
+    skipped_downstream_work: bool = False

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard.css
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard.css
@@ -223,6 +223,26 @@
     }
     .card span { display: block; color: var(--muted); font-size: 12px; font-weight: 680; }
     .card strong { display: block; margin-top: 7px; font-size: 22px; }
+    .usage-card {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .usage-reconcile {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      margin-top: 10px;
+      padding: 3px 8px;
+      border: 1px solid #fed7aa;
+      border-radius: 999px;
+      background: #fff7ed;
+      color: #9a3412;
+      font-size: 11px;
+      font-weight: 800;
+      line-height: 1.2;
+      cursor: help;
+    }
     .row-load-progress {
       display: grid;
       gap: 8px;

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
@@ -1247,12 +1247,13 @@
     }
     function applyDashboardPayload(nextPayload, options = null) {
       const applyOptions = options || {};
+      const appendRows = Boolean(applyOptions.appendRows);
       if (i18n.updatePayload(nextPayload)) {
         populateLanguageOptions();
       }
       applyTranslations();
       const nextRows = payloadRows(nextPayload);
-      if (applyOptions.appendRows) {
+      if (appendRows) {
         data = mergedRows(data, nextRows);
       } else if (applyOptions.preserveRows) {
         data = data.length ? data : nextRows;
@@ -1260,30 +1261,49 @@
         data = nextRows;
       }
       summaryData = nextPayload.summary || summaryData;
-      pricingConfigured = Boolean(nextPayload.pricing_configured);
-      pricingSource = nextPayload.pricing_source || {};
-      pricingSnapshotWarning = nextPayload.pricing_snapshot_warning || '';
-      allowanceConfigured = Boolean(nextPayload.allowance_configured);
-      allowanceSource = nextPayload.allowance_source || {};
-      allowanceWindows = Array.isArray(nextPayload.allowance_windows) ? nextPayload.allowance_windows : [];
-      allowanceError = nextPayload.allowance_error || '';
+      if (!appendRows || Object.prototype.hasOwnProperty.call(nextPayload, 'pricing_configured')) {
+        pricingConfigured = Boolean(nextPayload.pricing_configured);
+      }
+      pricingSource = nextPayload.pricing_source || pricingSource || {};
+      pricingSnapshotWarning = nextPayload.pricing_snapshot_warning ?? pricingSnapshotWarning;
+      if (!appendRows || Object.prototype.hasOwnProperty.call(nextPayload, 'allowance_configured')) {
+        allowanceConfigured = Boolean(nextPayload.allowance_configured);
+      }
+      allowanceSource = nextPayload.allowance_source || allowanceSource || {};
+      allowanceWindows = Array.isArray(nextPayload.allowance_windows) ? nextPayload.allowance_windows : allowanceWindows;
+      allowanceError = nextPayload.allowance_error ?? allowanceError;
       observedUsage = nextPayload.observed_usage || observedUsage || {};
-      rateCardError = nextPayload.rate_card_error || '';
-      parserDiagnostics = nextPayload.parser_diagnostics || {};
-      projectMetadataPrivacy = nextPayload.project_metadata_privacy || { mode: nextPayload.privacy_mode || 'normal' };
+      rateCardError = nextPayload.rate_card_error ?? rateCardError;
+      parserDiagnostics = nextPayload.parser_diagnostics || parserDiagnostics || {};
+      projectMetadataPrivacy = nextPayload.project_metadata_privacy || projectMetadataPrivacy || { mode: nextPayload.privacy_mode || 'normal' };
       apiToken = nextPayload.api_token || apiToken;
-      contextApiEnabled = Boolean(nextPayload.context_api_enabled);
+      if (!appendRows || Object.prototype.hasOwnProperty.call(nextPayload, 'context_api_enabled')) {
+        contextApiEnabled = Boolean(nextPayload.context_api_enabled);
+      }
       actionThresholds = nextPayload.action_thresholds || actionThresholds;
       latestRefreshAt = nextPayload.latest_refresh_at || latestRefreshAt;
-      totalAvailableRows = Number(nextPayload.total_available_rows || data.length);
-      activeAvailableRows = Number(nextPayload.active_available_rows || data.length);
-      allHistoryAvailableRows = Number(nextPayload.all_history_available_rows || totalAvailableRows);
-      archivedAvailableRows = Number(nextPayload.archived_available_rows || Math.max(allHistoryAvailableRows - activeAvailableRows, 0));
-      includeArchived = Boolean(nextPayload.include_archived);
-      if (!applyOptions.appendRows) loadedLimit = payloadLimit(nextPayload);
-      if (!applyOptions.appendRows) supplementalRowsByRecordId = new Map();
+      if (nextPayload.total_available_rows !== undefined) {
+        totalAvailableRows = Number(nextPayload.total_available_rows || data.length);
+      }
+      if (nextPayload.total_matched_rows !== undefined && !nextPayload.total_available_rows && totalAvailableRows < Number(nextPayload.total_matched_rows || 0)) {
+        totalAvailableRows = Number(nextPayload.total_matched_rows || totalAvailableRows);
+      }
+      if (nextPayload.active_available_rows !== undefined) {
+        activeAvailableRows = Number(nextPayload.active_available_rows || data.length);
+      }
+      if (nextPayload.all_history_available_rows !== undefined) {
+        allHistoryAvailableRows = Number(nextPayload.all_history_available_rows || totalAvailableRows);
+      }
+      if (nextPayload.archived_available_rows !== undefined) {
+        archivedAvailableRows = Number(nextPayload.archived_available_rows || Math.max(allHistoryAvailableRows - activeAvailableRows, 0));
+      }
+      if (Object.prototype.hasOwnProperty.call(nextPayload, 'include_archived')) {
+        includeArchived = Boolean(nextPayload.include_archived);
+      }
+      if (!appendRows) loadedLimit = payloadLimit(nextPayload);
+      if (!appendRows) supplementalRowsByRecordId = new Map();
       restoredAggregatePayloadFromCache = false;
-      if (!nextPayload.shell_boot && !applyOptions.appendRows) {
+      if (!nextPayload.shell_boot && !appendRows) {
         dashboardPayloadCache.writeAggregatePayloadCache({ ...nextPayload, api_token: apiToken });
       }
       rebuildDashboardIndexes();

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
@@ -471,6 +471,7 @@
     }
     dashboardStatus = dashboardStatusFactory.create({
       allowanceImpactElement: document.getElementById('allowanceImpact'),
+      allowanceReconcileElement: document.getElementById('allowanceReconcile'),
       allowanceSourceElement: document.getElementById('allowanceSource'),
       creditCoverageRatio,
       credits,
@@ -515,7 +516,6 @@
       historyScopeEl,
       i18n,
       initialHydrationChunkSize,
-      latestRefreshAt: () => latestRefreshAt,
       limitValue,
       liveRefreshIntervalMs,
       liveRefreshSupported,

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -153,6 +153,83 @@
         || refreshResultNumber(result, 'full_reparse_source_files') > 0;
     }
 
+    function liveApiHttpMessage(status) {
+      const reloadHint = t('live.refresh_suffix').replace(/^\.\s*/, '');
+      return `${tf('context.api_http', { status })} ${reloadHint}`;
+    }
+
+    function liveApiResponseMessage(response) {
+      if (response.status === 401 || response.status === 403) {
+        return liveApiHttpMessage(String(response.status));
+      }
+      return `HTTP ${response.status}`;
+    }
+
+    function stopLiveRefreshForAuthFailure(response) {
+      if (response.status !== 401 && response.status !== 403) return false;
+      if (autoRefreshEl) autoRefreshEl.checked = false;
+      scheduleAutoRefresh();
+      rowHydrationRestartRequested = false;
+      rowHydrationError = liveApiResponseMessage(response);
+      updateLiveStatus('status.refresh_error', tf('live.refresh_unavailable', { message: rowHydrationError, suffix: '' }));
+      updateRowLoadProgress();
+      return true;
+    }
+
+    async function fetchCallRows(limit, offset) {
+      const params = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+        include_archived: getIncludeArchived() ? '1' : '0',
+        sort: 'time',
+        direction: 'desc',
+        lang: i18n.currentLanguage,
+        _: String(Date.now()),
+      });
+      const response = await fetch(`/api/calls?${params.toString()}`, {
+        headers: {
+          'Accept': 'application/json',
+          'X-Codex-Usage-Token': apiToken(),
+        },
+        cache: 'no-store',
+      });
+      if (!response.ok) {
+        stopLiveRefreshForAuthFailure(response);
+        throw new Error(liveApiResponseMessage(response));
+      }
+      const payload = await response.json();
+      if (payload.error) throw new Error(payload.error);
+      return payload;
+    }
+
+    async function refreshAppendedRows(refreshResult, scopedRows) {
+      if (!liveRefreshSupported || activeView() === 'call') return;
+      if (rowHydrationInFlight) {
+        rowHydrationRestartRequested = true;
+        return;
+      }
+      const inserted = Math.max(
+        refreshResultNumber(refreshResult, 'inserted_records'),
+        refreshResultNumber(refreshResult, 'inserted_or_updated_events'),
+        1,
+      );
+      const chunkLimit = Math.min(
+        Math.max(inserted, initialHydrationChunkSize),
+        Math.max(initialHydrationChunkSize, backgroundHydrationChunkSize),
+      );
+      rowHydrationError = '';
+      updateLiveStatus('status.checking', t('live.loading_rows'));
+      updateRowLoadProgress();
+      const payload = await fetchCallRows(chunkLimit, 0);
+      if (Number.isFinite(scopedRows) && payload.total_matched_rows === undefined) {
+        payload.total_matched_rows = scopedRows;
+      }
+      applyDashboardPayload(payload, { appendRows: true });
+      rowHydrationComplete = getData().length >= rowHydrationTarget();
+      updateRowLoadProgress();
+      updateLiveStatus(autoRefreshEl.checked ? 'badge.live' : 'status.updated', `${loadedRowsDescription()}. ${historyRowsDescription()}`);
+    }
+
     async function hydrateDashboardRows(options = null) {
       if (!liveRefreshSupported || activeView() === 'call') return;
       const hydrateOptions = options || {};
@@ -193,23 +270,7 @@
             offset === 0 ? initialHydrationChunkSize : backgroundHydrationChunkSize,
             remaining,
           );
-          const params = new URLSearchParams({
-            limit: String(chunkSize),
-            offset: String(offset),
-            include_archived: getIncludeArchived() ? '1' : '0',
-            lang: i18n.currentLanguage,
-            _: String(Date.now()),
-          });
-          const response = await fetch(`/api/usage?${params.toString()}`, {
-            headers: {
-              'Accept': 'application/json',
-              'X-Codex-Usage-Token': apiToken(),
-            },
-            cache: 'no-store',
-          });
-          if (!response.ok) throw new Error(`HTTP ${response.status}`);
-          const payload = await response.json();
-          if (payload.error) throw new Error(payload.error);
+          const payload = await fetchCallRows(chunkSize, offset);
           if (payload.usage_impact_pending) usageImpactPending = true;
           if (generation !== rowHydrationGeneration || activeView() === 'call') break;
           const rows = payloadRows(payload);
@@ -253,7 +314,10 @@
           },
           cache: 'no-store',
         });
-        if (!response.ok) return;
+        if (!response.ok) {
+          stopLiveRefreshForAuthFailure(response);
+          return;
+        }
         const payload = await response.json();
         const scopedRows = Number(payload.row_counts?.scoped_rows);
         if (payload.observed_usage) {
@@ -268,7 +332,7 @@
         if (refreshResultNeedsReset(refreshResult)) {
           refreshDashboardData(false, { refreshLogs: false, resetRows: true });
         } else if (refreshResultHasRowChanges(refreshResult) || rowCountChanged) {
-          refreshDashboardData(false, { refreshLogs: false, resetRows: true });
+          await refreshAppendedRows(refreshResult, scopedRows);
         } else if (rowsNeedHydration()) {
           hydrateDashboardRows();
         }
@@ -310,7 +374,8 @@
           cache: 'no-store',
         });
         if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
+          stopLiveRefreshForAuthFailure(response);
+          throw new Error(liveApiResponseMessage(response));
         }
         const nextPayload = await response.json();
         if (nextPayload.error) throw new Error(nextPayload.error);

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -221,24 +221,24 @@
       try {
         const params = new URLSearchParams({
           include_archived: getIncludeArchived() ? '1' : '0',
+          refresh: '1',
           _: String(Date.now()),
         });
         const response = await fetch(`/api/status?${params.toString()}`, {
           headers: {
             'Accept': 'application/json',
+            'X-Codex-Usage-Token': apiToken(),
           },
           cache: 'no-store',
         });
         if (!response.ok) return;
         const payload = await response.json();
-        const statusRefreshAt = payload.latest_refresh_at || '';
         const scopedRows = Number(payload.row_counts?.scoped_rows);
         if (payload.observed_usage) {
           setObservedUsage(payload.observed_usage);
         }
         const rowCountChanged = Number.isFinite(scopedRows) && scopedRows !== getTotalAvailableRows();
-        const refreshChanged = statusRefreshAt && statusRefreshAt !== deps.latestRefreshAt();
-        if (rowCountChanged || refreshChanged) {
+        if (rowCountChanged) {
           refreshDashboardData(false, { refreshLogs: false, resetRows: true });
         } else if (rowsNeedHydration()) {
           hydrateDashboardRows();

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -131,6 +131,28 @@
       }, 1200);
     }
 
+    function refreshResultNumber(result, key) {
+      return Number(result?.[key] || 0);
+    }
+
+    function refreshResultHasDelta(result) {
+      return result && Object.prototype.hasOwnProperty.call(result, 'skipped_downstream_work');
+    }
+
+    function refreshResultIsNoOp(result) {
+      return refreshResultHasDelta(result) && result.skipped_downstream_work === true;
+    }
+
+    function refreshResultHasRowChanges(result) {
+      return refreshResultNumber(result, 'inserted_records') > 0
+        || refreshResultNumber(result, 'inserted_or_updated_events') > 0;
+    }
+
+    function refreshResultNeedsReset(result) {
+      return refreshResultNumber(result, 'deleted_records') > 0
+        || refreshResultNumber(result, 'full_reparse_source_files') > 0;
+    }
+
     async function hydrateDashboardRows(options = null) {
       if (!liveRefreshSupported || activeView() === 'call') return;
       const hydrateOptions = options || {};
@@ -237,8 +259,15 @@
         if (payload.observed_usage) {
           setObservedUsage(payload.observed_usage);
         }
+        const refreshResult = payload.refresh_result || {};
+        if (refreshResultIsNoOp(refreshResult)) {
+          if (rowsNeedHydration()) hydrateDashboardRows();
+          return;
+        }
         const rowCountChanged = Number.isFinite(scopedRows) && scopedRows !== getTotalAvailableRows();
-        if (rowCountChanged) {
+        if (refreshResultNeedsReset(refreshResult)) {
+          refreshDashboardData(false, { refreshLogs: false, resetRows: true });
+        } else if (refreshResultHasRowChanges(refreshResult) || rowCountChanged) {
           refreshDashboardData(false, { refreshLogs: false, resetRows: true });
         } else if (rowsNeedHydration()) {
           hydrateDashboardRows();

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_status.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_status.js
@@ -2,6 +2,7 @@
   function createDashboardStatus(deps) {
     const {
       allowanceImpactElement,
+      allowanceReconcileElement,
       allowanceSourceElement,
       creditCoverageRatio,
       credits,
@@ -84,9 +85,6 @@
       const lines = windows
         .map(window => observedWindowText(window))
         .filter(Boolean);
-      if (observed.reconciliation && observed.reconciliation.recommended) {
-        lines.push(t('allowance.live_check_short'));
-      }
       return lines.join('\n');
     }
 
@@ -260,6 +258,21 @@
         allowanceImpactElement,
         observedUsageTooltip() || allowanceWindowText(totalCredits, 'remaining') || t('allowance.title_hint'),
       );
+      updateAllowanceReconciliation();
+    }
+
+    function updateAllowanceReconciliation() {
+      if (!allowanceReconcileElement) return;
+      const observed = getObservedUsage() || {};
+      const tooltip = observedReconciliationTooltip(observed);
+      const show = Boolean(observed.reconciliation && observed.reconciliation.recommended);
+      allowanceReconcileElement.hidden = !show;
+      if (!show) {
+        setFastTooltip(allowanceReconcileElement, '');
+        return;
+      }
+      allowanceReconcileElement.textContent = t('allowance.live_check_short');
+      setFastTooltip(allowanceReconcileElement, tooltip || t('allowance.observed_source_hint'));
     }
 
     function renderLiveStatus() {

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_template.html
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_template.html
@@ -69,7 +69,7 @@
       <div class="card"><span data-i18n="metric.reasoning_output">Reasoning Output</span><strong id="reasoningTokens">0</strong></div>
       <div class="card"><span data-i18n="metric.estimated_cost">Estimated Cost</span><strong id="estimatedCost">$0.00</strong></div>
       <div class="card"><span data-i18n="metric.codex_credits">Codex Credits</span><strong id="usageCredits">0</strong></div>
-      <div class="card"><span data-i18n="metric.usage_remaining">Remaining usage</span><strong id="allowanceImpact" data-i18n="action.set_limits">Set limits</strong></div>
+      <div class="card usage-card"><span data-i18n="metric.usage_remaining">Remaining usage</span><strong id="allowanceImpact" data-i18n="action.set_limits">Set limits</strong><span id="allowanceReconcile" class="usage-reconcile" hidden data-i18n="allowance.live_check_short">Verify live</span></div>
     </div>
     <section id="insightsPanel" class="insights-panel" aria-labelledby="insightsTitle">
       <div class="insights-layout">

--- a/src/codex_usage_tracker/server.py
+++ b/src/codex_usage_tracker/server.py
@@ -550,7 +550,17 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
     def _handle_status(self, query: str) -> None:
         params = parse_qs(query)
         include_archived = _parse_bool(_first(params.get("include_archived")), self._include_archived)
+        refresh_result: dict[str, object] | None = None
+        refresh_ms: float | None = None
         try:
+            if _truthy(_first(params.get("refresh"))):
+                if not self._has_valid_api_token(params):
+                    self._send_json(
+                        HTTPStatus.FORBIDDEN,
+                        {"error": "Valid API token is required for refresh"},
+                    )
+                    return
+                refresh_result, refresh_ms = self._refresh_usage_index(include_archived)
             counts = query_usage_status(
                 db_path=self._db_path,
                 include_archived=include_archived,
@@ -567,20 +577,21 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
             )
             return
         parser_diagnostics = dashboard_parser_diagnostics(metadata)
-        self._send_json(
-            HTTPStatus.OK,
-            {
-                "schema": "codex-usage-tracker-status-v1",
-                "payload_schema": "codex-usage-tracker-live-api-v1",
-                "latest_refresh_at": metadata.get("latest_refresh_at"),
-                "include_archived": include_archived,
-                "row_counts": counts,
-                "max_event_timestamp": counts.get("max_event_timestamp"),
-                "observed_usage": observed_usage,
-                "parser_adapter": metadata.get("parser_adapter"),
-                "parser_diagnostics": parser_diagnostics,
-            },
-        )
+        payload: dict[str, object] = {
+            "schema": "codex-usage-tracker-status-v1",
+            "payload_schema": "codex-usage-tracker-live-api-v1",
+            "latest_refresh_at": metadata.get("latest_refresh_at"),
+            "include_archived": include_archived,
+            "row_counts": counts,
+            "max_event_timestamp": counts.get("max_event_timestamp"),
+            "observed_usage": observed_usage,
+            "parser_adapter": metadata.get("parser_adapter"),
+            "parser_diagnostics": parser_diagnostics,
+        }
+        if refresh_result is not None:
+            payload["refresh_result"] = refresh_result
+            payload["refresh_ms"] = refresh_ms
+        self._send_json(HTTPStatus.OK, payload)
 
     def _handle_calls(self, query: str) -> None:
         params = parse_qs(query)
@@ -958,25 +969,7 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
                         {"error": "Valid API token is required for refresh"},
                     )
                     return
-                refresh_started = perf_counter()
-                with self._refresh_lock:
-                    result = refresh_usage_index(
-                        codex_home=self._codex_home,
-                        db_path=self._db_path,
-                        include_archived=include_archived,
-                    )
-                self._usage_impact_cache.invalidate()
-                self._usage_impact_cache.warm_async(include_archived=include_archived)
-                refresh_ms = _elapsed_ms(refresh_started)
-                refresh_result = {
-                    "scanned_files": result.scanned_files,
-                    "parsed_events": result.parsed_events,
-                    "skipped_events": result.skipped_events,
-                    "inserted_or_updated_events": result.inserted_or_updated_events,
-                    "db_path": result.db_path,
-                    "parser_diagnostics": result.parser_diagnostics,
-                    "include_archived": include_archived,
-                }
+                refresh_result, refresh_ms = self._refresh_usage_index(include_archived)
             payload_started = perf_counter()
             payload = dashboard_payload(
                 db_path=self._db_path,
@@ -1035,6 +1028,29 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
                 diagnostic_payload["refresh_ms"] = refresh_ms
             payload["diagnostics"] = diagnostic_payload
         self._send_json(HTTPStatus.OK, payload)
+
+    def _refresh_usage_index(self, include_archived: bool) -> tuple[dict[str, object], float]:
+        refresh_started = perf_counter()
+        with self._refresh_lock:
+            result = refresh_usage_index(
+                codex_home=self._codex_home,
+                db_path=self._db_path,
+                include_archived=include_archived,
+            )
+        self._usage_impact_cache.invalidate()
+        self._usage_impact_cache.warm_async(include_archived=include_archived)
+        return (
+            {
+                "scanned_files": result.scanned_files,
+                "parsed_events": result.parsed_events,
+                "skipped_events": result.skipped_events,
+                "inserted_or_updated_events": result.inserted_or_updated_events,
+                "db_path": result.db_path,
+                "parser_diagnostics": result.parser_diagnostics,
+                "include_archived": include_archived,
+            },
+            _elapsed_ms(refresh_started),
+        )
 
     def _request_origin_allowed(self) -> bool:
         if not _allowed_loopback_host(_host_header_name(self.headers.get("Host"))):

--- a/src/codex_usage_tracker/server.py
+++ b/src/codex_usage_tracker/server.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qs, urlparse
 
 from codex_usage_tracker import server_utils
 from codex_usage_tracker.allowance import annotate_rows_with_allowance, load_allowance_config
+from codex_usage_tracker.api_payloads import refresh_result_payload
 from codex_usage_tracker.call_origin import ensure_call_origin
 from codex_usage_tracker.context import (
     CONTEXT_MODE_QUICK,
@@ -92,6 +93,20 @@ _url_host = server_utils.url_host
 _utc_now = server_utils.utc_now
 _validate_context_api_mode = server_utils.validate_context_api_mode
 _validate_loopback_host = server_utils.validate_loopback_host
+
+
+def _refresh_result_invalidates_usage_impact(result: object) -> bool:
+    if bool(getattr(result, "skipped_downstream_work", False)):
+        return False
+    return any(
+        int(getattr(result, field, 0) or 0) > 0
+        for field in (
+            "inserted_records",
+            "deleted_records",
+            "full_reparse_source_files",
+            "inserted_or_updated_events",
+        )
+    )
 
 
 class _ContextApiState:
@@ -1037,18 +1052,17 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
                 db_path=self._db_path,
                 include_archived=include_archived,
             )
-        self._usage_impact_cache.invalidate()
-        self._usage_impact_cache.warm_async(include_archived=include_archived)
+        if _refresh_result_invalidates_usage_impact(result):
+            self._usage_impact_cache.invalidate()
+            self._usage_impact_cache.warm_async(include_archived=include_archived)
+        payload = refresh_result_payload(
+            result,
+            schema="codex-usage-tracker-refresh-v1",
+        )
+        payload.pop("schema", None)
+        payload["include_archived"] = include_archived
         return (
-            {
-                "scanned_files": result.scanned_files,
-                "parsed_events": result.parsed_events,
-                "skipped_events": result.skipped_events,
-                "inserted_or_updated_events": result.inserted_or_updated_events,
-                "db_path": result.db_path,
-                "parser_diagnostics": result.parser_diagnostics,
-                "include_archived": include_archived,
-            },
+            payload,
             _elapsed_ms(refresh_started),
         )
 

--- a/src/codex_usage_tracker/store.py
+++ b/src/codex_usage_tracker/store.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import csv
 import sqlite3
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,7 @@ from codex_usage_tracker.store_query_sql import (
     _normalize_offset,
     _normalize_sort_direction,
     _since_where_clause,
+    _thread_key_expression,
     _usage_api_sort_expression,
     _usage_api_where_clause,
     _usage_where_clause,
@@ -52,6 +54,40 @@ __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 OBSERVED_USAGE_RECONCILIATION_THRESHOLD = 3
 
 
+@dataclass
+class RefreshDelta:
+    changed_source_files: set[str] = field(default_factory=set)
+    append_source_files: set[str] = field(default_factory=set)
+    full_reparse_source_files: set[str] = field(default_factory=set)
+    inserted_record_ids: set[str] = field(default_factory=set)
+    deleted_record_ids: set[str] = field(default_factory=set)
+    affected_thread_keys: set[str] = field(default_factory=set)
+    changed_time_start: str | None = None
+    changed_time_end: str | None = None
+    skipped_downstream_work: bool = False
+
+    def merge_upsert(self, upsert_delta: UpsertDelta) -> None:
+        self.inserted_record_ids.update(upsert_delta.inserted_record_ids)
+        self.deleted_record_ids.update(upsert_delta.deleted_record_ids)
+        self.affected_thread_keys.update(upsert_delta.affected_thread_keys)
+        self.changed_time_start, self.changed_time_end = _merge_time_ranges(
+            (self.changed_time_start, self.changed_time_end),
+            (upsert_delta.changed_time_start, upsert_delta.changed_time_end),
+        )
+        self.skipped_downstream_work = upsert_delta.skipped_downstream_work
+
+
+@dataclass
+class UpsertDelta:
+    inserted_or_updated_count: int = 0
+    inserted_record_ids: set[str] = field(default_factory=set)
+    deleted_record_ids: set[str] = field(default_factory=set)
+    affected_thread_keys: set[str] = field(default_factory=set)
+    changed_time_start: str | None = None
+    changed_time_end: str | None = None
+    skipped_downstream_work: bool = False
+
+
 def refresh_usage_index(
     codex_home: Path = DEFAULT_CODEX_HOME,
     db_path: Path = DEFAULT_DB_PATH,
@@ -60,10 +96,44 @@ def refresh_usage_index(
     """Scan Codex logs and upsert aggregate usage events."""
 
     logs = find_session_logs(codex_home=codex_home, include_archived=include_archived)
-    session_index = load_session_index(codex_home)
     with connect(db_path) as conn:
         init_db(conn)
         parse_plans = source_logs_requiring_parse(conn, logs)
+    delta = RefreshDelta(
+        changed_source_files={str(plan.path) for plan in parse_plans},
+        append_source_files={str(plan.path) for plan in parse_plans if not plan.replace_existing},
+        full_reparse_source_files={
+            str(plan.path) for plan in parse_plans if plan.replace_existing
+        },
+    )
+    if not parse_plans:
+        delta.skipped_downstream_work = True
+        record_refresh_metadata(
+            db_path=db_path,
+            scanned_files=len(logs),
+            parsed_events=0,
+            skipped_events=0,
+            inserted_or_updated_events=0,
+            parser_diagnostics={},
+            parsed_source_files=0,
+            skipped_source_files=len(logs),
+        )
+        return RefreshResult(
+            scanned_files=len(logs),
+            parsed_events=0,
+            inserted_or_updated_events=0,
+            db_path=str(db_path),
+            skipped_events=0,
+            parser_diagnostics={},
+            changed_source_files=0,
+            append_source_files=0,
+            full_reparse_source_files=0,
+            inserted_records=0,
+            deleted_records=0,
+            affected_threads=0,
+            skipped_downstream_work=True,
+        )
+    session_index = load_session_index(codex_home)
     stats: dict[str, int] = {}
     events: list[UsageEvent] = []
     parsed_files: list[ParsedSourceFile] = []
@@ -90,11 +160,12 @@ def refresh_usage_index(
         )
         for key, value in file_stats.items():
             stats[key] = stats.get(key, 0) + int(value)
-    inserted = upsert_usage_events(
+    upsert_delta = _upsert_usage_events_with_delta(
         events,
         db_path=db_path,
         replace_source_files=(plan.path for plan in parse_plans if plan.replace_existing),
     )
+    delta.merge_upsert(upsert_delta)
     record_source_file_metadata(db_path=db_path, parsed_files=parsed_files)
     skipped_events = stats.get("skipped_events", 0)
     diagnostics = compact_parser_diagnostics(stats)
@@ -103,7 +174,7 @@ def refresh_usage_index(
         scanned_files=len(logs),
         parsed_events=len(events),
         skipped_events=skipped_events,
-        inserted_or_updated_events=inserted,
+        inserted_or_updated_events=upsert_delta.inserted_or_updated_count,
         parser_diagnostics=diagnostics,
         parsed_source_files=len(parse_plans),
         skipped_source_files=len(logs) - len(parse_plans),
@@ -111,10 +182,17 @@ def refresh_usage_index(
     return RefreshResult(
         scanned_files=len(logs),
         parsed_events=len(events),
-        inserted_or_updated_events=inserted,
+        inserted_or_updated_events=upsert_delta.inserted_or_updated_count,
         db_path=str(db_path),
         skipped_events=skipped_events,
         parser_diagnostics=diagnostics,
+        changed_source_files=len(delta.changed_source_files),
+        append_source_files=len(delta.append_source_files),
+        full_reparse_source_files=len(delta.full_reparse_source_files),
+        inserted_records=len(delta.inserted_record_ids),
+        deleted_records=len(delta.deleted_record_ids),
+        affected_threads=len(delta.affected_thread_keys),
+        skipped_downstream_work=delta.skipped_downstream_work,
     )
 
 
@@ -273,6 +351,45 @@ def record_source_file_metadata(
         upsert_source_file_metadata(conn, parsed_files=parsed)
 
 
+def _row_value(row: Mapping[str, Any] | sqlite3.Row, key: str) -> Any:
+    try:
+        return row[key]
+    except (IndexError, KeyError):
+        return None
+
+
+def _usage_event_partition_key(row: Mapping[str, Any] | sqlite3.Row) -> str:
+    thread_key = _row_value(row, "thread_key")
+    if thread_key:
+        return str(thread_key)
+    thread_name = _row_value(row, "thread_name")
+    if thread_name:
+        return f"thread:{thread_name}"
+    return f"session:{_row_value(row, 'session_id')}"
+
+
+def _row_time_range(
+    rows: Iterable[Mapping[str, Any] | sqlite3.Row],
+) -> tuple[str | None, str | None]:
+    timestamps = [
+        str(timestamp)
+        for row in rows
+        if (timestamp := _row_value(row, "event_timestamp"))
+    ]
+    if not timestamps:
+        return None, None
+    return min(timestamps), max(timestamps)
+
+
+def _merge_time_ranges(
+    first: tuple[str | None, str | None],
+    second: tuple[str | None, str | None],
+) -> tuple[str | None, str | None]:
+    starts = [value for value in (first[0], second[0]) if value is not None]
+    ends = [value for value in (first[1], second[1]) if value is not None]
+    return (min(starts) if starts else None, max(ends) if ends else None)
+
+
 def upsert_usage_events(
     events: Iterable[UsageEvent],
     db_path: Path = DEFAULT_DB_PATH,
@@ -280,21 +397,69 @@ def upsert_usage_events(
     refresh_links: bool = True,
     replace_source_files: Iterable[Path] | None = None,
 ) -> int:
+    return _upsert_usage_events_with_delta(
+        events,
+        db_path=db_path,
+        refresh_links=refresh_links,
+        replace_source_files=replace_source_files,
+    ).inserted_or_updated_count
+
+
+def _upsert_usage_events_with_delta(
+    events: Iterable[UsageEvent],
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    refresh_links: bool = True,
+    replace_source_files: Iterable[Path] | None = None,
+) -> UpsertDelta:
     rows = [event.to_row() for event in events]
     source_files_to_replace = [str(path) for path in replace_source_files or []]
+    delta = UpsertDelta(
+        inserted_or_updated_count=len(rows),
+        inserted_record_ids={str(row["record_id"]) for row in rows},
+        affected_thread_keys={
+            _usage_event_partition_key(row)
+            for row in rows
+            if _usage_event_partition_key(row)
+        },
+    )
+    delta.changed_time_start, delta.changed_time_end = _row_time_range(rows)
     with connect(db_path) as conn:
         init_db(conn)
+        old_rows: list[sqlite3.Row] = []
         if source_files_to_replace:
             placeholders = ", ".join("?" for _source in source_files_to_replace)
+            old_rows = conn.execute(
+                f"""
+                SELECT record_id, thread_key, thread_name, session_id, event_timestamp
+                FROM usage_events
+                WHERE source_file IN ({placeholders})
+                """,
+                source_files_to_replace,
+            ).fetchall()
+            delta.deleted_record_ids.update(str(row["record_id"]) for row in old_rows)
+            delta.affected_thread_keys.update(
+                key
+                for row in old_rows
+                if (key := _usage_event_partition_key(row))
+            )
+            old_time_start, old_time_end = _row_time_range(old_rows)
+            delta.changed_time_start, delta.changed_time_end = _merge_time_ranges(
+                (delta.changed_time_start, delta.changed_time_end),
+                (old_time_start, old_time_end),
+            )
             conn.execute(
                 f"DELETE FROM usage_events WHERE source_file IN ({placeholders})",
                 source_files_to_replace,
             )
         if not rows:
-            if source_files_to_replace and refresh_links:
-                _refresh_usage_event_links(conn)
-                rebuild_thread_summaries(conn)
-            return 0
+            if source_files_to_replace and refresh_links and delta.affected_thread_keys:
+                refresh_usage_event_links_for_threads(conn, delta.affected_thread_keys)
+                rebuild_thread_summaries(conn, thread_keys=delta.affected_thread_keys)
+            delta.skipped_downstream_work = not (
+                refresh_links and delta.affected_thread_keys
+            )
+            return delta
         placeholders = ", ".join("?" for _ in EVENT_COLUMNS)
         update_clause = ", ".join(
             f"{column}=excluded.{column}"
@@ -307,10 +472,13 @@ def upsert_usage_events(
             f"ON CONFLICT(record_id) DO UPDATE SET {update_clause}"
         )
         conn.executemany(sql, [[row[column] for column in EVENT_COLUMNS] for row in rows])
-        if refresh_links:
-            _refresh_usage_event_links(conn)
-            rebuild_thread_summaries(conn)
-        return len(rows)
+        if refresh_links and delta.affected_thread_keys:
+            refresh_usage_event_links_for_threads(conn, delta.affected_thread_keys)
+            rebuild_thread_summaries(conn, thread_keys=delta.affected_thread_keys)
+            delta.skipped_downstream_work = False
+        else:
+            delta.skipped_downstream_work = True
+        return delta
 
 
 def refresh_usage_event_links(db_path: Path = DEFAULT_DB_PATH) -> int:
@@ -323,28 +491,58 @@ def refresh_usage_event_links(db_path: Path = DEFAULT_DB_PATH) -> int:
         return changed
 
 
+def refresh_usage_event_links_for_threads(
+    conn: sqlite3.Connection,
+    affected_thread_keys: Iterable[str],
+) -> int:
+    """Recompute chronological adjacency for affected thread partitions only."""
+
+    thread_keys = sorted({key for key in affected_thread_keys if key})
+    if not thread_keys:
+        return 0
+    placeholders = ", ".join("?" for _key in thread_keys)
+    thread_key_expr = _thread_key_expression()
+    return _refresh_usage_event_links_scoped(
+        conn,
+        where_clause=f"WHERE {thread_key_expr} IN ({placeholders})",
+        params=thread_keys,
+    )
+
+
 def _refresh_usage_event_links(conn: sqlite3.Connection) -> int:
+    return _refresh_usage_event_links_scoped(conn)
+
+
+def _refresh_usage_event_links_scoped(
+    conn: sqlite3.Connection,
+    *,
+    where_clause: str = "",
+    params: Iterable[Any] = (),
+) -> int:
     before = conn.total_changes
+    thread_key_expr = _thread_key_expression()
     conn.execute("DROP TABLE IF EXISTS temp_usage_event_links")
     conn.execute(
-        """
+        f"""
         CREATE TEMP TABLE temp_usage_event_links AS
         SELECT
             record_id,
             ROW_NUMBER() OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                PARTITION BY {thread_key_expr}
                 ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
             ) AS next_thread_call_index,
             LAG(record_id) OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                PARTITION BY {thread_key_expr}
                 ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
             ) AS previous_id,
             LEAD(record_id) OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                PARTITION BY {thread_key_expr}
                 ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
             ) AS next_id
         FROM usage_events
-        """
+        {where_clause}
+        """,
+        list(params),
     )
     conn.execute(
         "CREATE UNIQUE INDEX temp_usage_event_links_record_id ON temp_usage_event_links(record_id)"

--- a/src/codex_usage_tracker/store_thread_summaries.py
+++ b/src/codex_usage_tracker/store_thread_summaries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from datetime import datetime, timezone
 
 from codex_usage_tracker.store_query_sql import (
@@ -11,23 +12,39 @@ from codex_usage_tracker.store_query_sql import (
 )
 
 
-def rebuild_thread_summaries(conn: sqlite3.Connection) -> int:
+def rebuild_thread_summaries(
+    conn: sqlite3.Connection,
+    *,
+    thread_keys: Iterable[str] | None = None,
+) -> int:
     """Rebuild materialized per-thread aggregate summaries."""
 
     before = conn.total_changes
-    conn.execute("DELETE FROM thread_summaries")
+    normalized_thread_keys = sorted({key for key in thread_keys or [] if key})
+    if thread_keys is None:
+        conn.execute("DELETE FROM thread_summaries")
+    elif not normalized_thread_keys:
+        return 0
+    else:
+        placeholders = ", ".join("?" for _key in normalized_thread_keys)
+        conn.execute(
+            f"DELETE FROM thread_summaries WHERE thread_key IN ({placeholders})",
+            normalized_thread_keys,
+        )
     updated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     _insert_thread_summary_scope(
         conn,
         scope="active",
         include_archived=False,
         updated_at=updated_at,
+        thread_keys=normalized_thread_keys if thread_keys is not None else None,
     )
     _insert_thread_summary_scope(
         conn,
         scope="all-history",
         include_archived=True,
         updated_at=updated_at,
+        thread_keys=normalized_thread_keys if thread_keys is not None else None,
     )
     return conn.total_changes - before
 
@@ -38,9 +55,20 @@ def _insert_thread_summary_scope(
     scope: str,
     include_archived: bool,
     updated_at: str,
+    thread_keys: list[str] | None = None,
 ) -> None:
     where_clause, params = _usage_where_clause(include_archived=include_archived)
     thread_key_expr = _thread_key_expression()
+    clauses: list[str] = []
+    if where_clause:
+        clauses.append(where_clause.removeprefix("WHERE "))
+    if thread_keys is not None:
+        placeholders = ", ".join("?" for _key in thread_keys)
+        clauses.append(f"{thread_key_expr} IN ({placeholders})")
+        params = [*params, *thread_keys]
+    scoped_where_clause = "WHERE " + " AND ".join(f"({clause})" for clause in clauses)
+    if not clauses:
+        scoped_where_clause = ""
     conn.execute(
         f"""
         INSERT INTO thread_summaries (
@@ -128,7 +156,7 @@ def _insert_thread_summary_scope(
                 AS archived_call_count,
             ? AS updated_at
         FROM usage_events
-        {where_clause}
+        {scoped_where_clause}
         GROUP BY {thread_key_expr}
         """,
         [scope, updated_at, *params],

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -58,6 +58,49 @@ const helpers = context.window.CodexUsageDashboardFormat;
     return json.loads(result.stdout)
 
 
+def _run_dashboard_live_script(script: str) -> dict[str, object]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for dashboard live helper tests")
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard_live.js"
+    wrapped = f"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync({json.dumps(str(script_path))}, 'utf8');
+const context = {{
+  window: {{
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  }},
+  document: {{ visibilityState: 'visible' }},
+  URLSearchParams,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+}};
+vm.createContext(context);
+vm.runInContext(code, context);
+const helpers = context.window.CodexUsageDashboardLive;
+(async () => {{
+{script}
+}})().catch(error => {{
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        [node, "-e", wrapped],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
 def test_compact_number_collapses_billion_scale_values() -> None:
     payload = _run_dashboard_format_script(
         """
@@ -76,6 +119,184 @@ console.log(JSON.stringify({
         "decimal": "1.2B",
         "large": "2.3B",
     }
+
+
+def test_live_refresh_append_delta_hydrates_rows_through_calls_api() -> None:
+    payload = _run_dashboard_live_script(
+        """
+let data = [{ record_id: 'b' }, { record_id: 'c' }];
+let totalAvailableRows = 2;
+let requestUrls = [];
+let appliedPayloads = [];
+let liveStatuses = [];
+let renderCount = 0;
+let fetchIndex = 0;
+const responses = [
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      row_counts: { scoped_rows: 3 },
+      refresh_result: {
+        skipped_downstream_work: false,
+        inserted_records: 1,
+        deleted_records: 0,
+        full_reparse_source_files: 0,
+      },
+      observed_usage: { available: true },
+    }),
+  },
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [{ record_id: 'a' }, { record_id: 'b' }],
+      row_count: 2,
+      total_matched_rows: 3,
+      has_more: true,
+      usage_impact_pending: false,
+    }),
+  },
+];
+context.fetch = async url => {
+  requestUrls.push(String(url));
+  return responses[fetchIndex++];
+};
+const runtime = helpers.create({
+  activeView: () => 'calls',
+  apiToken: () => 'token',
+  applyDashboardPayload: (payload, options = {}) => {
+    appliedPayloads.push({ appendRows: Boolean(options.appendRows), keys: Object.keys(payload).sort() });
+    if (options.appendRows) {
+      const seen = new Set(data.map(row => row.record_id));
+      data = data.concat((payload.rows || []).filter(row => {
+        if (!row.record_id || seen.has(row.record_id)) return false;
+        seen.add(row.record_id);
+        return true;
+      }));
+    } else {
+      data = payload.rows || [];
+      if (payload.total_available_rows !== undefined) totalAvailableRows = payload.total_available_rows;
+    }
+  },
+  autoRefreshEl: { checked: true },
+  formatTimestamp: value => String(value || ''),
+  getData: () => data,
+  getIncludeArchived: () => true,
+  getLoadedLimit: () => null,
+  getTotalAvailableRows: () => totalAvailableRows,
+  getArchivedAvailableRows: () => 0,
+  historyScopeEl: { value: 'all', parentElement: {} },
+  initialHydrationChunkSize: 2,
+  backgroundHydrationChunkSize: 2,
+  i18n: { currentLanguage: 'en' },
+  liveRefreshIntervalMs: 10000,
+  liveRefreshSupported: true,
+  loadLimitEl: { value: 'all', options: [], insertBefore: () => {}, lastElementChild: null },
+  limitValue: value => value === null ? 'all' : String(value),
+  number: { format: value => String(value) },
+  payloadRows: payload => payload.rows || [],
+  rebuildDashboardIndexes: () => {},
+  rebuildFilterOptions: () => {},
+  refreshDashboardEl: { disabled: false },
+  render: () => { renderCount += 1; },
+  resetRowsForHydration: () => { data = []; },
+  rowLoadProgressBarEl: { style: {} },
+  rowLoadProgressCountEl: { textContent: '' },
+  rowLoadProgressEl: { hidden: true },
+  rowLoadProgressLabelEl: { textContent: '' },
+  setFastTooltip: () => {},
+  setObservedUsage: () => {},
+  t: key => key,
+  tf: (key, values) => `${key}:${JSON.stringify(values || {})}`,
+  updateLiveStatus: (key, detail) => liveStatuses.push({ key, detail }),
+});
+await runtime.refreshDashboardIfStale();
+await new Promise(resolve => setTimeout(resolve, 25));
+console.log(JSON.stringify({
+  requestUrls,
+  appliedPayloads,
+  dataLength: data.length,
+  liveStatuses,
+  renderCount,
+}));
+"""
+    )
+
+    assert payload["dataLength"] == 3
+    assert payload["requestUrls"][0].startswith("/api/status?")
+    assert payload["requestUrls"][1].startswith("/api/calls?")
+    assert len(payload["requestUrls"]) == 2
+    assert all(not url.startswith("/api/usage?") for url in payload["requestUrls"])
+    assert payload["appliedPayloads"][0]["appendRows"] is True
+
+
+def test_live_refresh_auth_failure_stops_polling_and_surfaces_error() -> None:
+    payload = _run_dashboard_live_script(
+        """
+let liveStatuses = [];
+let progressHidden = true;
+const autoRefreshEl = { checked: true };
+context.fetch = async url => ({
+  ok: false,
+  status: 403,
+  json: async () => ({ error: 'bad token' }),
+});
+const runtime = helpers.create({
+  activeView: () => 'calls',
+  apiToken: () => 'stale-token',
+  applyDashboardPayload: () => {},
+  autoRefreshEl,
+  formatTimestamp: value => String(value || ''),
+  getData: () => [],
+  getIncludeArchived: () => true,
+  getLoadedLimit: () => null,
+  getTotalAvailableRows: () => 10,
+  getArchivedAvailableRows: () => 0,
+  historyScopeEl: { value: 'all', parentElement: {} },
+  initialHydrationChunkSize: 2,
+  backgroundHydrationChunkSize: 2,
+  i18n: { currentLanguage: 'en' },
+  liveRefreshIntervalMs: 10000,
+  liveRefreshSupported: true,
+  loadLimitEl: { value: 'all', options: [], insertBefore: () => {}, lastElementChild: null },
+  limitValue: value => value === null ? 'all' : String(value),
+  number: { format: value => String(value) },
+  payloadRows: payload => payload.rows || [],
+  rebuildDashboardIndexes: () => {},
+  rebuildFilterOptions: () => {},
+  refreshDashboardEl: { disabled: false },
+  render: () => {},
+  resetRowsForHydration: () => {},
+  rowLoadProgressBarEl: { style: {} },
+  rowLoadProgressCountEl: { textContent: '' },
+  rowLoadProgressEl: {
+    get hidden() { return progressHidden; },
+    set hidden(value) { progressHidden = value; },
+  },
+  rowLoadProgressLabelEl: { textContent: '' },
+  setFastTooltip: () => {},
+  setObservedUsage: () => {},
+  t: key => key === 'live.refresh_suffix'
+    ? '. Reload this page after regenerating a static dashboard, or run codex-usage-tracker serve-dashboard.'
+    : key,
+  tf: (key, values) => `${key}:${JSON.stringify(values || {})}`,
+  updateLiveStatus: (key, detail) => liveStatuses.push({ key, detail }),
+});
+await runtime.refreshDashboardIfStale();
+console.log(JSON.stringify({
+  autoRefreshChecked: autoRefreshEl.checked,
+  liveStatuses,
+  progressHidden,
+}));
+"""
+    )
+
+    assert payload["autoRefreshChecked"] is False
+    assert payload["progressHidden"] is False
+    assert payload["liveStatuses"][-1]["key"] == "status.refresh_error"
+    assert "403" in payload["liveStatuses"][-1]["detail"]
+    assert "Reload this page" in payload["liveStatuses"][-1]["detail"]
 
 
 def test_cache_diagnostic_classification_handles_expected_patterns() -> None:

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -16,6 +16,7 @@ from store_dashboard_helpers import (
     _http_error_json,
     _make_codex_home,
     _read_json,
+    _token_event,
     _usage_event,
     _write_archived_log,
     _write_pricing,
@@ -163,6 +164,65 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
     assert limited_payload["context_api_enabled"] is True
     assert forbidden_origin["status"] == 403
     assert "SECRET RAW PROMPT" not in json.dumps(limited_payload)
+
+
+def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_path: Path) -> None:
+    from codex_usage_tracker.server import _UsageDashboardHandler
+
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    log_path = next(
+        path for path in (codex_home / "sessions").glob("**/*.jsonl") if SESSION_ID in path.name
+    )
+    first_refresh = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(_token_event(650, 350)) + "\n")
+    handler = partial(
+        _UsageDashboardHandler,
+        directory=str(tmp_path),
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        thresholds_path=tmp_path / "thresholds.json",
+        projects_path=tmp_path / "projects.json",
+        limit=5000,
+        since=None,
+        codex_home=codex_home,
+        include_archived=False,
+        dashboard_name="dashboard.html",
+        context_chars=2000,
+        api_token="test-token",
+        context_api_enabled=True,
+        refresh_lock=threading.Lock(),
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        forbidden = _http_error_json(
+            f"http://127.0.0.1:{server.server_port}/api/status?refresh=1"
+        )
+        live_payload = _read_json(
+            f"http://127.0.0.1:{server.server_port}/api/status?refresh=1",
+            headers={"X-Codex-Usage-Token": "test-token"},
+        )
+        second_payload = _read_json(
+            f"http://127.0.0.1:{server.server_port}/api/status?refresh=1",
+            headers={"X-Codex-Usage-Token": "test-token"},
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert first_refresh.parsed_events == 4
+    assert forbidden["status"] == 403
+    assert live_payload["refresh_result"]["parsed_events"] == 1
+    assert live_payload["refresh_result"]["inserted_or_updated_events"] == 1
+    assert live_payload["row_counts"]["scoped_rows"] == 5
+    assert second_payload["refresh_result"]["parsed_events"] == 0
+    assert second_payload["refresh_result"]["inserted_or_updated_events"] == 0
 
 
 def test_dashboard_history_scope_excludes_archived_rows_by_default(tmp_path: Path) -> None:

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -117,6 +117,9 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
     assert dashboard_shell_payload["summary"]["visible_calls"] == 0
     assert limited_payload["refresh_result"]["parsed_events"] == 4
     assert limited_payload["refresh_result"]["skipped_events"] == 0
+    assert limited_payload["refresh_result"]["changed_source_files"] >= 1
+    assert limited_payload["refresh_result"]["inserted_records"] == 4
+    assert limited_payload["refresh_result"]["skipped_downstream_work"] is False
     assert limited_payload["refresh_result"]["parser_diagnostics"] == {}
     assert len(limited_payload["rows"]) == 2
     assert limited_payload["loaded_row_count"] == 2
@@ -169,9 +172,22 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
 def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_path: Path) -> None:
     from codex_usage_tracker.server import _UsageDashboardHandler
 
+    class FakeUsageImpactCache:
+        def __init__(self) -> None:
+            self.invalidations = 0
+            self.warms = 0
+
+        def invalidate(self) -> None:
+            self.invalidations += 1
+
+        def warm_async(self, *, include_archived: bool) -> None:
+            _ = include_archived
+            self.warms += 1
+
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     pricing_path = _write_pricing(tmp_path / "pricing.json")
+    usage_impact_cache = FakeUsageImpactCache()
     log_path = next(
         path for path in (codex_home / "sessions").glob("**/*.jsonl") if SESSION_ID in path.name
     )
@@ -195,6 +211,7 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
         api_token="test-token",
         context_api_enabled=True,
         refresh_lock=threading.Lock(),
+        usage_impact_cache=usage_impact_cache,
     )
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -220,9 +237,22 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
     assert forbidden["status"] == 403
     assert live_payload["refresh_result"]["parsed_events"] == 1
     assert live_payload["refresh_result"]["inserted_or_updated_events"] == 1
+    assert live_payload["refresh_result"]["changed_source_files"] == 1
+    assert live_payload["refresh_result"]["append_source_files"] == 1
+    assert live_payload["refresh_result"]["full_reparse_source_files"] == 0
+    assert live_payload["refresh_result"]["inserted_records"] == 1
+    assert live_payload["refresh_result"]["deleted_records"] == 0
+    assert live_payload["refresh_result"]["affected_threads"] == 1
+    assert live_payload["refresh_result"]["skipped_downstream_work"] is False
     assert live_payload["row_counts"]["scoped_rows"] == 5
     assert second_payload["refresh_result"]["parsed_events"] == 0
     assert second_payload["refresh_result"]["inserted_or_updated_events"] == 0
+    assert second_payload["refresh_result"]["changed_source_files"] == 0
+    assert second_payload["refresh_result"]["inserted_records"] == 0
+    assert second_payload["refresh_result"]["affected_threads"] == 0
+    assert second_payload["refresh_result"]["skipped_downstream_work"] is True
+    assert usage_impact_cache.invalidations == 1
+    assert usage_impact_cache.warms == 1
 
 
 def test_dashboard_history_scope_excludes_archived_rows_by_default(tmp_path: Path) -> None:

--- a/tests/test_store_dashboard_mcp.py
+++ b/tests/test_store_dashboard_mcp.py
@@ -36,6 +36,7 @@ from codex_usage_tracker.store import (
     schema_state,
     upsert_usage_events,
 )
+from codex_usage_tracker.store_query_sql import _thread_key_expression
 
 
 def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
@@ -105,6 +106,44 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert any(row["latest_record_id"] for row in source_rows)
     assert all(row["parser_state_json"] for row in source_rows)
     assert "SECRET RAW PROMPT" not in json.dumps(source_rows)
+
+
+def test_noop_refresh_skips_parser_upsert_and_downstream_rebuilds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+
+    first = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    def fail_if_called(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("no-op refresh should not parse or rebuild downstream models")
+
+    monkeypatch.setattr(
+        store_module,
+        "parse_usage_events_from_file_with_state",
+        fail_if_called,
+    )
+    monkeypatch.setattr(store_module, "_upsert_usage_events_with_delta", fail_if_called)
+    monkeypatch.setattr(store_module, "refresh_usage_event_links_for_threads", fail_if_called)
+    monkeypatch.setattr(store_module, "rebuild_thread_summaries", fail_if_called)
+
+    second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    metadata = refresh_metadata(db_path)
+
+    assert first.parsed_events == 4
+    assert second.parsed_events == 0
+    assert second.inserted_or_updated_events == 0
+    assert second.changed_source_files == 0
+    assert second.append_source_files == 0
+    assert second.full_reparse_source_files == 0
+    assert second.inserted_records == 0
+    assert second.deleted_records == 0
+    assert second.affected_threads == 0
+    assert second.skipped_downstream_work is True
+    assert metadata["parsed_source_files"] == "0"
+    assert metadata["skipped_source_files"] == "3"
 
 
 def test_latest_observed_usage_prefers_normal_codex_limit_pool(tmp_path: Path) -> None:
@@ -302,7 +341,37 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
         "parse_usage_events_from_file_with_state",
         tracking_parse,
     )
+    link_calls: list[set[str]] = []
+    summary_calls: list[set[str] | None] = []
+    original_link_refresh = store_module.refresh_usage_event_links_for_threads
+    original_summary_rebuild = store_module.rebuild_thread_summaries
+
+    def tracking_link_refresh(conn: sqlite3.Connection, thread_keys: object) -> int:
+        normalized = set(thread_keys) if thread_keys is not None else set()
+        link_calls.append(normalized)
+        return original_link_refresh(conn, thread_keys)  # type: ignore[arg-type]
+
+    def tracking_summary_rebuild(
+        conn: sqlite3.Connection,
+        *,
+        thread_keys: object = None,
+    ) -> int:
+        normalized = set(thread_keys) if thread_keys is not None else None
+        summary_calls.append(normalized)
+        return original_summary_rebuild(conn, thread_keys=thread_keys)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(store_module, "refresh_usage_event_links_for_threads", tracking_link_refresh)
+    monkeypatch.setattr(store_module, "rebuild_thread_summaries", tracking_summary_rebuild)
+
     second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    partial_link_calls = list(link_calls)
+    partial_summary_calls = list(summary_calls)
+    affected_keys = link_calls[0] if link_calls else set()
+    before_full_repair_links = _thread_link_snapshot(db_path, affected_keys)
+    before_full_repair_summaries = _thread_summary_snapshot(db_path, affected_keys)
+    store_module.refresh_usage_event_links(db_path)
+    after_full_repair_links = _thread_link_snapshot(db_path, affected_keys)
+    after_full_repair_summaries = _thread_summary_snapshot(db_path, affected_keys)
     third = refresh_usage_index(codex_home=codex_home, db_path=db_path)
     rows = query_session_usage(db_path=db_path, session_id=SESSION_ID)
     metadata = refresh_metadata(db_path)
@@ -318,7 +387,19 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
     assert parse_calls[0]["initial_state"] is not None
     assert second.parsed_events == 1
     assert second.inserted_or_updated_events == 1
+    assert second.changed_source_files == 1
+    assert second.append_source_files == 1
+    assert second.full_reparse_source_files == 0
+    assert second.inserted_records == 1
+    assert second.deleted_records == 0
+    assert second.affected_threads == 1
+    assert second.skipped_downstream_work is False
+    assert partial_link_calls == [{"thread:Add Codex token tracking"}]
+    assert partial_summary_calls == [{"thread:Add Codex token tracking"}]
+    assert before_full_repair_links == after_full_repair_links
+    assert before_full_repair_summaries == after_full_repair_summaries
     assert third.parsed_events == 0
+    assert third.skipped_downstream_work is True
     assert [row["cumulative_total_tokens"] for row in rows] == [100, 300, 650]
     assert metadata["parsed_source_files"] == "0"
     assert metadata["skipped_source_files"] == "3"
@@ -374,6 +455,72 @@ def test_refresh_replaces_source_when_parser_adapter_changes(
             (str(log_path),),
         ).fetchone()
     assert source_after["parser_adapter"] == PARSER_ADAPTER_VERSION
+
+
+def test_full_reparse_invalidates_old_and_new_thread_summaries(tmp_path: Path) -> None:
+    session_id = "019e37d5-f19f-7e4d-84cb-50894143c002"
+    codex_home = tmp_path / ".codex"
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "17"
+        / f"rollout-2026-05-17T19-00-00-{session_id}.jsonl"
+    )
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [
+            {
+                "id": session_id,
+                "thread_name": "Original thread",
+                "updated_at": "2026-05-17T19:00:00Z",
+            }
+        ],
+    )
+    _write_jsonl(
+        log_path,
+        [
+            _entry("session_meta", {"id": session_id}),
+            _entry("turn_context", {"turn_id": "turn-a", "model": "gpt-5.5"}),
+            _token_event(100, 100),
+        ],
+    )
+    db_path = tmp_path / "usage.sqlite3"
+
+    first = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [
+            {
+                "id": session_id,
+                "thread_name": "Replacement thread",
+                "updated_at": "2026-05-17T19:05:00Z",
+            }
+        ],
+    )
+    with connect(db_path) as conn:
+        init_db(conn)
+        conn.execute(
+            "UPDATE source_files SET parser_adapter = ? WHERE source_file = ?",
+            ("codex-jsonl-v1", str(log_path)),
+        )
+
+    second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    summaries = query_thread_summaries(db_path=db_path, limit=0)
+    summary_keys = {row["thread_key"] for row in summaries}
+
+    assert first.parsed_events == 1
+    assert second.parsed_events == 1
+    assert second.changed_source_files == 1
+    assert second.append_source_files == 0
+    assert second.full_reparse_source_files == 1
+    assert second.inserted_records == 1
+    assert second.deleted_records == 1
+    assert second.affected_threads == 2
+    assert second.skipped_downstream_work is False
+    assert "thread:Original thread" not in summary_keys
+    assert "thread:Replacement thread" in summary_keys
 
 
 def test_append_cursor_preserves_pending_call_origin_between_refreshes(
@@ -773,6 +920,63 @@ def test_thread_summaries_keep_active_and_all_history_scopes_separate(
     assert sum(row["call_count"] for row in all_summaries) == 5
     assert sum(row["archived_call_count"] for row in active_summaries) == 0
     assert sum(row["archived_call_count"] for row in all_summaries) == 1
+
+
+def _thread_link_snapshot(db_path: Path, thread_keys: set[str]) -> list[dict[str, object]]:
+    if not thread_keys:
+        return []
+    placeholders = ", ".join("?" for _key in thread_keys)
+    thread_key_expr = _thread_key_expression()
+    with connect(db_path) as conn:
+        init_db(conn)
+        rows = conn.execute(
+            f"""
+            SELECT record_id, thread_call_index, previous_record_id, next_record_id
+            FROM usage_events
+            WHERE {thread_key_expr} IN ({placeholders})
+            ORDER BY record_id
+            """,
+            sorted(thread_keys),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _thread_summary_snapshot(db_path: Path, thread_keys: set[str]) -> list[dict[str, object]]:
+    if not thread_keys:
+        return []
+    placeholders = ", ".join("?" for _key in thread_keys)
+    with connect(db_path) as conn:
+        init_db(conn)
+        rows = conn.execute(
+            f"""
+            SELECT
+                thread_key,
+                is_archived_scope,
+                thread_label,
+                first_event_timestamp,
+                latest_event_timestamp,
+                call_count,
+                session_count,
+                input_tokens,
+                cached_input_tokens,
+                uncached_input_tokens,
+                output_tokens,
+                reasoning_output_tokens,
+                total_tokens,
+                avg_cache_ratio,
+                max_context_window_percent,
+                max_recommendation_score,
+                primary_recommendation,
+                call_initiator_summary,
+                archived_call_count
+            FROM thread_summaries
+            WHERE thread_key IN ({placeholders})
+            ORDER BY thread_key, is_archived_scope
+            """,
+            sorted(thread_keys),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
 
 def test_dashboard_query_limit_zero_loads_all_rows(tmp_path: Path) -> None:
     codex_home = _make_codex_home(tmp_path)


### PR DESCRIPTION
## Summary
- commits the live dashboard status-poll refresh behavior as the first logical slice
- brings in the refresh-delta foundation so no-op refreshes skip downstream work and append refreshes update only affected thread read models
- exposes additive refresh delta counts through token-protected status refresh payloads
- avoids usage-impact cache invalidation/warming on no-op status refreshes
- teaches live polling to ignore no-op refreshes and only reset visible rows for append/full-reparse changes

## Validation
- .venv/bin/python -m pytest tests/test_dashboard_server.py::test_dashboard_status_live_refresh_parses_appended_events_incrementally tests/test_dashboard_server.py::test_dashboard_server_usage_api_refreshes_aggregate_rows -q
- .venv/bin/python -m pytest tests/test_store_migrations.py tests/test_dashboard_server.py tests/test_dashboard_payload.py -q
- .venv/bin/python -m pytest tests/test_store_dashboard_mcp.py -q
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy
- for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "" || exit 1; done
- .venv/bin/python -m pytest
- .venv/bin/python -m compileall src
- .venv/bin/python scripts/check_release.py
- git diff --check
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- .venv/bin/python scripts/check_release.py --dist