### PR TITLE
Fix live row hydration retry loop

### DIFF
--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard.js
@@ -445,11 +445,19 @@
       callAdjacencyByRecordId = buildCallAdjacencyIndex(indexedRows);
     }
     function mergedRows(existingRows, nextRows) {
-      const seen = new Set(existingRows.map(row => row.record_id).filter(Boolean));
       const merged = [...existingRows];
+      const indexesByRecordId = new Map();
+      existingRows.forEach((row, index) => {
+        if (row?.record_id) indexesByRecordId.set(row.record_id, index);
+      });
       for (const row of nextRows) {
-        if (!row?.record_id || seen.has(row.record_id)) continue;
-        seen.add(row.record_id);
+        if (!row?.record_id) continue;
+        if (indexesByRecordId.has(row.record_id)) {
+          const index = indexesByRecordId.get(row.record_id);
+          merged[index] = { ...merged[index], ...row };
+          continue;
+        }
+        indexesByRecordId.set(row.record_id, merged.length);
         merged.push(row);
       }
       return merged;

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_cells.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_cells.js
@@ -200,7 +200,7 @@
       if (!weekly && !primary) {
         if (row?.usage_impact_pending) {
           const title = `${t('state.loading')}: usage-impact calibration is running in the background. ${t('allowance.observed_source_hint')}`;
-          return `<span class="metric-stack usage-impact-cell muted" ${tooltipAttributes(title)}><span>${escapeHtml(t('state.loading'))}</span></span>`;
+          return `<span class="metric-stack usage-impact-cell muted" ${tooltipAttributes(title)}><span>-</span></span>`;
         }
         const limitId = String(row?.rate_limit_limit_id || '').trim();
         if (limitId && limitId !== 'codex') {

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -127,8 +127,8 @@
       usageImpactRetryTimer = window.setTimeout(() => {
         usageImpactRetryTimer = null;
         usageImpactRetryAttempts += 1;
-        hydrateDashboardRows({ reset: true, usageImpactRetry: true });
-      }, 1200);
+        refreshLoadedUsageImpactRows();
+      }, Math.min(5000, 1200 + (usageImpactRetryAttempts * 600)));
     }
 
     function refreshResultNumber(result, key) {
@@ -200,6 +200,28 @@
       const payload = await response.json();
       if (payload.error) throw new Error(payload.error);
       return payload;
+    }
+
+    async function refreshLoadedUsageImpactRows() {
+      if (!liveRefreshSupported || activeView() === 'call' || !getData().length) return;
+      if (rowHydrationInFlight) {
+        scheduleUsageImpactRetry();
+        return;
+      }
+      try {
+        const limit = Math.max(1, Math.min(getData().length, initialHydrationChunkSize || 500));
+        const payload = await fetchCallRows(limit, 0);
+        applyDashboardPayload(payload, { appendRows: true });
+        if (payload.usage_impact_pending) {
+          scheduleUsageImpactRetry();
+        } else {
+          usageImpactRetryAttempts = 0;
+        }
+        render();
+      } catch (_error) {
+        // Usage-impact estimates are supplemental. Row hydration and live
+        // refresh must stay usable even if this background update fails.
+      }
     }
 
     async function refreshAppendedRows(refreshResult, scopedRows) {

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -231,6 +231,117 @@ console.log(JSON.stringify({
     assert payload["appliedPayloads"][0]["appendRows"] is True
 
 
+def test_live_usage_impact_retry_updates_loaded_rows_without_rehydrating_table() -> None:
+    payload = _run_dashboard_live_script(
+        """
+let data = [];
+let requestUrls = [];
+let resetCalls = 0;
+let renderCount = 0;
+let fetchIndex = 0;
+const responses = [
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [
+        { record_id: 'a', usage_impact_pending: true, usage_impact: { primary: null, secondary: null } },
+        { record_id: 'b', usage_impact_pending: true, usage_impact: { primary: null, secondary: null } },
+      ],
+      row_count: 2,
+      total_matched_rows: 2,
+      has_more: false,
+      usage_impact_pending: true,
+    }),
+  },
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [
+        { record_id: 'a', usage_impact: { primary: null, secondary: { estimate_percent: 0.123 } } },
+        { record_id: 'b', usage_impact: { primary: null, secondary: { estimate_percent: 0.456 } } },
+      ],
+      row_count: 2,
+      total_matched_rows: 2,
+      has_more: false,
+      usage_impact_pending: false,
+    }),
+  },
+];
+context.fetch = async url => {
+  requestUrls.push(String(url));
+  return responses[fetchIndex++];
+};
+const runtime = helpers.create({
+  activeView: () => 'calls',
+  apiToken: () => 'token',
+  applyDashboardPayload: (payload, options = {}) => {
+    if (!options.appendRows) {
+      data = payload.rows || [];
+      return;
+    }
+    const indexById = new Map(data.map((row, index) => [row.record_id, index]));
+    for (const row of payload.rows || []) {
+      if (indexById.has(row.record_id)) {
+        data[indexById.get(row.record_id)] = { ...data[indexById.get(row.record_id)], ...row };
+      } else {
+        indexById.set(row.record_id, data.length);
+        data.push(row);
+      }
+    }
+  },
+  autoRefreshEl: { checked: true },
+  formatTimestamp: value => String(value || ''),
+  getData: () => data,
+  getIncludeArchived: () => true,
+  getLoadedLimit: () => null,
+  getTotalAvailableRows: () => 2,
+  getArchivedAvailableRows: () => 0,
+  historyScopeEl: { value: 'all', parentElement: {} },
+  initialHydrationChunkSize: 2,
+  backgroundHydrationChunkSize: 2,
+  i18n: { currentLanguage: 'en' },
+  liveRefreshIntervalMs: 10000,
+  liveRefreshSupported: true,
+  loadLimitEl: { value: 'all', options: [], insertBefore: () => {}, lastElementChild: null },
+  limitValue: value => value === null ? 'all' : String(value),
+  number: { format: value => String(value) },
+  payloadRows: payload => payload.rows || [],
+  rebuildDashboardIndexes: () => {},
+  rebuildFilterOptions: () => {},
+  refreshDashboardEl: { disabled: false },
+  render: () => { renderCount += 1; },
+  resetRowsForHydration: () => { resetCalls += 1; data = []; },
+  rowLoadProgressBarEl: { style: {} },
+  rowLoadProgressCountEl: { textContent: '' },
+  rowLoadProgressEl: { hidden: true },
+  rowLoadProgressLabelEl: { textContent: '' },
+  setFastTooltip: () => {},
+  setObservedUsage: () => {},
+  t: key => key,
+  tf: (key, values) => `${key}:${JSON.stringify(values || {})}`,
+  updateLiveStatus: () => {},
+});
+await runtime.hydrateDashboardRows();
+await new Promise(resolve => setTimeout(resolve, 2100));
+console.log(JSON.stringify({
+  requestUrls,
+  resetCalls,
+  renderCount,
+  data,
+}));
+"""
+    )
+
+    assert payload["resetCalls"] == 0
+    assert payload["renderCount"] >= 1
+    assert len(payload["requestUrls"]) == 2
+    assert all(url.startswith("/api/calls?") for url in payload["requestUrls"])
+    assert payload["data"][0]["record_id"] == "a"
+    assert payload["data"][0]["usage_impact"]["secondary"]["estimate_percent"] == 0.123
+
+
 def test_live_refresh_auth_failure_stops_polling_and_surfaces_error() -> None:
     payload = _run_dashboard_live_script(
         """


### PR DESCRIPTION
## Summary
- Prevent usage-impact retry from resetting and rehydrating the full row table.
- Merge retry results into already-loaded rows by record id so background estimates can update in place.
- Show pending usage-impact cells as a quiet dash with tooltip instead of table-wide `Loading` text.

## Verification
- Browser-tested the live dashboard at http://127.0.0.1:8900/dashboard.html with all-history data; rows hydrated, progress hid after completion, and no console errors appeared.
- `.venv/bin/python -m pytest tests/test_dashboard_data.py tests/test_dashboard_server.py tests/test_dashboard_payload.py -q`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m compileall src`
- `.venv/bin/python scripts/check_release.py`
- `.venv/bin/python -m build && .venv/bin/python scripts/check_release.py --dist && .venv/bin/python -m twine check dist/*`
- `git diff --check`