### PR TITLE
Persist usage impact read model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Make refresh delta-aware so no-op refreshes skip downstream adjacency and
   thread-summary rebuild work, and append refreshes update only affected thread
   read models.
+- Warm usage-impact estimates only for pending/stale affected records after live
+  refreshes, and keep investigator allowance-impact estimates separate from
+  exact token accounting.
 
 ## 0.6.1 - 2026-06-13
 

--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -46,6 +46,8 @@ Tracked schema ids:
 | `codex-usage-tracker-reset-db-v1` | CLI `reset-db --yes --json` |
 | `codex-usage-tracker-summary-v1` | CLI `summary --json`, CLI `expensive --json`, MCP summary/expensive JSON |
 | `codex-usage-tracker-query-v1` | CLI `query`, MCP `usage_query(...)` |
+| `codex-usage-tracker-usage-impact-v1` | CLI `usage-impact --json`, dashboard server `/api/usage-impact`, `/api/call` usage-impact payload |
+| `codex-usage-tracker-usage-impact-estimate-v1` | Nested dashboard row `usage_impact.primary` and `usage_impact.secondary` estimate objects |
 | `codex-usage-tracker-recommendations-v1` | CLI `recommendations --json`, MCP `usage_recommendations(response_format="json")` |
 | `codex-usage-tracker-session-v1` | CLI `session --json`, MCP `session_usage(response_format="json")` |
 | `codex-usage-tracker-context-v1` | CLI `context`, MCP `usage_call_context` when raw context is explicitly enabled |
@@ -161,6 +163,34 @@ Supported filters:
 - `privacy_mode`: `normal`, `redacted`, or `strict`
 
 Privacy mode affects returned metadata after matching rows. `redacted` hides raw cwd/source paths, hides Git remote labels, and hashes unnamed project names. `strict` also hides project-relative cwd, Git branch, and tags. Configured project aliases are treated as explicit display opt-ins.
+
+## Usage Impact
+
+Command:
+
+```bash
+codex-usage-tracker usage-impact --record-id <record-id> --json
+```
+
+Dashboard API:
+
+- `/api/usage-impact?record_id=<record-id>`
+- `/api/call?record_id=<record-id>` includes a nested `usage_impact` payload
+
+Schema: `codex-usage-tracker-usage-impact-v1`
+
+```json
+{
+  "schema": "codex-usage-tracker-usage-impact-v1",
+  "record_id": "record-123",
+  "limit": 100,
+  "row_count": 2,
+  "rows": [],
+  "raw_context_included": false
+}
+```
+
+Rows are derived from local observed Codex usage snapshots and the configured/local Codex credit estimate. They are useful for comparing likely per-call allowance movement, but they are not exact billing data and may exclude usage outside local Codex logs.
 
 ## Recommendations
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -119,11 +119,14 @@ Useful investigations:
 codex-usage-tracker query --since 2026-06-01 --project codex-usage-tracker --min-credits 1
 codex-usage-tracker query --pricing-status unpriced --limit 0
 codex-usage-tracker recommendations --since 2026-06-01 --json
+codex-usage-tracker usage-impact --record-id <record-id> --json
 codex-usage-tracker summary --group-by model --json
 codex-usage-tracker session <session-id> --json
 ```
 
 Use `query` when you need stable JSON for automation across project, model, effort, thread, pricing, token, or credit filters.
+
+Use `usage-impact` when you need the persisted, derived estimate of how a selected call likely moved observed Codex usage windows. By default it rebuilds the local read model first; add `--no-rebuild` to inspect the current table only. Use `--window-type primary` or `--window-type secondary` to isolate one observed window. These rows are estimates from local observed rate-limit snapshots and Codex credit weights, not exact billing impact.
 
 ## Session And Context
 

--- a/docs/roadmap/usage-impact-read-model.md
+++ b/docs/roadmap/usage-impact-read-model.md
@@ -1,0 +1,88 @@
+# Usage Impact Read Model Roadmap
+
+Branch: `refactor/usage-impact-read-model`
+Base: `perf/parallel-refresh-indexing` after source-byte-offset context seek.
+
+## Goals
+
+- Create or harden a derived usage-impact read model for observed allowance/rate-limit movement per call and window.
+- Keep exact observed rate-limit facts separate from inferred per-call allocation.
+- Use refresh deltas so no-op refreshes do not recalculate usage impact and append refreshes touch only affected/adjacent records.
+- Expose usage-impact data through stable CLI/API/dashboard surfaces without claiming exact billing truth.
+
+## Non-Goals
+
+- No Sessions tab.
+- No task receipts.
+- No frontend rewrite.
+- No exact billing claims.
+- No raw prompt, assistant, tool output, raw JSONL, compaction replacement text, or reconstructed transcript persistence.
+- No publishing, tagging, or main-branch merge.
+
+## Privacy Constraints
+
+- Persist only aggregate counters, ids, timestamps, limit metadata, confidence/status labels, and derived numeric estimates.
+- Do not store raw commands or command output by default.
+- Raw evidence remains explicit, redacted, on-demand, and not written back to SQLite or generated dashboard HTML.
+
+## Schema / Read Model
+
+Target `usage_impact` table fields:
+
+- `record_id TEXT NOT NULL`
+- `window_type TEXT NOT NULL` (`primary`, `secondary`)
+- `plan_type TEXT`
+- `limit_id TEXT`
+- `observed_used_percent REAL`
+- `observed_window_minutes INTEGER`
+- `observed_resets_at INTEGER`
+- `previous_observed_record_id TEXT`
+- `previous_observed_used_percent REAL`
+- `next_observed_record_id TEXT`
+- `delta_used_percent REAL`
+- `tokens_since_previous INTEGER`
+- `estimated_tokens_per_percent REAL`
+- `estimated_usage_credits REAL`
+- `confidence TEXT NOT NULL` (`high`, `medium`, `low`, `unknown`)
+- `status TEXT NOT NULL` (`fresh`, `pending`, `stale`, `unavailable`)
+- `reason TEXT`
+- `recalculated_at TEXT NOT NULL`
+- primary key: `(record_id, window_type)`
+
+## Implementation Checklist
+
+- [ ] M0: Add this roadmap/checklist before implementation.
+- [ ] M1: Audit existing usage-impact code and mark what already satisfies this roadmap.
+- [ ] M2: Add or repair `usage_impact` schema, migration, indexes, and repair behavior.
+- [ ] M3: Add calculator behavior for observed primary/secondary deltas and confidence/status labels.
+- [ ] M4: Wire refresh-delta invalidation so no-op skips work and append/full-reparse rebuild affected intervals only.
+- [ ] M5: Expose usage-impact CLI/API/call payload contracts with schema id `codex-usage-tracker-usage-impact-v1`.
+- [ ] M6: Add compact dashboard call-detail chips without exact-billing language.
+- [ ] M7: Add focused tests for windows, pools, no-op, append, ambiguity, JSON contracts, and privacy.
+- [ ] M8: Run validation and benchmarks.
+- [ ] M9: Commit, push, and open the branch PR without merging to `main`.
+
+## Tests
+
+- Primary and secondary windows remain separate.
+- Compatible limit pools are compared; ambiguous pools are pending or low confidence.
+- Adjacent observed intervals update when one record changes.
+- No-op refresh does not invalidate/recalculate usage impact.
+- Append refresh updates only inserted/affected adjacent observed intervals.
+- JSON contracts expose no raw content.
+- Privacy tests prove no raw content is persisted.
+
+## Validation
+
+- `python -m pytest tests/test_usage_impact.py`
+- `python -m pytest tests/test_usage_impact_cache.py`
+- `python -m pytest tests/test_store_dashboard_mcp.py`
+- `python -m pytest tests/test_json_contracts.py`
+- `python -m pytest tests/test_privacy.py`
+- `python scripts/check_release.py`
+- broader branch validation before PR.
+
+## Known Caveats
+
+- Usage impact is estimated from observed local Codex rate-limit snapshots and may exclude external usage or rounded snapshot changes.
+- Confidence/status must communicate uncertainty; never call inferred per-call impact exact billing impact.

--- a/docs/roadmap/usage-impact-read-model.md
+++ b/docs/roadmap/usage-impact-read-model.md
@@ -61,17 +61,17 @@ Target `usage_impact` table fields:
 - [x] M1: Audit existing usage-impact code and mark what already satisfies this roadmap.
 - [x] M2: Add or repair `usage_impact` schema, migration, indexes, and repair behavior.
 - [x] M3: Add calculator behavior for observed primary/secondary deltas and confidence/status labels.
-- [ ] M4: Wire refresh-delta invalidation so no-op skips work and append/full-reparse rebuild affected intervals only.
+- [x] M4: Wire refresh-delta invalidation so no-op skips work and append/full-reparse rebuild affected intervals only.
 - [x] M5: Expose usage-impact CLI/API/call payload contracts with schema id `codex-usage-tracker-usage-impact-v1`.
-- [ ] M6: Add compact dashboard call-detail chips without exact-billing language.
+- [x] M6: Add compact dashboard call-detail chips without exact-billing language.
 - [x] M7: Add focused tests for windows, pools, no-op, append, ambiguity, JSON contracts, and privacy.
 - [x] M8: Run validation and benchmarks.
 - [ ] M9: Commit, push, and open the branch PR without merging to `main`.
 
 Progress notes:
 
-- M4 is partially implemented: refresh deltas now delete stale records, insert pending rows for newly appended records, and no-op refreshes avoid usage-impact invalidation. Recalculating only affected observed intervals remains open; the current cache rebuild still materializes from full-history rows when a recalculation is needed.
-- M6 is partially implemented through existing dashboard usage-impact cells and call payload exposure. The final call-detail presentation still needs a focused UI pass after the persistent read model is stable.
+- M4 is implemented: refresh deltas delete stale records, insert pending rows for newly appended records, no-op refreshes avoid usage-impact invalidation, and live refreshes warm only pending/stale/missing usage-impact record ids instead of immediately scheduling a full-history read-model rebuild. Targeted recalculation still uses full aggregate context for estimator correctness, but only affected read-model rows are replaced.
+- M6 is implemented: the call investigator now keeps exact token accounting separate from estimated allowance impact and presents compact weekly/5h impact cards with derived/on-demand wording instead of exact-billing language.
 
 ## Tests
 

--- a/docs/roadmap/usage-impact-read-model.md
+++ b/docs/roadmap/usage-impact-read-model.md
@@ -66,12 +66,13 @@ Target `usage_impact` table fields:
 - [x] M6: Add compact dashboard call-detail chips without exact-billing language.
 - [x] M7: Add focused tests for windows, pools, no-op, append, ambiguity, JSON contracts, and privacy.
 - [x] M8: Run validation and benchmarks.
-- [ ] M9: Commit, push, and open the branch PR without merging to `main`.
+- [x] M9: Commit, push, and open the branch PR without merging to `main`.
 
 Progress notes:
 
 - M4 is implemented: refresh deltas delete stale records, insert pending rows for newly appended records, no-op refreshes avoid usage-impact invalidation, and live refreshes warm only pending/stale/missing usage-impact record ids instead of immediately scheduling a full-history read-model rebuild. Targeted recalculation still uses full aggregate context for estimator correctness, but only affected read-model rows are replaced.
 - M6 is implemented: the call investigator now keeps exact token accounting separate from estimated allowance impact and presents compact weekly/5h impact cards with derived/on-demand wording instead of exact-billing language.
+- M9 is complete on PR #39, targeting `perf/parallel-refresh-indexing`; this branch is not merged to `main`.
 
 ## Tests
 

--- a/docs/roadmap/usage-impact-read-model.md
+++ b/docs/roadmap/usage-impact-read-model.md
@@ -43,6 +43,12 @@ Target `usage_impact` table fields:
 - `tokens_since_previous INTEGER`
 - `estimated_tokens_per_percent REAL`
 - `estimated_usage_credits REAL`
+- `estimated_usage_percent REAL`
+- `lower_percent REAL`
+- `upper_percent REAL`
+- `basis TEXT`
+- `source TEXT`
+- `interval_call_count INTEGER`
 - `confidence TEXT NOT NULL` (`high`, `medium`, `low`, `unknown`)
 - `status TEXT NOT NULL` (`fresh`, `pending`, `stale`, `unavailable`)
 - `reason TEXT`
@@ -51,16 +57,21 @@ Target `usage_impact` table fields:
 
 ## Implementation Checklist
 
-- [ ] M0: Add this roadmap/checklist before implementation.
-- [ ] M1: Audit existing usage-impact code and mark what already satisfies this roadmap.
-- [ ] M2: Add or repair `usage_impact` schema, migration, indexes, and repair behavior.
-- [ ] M3: Add calculator behavior for observed primary/secondary deltas and confidence/status labels.
+- [x] M0: Add this roadmap/checklist before implementation.
+- [x] M1: Audit existing usage-impact code and mark what already satisfies this roadmap.
+- [x] M2: Add or repair `usage_impact` schema, migration, indexes, and repair behavior.
+- [x] M3: Add calculator behavior for observed primary/secondary deltas and confidence/status labels.
 - [ ] M4: Wire refresh-delta invalidation so no-op skips work and append/full-reparse rebuild affected intervals only.
-- [ ] M5: Expose usage-impact CLI/API/call payload contracts with schema id `codex-usage-tracker-usage-impact-v1`.
+- [x] M5: Expose usage-impact CLI/API/call payload contracts with schema id `codex-usage-tracker-usage-impact-v1`.
 - [ ] M6: Add compact dashboard call-detail chips without exact-billing language.
-- [ ] M7: Add focused tests for windows, pools, no-op, append, ambiguity, JSON contracts, and privacy.
-- [ ] M8: Run validation and benchmarks.
+- [x] M7: Add focused tests for windows, pools, no-op, append, ambiguity, JSON contracts, and privacy.
+- [x] M8: Run validation and benchmarks.
 - [ ] M9: Commit, push, and open the branch PR without merging to `main`.
+
+Progress notes:
+
+- M4 is partially implemented: refresh deltas now delete stale records, insert pending rows for newly appended records, and no-op refreshes avoid usage-impact invalidation. Recalculating only affected observed intervals remains open; the current cache rebuild still materializes from full-history rows when a recalculation is needed.
+- M6 is partially implemented through existing dashboard usage-impact cells and call payload exposure. The final call-detail presentation still needs a focused UI pass after the persistent read model is stable.
 
 ## Tests
 

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -45,6 +45,7 @@ CLI_HELP_SUBCOMMANDS = [
     "reset-db",
     "summary",
     "query",
+    "usage-impact",
     "recommendations",
     "session",
     "context",

--- a/src/codex_usage_tracker/cli.py
+++ b/src/codex_usage_tracker/cli.py
@@ -58,6 +58,11 @@ from codex_usage_tracker.store import (
     reset_usage_database,
 )
 from codex_usage_tracker.support import build_support_bundle
+from codex_usage_tracker.usage_impact_cache import UsageImpactCache
+from codex_usage_tracker.usage_impact_store import (
+    query_usage_impact_rows,
+    usage_impact_payload,
+)
 
 
 def main() -> int:
@@ -361,6 +366,44 @@ def _run_query(args: argparse.Namespace) -> int:
         privacy_mode=args.privacy_mode,
     )
     _print_json(report.payload)
+    return 0
+
+
+def _run_usage_impact(args: argparse.Namespace) -> int:
+    if not args.no_rebuild:
+        cache = UsageImpactCache(
+            db_path=args.db,
+            pricing_path=args.pricing,
+            allowance_path=args.allowance,
+            rate_card_path=args.rate_card,
+        )
+        cache.rebuild(include_archived=args.include_archived)
+    rows = query_usage_impact_rows(
+        db_path=args.db,
+        record_id=args.record_id,
+        limit=args.limit,
+        offset=args.offset,
+        window_type=args.window_type,
+    )
+    payload = usage_impact_payload(
+        rows,
+        record_id=args.record_id,
+        limit=None if args.limit <= 0 else args.limit,
+    )
+    if args.as_json:
+        _print_json(payload)
+        return 0
+    if not rows:
+        print("No usage-impact rows found.")
+        return 0
+    for row in rows:
+        estimate = row.get("estimated_usage_percent")
+        label = row.get("window_type")
+        estimate_text = "-" if estimate is None else f"~{float(estimate):.3f}%"
+        print(
+            f"{row['record_id']} {label}: {estimate_text} "
+            f"({row['status']}, {row['confidence']})"
+        )
     return 0
 
 
@@ -804,6 +847,7 @@ _COMMAND_HANDLERS = {
     "reset-db": _run_reset_db,
     "summary": _run_summary,
     "query": _run_query,
+    "usage-impact": _run_usage_impact,
     "recommendations": _run_recommendations,
     "session": _run_session,
     "context": _run_context,

--- a/src/codex_usage_tracker/cli_parser.py
+++ b/src/codex_usage_tracker/cli_parser.py
@@ -69,6 +69,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_reset_db_parser(subparsers)
     _add_summary_parser(subparsers)
     _add_query_parser(subparsers)
+    _add_usage_impact_parser(subparsers)
     _add_recommendations_parser(subparsers)
     _add_session_parser(subparsers)
     _add_context_parser(subparsers)
@@ -261,6 +262,39 @@ def _add_query_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
         dest="as_json",
         help="Accepted for consistency; query always returns JSON.",
     )
+
+
+def _add_usage_impact_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    usage_impact = subparsers.add_parser(
+        "usage-impact",
+        help="Show estimated usage-impact read-model rows",
+    )
+    usage_impact.add_argument("--record-id", help="Only include one aggregate usage record")
+    usage_impact.add_argument(
+        "--window-type",
+        choices=("primary", "secondary"),
+        help="Only include one observed usage window type.",
+    )
+    usage_impact.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum read-model rows to return; use 0 for all",
+    )
+    usage_impact.add_argument("--offset", type=int, default=0)
+    usage_impact.add_argument(
+        "--include-archived",
+        action="store_true",
+        help="Include archived sessions when materializing usage-impact estimates.",
+    )
+    usage_impact.add_argument(
+        "--no-rebuild",
+        action="store_true",
+        help="Read the current table without rebuilding estimates first.",
+    )
+    usage_impact.add_argument("--json", action="store_true", dest="as_json")
 
 
 def _add_recommendations_parser(

--- a/src/codex_usage_tracker/json_contracts.py
+++ b/src/codex_usage_tracker/json_contracts.py
@@ -110,6 +110,34 @@ JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
+    "codex-usage-tracker-usage-impact-v1": {
+        "required": {
+            "record_id": (str, NoneType),
+            "limit": (int, NoneType),
+            "row_count": int,
+            "rows": list,
+            "raw_context_included": bool,
+        }
+    },
+    "codex-usage-tracker-usage-impact-estimate-v1": {
+        "required": {
+            "label": (str, NoneType),
+            "window_minutes": (int, NoneType),
+            "estimate_percent": (int, float, NoneType),
+            "lower_percent": (int, float, NoneType),
+            "upper_percent": (int, float, NoneType),
+            "observed_delta_percent": (int, float, NoneType),
+            "interval_call_count": (int, NoneType),
+            "basis": (str, NoneType),
+            "source": (str, NoneType),
+            "plan_type": (str, NoneType),
+            "limit_id": (str, NoneType),
+            "resets_at": (int, NoneType),
+            "confidence": (str, NoneType),
+            "status": (str, NoneType),
+            "reason": (str, NoneType),
+        }
+    },
     "codex-usage-tracker-recommendations-v1": {
         "required": {
             "filters": dict,
@@ -203,6 +231,7 @@ JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "record": dict,
             "previous_record_id": (str, NoneType),
             "next_record_id": (str, NoneType),
+            "usage_impact": dict,
             "raw_context_included": bool,
         }
     },

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_call_investigator.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_call_investigator.js
@@ -344,11 +344,20 @@
                   ${callMetricCard(t('metric.uncached_input'), number.format(uncachedInputTokens(row)), t('call.exact_label'))}
                   ${callMetricCard(t('metric.output'), number.format(outputTokens(row)), t('metric.reasoning_output'))}
                   ${callMetricCard(t('table.initiated'), callInitiatorText(row), t('call.exact_label'))}
-                  ${callMetricCard(t('table.usage_impact'), usageImpactValue(row, 'secondary'), usageImpactSubtitle(row, 'secondary'))}
-                  ${callMetricCard('5h', usageImpactValue(row, 'primary'), usageImpactSubtitle(row, 'primary'))}
                   ${callMetricCard(t('metric.estimated_cost'), moneyText(row.estimated_cost_usd), pricingStatusText(row))}
                   ${callMetricCard(t('metric.codex_credits'), creditsText(usageCreditValue(row)), usageCreditStatusLabel(row), usageCreditsWithStatus(row))}
                 </div>
+              </section>
+              <section class="call-diagnostic-section usage-impact">
+                <div class="section-heading compact">
+                  <h3>${escapeHtml(t('detail.allowance_impact'))}</h3>
+                  <span class="evidence-chip derived">${escapeHtml(t('call.derived_label'))}</span>
+                </div>
+                <div class="call-metric-grid">
+                  ${callMetricCard(t('table.usage_impact'), usageImpactValue(row, 'secondary'), usageImpactSubtitle(row, 'secondary'))}
+                  ${callMetricCard('5h', usageImpactValue(row, 'primary'), usageImpactSubtitle(row, 'primary'))}
+                </div>
+                <p class="muted">${escapeHtml(t('allowance.observed_source_hint'))}</p>
               </section>
               ${renderAggregateMetadata(row)}
               <section class="call-diagnostic-section delta">

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -362,11 +362,15 @@
           setObservedUsage(payload.observed_usage);
         }
         const refreshResult = payload.refresh_result || {};
+        const rowCountChanged = Number.isFinite(scopedRows) && scopedRows !== getTotalAvailableRows();
         if (refreshResultIsNoOp(refreshResult)) {
-          if (rowsNeedHydration()) hydrateDashboardRows();
+          if (rowCountChanged) {
+            await refreshAppendedRows(refreshResult, scopedRows);
+          } else if (rowsNeedHydration()) {
+            hydrateDashboardRows();
+          }
           return;
         }
-        const rowCountChanged = Number.isFinite(scopedRows) && scopedRows !== getTotalAvailableRows();
         if (refreshResultNeedsReset(refreshResult)) {
           refreshDashboardData(false, { refreshLogs: false, resetRows: true });
         } else if (refreshResultHasRowChanges(refreshResult) || rowCountChanged) {

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -40,6 +40,7 @@
     let refreshInFlight = false;
     let rowHydrationInFlight = false;
     let rowHydrationComplete = getData().length > 0;
+    let rowHydrationNextOffset = getData().length;
     let rowHydrationError = '';
     let rowHydrationGeneration = 0;
     let rowHydrationRestartRequested = false;
@@ -67,13 +68,13 @@
 
     function rowsNeedHydration() {
       const target = rowHydrationTarget();
-      return liveRefreshSupported && target > 0 && getData().length < target;
+      return liveRefreshSupported && !rowHydrationComplete && target > 0 && Math.max(getData().length, rowHydrationNextOffset) < target;
     }
 
     function updateRowLoadProgress() {
       if (!rowLoadProgressEl) return;
       const target = rowHydrationTarget();
-      const loaded = Math.min(getData().length, target || getData().length);
+      const loaded = Math.min(Math.max(getData().length, rowHydrationNextOffset), target || getData().length);
       const shouldShow = activeView() !== 'call' && liveRefreshSupported && (rowHydrationInFlight || rowsNeedHydration() || rowHydrationError);
       rowLoadProgressEl.hidden = !shouldShow;
       if (!shouldShow) return;
@@ -262,12 +263,14 @@
       const target = rowHydrationTarget();
       if (!target) {
         rowHydrationComplete = true;
+        rowHydrationNextOffset = 0;
         updateRowLoadProgress();
         return;
       }
       if (hydrateOptions.reset) {
         resetRowsForHydration();
         rowHydrationComplete = false;
+        rowHydrationNextOffset = 0;
         rowHydrationGeneration += 1;
         rebuildDashboardIndexes();
         rebuildFilterOptions();
@@ -275,6 +278,7 @@
       }
       if (getData().length >= target) {
         rowHydrationComplete = true;
+        rowHydrationNextOffset = Math.max(rowHydrationNextOffset, target);
         updateRowLoadProgress();
         return;
       }
@@ -282,12 +286,14 @@
       rowHydrationInFlight = true;
       rowHydrationError = '';
       let usageImpactPending = false;
+      let reachedEnd = false;
       updateLiveStatus('status.checking', t('live.loading_rows'));
       updateRowLoadProgress();
       try {
-        while (getData().length < target && generation === rowHydrationGeneration && activeView() !== 'call') {
-          const offset = getData().length;
+        while (Math.max(getData().length, rowHydrationNextOffset) < target && generation === rowHydrationGeneration && activeView() !== 'call') {
+          const offset = Math.max(0, rowHydrationNextOffset);
           const remaining = target - offset;
+          if (remaining <= 0) break;
           const chunkSize = Math.min(
             offset === 0 ? initialHydrationChunkSize : backgroundHydrationChunkSize,
             remaining,
@@ -296,12 +302,22 @@
           if (payload.usage_impact_pending) usageImpactPending = true;
           if (generation !== rowHydrationGeneration || activeView() === 'call') break;
           const rows = payloadRows(payload);
-          if (!rows.length) break;
+          if (!rows.length) {
+            reachedEnd = true;
+            break;
+          }
+          const nextOffset = Number(payload.next_offset);
+          rowHydrationNextOffset = Number.isFinite(nextOffset) && nextOffset > offset
+            ? nextOffset
+            : offset + rows.length;
           applyDashboardPayload(payload, { appendRows: true });
           updateRowLoadProgress();
-          if (!payload.has_more || rows.length < chunkSize) break;
+          if (!payload.has_more || rows.length < chunkSize) {
+            reachedEnd = true;
+            break;
+          }
         }
-        rowHydrationComplete = getData().length >= rowHydrationTarget();
+        rowHydrationComplete = reachedEnd || Math.max(getData().length, rowHydrationNextOffset) >= rowHydrationTarget();
         if (!usageImpactPending) usageImpactRetryAttempts = 0;
         updateLiveStatus(autoRefreshEl.checked ? 'badge.live' : 'status.updated', `${loadedRowsDescription()}. ${historyRowsDescription()}`);
       } catch (error) {
@@ -405,6 +421,7 @@
           resetRowsForHydration();
           rowHydrationGeneration += 1;
           rowHydrationComplete = false;
+          rowHydrationNextOffset = 0;
         }
         applyDashboardPayload(nextPayload);
         if (activeView() !== 'call') hydrateDashboardRows({ reset: resetRows });

--- a/src/codex_usage_tracker/server.py
+++ b/src/codex_usage_tracker/server.py
@@ -1012,6 +1012,7 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
             rows,
             include_archived=include_archived,
             block=False,
+            schedule_warm=False,
         )
         rows = annotate_rows_with_recommendations(rows, thresholds)
         rows = annotate_rows_with_project_identity(rows, projects)

--- a/src/codex_usage_tracker/server.py
+++ b/src/codex_usage_tracker/server.py
@@ -1106,7 +1106,7 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
             )
         if _refresh_result_invalidates_usage_impact(result):
             self._usage_impact_cache.invalidate()
-            self._usage_impact_cache.warm_async(include_archived=include_archived)
+            self._usage_impact_cache.warm_pending_async(include_archived=include_archived)
         payload = refresh_result_payload(
             result,
             schema="codex-usage-tracker-refresh-v1",

--- a/src/codex_usage_tracker/server.py
+++ b/src/codex_usage_tracker/server.py
@@ -70,6 +70,10 @@ from codex_usage_tracker.store import (
 )
 from codex_usage_tracker.threads import annotate_thread_attachments
 from codex_usage_tracker.usage_impact_cache import UsageImpactCache
+from codex_usage_tracker.usage_impact_store import (
+    query_usage_impact_rows,
+    usage_impact_payload,
+)
 
 _allowed_loopback_host = server_utils.allowed_loopback_host
 _elapsed_ms = server_utils.elapsed_ms
@@ -297,6 +301,9 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
             return
         if parsed.path == "/api/call":
             self._handle_call(parsed.query)
+            return
+        if parsed.path == "/api/usage-impact":
+            self._handle_usage_impact(parsed.query)
             return
         if parsed.path == "/api/threads":
             self._handle_threads(parsed.query)
@@ -682,6 +689,11 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
                 if candidate.get("record_id")
             }
             selected_row = rows_by_id.get(record_id, row)
+            usage_impact_rows = query_usage_impact_rows(
+                db_path=self._db_path,
+                record_id=record_id,
+                limit=0,
+            )
         except sqlite3.Error as exc:
             self._send_json(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -704,8 +716,47 @@ class _UsageDashboardHandler(SimpleHTTPRequestHandler):
                 ],
                 "previous_record_id": row.get("previous_record_id"),
                 "next_record_id": row.get("next_record_id"),
+                "usage_impact": usage_impact_payload(
+                    usage_impact_rows,
+                    record_id=record_id,
+                    limit=None,
+                ),
                 "raw_context_included": False,
             },
+        )
+
+    def _handle_usage_impact(self, query: str) -> None:
+        params = parse_qs(query)
+        record_id = _first(params.get("record_id")) or _first(params.get("record"))
+        limit = _parse_api_limit(_first(params.get("limit")), 100)
+        offset = _parse_api_offset(_first(params.get("offset")))
+        window_type = _first(params.get("window_type"))
+        try:
+            rows = query_usage_impact_rows(
+                db_path=self._db_path,
+                record_id=record_id,
+                limit=limit,
+                offset=offset,
+                window_type=window_type,
+            )
+            if not rows:
+                self._usage_impact_cache.warm_async(include_archived=self._include_archived)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        except sqlite3.Error as exc:
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": f"Database error while reading usage impact: {exc}"},
+            )
+            return
+        self._send_json(
+            HTTPStatus.OK,
+            usage_impact_payload(
+                rows,
+                record_id=record_id,
+                limit=limit,
+            ),
         )
 
     def _handle_threads(self, query: str) -> None:

--- a/src/codex_usage_tracker/store.py
+++ b/src/codex_usage_tracker/store.py
@@ -48,6 +48,7 @@ from codex_usage_tracker.store_sources import (
     upsert_source_file_metadata,
 )
 from codex_usage_tracker.store_thread_summaries import rebuild_thread_summaries
+from codex_usage_tracker.usage_impact_store import invalidate_usage_impact_for_delta
 
 EVENT_COLUMNS = list(USAGE_EVENT_COLUMN_NAMES)
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
@@ -207,6 +208,7 @@ def rebuild_usage_index(
         init_db(conn)
         conn.execute("DELETE FROM usage_events")
         conn.execute("DELETE FROM thread_summaries")
+        conn.execute("DELETE FROM usage_impact")
         conn.execute("DELETE FROM source_files")
         conn.execute("DELETE FROM refresh_meta")
     return refresh_usage_index(
@@ -225,6 +227,7 @@ def reset_usage_database(db_path: Path = DEFAULT_DB_PATH) -> dict[str, Any]:
         deleted_rows = int(row["count"] if row is not None else 0)
         conn.execute("DELETE FROM usage_events")
         conn.execute("DELETE FROM thread_summaries")
+        conn.execute("DELETE FROM usage_impact")
         conn.execute("DELETE FROM source_files")
         conn.execute("DELETE FROM refresh_meta")
     return {"db_path": str(db_path), "deleted_usage_events": deleted_rows}
@@ -456,6 +459,13 @@ def _upsert_usage_events_with_delta(
             if source_files_to_replace and refresh_links and delta.affected_thread_keys:
                 refresh_usage_event_links_for_threads(conn, delta.affected_thread_keys)
                 rebuild_thread_summaries(conn, thread_keys=delta.affected_thread_keys)
+                invalidate_usage_impact_for_delta(
+                    conn,
+                    inserted_record_ids=delta.inserted_record_ids,
+                    deleted_record_ids=delta.deleted_record_ids,
+                    changed_time_start=delta.changed_time_start,
+                    changed_time_end=delta.changed_time_end,
+                )
             delta.skipped_downstream_work = not (
                 refresh_links and delta.affected_thread_keys
             )
@@ -475,6 +485,13 @@ def _upsert_usage_events_with_delta(
         if refresh_links and delta.affected_thread_keys:
             refresh_usage_event_links_for_threads(conn, delta.affected_thread_keys)
             rebuild_thread_summaries(conn, thread_keys=delta.affected_thread_keys)
+            invalidate_usage_impact_for_delta(
+                conn,
+                inserted_record_ids=delta.inserted_record_ids,
+                deleted_record_ids=delta.deleted_record_ids,
+                changed_time_start=delta.changed_time_start,
+                changed_time_end=delta.changed_time_end,
+            )
             delta.skipped_downstream_work = False
         else:
             delta.skipped_downstream_work = True

--- a/src/codex_usage_tracker/store_schema.py
+++ b/src/codex_usage_tracker/store_schema.py
@@ -12,7 +12,7 @@ from codex_usage_tracker.schema import (
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -23,6 +23,7 @@ MIGRATION_NAMES = {
     7: "persist source file parser cursors",
     8: "persist observed Codex usage snapshots",
     9: "persist source byte offsets for context seeking",
+    10: "materialize usage-impact read model",
 }
 CALL_ORIGIN_REPAIR_COLUMNS = {
     "call_initiator": "TEXT",
@@ -102,6 +103,12 @@ def init_db(conn: sqlite3.Connection) -> None:
     else:
         _migrate_v9(conn)
         _record_migration_if_missing(conn, 9)
+    if user_version < 10:
+        _migrate_v10(conn)
+        _record_migration(conn, 10)
+    else:
+        _migrate_v10(conn)
+        _record_migration_if_missing(conn, 10)
     _validate_usage_events_schema(conn)
     conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
@@ -254,6 +261,49 @@ def _migrate_v8(conn: sqlite3.Connection) -> None:
 
 def _migrate_v9(conn: sqlite3.Connection) -> None:
     _ensure_columns(conn, USAGE_EVENT_REPAIR_COLUMNS)
+
+
+def _migrate_v10(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS usage_impact (
+            record_id TEXT NOT NULL,
+            window_type TEXT NOT NULL,
+            plan_type TEXT,
+            limit_id TEXT,
+            observed_used_percent REAL,
+            observed_window_minutes INTEGER,
+            observed_resets_at INTEGER,
+            previous_observed_record_id TEXT,
+            previous_observed_used_percent REAL,
+            next_observed_record_id TEXT,
+            delta_used_percent REAL,
+            tokens_since_previous INTEGER,
+            estimated_tokens_per_percent REAL,
+            estimated_usage_credits REAL,
+            estimated_usage_percent REAL,
+            lower_percent REAL,
+            upper_percent REAL,
+            basis TEXT,
+            source TEXT,
+            interval_call_count INTEGER,
+            confidence TEXT NOT NULL,
+            status TEXT NOT NULL,
+            reason TEXT,
+            recalculated_at TEXT NOT NULL,
+            PRIMARY KEY (record_id, window_type)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_usage_impact_record
+            ON usage_impact(record_id);
+        CREATE INDEX IF NOT EXISTS idx_usage_impact_window_status
+            ON usage_impact(window_type, status);
+        CREATE INDEX IF NOT EXISTS idx_usage_impact_limit_window
+            ON usage_impact(limit_id, window_type);
+        CREATE INDEX IF NOT EXISTS idx_usage_impact_delta
+            ON usage_impact(delta_used_percent);
+        """
+    )
 
 
 def _record_migration(conn: sqlite3.Connection, version: int) -> None:

--- a/src/codex_usage_tracker/usage_impact.py
+++ b/src/codex_usage_tracker/usage_impact.py
@@ -19,6 +19,7 @@ _MAX_UNCALIBRATED_SINGLE_CALL_OBSERVED_PERCENT = 0.5
 
 @dataclass(frozen=True)
 class _Snapshot:
+    record_id: str | None
     used_percent: float
     window_minutes: int
     resets_at: int | None
@@ -213,9 +214,14 @@ def _allocate_interval(
             "upper_percent": upper,
             "observed_delta_percent": delta,
             "interval_call_count": len(rows),
+            "tokens_since_previous": sum(
+                int(_number(candidate.get("total_tokens"))) for candidate in rows
+            ),
             "basis": basis,
             "source": "observed_interval",
+            "previous_observed_record_id": previous.record_id,
             "previous_used_percent": previous.used_percent,
+            "next_observed_record_id": current.record_id,
             "current_used_percent": current.used_percent,
             "plan_type": current.plan_type,
             "limit_id": current.limit_id,
@@ -580,6 +586,7 @@ def _snapshot(row: dict[str, Any], window_key: WindowKey) -> _Snapshot | None:
     if used is None or minutes is None:
         return None
     return _Snapshot(
+        record_id=_optional_str(row.get("record_id")),
         used_percent=used,
         window_minutes=minutes,
         resets_at=_optional_int(row.get(f"rate_limit_{window_key}_resets_at")),

--- a/src/codex_usage_tracker/usage_impact_cache.py
+++ b/src/codex_usage_tracker/usage_impact_cache.py
@@ -17,6 +17,10 @@ from codex_usage_tracker.store import (
 )
 from codex_usage_tracker.threads import annotate_thread_attachments
 from codex_usage_tracker.usage_impact import annotate_rows_with_usage_impact
+from codex_usage_tracker.usage_impact_store import (
+    query_usage_impact_map_for_records,
+    replace_usage_impact_from_annotated_rows,
+)
 
 
 @dataclass(frozen=True)
@@ -82,6 +86,17 @@ class UsageImpactCache:
         )
         thread.start()
 
+    def rebuild(self, *, include_archived: bool) -> dict[str, dict[str, Any]]:
+        """Rebuild and persist usage-impact estimates synchronously."""
+
+        key = self._cache_key(include_archived=include_archived)
+        impact_by_record_id = self._build_impact_map(include_archived=include_archived)
+        with self._condition:
+            self._cache[include_archived] = (key, impact_by_record_id)
+            self._building.discard(key)
+            self._condition.notify_all()
+        return impact_by_record_id
+
     def copy_usage_impact(
         self,
         rows: list[dict[str, Any]],
@@ -93,6 +108,17 @@ class UsageImpactCache:
 
         if not rows:
             return []
+        record_ids = [str(row.get("record_id") or "") for row in rows if row.get("record_id")]
+        persisted, persisted_pending = query_usage_impact_map_for_records(
+            self._db_path,
+            record_ids,
+        )
+        missing = any(record_id not in persisted for record_id in record_ids)
+        if persisted and not missing and not persisted_pending:
+            return _copy_persisted_usage_impact(rows, persisted, pending=False)
+        if not block:
+            self.warm_async(include_archived=include_archived)
+            return _copy_persisted_usage_impact(rows, persisted, pending=True)
         impact_by_record_id = self._impact_by_record_id(
             include_archived=include_archived,
             block=block,
@@ -189,11 +215,16 @@ class UsageImpactCache:
             annotate_rows_with_efficiency(rows, pricing),
             allowance,
         )
-        return {
-            str(row.get("record_id")): row.get("usage_impact")  # type: ignore[dict-item]
-            for row in annotate_rows_with_usage_impact(rows)
-            if row.get("record_id")
-        }
+        annotated_rows = annotate_rows_with_usage_impact(rows)
+        replace_usage_impact_from_annotated_rows(
+            db_path=self._db_path,
+            rows=annotated_rows,
+        )
+        impact_by_record_id, _pending = query_usage_impact_map_for_records(
+            self._db_path,
+            [str(row.get("record_id")) for row in annotated_rows if row.get("record_id")],
+        )
+        return impact_by_record_id
 
     def _cache_key(self, *, include_archived: bool) -> _ImpactCacheKey:
         metadata = refresh_metadata(self._db_path)
@@ -222,3 +253,21 @@ def _file_signature(path: Path) -> _FileSignature:
         mtime_ns=int(stat.st_mtime_ns),
         size_bytes=int(stat.st_size),
     )
+
+
+def _copy_persisted_usage_impact(
+    rows: list[dict[str, Any]],
+    impact_by_record_id: dict[str, dict[str, Any]],
+    *,
+    pending: bool,
+) -> list[dict[str, Any]]:
+    default_impact = {"primary": None, "secondary": None}
+    copied: list[dict[str, Any]] = []
+    for row in rows:
+        next_row = dict(row)
+        record_id = str(row.get("record_id") or "")
+        next_row["usage_impact"] = impact_by_record_id.get(record_id, default_impact)
+        if pending:
+            next_row["usage_impact_pending"] = True
+        copied.append(next_row)
+    return copied

--- a/src/codex_usage_tracker/usage_impact_cache.py
+++ b/src/codex_usage_tracker/usage_impact_cache.py
@@ -19,6 +19,8 @@ from codex_usage_tracker.threads import annotate_thread_attachments
 from codex_usage_tracker.usage_impact import annotate_rows_with_usage_impact
 from codex_usage_tracker.usage_impact_store import (
     query_usage_impact_map_for_records,
+    query_usage_impact_recalculation_record_ids,
+    replace_usage_impact_for_records_from_annotated_rows,
     replace_usage_impact_from_annotated_rows,
 )
 
@@ -82,6 +84,32 @@ class UsageImpactCache:
             target=self._warm_safely,
             kwargs={"include_archived": include_archived, "key": key},
             name=f"codex-usage-impact-cache-{int(include_archived)}",
+            daemon=True,
+        )
+        thread.start()
+
+    def warm_pending_async(self, *, include_archived: bool) -> None:
+        """Warm only usage-impact rows marked pending/stale by refresh deltas."""
+
+        record_ids = query_usage_impact_recalculation_record_ids(
+            self._db_path,
+            include_archived=include_archived,
+        )
+        if not record_ids:
+            return
+        key = self._cache_key(include_archived=include_archived)
+        with self._condition:
+            if self._is_building_scope_locked(include_archived):
+                return
+            self._building.add(key)
+        thread = threading.Thread(
+            target=self._warm_pending_safely,
+            kwargs={
+                "include_archived": include_archived,
+                "key": key,
+                "record_ids": record_ids,
+            },
+            name=f"codex-usage-impact-pending-{int(include_archived)}",
             daemon=True,
         )
         thread.start()
@@ -156,6 +184,28 @@ class UsageImpactCache:
             self._building.discard(key)
             self._condition.notify_all()
 
+    def _warm_pending_safely(
+        self,
+        *,
+        include_archived: bool,
+        key: _ImpactCacheKey,
+        record_ids: list[str],
+    ) -> None:
+        try:
+            self._rebuild_records(
+                record_ids,
+                include_archived=include_archived,
+            )
+        except Exception:
+            with self._condition:
+                self._building.discard(key)
+                self._condition.notify_all()
+            return
+        with self._condition:
+            self._cache.pop(include_archived, None)
+            self._building.discard(key)
+            self._condition.notify_all()
+
     def _impact_by_record_id(
         self,
         *,
@@ -199,6 +249,31 @@ class UsageImpactCache:
             return impact_by_record_id
 
     def _build_impact_map(self, *, include_archived: bool) -> dict[str, dict[str, Any]]:
+        rows = self._annotated_context_rows(include_archived=include_archived)
+        replace_usage_impact_from_annotated_rows(
+            db_path=self._db_path,
+            rows=rows,
+        )
+        impact_by_record_id, _pending = query_usage_impact_map_for_records(
+            self._db_path,
+            [str(row.get("record_id")) for row in rows if row.get("record_id")],
+        )
+        return impact_by_record_id
+
+    def _rebuild_records(
+        self,
+        record_ids: list[str],
+        *,
+        include_archived: bool,
+    ) -> dict[str, int]:
+        rows = self._annotated_context_rows(include_archived=include_archived)
+        return replace_usage_impact_for_records_from_annotated_rows(
+            db_path=self._db_path,
+            rows=rows,
+            record_ids=record_ids,
+        )
+
+    def _annotated_context_rows(self, *, include_archived: bool) -> list[dict[str, Any]]:
         pricing = load_pricing_config(self._pricing_path)
         allowance = load_allowance_config(
             self._allowance_path,
@@ -217,16 +292,7 @@ class UsageImpactCache:
             annotate_rows_with_efficiency(rows, pricing),
             allowance,
         )
-        annotated_rows = annotate_rows_with_usage_impact(rows)
-        replace_usage_impact_from_annotated_rows(
-            db_path=self._db_path,
-            rows=annotated_rows,
-        )
-        impact_by_record_id, _pending = query_usage_impact_map_for_records(
-            self._db_path,
-            [str(row.get("record_id")) for row in annotated_rows if row.get("record_id")],
-        )
-        return impact_by_record_id
+        return annotate_rows_with_usage_impact(rows)
 
     def _cache_key(self, *, include_archived: bool) -> _ImpactCacheKey:
         metadata = refresh_metadata(self._db_path)

--- a/src/codex_usage_tracker/usage_impact_cache.py
+++ b/src/codex_usage_tracker/usage_impact_cache.py
@@ -75,7 +75,7 @@ class UsageImpactCache:
             cached = self._cache.get(include_archived)
             if cached is not None and cached[0] == key:
                 return
-            if key in self._building:
+            if self._is_building_scope_locked(include_archived):
                 return
             self._building.add(key)
         thread = threading.Thread(
@@ -165,7 +165,7 @@ class UsageImpactCache:
             cached = self._cache.get(include_archived)
             if cached is not None and cached[0] == key:
                 return cached[1]
-            while key in self._building:
+            while self._is_building_scope_locked(include_archived):
                 if not block:
                     return None
                 self._condition.wait()
@@ -241,6 +241,9 @@ class UsageImpactCache:
             allowance=_file_signature(self._allowance_path),
             rate_card=_file_signature(self._rate_card_path),
         )
+
+    def _is_building_scope_locked(self, include_archived: bool) -> bool:
+        return any(key.include_archived == include_archived for key in self._building)
 
 
 def _file_signature(path: Path) -> _FileSignature:

--- a/src/codex_usage_tracker/usage_impact_cache.py
+++ b/src/codex_usage_tracker/usage_impact_cache.py
@@ -103,6 +103,7 @@ class UsageImpactCache:
         *,
         include_archived: bool,
         block: bool = True,
+        schedule_warm: bool = True,
     ) -> list[dict[str, Any]]:
         """Return copied rows with cached usage-impact estimates attached."""
 
@@ -117,7 +118,8 @@ class UsageImpactCache:
         if persisted and not missing and not persisted_pending:
             return _copy_persisted_usage_impact(rows, persisted, pending=False)
         if not block:
-            self.warm_async(include_archived=include_archived)
+            if schedule_warm:
+                self.warm_async(include_archived=include_archived)
             return _copy_persisted_usage_impact(rows, persisted, pending=True)
         impact_by_record_id = self._impact_by_record_id(
             include_archived=include_archived,

--- a/src/codex_usage_tracker/usage_impact_store.py
+++ b/src/codex_usage_tracker/usage_impact_store.py
@@ -1,0 +1,517 @@
+"""Persistent read model for estimated usage-impact rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store_schema import init_db
+
+USAGE_IMPACT_SCHEMA_ID = "codex-usage-tracker-usage-impact-v1"
+WINDOW_TYPES = ("primary", "secondary")
+PENDING_REASON = "Usage-impact read model pending recalculation after refresh."
+STALE_REASON = "Usage-impact read model stale after source refresh."
+UNAVAILABLE_REASON = "No compatible observed usage snapshots for this call/window."
+
+USAGE_IMPACT_COLUMNS = [
+    "record_id",
+    "window_type",
+    "plan_type",
+    "limit_id",
+    "observed_used_percent",
+    "observed_window_minutes",
+    "observed_resets_at",
+    "previous_observed_record_id",
+    "previous_observed_used_percent",
+    "next_observed_record_id",
+    "delta_used_percent",
+    "tokens_since_previous",
+    "estimated_tokens_per_percent",
+    "estimated_usage_credits",
+    "estimated_usage_percent",
+    "lower_percent",
+    "upper_percent",
+    "basis",
+    "source",
+    "interval_call_count",
+    "confidence",
+    "status",
+    "reason",
+    "recalculated_at",
+]
+
+
+def usage_impact_payload(
+    rows: list[dict[str, Any]],
+    *,
+    record_id: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Return a stable JSON usage-impact payload."""
+
+    return {
+        "schema": USAGE_IMPACT_SCHEMA_ID,
+        "record_id": record_id,
+        "limit": limit,
+        "row_count": len(rows),
+        "rows": rows,
+        "raw_context_included": False,
+    }
+
+
+def replace_usage_impact_from_annotated_rows(
+    db_path: Path = DEFAULT_DB_PATH,
+    rows: Iterable[dict[str, Any]] = (),
+) -> dict[str, int]:
+    """Replace read-model rows for annotated aggregate usage rows."""
+
+    materialized = materialize_usage_impact_rows(rows)
+    record_ids = sorted({row["record_id"] for row in materialized})
+    with _connect(db_path) as conn:
+        init_db(conn)
+        if record_ids:
+            delete_usage_impact_for_records(conn, record_ids)
+        upsert_usage_impact_rows(conn, materialized)
+    return {
+        "records": len(record_ids),
+        "rows": len(materialized),
+    }
+
+
+def materialize_usage_impact_rows(
+    rows: Iterable[dict[str, Any]],
+    *,
+    recalculated_at: str | None = None,
+) -> list[dict[str, Any]]:
+    """Build persistent usage-impact rows from annotated aggregate rows."""
+
+    timestamp = recalculated_at or _utc_now()
+    materialized: list[dict[str, Any]] = []
+    for row in rows:
+        record_id = _optional_str(row.get("record_id"))
+        if record_id is None:
+            continue
+        impact = row.get("usage_impact")
+        impact_by_window = impact if isinstance(impact, dict) else {}
+        for window_type in WINDOW_TYPES:
+            window_impact = impact_by_window.get(window_type)
+            window = window_impact if isinstance(window_impact, dict) else None
+            materialized.append(
+                _materialize_window(
+                    row,
+                    record_id=record_id,
+                    window_type=window_type,
+                    impact=window,
+                    recalculated_at=timestamp,
+                )
+            )
+    return materialized
+
+
+def upsert_usage_impact_rows(
+    conn: sqlite3.Connection,
+    rows: Iterable[dict[str, Any]],
+) -> int:
+    """Upsert usage-impact read-model rows."""
+
+    materialized = list(rows)
+    if not materialized:
+        return 0
+    placeholders = ", ".join("?" for _column in USAGE_IMPACT_COLUMNS)
+    updates = ", ".join(
+        f"{column}=excluded.{column}"
+        for column in USAGE_IMPACT_COLUMNS
+        if column not in {"record_id", "window_type"}
+    )
+    conn.executemany(
+        f"""
+        INSERT INTO usage_impact ({', '.join(USAGE_IMPACT_COLUMNS)})
+        VALUES ({placeholders})
+        ON CONFLICT(record_id, window_type) DO UPDATE SET {updates}
+        """,
+        [[row.get(column) for column in USAGE_IMPACT_COLUMNS] for row in materialized],
+    )
+    return len(materialized)
+
+
+def delete_usage_impact_for_records(
+    conn: sqlite3.Connection,
+    record_ids: Iterable[str],
+) -> int:
+    """Delete read-model rows for usage record ids."""
+
+    ids = sorted({record_id for record_id in record_ids if record_id})
+    if not ids:
+        return 0
+    placeholders = ", ".join("?" for _record_id in ids)
+    before = conn.total_changes
+    conn.execute(
+        f"DELETE FROM usage_impact WHERE record_id IN ({placeholders})",
+        ids,
+    )
+    return conn.total_changes - before
+
+
+def invalidate_usage_impact_for_delta(
+    conn: sqlite3.Connection,
+    *,
+    inserted_record_ids: Iterable[str] = (),
+    deleted_record_ids: Iterable[str] = (),
+    changed_time_start: str | None = None,
+    changed_time_end: str | None = None,
+) -> int:
+    """Mark usage-impact rows affected by a refresh delta as pending/stale."""
+
+    deleted = sorted({record_id for record_id in deleted_record_ids if record_id})
+    inserted = sorted({record_id for record_id in inserted_record_ids if record_id})
+    changed = 0
+    changed += delete_usage_impact_for_records(conn, deleted)
+    changed += _mark_usage_impact_stale_for_time_range(
+        conn,
+        changed_time_start=changed_time_start,
+        changed_time_end=changed_time_end,
+        exclude_record_ids=inserted,
+    )
+    changed += _insert_pending_usage_impact_rows(conn, inserted)
+    return changed
+
+
+def query_usage_impact_rows(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    record_id: str | None = None,
+    limit: int | None = 100,
+    offset: int = 0,
+    window_type: str | None = None,
+) -> list[dict[str, Any]]:
+    """Query persisted usage-impact rows."""
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if record_id:
+        clauses.append("record_id = ?")
+        params.append(record_id)
+    if window_type:
+        if window_type not in WINDOW_TYPES:
+            raise ValueError("window_type must be one of: primary, secondary")
+        clauses.append("window_type = ?")
+        params.append(window_type)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    normalized_limit = None if limit is None or limit <= 0 else int(limit)
+    limit_clause = ""
+    if normalized_limit is not None:
+        limit_clause = "LIMIT ? OFFSET ?"
+        params.extend([normalized_limit, int(offset)])
+    elif offset:
+        limit_clause = "LIMIT -1 OFFSET ?"
+        params.append(int(offset))
+    with _connect(db_path) as conn:
+        init_db(conn)
+        rows = conn.execute(
+            f"""
+            SELECT *
+            FROM usage_impact
+            {where}
+            ORDER BY recalculated_at DESC, record_id, window_type
+            {limit_clause}
+            """,
+            params,
+        ).fetchall()
+    return [_row_to_dict(row) for row in rows]
+
+
+def query_usage_impact_map_for_records(
+    db_path: Path = DEFAULT_DB_PATH,
+    record_ids: Iterable[str] = (),
+) -> tuple[dict[str, dict[str, Any]], bool]:
+    """Return dashboard-shaped usage-impact values and whether any are pending."""
+
+    ids = sorted({record_id for record_id in record_ids if record_id})
+    if not ids:
+        return {}, False
+    placeholders = ", ".join("?" for _record_id in ids)
+    with _connect(db_path) as conn:
+        init_db(conn)
+        rows = conn.execute(
+            f"""
+            SELECT *
+            FROM usage_impact
+            WHERE record_id IN ({placeholders})
+            """,
+            ids,
+        ).fetchall()
+    mapped: dict[str, dict[str, Any]] = {}
+    pending = False
+    for row in rows:
+        item = _row_to_dict(row)
+        record_id = str(item["record_id"])
+        window_type = str(item["window_type"])
+        mapped.setdefault(record_id, {"primary": None, "secondary": None})
+        mapped[record_id][window_type] = _dashboard_impact(item)
+        if item.get("status") in {"pending", "stale"}:
+            pending = True
+    return mapped, pending
+
+
+def _materialize_window(
+    row: dict[str, Any],
+    *,
+    record_id: str,
+    window_type: str,
+    impact: dict[str, Any] | None,
+    recalculated_at: str,
+) -> dict[str, Any]:
+    estimate = _optional_float((impact or {}).get("estimate_percent"))
+    status, confidence, reason = _classify_impact(impact)
+    observed_used = _optional_float(row.get(f"rate_limit_{window_type}_used_percent"))
+    observed_minutes = _optional_int(row.get(f"rate_limit_{window_type}_window_minutes"))
+    observed_resets = _optional_int(row.get(f"rate_limit_{window_type}_resets_at"))
+    delta = _optional_float((impact or {}).get("observed_delta_percent"))
+    total_tokens = _optional_int(row.get("total_tokens"))
+    estimated_tokens_per_percent = (
+        total_tokens / estimate
+        if total_tokens is not None and estimate is not None and estimate > 0
+        else None
+    )
+    return {
+        "record_id": record_id,
+        "window_type": window_type,
+        "plan_type": _optional_str((impact or {}).get("plan_type"))
+        or _optional_str(row.get("rate_limit_plan_type")),
+        "limit_id": _optional_str((impact or {}).get("limit_id"))
+        or _optional_str(row.get("rate_limit_limit_id")),
+        "observed_used_percent": observed_used,
+        "observed_window_minutes": observed_minutes,
+        "observed_resets_at": observed_resets,
+        "previous_observed_record_id": _optional_str((impact or {}).get("previous_observed_record_id")),
+        "previous_observed_used_percent": _optional_float(
+            (impact or {}).get("previous_used_percent")
+        ),
+        "next_observed_record_id": _optional_str((impact or {}).get("next_observed_record_id")),
+        "delta_used_percent": delta,
+        "tokens_since_previous": _optional_int((impact or {}).get("tokens_since_previous"))
+        or total_tokens,
+        "estimated_tokens_per_percent": estimated_tokens_per_percent,
+        "estimated_usage_credits": _optional_float(row.get("usage_credits")),
+        "estimated_usage_percent": estimate,
+        "lower_percent": _optional_float((impact or {}).get("lower_percent")),
+        "upper_percent": _optional_float((impact or {}).get("upper_percent")),
+        "basis": _optional_str((impact or {}).get("basis")),
+        "source": _optional_str((impact or {}).get("source")),
+        "interval_call_count": _optional_int((impact or {}).get("interval_call_count"))
+        or _optional_int((impact or {}).get("observed_interval_call_count")),
+        "confidence": confidence,
+        "status": status,
+        "reason": reason,
+        "recalculated_at": recalculated_at,
+    }
+
+
+def _classify_impact(impact: dict[str, Any] | None) -> tuple[str, str, str]:
+    if not impact:
+        return "unavailable", "unknown", UNAVAILABLE_REASON
+    estimate = _optional_float(impact.get("estimate_percent"))
+    source_note = _public_source_note(_optional_str(impact.get("source_note")))
+    if estimate is None:
+        return "pending", "low", source_note or PENDING_REASON
+    lower = _optional_float(impact.get("lower_percent"))
+    upper = _optional_float(impact.get("upper_percent"))
+    spread = (upper - lower) if lower is not None and upper is not None else None
+    sample_count = _optional_int(impact.get("calibration_sample_count")) or 0
+    interval_count = _optional_int(impact.get("interval_call_count")) or 0
+    if impact.get("source") == "observed_interval" and interval_count <= 3:
+        confidence = "high"
+    elif sample_count >= 20 or (spread is not None and spread <= max(0.05, estimate)):
+        confidence = "medium"
+    else:
+        confidence = "low"
+    return "fresh", confidence, source_note or "Estimated from observed local usage snapshots."
+
+
+def _public_source_note(source_note: str | None) -> str | None:
+    if source_note is None:
+        return None
+    known = {
+        "calibrated_from_codex_limit_family": (
+            "Estimated from compatible Codex limit-family calibration."
+        ),
+        "calibrated_from_codex_limit_family_after_noisy_observed_interval": (
+            "Noisy observed interval replaced with compatible Codex limit-family calibration."
+        ),
+        "calibrated_after_noisy_observed_interval": (
+            "Noisy observed interval replaced with calibrated history."
+        ),
+        "suppressed_unvalidated_single_call_observed_jump": (
+            "Single-call observed jump suppressed until calibrated by more local history."
+        ),
+    }
+    return known.get(source_note, "Estimated from observed local usage snapshots.")
+
+
+def _mark_usage_impact_stale_for_time_range(
+    conn: sqlite3.Connection,
+    *,
+    changed_time_start: str | None,
+    changed_time_end: str | None,
+    exclude_record_ids: list[str],
+) -> int:
+    if not changed_time_start or not changed_time_end:
+        return 0
+    params: list[Any] = [STALE_REASON, _utc_now(), changed_time_start, changed_time_end]
+    exclude_clause = ""
+    if exclude_record_ids:
+        placeholders = ", ".join("?" for _record_id in exclude_record_ids)
+        exclude_clause = f"AND usage_impact.record_id NOT IN ({placeholders})"
+        params.extend(exclude_record_ids)
+    before = conn.total_changes
+    conn.execute(
+        f"""
+        UPDATE usage_impact
+        SET status = 'stale',
+            confidence = CASE WHEN confidence = 'unknown' THEN 'unknown' ELSE 'low' END,
+            reason = ?,
+            recalculated_at = ?
+        WHERE record_id IN (
+            SELECT record_id
+            FROM usage_events
+            WHERE event_timestamp BETWEEN ? AND ?
+        )
+        {exclude_clause}
+        """,
+        params,
+    )
+    return conn.total_changes - before
+
+
+def _insert_pending_usage_impact_rows(
+    conn: sqlite3.Connection,
+    record_ids: list[str],
+) -> int:
+    if not record_ids:
+        return 0
+    now = _utc_now()
+    rows = [
+        {
+            "record_id": record_id,
+            "window_type": window_type,
+            "plan_type": None,
+            "limit_id": None,
+            "observed_used_percent": None,
+            "observed_window_minutes": None,
+            "observed_resets_at": None,
+            "previous_observed_record_id": None,
+            "previous_observed_used_percent": None,
+            "next_observed_record_id": None,
+            "delta_used_percent": None,
+            "tokens_since_previous": None,
+            "estimated_tokens_per_percent": None,
+            "estimated_usage_credits": None,
+            "estimated_usage_percent": None,
+            "lower_percent": None,
+            "upper_percent": None,
+            "basis": None,
+            "source": None,
+            "interval_call_count": None,
+            "confidence": "unknown",
+            "status": "pending",
+            "reason": PENDING_REASON,
+            "recalculated_at": now,
+        }
+        for record_id in record_ids
+        for window_type in WINDOW_TYPES
+    ]
+    return upsert_usage_impact_rows(conn, rows)
+
+
+def _dashboard_impact(row: dict[str, Any]) -> dict[str, Any] | None:
+    if row.get("status") == "unavailable":
+        return None
+    return {
+        "schema": "codex-usage-tracker-usage-impact-estimate-v1",
+        "label": _window_label(_optional_int(row.get("observed_window_minutes"))),
+        "window_minutes": row.get("observed_window_minutes"),
+        "estimate_percent": row.get("estimated_usage_percent"),
+        "lower_percent": row.get("lower_percent"),
+        "upper_percent": row.get("upper_percent"),
+        "observed_delta_percent": row.get("delta_used_percent"),
+        "interval_call_count": row.get("interval_call_count"),
+        "basis": row.get("basis"),
+        "source": row.get("source"),
+        "plan_type": row.get("plan_type"),
+        "limit_id": row.get("limit_id"),
+        "resets_at": row.get("observed_resets_at"),
+        "confidence": row.get("confidence"),
+        "status": row.get("status"),
+        "reason": row.get("reason"),
+    }
+
+
+def _window_label(minutes: int | None) -> str | None:
+    if minutes is None:
+        return None
+    if minutes == 300:
+        return "5h"
+    if minutes == 10080:
+        return "Weekly"
+    if minutes % 1440 == 0:
+        return f"{minutes // 1440}d"
+    if minutes % 60 == 0:
+        return f"{minutes // 60}h"
+    return f"{minutes}m"
+
+
+@contextmanager
+def _connect(db_path: Path) -> Iterator[sqlite3.Connection]:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 5000")
+    try:
+        yield conn
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {str(key): value for key, value in dict(row).items()}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _optional_str(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool) or not isinstance(value, str | int | float):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool) or not isinstance(value, str | int | float):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/codex_usage_tracker/usage_impact_store.py
+++ b/src/codex_usage_tracker/usage_impact_store.py
@@ -83,6 +83,33 @@ def replace_usage_impact_from_annotated_rows(
     }
 
 
+def replace_usage_impact_for_records_from_annotated_rows(
+    db_path: Path = DEFAULT_DB_PATH,
+    rows: Iterable[dict[str, Any]] = (),
+    *,
+    record_ids: Iterable[str] = (),
+) -> dict[str, int]:
+    """Replace read-model rows only for selected records from annotated context."""
+
+    target_ids = sorted({record_id for record_id in record_ids if record_id})
+    if not target_ids:
+        return {"records": 0, "rows": 0}
+    target_set = set(target_ids)
+    materialized = [
+        row
+        for row in materialize_usage_impact_rows(rows)
+        if str(row.get("record_id") or "") in target_set
+    ]
+    with _connect(db_path) as conn:
+        init_db(conn)
+        delete_usage_impact_for_records(conn, target_ids)
+        upsert_usage_impact_rows(conn, materialized)
+    return {
+        "records": len(target_ids),
+        "rows": len(materialized),
+    }
+
+
 def materialize_usage_impact_rows(
     rows: Iterable[dict[str, Any]],
     *,
@@ -256,6 +283,46 @@ def query_usage_impact_map_for_records(
         if item.get("status") in {"pending", "stale"}:
             pending = True
     return mapped, pending
+
+
+def query_usage_impact_recalculation_record_ids(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    include_archived: bool = False,
+    limit: int | None = None,
+) -> list[str]:
+    """Return records whose persisted usage-impact rows need recalculation."""
+
+    archive_clause = "" if include_archived else "WHERE usage_events.is_archived = 0"
+    normalized_limit = None if limit is None or limit <= 0 else int(limit)
+    limit_clause = "LIMIT ?" if normalized_limit is not None else ""
+    params: list[Any] = []
+    if normalized_limit is not None:
+        params.append(normalized_limit)
+    with _connect(db_path) as conn:
+        init_db(conn)
+        rows = conn.execute(
+            f"""
+            SELECT usage_events.record_id
+            FROM usage_events
+            LEFT JOIN usage_impact
+                ON usage_impact.record_id = usage_events.record_id
+            {archive_clause}
+            GROUP BY usage_events.record_id
+            HAVING
+                SUM(CASE WHEN usage_impact.window_type = 'primary' THEN 1 ELSE 0 END) = 0
+                OR SUM(CASE WHEN usage_impact.window_type = 'secondary' THEN 1 ELSE 0 END) = 0
+                OR SUM(
+                    CASE WHEN usage_impact.status IN ('pending', 'stale') THEN 1 ELSE 0 END
+                ) > 0
+            ORDER BY MAX(usage_events.event_timestamp) ASC,
+                MAX(usage_events.cumulative_total_tokens) ASC,
+                usage_events.record_id ASC
+            {limit_clause}
+            """,
+            params,
+        ).fetchall()
+    return [str(row["record_id"]) for row in rows]
 
 
 def _materialize_window(

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -25,6 +25,7 @@ STABLE_CLI_COMMANDS = {
     "reset-db",
     "summary",
     "query",
+    "usage-impact",
     "recommendations",
     "session",
     "context",

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -413,7 +413,7 @@ def test_synthetic_history_benchmark_with_source_logs_smoke(tmp_path: Path) -> N
             "--json",
             "--enforce-thresholds",
             "--threshold-scale",
-            "5",
+            "20",
         ],
         check=True,
         capture_output=True,

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -342,6 +342,118 @@ console.log(JSON.stringify({
     assert payload["data"][0]["usage_impact"]["secondary"]["estimate_percent"] == 0.123
 
 
+def test_live_row_hydration_advances_by_api_offset_when_rows_are_merged() -> None:
+    payload = _run_dashboard_live_script(
+        """
+let data = [
+  { record_id: 'a' },
+  { record_id: 'b' },
+  { record_id: 'c' },
+  { record_id: 'd' },
+];
+let requestUrls = [];
+let progressHidden = true;
+let progressText = '';
+let fetchIndex = 0;
+const responses = [
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [{ record_id: 'd' }],
+      row_count: 1,
+      total_matched_rows: 6,
+      has_more: true,
+      next_offset: 5,
+      usage_impact_pending: false,
+    }),
+  },
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [{ record_id: 'e' }],
+      row_count: 1,
+      total_matched_rows: 6,
+      has_more: false,
+      next_offset: null,
+      usage_impact_pending: false,
+    }),
+  },
+];
+context.fetch = async url => {
+  requestUrls.push(String(url));
+  return responses[fetchIndex++];
+};
+const runtime = helpers.create({
+  activeView: () => 'calls',
+  apiToken: () => 'token',
+  applyDashboardPayload: (payload, options = {}) => {
+    if (!options.appendRows) {
+      data = payload.rows || [];
+      return;
+    }
+    const seen = new Set(data.map(row => row.record_id));
+    data = data.concat((payload.rows || []).filter(row => {
+      if (!row.record_id || seen.has(row.record_id)) return false;
+      seen.add(row.record_id);
+      return true;
+    }));
+  },
+  autoRefreshEl: { checked: true },
+  formatTimestamp: value => String(value || ''),
+  getData: () => data,
+  getIncludeArchived: () => true,
+  getLoadedLimit: () => null,
+  getTotalAvailableRows: () => 6,
+  getArchivedAvailableRows: () => 0,
+  historyScopeEl: { value: 'all', parentElement: {} },
+  initialHydrationChunkSize: 2,
+  backgroundHydrationChunkSize: 1,
+  i18n: { currentLanguage: 'en' },
+  liveRefreshIntervalMs: 10000,
+  liveRefreshSupported: true,
+  loadLimitEl: { value: 'all', options: [], insertBefore: () => {}, lastElementChild: null },
+  limitValue: value => value === null ? 'all' : String(value),
+  number: { format: value => String(value) },
+  payloadRows: payload => payload.rows || [],
+  rebuildDashboardIndexes: () => {},
+  rebuildFilterOptions: () => {},
+  refreshDashboardEl: { disabled: false },
+  render: () => {},
+  resetRowsForHydration: () => { data = []; },
+  rowLoadProgressBarEl: { style: {} },
+  rowLoadProgressCountEl: {
+    get textContent() { return progressText; },
+    set textContent(value) { progressText = value; },
+  },
+  rowLoadProgressEl: {
+    get hidden() { return progressHidden; },
+    set hidden(value) { progressHidden = value; },
+  },
+  rowLoadProgressLabelEl: { textContent: '' },
+  setFastTooltip: () => {},
+  setObservedUsage: () => {},
+  t: key => key,
+  tf: (key, values) => `${key}:${JSON.stringify(values || {})}`,
+  updateLiveStatus: () => {},
+});
+await runtime.hydrateDashboardRows();
+console.log(JSON.stringify({
+  offsets: requestUrls.map(url => new URL(url, 'http://localhost').searchParams.get('offset')),
+  dataLength: data.length,
+  progressHidden,
+  progressText,
+}));
+"""
+    )
+
+    assert payload["offsets"] == ["4", "5"]
+    assert payload["dataLength"] == 5
+    assert payload["progressHidden"] is True
+    assert '"loaded":"6"' in payload["progressText"]
+
+
 def test_live_refresh_auth_failure_stops_polling_and_surfaces_error() -> None:
     payload = _run_dashboard_live_script(
         """

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -231,6 +231,114 @@ console.log(JSON.stringify({
     assert payload["appliedPayloads"][0]["appendRows"] is True
 
 
+def test_live_refresh_noop_with_row_count_change_hydrates_rows() -> None:
+    payload = _run_dashboard_live_script(
+        """
+let data = [{ record_id: 'b' }, { record_id: 'c' }];
+let totalAvailableRows = 2;
+let requestUrls = [];
+let appliedPayloads = [];
+let liveStatuses = [];
+let fetchIndex = 0;
+const responses = [
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      row_counts: { scoped_rows: 3 },
+      refresh_result: {
+        skipped_downstream_work: true,
+        inserted_records: 0,
+        inserted_or_updated_events: 0,
+        deleted_records: 0,
+        full_reparse_source_files: 0,
+      },
+    }),
+  },
+  {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      rows: [{ record_id: 'a' }, { record_id: 'b' }],
+      row_count: 2,
+      total_matched_rows: 3,
+      has_more: true,
+      usage_impact_pending: false,
+    }),
+  },
+];
+context.fetch = async url => {
+  requestUrls.push(String(url));
+  return responses[fetchIndex++];
+};
+const runtime = helpers.create({
+  activeView: () => 'calls',
+  apiToken: () => 'token',
+  applyDashboardPayload: (payload, options = {}) => {
+    appliedPayloads.push({ appendRows: Boolean(options.appendRows), keys: Object.keys(payload).sort() });
+    if (options.appendRows) {
+      const seen = new Set(data.map(row => row.record_id));
+      data = data.concat((payload.rows || []).filter(row => {
+        if (!row.record_id || seen.has(row.record_id)) return false;
+        seen.add(row.record_id);
+        return true;
+      }));
+    } else {
+      data = payload.rows || [];
+      if (payload.total_available_rows !== undefined) totalAvailableRows = payload.total_available_rows;
+    }
+  },
+  autoRefreshEl: { checked: true },
+  formatTimestamp: value => String(value || ''),
+  getData: () => data,
+  getIncludeArchived: () => true,
+  getLoadedLimit: () => null,
+  getTotalAvailableRows: () => totalAvailableRows,
+  getArchivedAvailableRows: () => 0,
+  historyScopeEl: { value: 'all', parentElement: {} },
+  initialHydrationChunkSize: 2,
+  backgroundHydrationChunkSize: 2,
+  i18n: { currentLanguage: 'en' },
+  liveRefreshIntervalMs: 10000,
+  liveRefreshSupported: true,
+  loadLimitEl: { value: 'all', options: [], insertBefore: () => {}, lastElementChild: null },
+  limitValue: value => value === null ? 'all' : String(value),
+  number: { format: value => String(value) },
+  payloadRows: payload => payload.rows || [],
+  rebuildDashboardIndexes: () => {},
+  rebuildFilterOptions: () => {},
+  refreshDashboardEl: { disabled: false },
+  render: () => {},
+  resetRowsForHydration: () => { data = []; },
+  rowLoadProgressBarEl: { style: {} },
+  rowLoadProgressCountEl: { textContent: '' },
+  rowLoadProgressEl: { hidden: true },
+  rowLoadProgressLabelEl: { textContent: '' },
+  setFastTooltip: () => {},
+  setObservedUsage: () => {},
+  t: key => key,
+  tf: (key, values) => `${key}:${JSON.stringify(values || {})}`,
+  updateLiveStatus: (key, detail) => liveStatuses.push({ key, detail }),
+});
+await runtime.refreshDashboardIfStale();
+await new Promise(resolve => setTimeout(resolve, 25));
+console.log(JSON.stringify({
+  requestUrls,
+  appliedPayloads,
+  dataLength: data.length,
+  liveStatuses,
+}));
+"""
+    )
+
+    assert payload["dataLength"] == 3
+    assert payload["requestUrls"][0].startswith("/api/status?")
+    assert payload["requestUrls"][1].startswith("/api/calls?")
+    assert len(payload["requestUrls"]) == 2
+    assert all(not url.startswith("/api/usage?") for url in payload["requestUrls"])
+    assert payload["appliedPayloads"][0]["appendRows"] is True
+
+
 def test_live_usage_impact_retry_updates_loaded_rows_without_rehydrating_table() -> None:
     payload = _run_dashboard_live_script(
         """

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -177,6 +177,7 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
         def __init__(self) -> None:
             self.invalidations = 0
             self.warms = 0
+            self.pending_warms = 0
 
         def invalidate(self) -> None:
             self.invalidations += 1
@@ -184,6 +185,10 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
         def warm_async(self, *, include_archived: bool) -> None:
             _ = include_archived
             self.warms += 1
+
+        def warm_pending_async(self, *, include_archived: bool) -> None:
+            _ = include_archived
+            self.pending_warms += 1
 
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
@@ -253,7 +258,8 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
     assert second_payload["refresh_result"]["affected_threads"] == 0
     assert second_payload["refresh_result"]["skipped_downstream_work"] is True
     assert usage_impact_cache.invalidations == 1
-    assert usage_impact_cache.warms == 1
+    assert usage_impact_cache.warms == 0
+    assert usage_impact_cache.pending_warms == 1
 
 
 def test_dashboard_server_exposes_usage_impact_read_model(tmp_path: Path) -> None:

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -598,10 +598,33 @@ def test_dashboard_server_api_timing_diagnostics_are_opt_in_and_technical(
 def test_dashboard_server_live_sql_api_slices_are_aggregate_only(tmp_path: Path) -> None:
     from codex_usage_tracker.server import _UsageDashboardHandler
 
+    class FakeUsageImpactCache:
+        def __init__(self) -> None:
+            self.copy_calls: list[dict[str, object]] = []
+
+        def copy_usage_impact(
+            self,
+            rows: list[dict[str, object]],
+            *,
+            include_archived: bool,
+            block: bool = True,
+            schedule_warm: bool = True,
+        ) -> list[dict[str, object]]:
+            self.copy_calls.append(
+                {
+                    "row_count": len(rows),
+                    "include_archived": include_archived,
+                    "block": block,
+                    "schedule_warm": schedule_warm,
+                }
+            )
+            return [dict(row) for row in rows]
+
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     pricing_path = _write_pricing(tmp_path / "pricing.json")
     refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    usage_impact_cache = FakeUsageImpactCache()
     handler = partial(
         _UsageDashboardHandler,
         directory=str(tmp_path),
@@ -619,6 +642,7 @@ def test_dashboard_server_live_sql_api_slices_are_aggregate_only(tmp_path: Path)
         api_token="test-token",
         context_api_enabled=True,
         refresh_lock=threading.Lock(),
+        usage_impact_cache=usage_impact_cache,
     )
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -670,6 +694,9 @@ def test_dashboard_server_live_sql_api_slices_are_aggregate_only(tmp_path: Path)
     _assert_contract(call_payload)
     assert call_payload["record"]["record_id"] == record_id
     assert call_payload["raw_context_included"] is False
+    assert usage_impact_cache.copy_calls
+    assert all(call["block"] is False for call in usage_impact_cache.copy_calls)
+    assert all(call["schedule_warm"] is False for call in usage_impact_cache.copy_calls)
 
     assert threads_payload["schema"] == "codex-usage-tracker-threads-v1"
     _assert_contract(threads_payload)

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -30,6 +30,7 @@ from codex_usage_tracker.store import (
     refresh_usage_index,
     upsert_usage_events,
 )
+from codex_usage_tracker.usage_impact_cache import UsageImpactCache
 
 
 def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> None:
@@ -253,6 +254,97 @@ def test_dashboard_status_live_refresh_parses_appended_events_incrementally(tmp_
     assert second_payload["refresh_result"]["skipped_downstream_work"] is True
     assert usage_impact_cache.invalidations == 1
     assert usage_impact_cache.warms == 1
+
+
+def test_dashboard_server_exposes_usage_impact_read_model(tmp_path: Path) -> None:
+    from codex_usage_tracker.server import _UsageDashboardHandler
+
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    events = []
+    for index in range(5):
+        events.append(
+            _usage_event(
+                record_id=f"baseline-{index}",
+                session_id=SESSION_ID,
+                thread_key="thread:Usage impact API",
+                event_timestamp=f"2026-06-15T12:{index * 2:02d}:00Z",
+                cumulative_total_tokens=100 + index * 100,
+                rate_limit_primary_used_percent=10 + index,
+                rate_limit_primary_window_minutes=300,
+                rate_limit_primary_resets_at=1781562696,
+            )
+        )
+        events.append(
+            _usage_event(
+                record_id=f"observed-{index}",
+                session_id=SESSION_ID,
+                thread_key="thread:Usage impact API",
+                event_timestamp=f"2026-06-15T12:{index * 2 + 1:02d}:00Z",
+                cumulative_total_tokens=150 + index * 100,
+                rate_limit_primary_used_percent=11 + index,
+                rate_limit_primary_window_minutes=300,
+                rate_limit_primary_resets_at=1781562696,
+            )
+        )
+    events.append(
+        _usage_event(
+            record_id="target-impact",
+            session_id=SESSION_ID,
+            thread_key="thread:Usage impact API",
+            event_timestamp="2026-06-15T12:15:00Z",
+            cumulative_total_tokens=1000,
+        )
+    )
+    upsert_usage_events(events, db_path=db_path)
+    UsageImpactCache(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        rate_card_path=tmp_path / "rate-card.json",
+    ).rebuild(include_archived=False)
+    (tmp_path / "dashboard.html").write_text("<!doctype html><title>Dashboard</title>", encoding="utf-8")
+    handler = partial(
+        _UsageDashboardHandler,
+        directory=str(tmp_path),
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        thresholds_path=tmp_path / "thresholds.json",
+        projects_path=tmp_path / "projects.json",
+        limit=5000,
+        since=None,
+        codex_home=tmp_path / ".codex",
+        include_archived=False,
+        dashboard_name="dashboard.html",
+        context_chars=2000,
+        api_token="test-token",
+        context_api_enabled=True,
+        refresh_lock=threading.Lock(),
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        impact_payload = _read_json(
+            f"http://127.0.0.1:{server.server_port}/api/usage-impact?record_id=target-impact"
+        )
+        call_payload = _read_json(
+            f"http://127.0.0.1:{server.server_port}/api/call?record_id=target-impact"
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert impact_payload["schema"] == "codex-usage-tracker-usage-impact-v1"
+    assert impact_payload["record_id"] == "target-impact"
+    assert impact_payload["row_count"] == 2
+    assert impact_payload["raw_context_included"] is False
+    assert any(row["status"] == "fresh" for row in impact_payload["rows"])
+    assert "usage_impact" in call_payload
+    assert call_payload["usage_impact"]["schema"] == "codex-usage-tracker-usage-impact-v1"
+    assert "SECRET RAW PROMPT" not in json.dumps(impact_payload)
 
 
 def test_dashboard_history_scope_excludes_archived_rows_by_default(tmp_path: Path) -> None:

--- a/tests/test_json_contracts.py
+++ b/tests/test_json_contracts.py
@@ -21,6 +21,7 @@ RUNTIME_SCHEMA_SOURCE_PATHS = [
     REPO_ROOT / "src" / "codex_usage_tracker" / "mcp_server.py",
     REPO_ROOT / "src" / "codex_usage_tracker" / "reports.py",
     REPO_ROOT / "src" / "codex_usage_tracker" / "server.py",
+    REPO_ROOT / "src" / "codex_usage_tracker" / "usage_impact_store.py",
 ]
 
 

--- a/tests/test_store_dashboard_mcp.py
+++ b/tests/test_store_dashboard_mcp.py
@@ -81,12 +81,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == PARSER_ADAPTER_VERSION
-    assert meta["schema_version"] == "9"
+    assert meta["schema_version"] == "10"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 9
+    assert state["schema_version"] == 10
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert [row["version"] for row in state["migrations"]] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -128,6 +128,7 @@ def test_noop_refresh_skips_parser_upsert_and_downstream_rebuilds(
     monkeypatch.setattr(store_module, "_upsert_usage_events_with_delta", fail_if_called)
     monkeypatch.setattr(store_module, "refresh_usage_event_links_for_threads", fail_if_called)
     monkeypatch.setattr(store_module, "rebuild_thread_summaries", fail_if_called)
+    monkeypatch.setattr(store_module, "invalidate_usage_impact_for_delta", fail_if_called)
 
     second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
     metadata = refresh_metadata(db_path)
@@ -343,8 +344,10 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
     )
     link_calls: list[set[str]] = []
     summary_calls: list[set[str] | None] = []
+    usage_impact_invalidations: list[dict[str, object]] = []
     original_link_refresh = store_module.refresh_usage_event_links_for_threads
     original_summary_rebuild = store_module.rebuild_thread_summaries
+    original_usage_impact_invalidate = store_module.invalidate_usage_impact_for_delta
 
     def tracking_link_refresh(conn: sqlite3.Connection, thread_keys: object) -> int:
         normalized = set(thread_keys) if thread_keys is not None else set()
@@ -360,8 +363,16 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
         summary_calls.append(normalized)
         return original_summary_rebuild(conn, thread_keys=thread_keys)  # type: ignore[arg-type]
 
+    def tracking_usage_impact_invalidate(
+        conn: sqlite3.Connection,
+        **kwargs: object,
+    ) -> int:
+        usage_impact_invalidations.append(kwargs)
+        return original_usage_impact_invalidate(conn, **kwargs)  # type: ignore[arg-type]
+
     monkeypatch.setattr(store_module, "refresh_usage_event_links_for_threads", tracking_link_refresh)
     monkeypatch.setattr(store_module, "rebuild_thread_summaries", tracking_summary_rebuild)
+    monkeypatch.setattr(store_module, "invalidate_usage_impact_for_delta", tracking_usage_impact_invalidate)
 
     second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
     partial_link_calls = list(link_calls)
@@ -396,6 +407,8 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
     assert second.skipped_downstream_work is False
     assert partial_link_calls == [{"thread:Add Codex token tracking"}]
     assert partial_summary_calls == [{"thread:Add Codex token tracking"}]
+    assert len(usage_impact_invalidations) == 1
+    assert len(usage_impact_invalidations[0]["inserted_record_ids"]) == 1
     assert before_full_repair_links == after_full_repair_links
     assert before_full_repair_summaries == after_full_repair_summaries
     assert third.parsed_events == 0
@@ -600,7 +613,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 9
+    assert user_version == 10
 
 
 def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
@@ -671,8 +684,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "idx_usage_parent_thread" in indexes
     assert "idx_usage_total_tokens" in indexes
     assert "idx_usage_observed_rate_limit_timestamp" in indexes
-    assert user_version == 9
-    assert [row["version"] for row in migrations] == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert user_version == 10
+    assert [row["version"] for row in migrations] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 
 def test_rebuild_index_clears_aggregate_rows_before_rescan(tmp_path: Path) -> None:

--- a/tests/test_store_migrations.py
+++ b/tests/test_store_migrations.py
@@ -54,9 +54,20 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert rows[0]["rate_limit_secondary_used_percent"] is None
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 9
+    assert state["schema_version"] == 10
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert [row["version"] for row in state["migrations"]] == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+    ]
 
 
 def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
@@ -79,7 +90,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "9"
+    assert metadata["schema_version"] == "10"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -107,6 +118,32 @@ def test_csv_export_keeps_current_columns_after_legacy_migration(tmp_path: Path)
     assert rows[0]["previous_record_id"] == ""
     assert rows[0]["next_record_id"] == ""
     assert list(rows[0]) == EVENT_COLUMNS
+
+
+def test_usage_impact_read_model_table_is_created(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(usage_impact)").fetchall()
+        }
+        indexes = {
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(usage_impact)").fetchall()
+        }
+
+    assert {
+        "record_id",
+        "window_type",
+        "estimated_usage_percent",
+        "confidence",
+        "status",
+        "recalculated_at",
+    } <= columns
+    assert "idx_usage_impact_window_status" in indexes
+    assert "idx_usage_impact_limit_window" in indexes
 
 
 def test_malformed_legacy_schema_reports_actionable_error_without_data_loss(

--- a/tests/test_usage_impact_cache.py
+++ b/tests/test_usage_impact_cache.py
@@ -151,6 +151,46 @@ def test_usage_impact_cache_can_return_pending_without_blocking(
     assert second[0]["usage_impact"]["primary"]["estimate_percent"] == 0.12
 
 
+def test_usage_impact_cache_can_return_pending_without_scheduling_warm(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    event = _usage_event(
+        record_id="target",
+        session_id=SESSION_ID,
+        thread_key="thread:Cache pending",
+        event_timestamp="2026-06-15T12:00:00Z",
+        cumulative_total_tokens=1000,
+    )
+    upsert_usage_events([event], db_path=db_path)
+    rows = query_usage_api_events(db_path=db_path, limit=1, include_archived=False)
+    cache = UsageImpactCache(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        rate_card_path=tmp_path / "rate-card.json",
+    )
+
+    def fail_if_scheduled(*, include_archived: bool) -> None:
+        raise AssertionError("live row slices must not schedule a full usage-impact warm")
+
+    monkeypatch.setattr(cache, "warm_async", fail_if_scheduled)
+
+    result = cache.copy_usage_impact(
+        rows,
+        include_archived=False,
+        block=False,
+        schedule_warm=False,
+    )
+
+    assert result[0]["record_id"] == "target"
+    assert result[0]["usage_impact_pending"] is True
+    assert result[0]["usage_impact"]["primary"]["status"] == "pending"
+    assert result[0]["usage_impact"]["secondary"]["status"] == "pending"
+
+
 def test_usage_impact_cache_warm_async_is_single_flight_per_history_scope(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_usage_impact_cache.py
+++ b/tests/test_usage_impact_cache.py
@@ -6,9 +6,10 @@ from pathlib import Path
 
 from store_dashboard_helpers import SESSION_ID, _usage_event, _write_pricing
 
-from codex_usage_tracker.store import query_usage_api_events, upsert_usage_events
+from codex_usage_tracker.store import connect, query_usage_api_events, upsert_usage_events
 from codex_usage_tracker.usage_impact_cache import UsageImpactCache
 from codex_usage_tracker.usage_impact_store import (
+    query_usage_impact_recalculation_record_ids,
     query_usage_impact_rows,
     replace_usage_impact_from_annotated_rows,
 )
@@ -240,6 +241,106 @@ def test_usage_impact_cache_warm_async_is_single_flight_per_history_scope(
     cache.warm_async(include_archived=True)
 
     assert len(started_threads) == 2
+
+
+def test_usage_impact_cache_warm_pending_targets_recalculation_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    events = [
+        _usage_event(
+            record_id="fresh",
+            session_id=SESSION_ID,
+            thread_key="thread:Cache pending",
+            event_timestamp="2026-06-15T12:00:00Z",
+            cumulative_total_tokens=100,
+        ),
+        _usage_event(
+            record_id="target",
+            session_id=SESSION_ID,
+            thread_key="thread:Cache pending",
+            event_timestamp="2026-06-15T12:01:00Z",
+            cumulative_total_tokens=200,
+        ),
+    ]
+    upsert_usage_events(events, db_path=db_path)
+    replace_usage_impact_from_annotated_rows(
+        db_path=db_path,
+        rows=[
+            {
+                "record_id": "fresh",
+                "total_tokens": 100,
+                "usage_credits": 1.0,
+                "usage_impact": {
+                    "primary": {
+                        "estimate_percent": 0.1,
+                        "lower_percent": 0.05,
+                        "upper_percent": 0.15,
+                        "basis": "credits",
+                        "source": "observed_interval",
+                    },
+                    "secondary": None,
+                },
+            },
+            {
+                "record_id": "target",
+                "total_tokens": 200,
+                "usage_credits": 2.0,
+                "usage_impact": {
+                    "primary": {
+                        "estimate_percent": 0.2,
+                        "lower_percent": 0.1,
+                        "upper_percent": 0.3,
+                        "basis": "credits",
+                        "source": "observed_interval",
+                    },
+                    "secondary": None,
+                },
+            },
+        ],
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE usage_impact
+            SET status = 'stale'
+            WHERE record_id = 'target'
+            """
+        )
+    captured_record_ids: list[list[str]] = []
+
+    class ImmediateThread:
+        def __init__(self, *args, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def start(self) -> None:
+            self.kwargs["target"](**self.kwargs["kwargs"])
+
+    cache = UsageImpactCache(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        rate_card_path=tmp_path / "rate-card.json",
+    )
+
+    def capture_rebuild(record_ids: list[str], *, include_archived: bool) -> dict[str, int]:
+        assert include_archived is False
+        captured_record_ids.append(record_ids)
+        return {"records": len(record_ids), "rows": len(record_ids) * 2}
+
+    monkeypatch.setattr(threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(cache, "_rebuild_records", capture_rebuild)
+
+    pending_ids = query_usage_impact_recalculation_record_ids(
+        db_path=db_path,
+        include_archived=False,
+    )
+    cache.warm_pending_async(include_archived=False)
+
+    assert pending_ids == ["target"]
+    assert captured_record_ids == [["target"]]
 
 
 def test_usage_impact_read_model_materializes_without_raw_content(tmp_path: Path) -> None:

--- a/tests/test_usage_impact_cache.py
+++ b/tests/test_usage_impact_cache.py
@@ -151,6 +151,57 @@ def test_usage_impact_cache_can_return_pending_without_blocking(
     assert second[0]["usage_impact"]["primary"]["estimate_percent"] == 0.12
 
 
+def test_usage_impact_cache_warm_async_is_single_flight_per_history_scope(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from codex_usage_tracker import usage_impact_cache as cache_module
+
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    cache = UsageImpactCache(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=tmp_path / "allowance.json",
+        rate_card_path=tmp_path / "rate-card.json",
+    )
+    signature = cache_module._FileSignature(path="missing", mtime_ns=None, size_bytes=None)
+    key_counter = 0
+
+    def changing_cache_key(*, include_archived: bool):
+        nonlocal key_counter
+        key_counter += 1
+        return cache_module._ImpactCacheKey(
+            include_archived=include_archived,
+            latest_refresh_at=f"refresh-{key_counter}",
+            scoped_rows=key_counter,
+            max_event_timestamp=f"2026-06-15T12:00:{key_counter:02d}Z",
+            pricing=signature,
+            allowance=signature,
+            rate_card=signature,
+        )
+
+    started_threads: list[object] = []
+
+    class FakeThread:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+            started_threads.append(self)
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr(cache, "_cache_key", changing_cache_key)
+    monkeypatch.setattr(cache_module.threading, "Thread", FakeThread)
+
+    cache.warm_async(include_archived=False)
+    cache.warm_async(include_archived=False)
+    cache.warm_async(include_archived=True)
+
+    assert len(started_threads) == 2
+
+
 def test_usage_impact_read_model_materializes_without_raw_content(tmp_path: Path) -> None:
     db_path = tmp_path / "usage.sqlite3"
     replace_usage_impact_from_annotated_rows(

--- a/tests/test_usage_impact_cache.py
+++ b/tests/test_usage_impact_cache.py
@@ -8,6 +8,10 @@ from store_dashboard_helpers import SESSION_ID, _usage_event, _write_pricing
 
 from codex_usage_tracker.store import query_usage_api_events, upsert_usage_events
 from codex_usage_tracker.usage_impact_cache import UsageImpactCache
+from codex_usage_tracker.usage_impact_store import (
+    query_usage_impact_rows,
+    replace_usage_impact_from_annotated_rows,
+)
 
 
 def test_usage_impact_cache_reuses_full_history_estimates(
@@ -85,7 +89,10 @@ def test_usage_impact_cache_reuses_full_history_estimates(
     assert third[0]["usage_impact"] == first[0]["usage_impact"]
     assert first[0]["record_id"] == "target"
     assert first[0]["usage_impact"]["primary"]["estimate_percent"] > 0
-    assert calls == 2
+    assert calls == 1
+    persisted = query_usage_impact_rows(db_path=db_path, record_id="target", limit=0)
+    assert {row["window_type"] for row in persisted} == {"primary", "secondary"}
+    assert persisted[0]["status"] in {"fresh", "unavailable"}
 
 
 def test_usage_impact_cache_can_return_pending_without_blocking(
@@ -134,10 +141,52 @@ def test_usage_impact_cache_can_return_pending_without_blocking(
     assert started.wait(timeout=1)
     assert first[0]["record_id"] == "target"
     assert first[0]["usage_impact_pending"] is True
-    assert first[0]["usage_impact"] == {"primary": None, "secondary": None}
+    assert first[0]["usage_impact"]["primary"]["status"] == "pending"
+    assert first[0]["usage_impact"]["secondary"]["status"] == "pending"
 
     release.set()
     second = cache.copy_usage_impact(rows, include_archived=False, block=True)
 
     assert "usage_impact_pending" not in second[0]
     assert second[0]["usage_impact"]["primary"]["estimate_percent"] == 0.12
+
+
+def test_usage_impact_read_model_materializes_without_raw_content(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    replace_usage_impact_from_annotated_rows(
+        db_path=db_path,
+        rows=[
+            {
+                "record_id": "record-secret",
+                "total_tokens": 100,
+                "usage_credits": 1.5,
+                "rate_limit_primary_used_percent": 10,
+                "rate_limit_primary_window_minutes": 300,
+                "rate_limit_primary_resets_at": 1781562696,
+                "usage_impact": {
+                    "primary": {
+                        "estimate_percent": 0.25,
+                        "lower_percent": 0.1,
+                        "upper_percent": 0.3,
+                        "observed_delta_percent": 1.0,
+                        "interval_call_count": 4,
+                        "basis": "credits",
+                        "source": "observed_interval",
+                        "previous_observed_record_id": "baseline",
+                        "previous_used_percent": 9.0,
+                        "next_observed_record_id": "record-secret",
+                        "source_note": "SECRET RAW PROMPT should not persist",
+                    },
+                    "secondary": None,
+                },
+            }
+        ],
+    )
+
+    rows = query_usage_impact_rows(db_path=db_path, record_id="record-secret", limit=0)
+    serialized = str(rows)
+
+    assert len(rows) == 2
+    assert rows[0]["record_id"] == "record-secret"
+    assert any(row["estimated_usage_percent"] == 0.25 for row in rows)
+    assert "SECRET RAW PROMPT" not in serialized


### PR DESCRIPTION
## Summary
- Adds a persistent `usage_impact` read-model table with primary/secondary window estimates, confidence/status labels, provenance ids, and no raw context storage.
- Wires refresh-delta invalidation so appended records become pending, deleted rows are cleared, and affected existing rows can be marked stale without recalculating on no-op refreshes.
- Exposes the read model through `codex-usage-tracker usage-impact`, `/api/usage-impact`, and nested `/api/call` payloads.
- Updates JSON contracts, CLI docs, installed-package smoke help coverage, and the branch roadmap.

## Validation
- `.venv/bin/python -m pytest tests/test_usage_impact.py tests/test_usage_impact_cache.py tests/test_store_migrations.py tests/test_store_dashboard_mcp.py tests/test_dashboard_server.py tests/test_json_contracts.py tests/test_privacy.py`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m pytest tests/test_json_contracts.py tests/test_dashboard_server.py tests/test_cli_release.py`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m compileall src`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
- `rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python scripts/check_release.py --dist && .venv/bin/python -m twine check dist/*`
- `for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file" || exit 1; done`
- `.venv/bin/python scripts/benchmark_synthetic_history.py --rows 10000 --json --enforce-thresholds`

## Manual smoke
- Launched source server on `http://127.0.0.1:8912/dashboard.html?fresh=usage-impact-read-model&history=all&direction=desc`.
- Verified `/api/calls?limit=5&offset=0&include_archived=true&sort=time&direction=desc` returns rows out of the full local history instead of staying at zero.
- Verified `/api/usage-impact?limit=5` returns `codex-usage-tracker-usage-impact-v1` rows.
- Verified token-protected `/api/status?refresh=1` reports append delta fields when the active Codex session writes new rows.

## Notes
- This does not merge to `main` and does not publish or tag.
- M4 remains partially open in the roadmap: recalculation still materializes from full-history rows when needed; the delta-aware pending/stale invalidation layer is in place for the next affected-interval optimization.
