### PR TITLE
fix: improve diagnostics weekly projection panels

### DIFF
--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_diagnostics.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_diagnostics.js
@@ -30,6 +30,7 @@
     let errorMessage = '';
     let snapshotRefreshStatus = 'idle';
     let snapshotRefreshError = '';
+    let sectionRefreshStatuses = {};
     let requestGeneration = 0;
     let payloads = emptyPayloads();
     let selectedFactKey = '';
@@ -82,6 +83,7 @@
       errorMessage = '';
       snapshotRefreshStatus = 'idle';
       snapshotRefreshError = '';
+      sectionRefreshStatuses = {};
       selectedFactKey = '';
       payloads = emptyPayloads();
       factCallPayloads.clear();
@@ -110,6 +112,7 @@
         errorMessage = '';
         snapshotRefreshStatus = 'idle';
         snapshotRefreshError = '';
+        sectionRefreshStatuses = {};
         selectedFactKey = '';
         payloads = emptyPayloads();
         factCallPayloads.clear();
@@ -134,6 +137,7 @@
         ]);
         if (generation !== requestGeneration || signature !== activeSignature) return;
         payloads = { facts, tools, compactions, ...snapshots };
+        sectionRefreshStatuses = {};
         status = 'ready';
       } catch (error) {
         if (generation !== requestGeneration || signature !== activeSignature) return;
@@ -173,11 +177,44 @@
         const snapshots = refreshPayload.sections || {};
         if (signature !== activeSignature) return;
         payloads = { ...payloads, ...snapshots };
+        sectionRefreshStatuses = {};
         snapshotRefreshStatus = 'ready';
       } catch (error) {
         if (signature !== activeSignature) return;
         snapshotRefreshStatus = 'error';
         snapshotRefreshError = error.message || String(error);
+      }
+      renderIfActive();
+    }
+
+    async function refreshDiagnosticSnapshot(sectionKey) {
+      const section = snapshotRenderer.sections.find(candidate => candidate.key === sectionKey);
+      if (!section || sectionRefreshStatuses[sectionKey] === 'refreshing') return;
+      const signature = activeSignature;
+      sectionRefreshStatuses = { ...sectionRefreshStatuses, [sectionKey]: 'refreshing' };
+      renderIfActive();
+      try {
+        const filters = getDiagnosticFilters();
+        const snapshotFilters = { include_archived: filters?.include_archived || '0' };
+        const payload = await fetchPayload(
+          section.refreshPath,
+          snapshotFilters,
+          { method: 'POST' },
+        );
+        if (signature !== activeSignature) return;
+        payloads = { ...payloads, [sectionKey]: payload };
+        sectionRefreshStatuses = { ...sectionRefreshStatuses, [sectionKey]: 'ready' };
+      } catch (error) {
+        if (signature !== activeSignature) return;
+        payloads = {
+          ...payloads,
+          [sectionKey]: {
+            ...(payloads[sectionKey] || {}),
+            status: 'error',
+            error: error.message || String(error),
+          },
+        };
+        sectionRefreshStatuses = { ...sectionRefreshStatuses, [sectionKey]: 'error' };
       }
       renderIfActive();
     }
@@ -308,7 +345,7 @@
             ${snapshotRenderer.readoutMetric('Snapshot sections', snapshotRenderer.readyCount(payloads))}
             <span class="diagnostics-note">Structured labels only. Raw context remains on-demand in the call investigator.</span>
           </div>
-          ${snapshotRenderer.renderPanels({ loading, payloads })}
+          ${snapshotRenderer.renderPanels({ loading, payloads, sectionRefreshStatuses })}
           ${factRenderer.renderFactSection('facts', 'Top Diagnostic Facts', 'Structured facts associated with model calls.', payloads.facts, loading)}
           ${factRenderer.renderFactSection('tools', 'Tool and Function Activity', 'Tool/function facts associated with model calls.', payloads.tools, loading)}
           ${factRenderer.renderFactSection('compactions', 'Compaction Activity', 'Compaction facts and post-compaction associated costs.', payloads.compactions, loading)}
@@ -475,6 +512,13 @@
         event.preventDefault();
         event.stopPropagation();
         void refreshDiagnosticSnapshots();
+        return;
+      }
+      const sectionRefreshButton = target.closest('[data-diagnostics-section-refresh]');
+      if (sectionRefreshButton && diagnosticsPanelEl.contains(sectionRefreshButton)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void refreshDiagnosticSnapshot(sectionRefreshButton.dataset.diagnosticsSectionRefresh || '');
         return;
       }
       const loadMoreButton = target.closest('[data-diagnostics-call-load-more]');

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_diagnostics_snapshots.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_diagnostics_snapshots.js
@@ -48,12 +48,12 @@
       `;
     }
 
-    function renderPanels({ loading, payloads }) {
+    function renderPanels({ loading, payloads, sectionRefreshStatuses = {} }) {
       const featuredUsageDrain = renderFeaturedUsageDrain(payloads.usageDrain);
       return `
         ${featuredUsageDrain}
         <div class="diagnostics-snapshot-grid">
-          ${sections.map(section => renderPanel(section, payloads[section.key], loading)).join('')}
+          ${sections.map(section => renderPanel(section, payloads[section.key], loading, sectionRefreshStatuses[section.key] || '')).join('')}
         </div>
       `;
     }
@@ -62,11 +62,11 @@
       if (!payload || payload.status !== 'ready') return '';
       const timeSeries = payload?.time_series || {};
       const charts = [];
-      if (Array.isArray(timeSeries.visible_usage?.points) && timeSeries.visible_usage.points.length) {
-        charts.push(renderVisibleUsageChart(timeSeries.visible_usage));
-      }
       if (Array.isArray(timeSeries.weekly_credit_projection?.points) && timeSeries.weekly_credit_projection.points.length) {
         charts.push(renderWeeklyProjectionChart(timeSeries.weekly_credit_projection));
+      }
+      if (Array.isArray(timeSeries.visible_usage?.points) && timeSeries.visible_usage.points.length) {
+        charts.push(renderVisibleUsageChart(timeSeries.visible_usage));
       }
       if (!charts.length) return '';
       return `
@@ -76,7 +76,7 @@
       `;
     }
 
-    function renderPanel(section, payload, loading) {
+    function renderPanel(section, payload, loading, sectionRefreshStatus) {
       const meta = snapshotMeta(payload);
       const state = snapshotState(payload, loading);
       const body = state ? renderState(state) : renderBody(section.key, payload);
@@ -87,11 +87,30 @@
               <h3>${escapeHtml(section.title)}</h3>
               <p>${escapeHtml(meta)}</p>
             </div>
-            <span>${escapeHtml(snapshotBadge(payload, loading))}</span>
+            ${renderSnapshotHeaderActions(section, payload, loading, sectionRefreshStatus)}
           </div>
           ${body}
         </div>
       `;
+    }
+
+    function renderSnapshotHeaderActions(section, payload, loading, sectionRefreshStatus) {
+      const refreshing = sectionRefreshStatus === 'refreshing';
+      const reloadButton = snapshotRefreshable(payload, loading)
+        ? `<button class="toolbar-button diagnostics-section-refresh" type="button" data-diagnostics-section-refresh="${escapeHtml(section.key)}" ${refreshing ? 'disabled' : ''}>${escapeHtml(refreshing ? 'Reloading...' : 'Reload')}</button>`
+        : '';
+      return `
+        <div class="diagnostics-section-actions">
+          <span>${escapeHtml(refreshing ? 'refreshing' : snapshotBadge(payload, loading))}</span>
+          ${reloadButton}
+        </div>
+      `;
+    }
+
+    function snapshotRefreshable(payload, loading) {
+      if (loading) return false;
+      if (!payload) return true;
+      return payload.status !== 'ready';
     }
 
     function renderBody(key, payload) {
@@ -475,13 +494,14 @@
           </div>
         </div>
         ${renderSimpleTable(
-          ['Week', 'Plan', 'Observed %', 'Credits', 'Projected/week', 'Confidence'],
+          ['Week', 'Plan', 'Observed %', 'Credits', 'Projected/week', '95% CI', 'Confidence'],
           chartPoints.slice(-6).map(point => [
             point.label,
             humanizeMetric(point.rate_limit_plan_type || 'unknown'),
             pct(Number(point.observed_usage_delta_percent || 0) / 100),
             numberText(point.observed_standard_usage_credits),
             numberText(point.projected_weekly_credits),
+            weeklyProjectionCiText(point),
             humanizeMetric(point.confidence),
           ]),
           'No weekly projection points in this snapshot.',
@@ -527,6 +547,13 @@
     function weeklyProjectionTickLabel(point) {
       const label = point.label || shortDate(point.end_event_timestamp);
       return String(label || '').replace(/^Reset\s+/i, '');
+    }
+
+    function weeklyProjectionCiText(point) {
+      if (point.ci_low === null || point.ci_low === undefined || point.ci_high === null || point.ci_high === undefined) {
+        return 'n/a';
+      }
+      return `${numberText(point.ci_low)} - ${numberText(point.ci_high)}`;
     }
 
     function weeklyProjectionPlanKey(point) {

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_tables.css
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_tables.css
@@ -344,7 +344,15 @@
       font-weight: 680;
       line-height: 1.35;
     }
-    .diagnostics-section-header > span {
+    .diagnostics-section-actions {
+      display: flex;
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .diagnostics-section-actions > span {
       flex: 0 0 auto;
       padding: 3px 8px;
       border: 1px solid var(--line);
@@ -354,6 +362,12 @@
       font-size: 11px;
       font-weight: 780;
       white-space: nowrap;
+    }
+    .diagnostics-section-refresh {
+      min-height: 26px;
+      padding: 5px 9px;
+      font-size: 11px;
+      line-height: 1.1;
     }
     .diagnostics-table-wrap {
       overflow-x: auto;

--- a/tests/test_dashboard_diagnostics_snapshots.py
+++ b/tests/test_dashboard_diagnostics_snapshots.py
@@ -294,6 +294,60 @@ console.log(JSON.stringify({
     assert payload["leaksRawPath"] is False
 
 
+def test_dashboard_stale_snapshot_panels_render_reload_buttons() -> None:
+    payload = _run_snapshot_renderer_script(
+        """
+const renderer = factory.create({
+  escapeHtml,
+  formatTimestamp: value => value,
+  number: new Intl.NumberFormat('en-US'),
+  pct: value => `${Math.round(Number(value || 0) * 100)}%`,
+  renderState: message => `<div>${escapeHtml(message)}</div>`,
+  rowInvestigatorLink: () => '<a>1,000</a>',
+  tokenText: value => new Intl.NumberFormat('en-US').format(Number(value || 0)),
+});
+const html = renderer.renderPanels({
+  loading: false,
+  payloads: {
+    overview: {
+      status: 'missing',
+      snapshot: {
+        history_scope: 'active',
+      },
+    },
+    toolOutput: {
+      status: 'ready',
+      refreshed: false,
+      snapshot: {
+        computed_at: '2026-06-20T00:00:00Z',
+        history_scope: 'active',
+        source_logs_scanned: 1,
+      },
+      summary: { function_calls: 1 },
+      functions: [],
+    },
+  },
+  sectionRefreshStatuses: {
+    overview: 'refreshing',
+  },
+});
+console.log(JSON.stringify({
+  hasOverviewReload: html.includes('data-diagnostics-section-refresh="overview"'),
+  overviewReloads: html.includes('Reloading...'),
+  hasCommandsReload: html.includes('data-diagnostics-section-refresh="commands"'),
+  hasToolOutputReload: html.includes('data-diagnostics-section-refresh="toolOutput"'),
+  readyBadgeStillVisible: html.includes('<span>stored</span>'),
+}));
+"""
+    )
+
+    assert payload["hasOverviewReload"] is True
+    assert payload["overviewReloads"] is True
+    assert payload["hasCommandsReload"] is True
+    assert payload["hasToolOutputReload"] is False
+    assert payload["readyBadgeStillVisible"] is True
+
+
 def test_dashboard_usage_drain_charts_render_as_featured_first() -> None:
     payload = _run_snapshot_renderer_script(
         """
@@ -370,11 +424,13 @@ const html = renderer.renderPanels({
 console.log(JSON.stringify({
   hasFeaturedBlock: html.includes('data-diagnostics-featured="usage-drain"'),
   featuredBeforeGrid: html.indexOf('data-diagnostics-featured="usage-drain"') < html.indexOf('diagnostics-snapshot-grid'),
-  weeklyBeforeProjection: html.indexOf('Weekly usage over time') < html.indexOf('Projected weekly credits over time'),
+  projectionBeforeWeekly: html.indexOf('Projected weekly credits over time') < html.indexOf('Weekly usage over time'),
   projectionBeforeOverview: html.indexOf('Projected weekly credits over time') < html.indexOf('Overview'),
   weeklyChartTitleCount: (html.match(/<strong>Weekly usage over time<\\/strong>/g) || []).length,
   weeklyRemainingPolylineCount: (html.match(/stroke="#059669"/g) || []).length,
   projectedChartTitleCount: (html.match(/<strong>Projected weekly credits over time<\\/strong>/g) || []).length,
+  hasCiColumn: html.includes('95% CI'),
+  hasFormattedCiRange: html.includes('25,000 - 35,000') && html.includes('36,000 - 44,000'),
   labelsRemainingAllowance: html.includes('Usage remaining') && html.includes('Weekly remaining'),
   labelsVisibleUsage: html.includes('Visible usage'),
   preservesMoneyCents: html.includes('$0.10'),
@@ -384,11 +440,13 @@ console.log(JSON.stringify({
 
     assert payload["hasFeaturedBlock"] is True
     assert payload["featuredBeforeGrid"] is True
-    assert payload["weeklyBeforeProjection"] is True
+    assert payload["projectionBeforeWeekly"] is True
     assert payload["projectionBeforeOverview"] is True
     assert payload["weeklyChartTitleCount"] == 1
     assert payload["weeklyRemainingPolylineCount"] == 2
     assert payload["projectedChartTitleCount"] == 1
+    assert payload["hasCiColumn"] is True
+    assert payload["hasFormattedCiRange"] is True
     assert payload["labelsRemainingAllowance"] is True
     assert payload["labelsVisibleUsage"] is False
     assert payload["preservesMoneyCents"] is True

--- a/tests/test_dashboard_payload.py
+++ b/tests/test_dashboard_payload.py
@@ -314,6 +314,9 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert "/api/diagnostics/usage-drain/refresh" in dashboard_diagnostics_snapshots_js
     assert "Refresh diagnostics" in dashboard_diagnostics_snapshots_js
     assert "data-diagnostics-refresh" in dashboard_diagnostics_js
+    assert "data-diagnostics-section-refresh" in dashboard_diagnostics_js
+    assert "data-diagnostics-section-refresh" in dashboard_diagnostics_snapshots_js
+    assert "refreshDiagnosticSnapshot" in dashboard_diagnostics_js
     assert "Live API required for diagnostics refresh" in dashboard_diagnostics_js
     assert "Overview" in dashboard_diagnostics_snapshots_js
     assert "Tool Output" in dashboard_diagnostics_snapshots_js


### PR DESCRIPTION
## Summary

- Move projected weekly credits ahead of weekly usage in the Diagnostics featured charts.
- Add a 95% CI column to the projected weekly credits table.
- Add per-section Reload buttons for stale/missing diagnostic snapshot cards.

## Validation

- .venv/bin/python -m pytest tests/test_dashboard_diagnostics_snapshots.py tests/test_dashboard_payload.py tests/test_dashboard_server.py tests/test_cli_lifecycle.py::test_diagnostics_cli_returns_aggregate_json -q
- for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check ""; done
- .venv/bin/python -m compileall src
- .venv/bin/python scripts/check_release.py
- git diff --check
- DASHBOARD_BASE_URL=http://127.0.0.1:8898 npm run smoke:dashboard:diagnostics
