### PR TITLE
fix: restore cli package module entrypoint

### DIFF
--- a/src/codex_usage_tracker/cli/__main__.py
+++ b/src/codex_usage_tracker/cli/__main__.py
@@ -1,0 +1,10 @@
+"""Run Codex Usage Tracker CLI with ``python -m codex_usage_tracker.cli``."""
+
+from __future__ import annotations
+
+import sys
+
+from codex_usage_tracker.cli.main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/test_cli_module_entrypoints.py
+++ b/tests/cli/test_cli_module_entrypoints.py
@@ -1,0 +1,30 @@
+"""CLI module entrypoint compatibility tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from codex_usage_tracker import __version__
+
+
+def test_cli_package_module_version() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "codex_usage_tracker.cli", "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_subprocess_env(),
+    )
+
+    assert f"codex-usage-tracker {__version__}" in result.stdout
+
+
+def _subprocess_env() -> dict[str, str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    src = str(repo_root / "src")
+    env["PYTHONPATH"] = src if not env.get("PYTHONPATH") else f"{src}{os.pathsep}{env['PYTHONPATH']}"
+    return env


### PR DESCRIPTION
## Summary
- Add `codex_usage_tracker/cli/__main__.py` so `python -m codex_usage_tracker.cli` works after `cli.py` became a package.
- Add a focused regression test for the source-checkout module entrypoint.

## Why
The package-domain refactor preserved the top-level `python -m codex_usage_tracker` entrypoint, but broke the documented source-checkout fallback `PYTHONPATH=src python -m codex_usage_tracker.cli ...`.

## Validation
Local checks passed:
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest -q` (`535 passed`)
- `.venv/bin/python -m compileall -q src tests`
- `.venv/bin/tach check`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
- `.venv/bin/python -m agent_maintainer verify --profile fast` passes with existing non-blocking structure-cohesion warnings.

Live smoke:
- Launched `serve-dashboard` via `PYTHONPATH=src python -m codex_usage_tracker.cli ...` on port 8899.
- Verified dashboard/API routes returned 200 and diagnostics rendered in browser.
