### PR TITLE
fix: batch diagnostic fact deletes

### DIFF
--- a/src/codex_usage_tracker/store.py
+++ b/src/codex_usage_tracker/store.py
@@ -53,6 +53,7 @@ EVENT_COLUMNS = list(USAGE_EVENT_COLUMN_NAMES)
 DIAGNOSTIC_FACT_COLUMNS = list(DIAGNOSTIC_FACT_COLUMN_NAMES)
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 OBSERVED_USAGE_RECONCILIATION_THRESHOLD = 3
+SQLITE_VARIABLE_BATCH_SIZE = 500
 USAGE_TIMING_SELECT_SQL = """
     previous_usage.event_timestamp AS previous_call_event_timestamp,
     previous_usage.session_id AS previous_call_session_id,
@@ -436,11 +437,14 @@ def _delete_diagnostic_facts_for_record_ids(
 ) -> None:
     if not record_ids:
         return
-    placeholders = ", ".join("?" for _record_id in record_ids)
-    conn.execute(
-        f"DELETE FROM call_diagnostic_facts WHERE record_id IN ({placeholders})",
-        record_ids,
-    )
+    unique_record_ids = list(dict.fromkeys(record_ids))
+    for start in range(0, len(unique_record_ids), SQLITE_VARIABLE_BATCH_SIZE):
+        chunk = unique_record_ids[start : start + SQLITE_VARIABLE_BATCH_SIZE]
+        placeholders = ", ".join("?" for _record_id in chunk)
+        conn.execute(
+            f"DELETE FROM call_diagnostic_facts WHERE record_id IN ({placeholders})",
+            chunk,
+        )
 
 
 def _insert_diagnostic_facts(

--- a/tests/test_store_large_batches.py
+++ b/tests/test_store_large_batches.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from store_dashboard_helpers import SESSION_ID, _usage_event
+
+from codex_usage_tracker import store
+from codex_usage_tracker.models import DiagnosticFact
+from codex_usage_tracker.store import connect, upsert_usage_events
+
+
+class _LimitedVariableConnection:
+    def __init__(self, conn: sqlite3.Connection, *, max_variables: int) -> None:
+        self._conn = conn
+        self._max_variables = max_variables
+
+    def execute(self, sql: str, parameters: Any = (), /) -> sqlite3.Cursor:
+        if _parameter_count(parameters) > self._max_variables:
+            raise sqlite3.OperationalError("too many SQL variables")
+        return self._conn.execute(sql, parameters)
+
+    def executemany(self, sql: str, parameters: Any, /) -> sqlite3.Cursor:
+        return self._conn.executemany(sql, parameters)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+
+def _parameter_count(parameters: Any) -> int:
+    if parameters is None:
+        return 0
+    try:
+        return len(parameters)
+    except TypeError:
+        return 0
+
+
+def test_upsert_usage_events_batches_diagnostic_fact_deletes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+
+    @contextmanager
+    def limited_connect(db_path: Path) -> Iterator[_LimitedVariableConnection]:
+        with connect(db_path) as conn:
+            yield _LimitedVariableConnection(conn, max_variables=600)
+
+    monkeypatch.setattr(store, "connect", limited_connect)
+
+    base_timestamp = datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc)
+    events = [
+        _usage_event(
+            record_id=f"issue-69-record-{index:04d}",
+            session_id=SESSION_ID,
+            thread_key="thread:issue-69",
+            event_timestamp=(base_timestamp + timedelta(seconds=index))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            cumulative_total_tokens=index + 1,
+        )
+        for index in range(1200)
+    ]
+    diagnostic_facts = [
+        DiagnosticFact(
+            record_id=event.record_id,
+            fact_type="function",
+            fact_name="exec_command",
+            fact_category="function",
+        )
+        for event in events
+    ]
+
+    upsert_usage_events(
+        events,
+        db_path=db_path,
+        refresh_links=False,
+        diagnostic_facts=diagnostic_facts,
+    )
+    assert _diagnostic_fact_row_count(db_path) == 1200
+
+    upsert_usage_events(events, db_path=db_path, refresh_links=False)
+    assert _diagnostic_fact_row_count(db_path) == 0
+
+
+def _diagnostic_fact_row_count(db_path: Path) -> int:
+    with connect(db_path) as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM call_diagnostic_facts").fetchone()[0])


### PR DESCRIPTION
## Summary
- Batch stale diagnostic-fact deletes during usage-event upserts so large refreshes do not exceed SQLite bound-parameter limits.
- Deduplicate incoming record IDs before deletion to avoid unnecessary SQL work.
- Add a synthetic regression that simulates a low SQLite variable ceiling and re-upserts 1,200 usage records.

## Root Cause
`_delete_diagnostic_facts_for_record_ids()` built one `DELETE ... WHERE record_id IN (?, ...)` statement containing every refreshed record ID. Large Codex histories can exceed SQLite's variable limit, causing `codex-usage-tracker setup` to abort during index refresh.

## Validation
- `.venv/bin/python -m pytest tests/test_store_large_batches.py -q`
- `.venv/bin/python -m pytest tests/test_store_large_batches.py tests/test_store_migrations.py tests/test_store_dashboard_mcp.py tests/test_dashboard_server.py -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall src`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`

Refs #69
