### PR TITLE
chore: prepare 0.11.2 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-usage-tracker",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
   "author": {
     "name": "Douglas Monsky"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 0.11.2 - 2026-06-23
 
+- Fix served dashboard shell hydration so `serve-dashboard --no-refresh` reliably populates the calls table from `/api/usage` when the initial HTML contains zero rows but indexed rows are available.
 - Harden the synthetic source-log benchmark smoke test so shared-runner timing noise does not leave a stale red release check.
 - Improve benchmark smoke test failures so future threshold failures report the parsed JSON payload and threshold details instead of only a generic subprocess error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.11.2 - 2026-06-23
+
+- Harden the synthetic source-log benchmark smoke test so shared-runner timing noise does not leave a stale red release check.
+- Improve benchmark smoke test failures so future threshold failures report the parsed JSON payload and threshold details instead of only a generic subprocess error.
+
 ## 0.11.1 - 2026-06-23
 
 - Move projected weekly credits to the top of the Diagnostics tab and add the 95% CI range to the projection table.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ fix/<issue-number>-short-description
 docs/<issue-number>-short-description
 chore/<issue-number>-short-description
 test/<issue-number>-short-description
-release/0.11.1
+release/0.11.2
 hotfix/0.3.3
 ```
 
@@ -91,7 +91,7 @@ blocked
 Recommended milestones:
 
 ```text
-0.11.1
+0.11.2
 1.0-readiness
 1.0.0
 ```
@@ -146,8 +146,8 @@ python scripts/smoke_installed_package.py --docker
 To verify the public PyPI package instead of the local checkout:
 
 ```bash
-python scripts/smoke_installed_package.py --from-pypi --version 0.11.1
-python scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.1
+python scripts/smoke_installed_package.py --from-pypi --version 0.11.2
+python scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.2
 ```
 
 `scripts/check_release.py` treats these public-package smoke commands as release-state claims. Keep their `--version` and `codex-usage-tracking==...` values aligned with `pyproject.toml`; the release gate fails when the docs claim a different public version. It also checks that install docs point at the real PyPI distribution, `codex-usage-tracking`, and keep the warning that `codex-usage-tracker` is a different PyPI package.
@@ -294,8 +294,8 @@ After the release branch merges, tag from updated `main`, not from an unreviewed
 ```bash
 git switch main
 git pull --ff-only
-git tag -a v0.11.1 -m "codex-usage-tracker 0.11.1"
-git push origin v0.11.1
+git tag -a v0.11.2 -m "codex-usage-tracker 0.11.2"
+git push origin v0.11.2
 ```
 
 Do not create or push release tags without maintainer approval.
@@ -304,7 +304,7 @@ Do not create or push release tags without maintainer approval.
 
 Publishing uses GitHub Actions Trusted Publishing through `.github/workflows/publish.yml`; do not upload from a local machine and do not add PyPI or TestPyPI API tokens.
 
-The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading. Minor release `0.4.0` added Python 3.14 support, release recovery docs, stricter privacy/support-bundle regression coverage, and large-history benchmark thresholds. Patch release `0.4.1` was published by workflow dispatch from `main`; it hardened the PyPI publish workflow and checked off completed 1.0 readiness gates. Minor release `0.5.0` added dashboard localization support and initial language catalogs. Minor release `0.6.0` is the performance and call-drilldown release with SQL-backed live API slices, materialized thread summaries, faster evidence loading, and dashboard runtime module refactors. Patch release `0.6.1` aligns the final README/package screenshots and companion plugin assets. Minor release `0.7.0` adds observed usage snapshots and the latest-observed dashboard card while keeping raw evidence on demand only. Minor release `0.8.0` adds aggregate diagnostics, source-offset context seeking, and live dashboard loading hardening. Patch release `0.8.1` improves Diagnostics fact table readability with pinned fact names and sortable fact columns. Minor release `0.9.0` adds persisted diagnostic snapshots, on-demand diagnostic refresh, tool/command/file-read/concentration reports, and Diagnostics dashboard panels. Minor release `0.10.0` adds Git/GitHub CLI diagnostics, file-modification diagnostics, and derived call timing fields across the dashboard and API. Patch release `0.10.1` adds lightweight action timing to context evidence and ships the synthetic Git Interactions README screenshot. Minor release `0.11.0` adds usage-drain diagnostic reports, projected weekly credit charts, and cumulative thread cost curves. Patch release `0.11.1` improves the Diagnostics weekly projection table and stale snapshot reload controls.
+The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading. Minor release `0.4.0` added Python 3.14 support, release recovery docs, stricter privacy/support-bundle regression coverage, and large-history benchmark thresholds. Patch release `0.4.1` was published by workflow dispatch from `main`; it hardened the PyPI publish workflow and checked off completed 1.0 readiness gates. Minor release `0.5.0` added dashboard localization support and initial language catalogs. Minor release `0.6.0` is the performance and call-drilldown release with SQL-backed live API slices, materialized thread summaries, faster evidence loading, and dashboard runtime module refactors. Patch release `0.6.1` aligns the final README/package screenshots and companion plugin assets. Minor release `0.7.0` adds observed usage snapshots and the latest-observed dashboard card while keeping raw evidence on demand only. Minor release `0.8.0` adds aggregate diagnostics, source-offset context seeking, and live dashboard loading hardening. Patch release `0.8.1` improves Diagnostics fact table readability with pinned fact names and sortable fact columns. Minor release `0.9.0` adds persisted diagnostic snapshots, on-demand diagnostic refresh, tool/command/file-read/concentration reports, and Diagnostics dashboard panels. Minor release `0.10.0` adds Git/GitHub CLI diagnostics, file-modification diagnostics, and derived call timing fields across the dashboard and API. Patch release `0.10.1` adds lightweight action timing to context evidence and ships the synthetic Git Interactions README screenshot. Minor release `0.11.0` adds usage-drain diagnostic reports, projected weekly credit charts, and cumulative thread cost curves. Patch release `0.11.1` improves the Diagnostics weekly projection table and stale snapshot reload controls. Patch release `0.11.2` hardens the synthetic source-log benchmark smoke test and improves benchmark failure diagnostics.
 
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.0`
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.1`

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -24,12 +24,12 @@ Not guaranteed:
 
 ## 1. Public Install And Package Metadata
 
-- [x] Verify the current public PyPI version is visible as `0.11.1`: `python -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/codex-usage-tracking/json'))['info']['version'])"`.
-- [x] Verify public venv install for `0.11.1`: `python -m venv /tmp/codex-usage-pypi-smoke && . /tmp/codex-usage-pypi-smoke/bin/activate && python -m pip install codex-usage-tracking==0.11.1 && codex-usage-tracker --version`.
-- [x] Verify public pipx install path for `0.11.1`: `PIPX_HOME=/tmp/codex-usage-pipx-home PIPX_BIN_DIR=/tmp/codex-usage-pipx-bin pipx install codex-usage-tracking==0.11.1 && /tmp/codex-usage-pipx-bin/codex-usage-tracker --version`.
+- [x] Verify the current public PyPI version is visible as `0.11.2`: `python -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/codex-usage-tracking/json'))['info']['version'])"`.
+- [x] Verify public venv install for `0.11.2`: `python -m venv /tmp/codex-usage-pypi-smoke && . /tmp/codex-usage-pypi-smoke/bin/activate && python -m pip install codex-usage-tracking==0.11.2 && codex-usage-tracker --version`.
+- [x] Verify public pipx install path for `0.11.2`: `PIPX_HOME=/tmp/codex-usage-pipx-home PIPX_BIN_DIR=/tmp/codex-usage-pipx-bin pipx install codex-usage-tracking==0.11.2 && /tmp/codex-usage-pipx-bin/codex-usage-tracker --version`.
 - [x] Verify installed package resources from a built wheel: `python scripts/smoke_installed_package.py`.
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
-- [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.1`.
+- [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.2`.
 - [x] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
 - [x] Add Python 3.14 as an official support target after CI, package classifiers, docs, and installed-package smoke coverage were added. Docker smoke coverage uses `python:3.14-slim` by default. Track this in issue #12.
 
@@ -134,14 +134,14 @@ Not guaranteed:
 
 ## Evidence References
 
-These references are the concrete proof behind completed checklist items. Public package smoke commands are version-specific to `0.11.1`; all repo tests use synthetic or aggregate-only data.
+These references are the concrete proof behind completed checklist items. Public package smoke commands are version-specific to `0.11.2`; all repo tests use synthetic or aggregate-only data.
 
 ### Public Install And Package Metadata
 
 - Public PyPI version, public venv install, and public pipx install are proven by the exact public-install commands in section 1.
 - Built-wheel and installed-resource coverage is proven by `scripts/smoke_installed_package.py` and `tests/test_cli_release.py::test_installed_package_smoke_checks_help_for_stable_commands`.
 - Linux package-resource coverage is proven by `scripts/smoke_installed_package.py --docker`.
-- Public PyPI Docker coverage is proven by `scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.1`.
+- Public PyPI Docker coverage is proven by `scripts/smoke_installed_package.py --docker --from-pypi --version 0.11.2`.
 - PyPI metadata, package/distribution names, package resources, source/wheel member names, Python 3.10-3.14 support metadata, CI workflow requirements, publish workflow safety text, and tracked secret patterns are proven by `scripts/check_release.py`, `scripts/check_release.py --dist`, and `tests/test_cli_release.py::test_release_check_script_passes`.
 
 ### Upgrade And Migration
@@ -219,8 +219,8 @@ These references are the concrete proof behind completed checklist items. Public
 - Publish workflow package name, Trusted Publishing, TestPyPI/PyPI job presence, event guards, no push/PR publishing, no token/password publishing, and manual PyPI main/tag preflight are proven by `scripts/check_release.py::_check_publish_workflow`.
 - The GitHub `pypi` environment gate is proven by `gh api repos/douglasmonsky/codex-usage-tracker/environments/pypi`, which reports a `required_reviewers` protection rule and `can_admins_bypass=false`.
 - Dist filename and wheel/sdist member checks are proven by `python -m build`, `python -m twine check dist/*`, and `python scripts/check_release.py --dist`.
-- TestPyPI publish process is proven by a workflow-dispatch run on `main`, followed by TestPyPI metadata and clean virtualenv install checks for `codex-usage-tracking==0.11.1`.
-- PyPI publish process is proven by a workflow-dispatch run on `main`, protected `pypi` environment approval, PyPI metadata visibility, clean virtualenv install, temporary pipx install, and Docker public-package smoke for `codex-usage-tracking==0.11.1`.
+- TestPyPI publish process is proven by a workflow-dispatch run on `main`, followed by TestPyPI metadata and clean virtualenv install checks for `codex-usage-tracking==0.11.2`.
+- PyPI publish process is proven by a workflow-dispatch run on `main`, protected `pypi` environment approval, PyPI metadata visibility, clean virtualenv install, temporary pipx install, and Docker public-package smoke for `codex-usage-tracking==0.11.2`.
 - Release recovery documentation is proven by `scripts/check_release.py` required-file and docs checks.
 
 ### Known Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codex-usage-tracking"
-version = "0.11.1"
+version = "0.11.2"
 description = "Unofficial local Codex plugin and dashboard for investigating aggregate token usage, costs, caching, and thread patterns."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "codex-usage-tracking==0.11.1",
+    "codex-usage-tracking==0.11.2",
 )
-RUNTIME_VERSION = "0.11.1"
+RUNTIME_VERSION = "0.11.2"
 PACKAGE_SPEC_MARKER = ".codex-usage-tracker-package-spec"
 MODULE_CHECK = (
     "import importlib.metadata; "

--- a/src/codex_usage_tracker/__init__.py
+++ b/src/codex_usage_tracker/__init__.py
@@ -2,6 +2,6 @@
 
 from codex_usage_tracker.models import UsageEvent
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 __all__ = ["UsageEvent", "__version__"]

--- a/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
+++ b/src/codex_usage_tracker/plugin_data/dashboard/dashboard_live.js
@@ -225,7 +225,7 @@
         if (rowCountChanged || refreshChanged) {
           refreshDashboardLive();
         } else if (rowsNeedHydration()) {
-          hydrateDashboardRows();
+          await hydrateDashboardRows();
         }
       } catch (_error) {
         // Background freshness checks must never interrupt the local dashboard.
@@ -291,7 +291,7 @@
           rowHydrationComplete = getData().length >= rowHydrationTarget();
           updateRowLoadProgress();
         } else if (rowsNeedHydration()) {
-          hydrateDashboardRows();
+          await hydrateDashboardRows();
         }
 
         const result = shellPayload.refresh_result || {};
@@ -356,7 +356,7 @@
           rowHydrationComplete = false;
         }
         applyDashboardPayload(nextPayload);
-        if (!['call', 'diagnostics'].includes(activeView())) hydrateDashboardRows({ reset: resetRows });
+        if (!['call', 'diagnostics'].includes(activeView())) await hydrateDashboardRows({ reset: resetRows });
         const result = nextPayload.refresh_result || {};
         const indexed = result.inserted_or_updated_events === undefined
           ? ''

--- a/tests/test_cli_release.py
+++ b/tests/test_cli_release.py
@@ -352,10 +352,8 @@ def test_cli_json_schema_doc_lists_tracked_contracts() -> None:
 
 
 def test_synthetic_history_benchmark_script_smoke(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-    result = subprocess.run(
+    payload = _run_benchmark_json(
         [
-            sys.executable,
             "scripts/benchmark_synthetic_history.py",
             "--rows",
             "100",
@@ -368,13 +366,7 @@ def test_synthetic_history_benchmark_script_smoke(tmp_path: Path) -> None:
             "--threshold-scale",
             "5",
         ],
-        check=True,
-        capture_output=True,
-        text=True,
-        cwd=repo_root,
-        env=_subprocess_env(),
     )
-    payload = json.loads(result.stdout)
 
     assert payload["threshold_scale"] == 5.0
     assert payload["benchmarks"][0]["rows"] == 100
@@ -398,10 +390,8 @@ def test_synthetic_history_benchmark_script_smoke(tmp_path: Path) -> None:
 
 
 def test_synthetic_history_benchmark_with_source_logs_smoke(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[1]
-    result = subprocess.run(
+    payload = _run_benchmark_json(
         [
-            sys.executable,
             "scripts/benchmark_synthetic_history.py",
             "--rows",
             "100",
@@ -413,17 +403,12 @@ def test_synthetic_history_benchmark_with_source_logs_smoke(tmp_path: Path) -> N
             "--json",
             "--enforce-thresholds",
             "--threshold-scale",
-            "5",
+            "10",
         ],
-        check=True,
-        capture_output=True,
-        text=True,
-        cwd=repo_root,
-        env=_subprocess_env(),
     )
-    payload = json.loads(result.stdout)
     benchmark = payload["benchmarks"][0]
 
+    assert payload["threshold_scale"] == 10.0
     assert benchmark["threshold_status"] == "pass"
     assert benchmark["threshold_failures"] == []
     assert benchmark["source_logs_generated"] > 0
@@ -441,6 +426,42 @@ def test_synthetic_history_benchmark_with_source_logs_smoke(tmp_path: Path) -> N
     assert {"early", "middle", "late"} == set(benchmark["context_loads"])
     assert benchmark["context_loads"]["middle"]["context_payload_json_bytes"] > 0
     assert benchmark["context_loads"]["middle"]["source_scan_ms"] >= 0
+
+
+def _run_benchmark_json(args: list[str]) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=_subprocess_env(),
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            "benchmark did not emit JSON\n"
+            f"returncode={result.returncode}\n"
+            f"stdout={result.stdout}\n"
+            f"stderr={result.stderr}"
+        ) from exc
+    if result.returncode != 0:
+        failures = [
+            failure
+            for benchmark in payload.get("benchmarks", [])
+            if isinstance(benchmark, dict)
+            for failure in benchmark.get("threshold_failures", [])
+        ]
+        raise AssertionError(
+            "benchmark exited nonzero\n"
+            f"returncode={result.returncode}\n"
+            f"threshold_failures={failures}\n"
+            f"stderr={result.stderr}\n"
+            f"payload={json.dumps(payload, indent=2)}"
+        )
+    return payload
 
 
 def _subprocess_env() -> dict[str, str]:

--- a/tests/test_dashboard_live.py
+++ b/tests/test_dashboard_live.py
@@ -320,6 +320,103 @@ def test_dashboard_live_prepends_new_rows_after_cached_index_refresh() -> None:
     assert payload["data"] == ["new-1", "old-1", "old-2", "old-3", "old-4"]
 
 
+def test_dashboard_live_hydrates_empty_shell_after_refresh() -> None:
+    payload = _run_dashboard_live_script(
+        """
+(async () => {
+  const calls = [];
+  const appliedPayloads = [];
+  let totalRows = 9862;
+  let data = [];
+  globalThis.__fetch = async (url, options) => {
+    calls.push({ url, headers: options.headers });
+    const shellRequest = url.includes('shell=1');
+    return {
+      ok: true,
+      json: async () => ({
+        rows: shellRequest
+          ? []
+          : [{ record_id: 'row-1' }, { record_id: 'row-2' }, { record_id: 'row-3' }],
+        refreshed_at: '2026-06-19T00:00:00Z',
+        refresh_result: {
+          inserted_or_updated_events: 0,
+          scanned_files: 411,
+          skipped_events: 0,
+        },
+        total_available_rows: 9862,
+        has_more: true,
+      }),
+    };
+  };
+  const runtime = factory.create({
+    activeView: () => 'calls',
+    apiToken: () => 'test-token',
+    applyDashboardPayload: (payload, options = {}) => {
+      appliedPayloads.push({
+        rows: (payload.rows || []).map(row => row.record_id),
+        options,
+      });
+      totalRows = payload.total_available_rows || totalRows;
+      if (options.appendRows) data = [...data, ...(payload.rows || [])];
+    },
+    autoRefreshEl: { checked: false },
+    backgroundHydrationChunkSize: 2000,
+    formatTimestamp: value => value,
+    getArchivedAvailableRows: () => 0,
+    getData: () => data,
+    getIncludeArchived: () => false,
+    getLoadedLimit: () => 5000,
+    getTotalAvailableRows: () => totalRows,
+    historyScopeEl: { value: 'active', parentElement: {} },
+    i18n: { currentLanguage: 'en' },
+    initialHydrationChunkSize: 500,
+    latestRefreshAt: () => '',
+    limitValue: value => value === null ? 'all' : String(value),
+    liveRefreshIntervalMs: 10000,
+    liveRefreshSupported: true,
+    loadLimitEl: { value: '5000', options: [], lastElementChild: null, insertBefore: () => {} },
+    number: new Intl.NumberFormat('en-US'),
+    payloadRows: payload => payload.rows || [],
+    rebuildDashboardIndexes: () => {},
+    rebuildFilterOptions: () => {},
+    refreshDashboardEl: { disabled: false },
+    render: () => {},
+    resetRowsForHydration: () => {},
+    rowLoadProgressBarEl: { style: {} },
+    rowLoadProgressCountEl: { textContent: '' },
+    rowLoadProgressEl: { hidden: true },
+    rowLoadProgressLabelEl: { textContent: '' },
+    setFastTooltip: () => {},
+    t: key => key,
+    tf: (key, values = {}) => `${key}:${JSON.stringify(values)}`,
+    updateLiveStatus: () => {},
+  });
+  await runtime.refreshDashboardLive();
+  console.log(JSON.stringify({
+    urls: calls.map(call => call.url.replace(/_=[0-9]+/, '_=<ts>')),
+    tokens: calls.map(call => call.headers['X-Codex-Usage-Token']),
+    appliedPayloads,
+    data: data.map(row => row.record_id),
+  }));
+})().catch(error => {
+  console.error(error);
+  process.exit(1);
+});
+"""
+    )
+
+    assert payload["urls"] == [
+        "/api/usage?limit=5000&include_archived=0&lang=en&shell=1&_=<ts>&refresh=1",
+        "/api/usage?limit=500&offset=0&include_archived=0&lang=en&_=<ts>",
+    ]
+    assert payload["tokens"] == ["test-token", "test-token"]
+    assert payload["appliedPayloads"] == [
+        {"rows": [], "options": {"preserveRows": True}},
+        {"rows": ["row-1", "row-2", "row-3"], "options": {"appendRows": True}},
+    ]
+    assert payload["data"] == ["row-1", "row-2", "row-3"]
+
+
 def test_dashboard_bootstraps_direct_diagnostics_view() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     dashboard_js = (


### PR DESCRIPTION
## Summary

- Fix `serve-dashboard` lazy shell hydration so a served dashboard with zero inline rows backfills rows from `/api/usage` when indexed rows are available.
- Harden the synthetic source-log benchmark smoke test that caused the stale red release check.
- Prepare patch release `0.11.2` with version pins, changelog, and release docs updated.

## Root Cause

`refreshDashboardLive()` only fetched visible rows when the available row count increased. A shell boot can start with `loaded_row_count = 0` while `total_available_rows` is already nonzero, so the delta was zero and the table never got populated after refresh. The fix awaits the existing hydration path whenever loaded rows are below the hydration target.

Fixes #66.

Thanks @Vadevious for the detailed Windows repro and root-cause analysis in #66.

## Validation

- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest` -> 322 passed
- `.venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing` -> 322 passed, 81% total coverage
- `.venv/bin/python -m compileall src`
- `for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file"; done`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
- `.venv/bin/python -m build`
- `.venv/bin/python -m twine check dist/*`
- `.venv/bin/python scripts/check_release.py --dist`
- `.venv/bin/python scripts/smoke_installed_package.py`
- `.venv/bin/python scripts/smoke_installed_package.py --docker`
- Browser smoke against synthetic `serve-dashboard --no-refresh`: active view `calls`, 109 table rows rendered, visible-call KPI populated.
