### PR TITLE
chore: prepare 0.12.1 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-usage-tracker",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
   "author": {
     "name": "Douglas Monsky"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.12.1 - 2026-06-29
+
+- Ship the package-domain boundary refactor behind compatibility facades so existing CLI, imports, dashboard routes, JSON payloads, and MCP entrypoints keep working while the source tree is organized by responsibility.
+- Add Tach domain configuration files, refreshed Agent Maintainer baselines, and package-boundary documentation for the new module layout.
+- Restore `python -m codex_usage_tracker.cli` after the CLI package split and add regression coverage for both module entrypoints.
+- Split allowance pricing helpers into smaller modules while preserving the public allowance facade.
+
 ## 0.12.0 - 2026-06-29
 
 - Refactor CLI, dashboard server routing, SQLite store/query boundaries, context parsing, diagnostics, and usage-drain modeling into smaller modules with compatibility facades.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ fix/<issue-number>-short-description
 docs/<issue-number>-short-description
 chore/<issue-number>-short-description
 test/<issue-number>-short-description
-release/0.12.0
+release/0.12.1
 hotfix/0.3.3
 ```
 
@@ -91,7 +91,7 @@ blocked
 Recommended milestones:
 
 ```text
-0.12.0
+0.12.1
 1.0-readiness
 1.0.0
 ```
@@ -146,8 +146,8 @@ python scripts/smoke_installed_package.py --docker
 To verify the public PyPI package instead of the local checkout:
 
 ```bash
-python scripts/smoke_installed_package.py --from-pypi --version 0.12.0
-python scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.0
+python scripts/smoke_installed_package.py --from-pypi --version 0.12.1
+python scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.1
 ```
 
 `scripts/check_release.py` treats these public-package smoke commands as release-state claims. Keep their `--version` and `codex-usage-tracking==...` values aligned with `pyproject.toml`; the release gate fails when the docs claim a different public version. It also checks that install docs point at the real PyPI distribution, `codex-usage-tracking`, and keep the warning that `codex-usage-tracker` is a different PyPI package.
@@ -294,8 +294,8 @@ After the release branch merges, tag from updated `main`, not from an unreviewed
 ```bash
 git switch main
 git pull --ff-only
-git tag -a v0.12.0 -m "codex-usage-tracker 0.12.0"
-git push origin v0.12.0
+git tag -a v0.12.1 -m "codex-usage-tracker 0.12.1"
+git push origin v0.12.1
 ```
 
 Do not create or push release tags without maintainer approval.
@@ -304,7 +304,7 @@ Do not create or push release tags without maintainer approval.
 
 Publishing uses GitHub Actions Trusted Publishing through `.github/workflows/publish.yml`; do not upload from a local machine and do not add PyPI or TestPyPI API tokens.
 
-The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading. Minor release `0.4.0` added Python 3.14 support, release recovery docs, stricter privacy/support-bundle regression coverage, and large-history benchmark thresholds. Patch release `0.4.1` was published by workflow dispatch from `main`; it hardened the PyPI publish workflow and checked off completed 1.0 readiness gates. Minor release `0.5.0` added dashboard localization support and initial language catalogs. Minor release `0.6.0` is the performance and call-drilldown release with SQL-backed live API slices, materialized thread summaries, faster evidence loading, and dashboard runtime module refactors. Patch release `0.6.1` aligns the final README/package screenshots and companion plugin assets. Minor release `0.7.0` adds observed usage snapshots and the latest-observed dashboard card while keeping raw evidence on demand only. Minor release `0.8.0` adds aggregate diagnostics, source-offset context seeking, and live dashboard loading hardening. Patch release `0.8.1` improves Diagnostics fact table readability with pinned fact names and sortable fact columns. Minor release `0.9.0` adds persisted diagnostic snapshots, on-demand diagnostic refresh, tool/command/file-read/concentration reports, and Diagnostics dashboard panels. Minor release `0.10.0` adds Git/GitHub CLI diagnostics, file-modification diagnostics, and derived call timing fields across the dashboard and API. Patch release `0.10.1` adds lightweight action timing to context evidence and ships the synthetic Git Interactions README screenshot. Minor release `0.11.0` adds usage-drain diagnostic reports, projected weekly credit charts, and cumulative thread cost curves. Patch release `0.11.1` improves the Diagnostics weekly projection table and stale snapshot reload controls. Patch release `0.11.2` fixes served dashboard shell hydration and hardens the synthetic source-log benchmark smoke test. Patch release `0.11.3` fixes Windows live dashboard asset MIME handling. Patch release `0.11.4` fixes large-history setup refresh failures from SQLite variable limits. Minor release `0.12.0` ships the maintainability architecture repair, dashboard diagnostics hardening, Agent Maintainer ratchets, and warning-clean test suite.
+The first public package release, `0.3.0`, was published on June 8, 2026. Patch release `0.3.1` followed the same day to ship the live-dashboard skill launch fix. Patch release `0.3.2` made dashboard launch refresh the default and added runtime enablement for context loading. Minor release `0.4.0` added Python 3.14 support, release recovery docs, stricter privacy/support-bundle regression coverage, and large-history benchmark thresholds. Patch release `0.4.1` was published by workflow dispatch from `main`; it hardened the PyPI publish workflow and checked off completed 1.0 readiness gates. Minor release `0.5.0` added dashboard localization support and initial language catalogs. Minor release `0.6.0` is the performance and call-drilldown release with SQL-backed live API slices, materialized thread summaries, faster evidence loading, and dashboard runtime module refactors. Patch release `0.6.1` aligns the final README/package screenshots and companion plugin assets. Minor release `0.7.0` adds observed usage snapshots and the latest-observed dashboard card while keeping raw evidence on demand only. Minor release `0.8.0` adds aggregate diagnostics, source-offset context seeking, and live dashboard loading hardening. Patch release `0.8.1` improves Diagnostics fact table readability with pinned fact names and sortable fact columns. Minor release `0.9.0` adds persisted diagnostic snapshots, on-demand diagnostic refresh, tool/command/file-read/concentration reports, and Diagnostics dashboard panels. Minor release `0.10.0` adds Git/GitHub CLI diagnostics, file-modification diagnostics, and derived call timing fields across the dashboard and API. Patch release `0.10.1` adds lightweight action timing to context evidence and ships the synthetic Git Interactions README screenshot. Minor release `0.11.0` adds usage-drain diagnostic reports, projected weekly credit charts, and cumulative thread cost curves. Patch release `0.11.1` improves the Diagnostics weekly projection table and stale snapshot reload controls. Patch release `0.11.2` fixes served dashboard shell hydration and hardens the synthetic source-log benchmark smoke test. Patch release `0.11.3` fixes Windows live dashboard asset MIME handling. Patch release `0.11.4` fixes large-history setup refresh failures from SQLite variable limits. Minor release `0.12.0` ships the maintainability architecture repair, dashboard diagnostics hardening, Agent Maintainer ratchets, and warning-clean test suite. Patch release `0.12.1` ships the package-domain boundary split, allowance helper split, refreshed maintainability baselines, and CLI module entrypoint fix.
 
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.0`
 - GitHub Release: `https://github.com/douglasmonsky/codex-usage-tracker/releases/tag/v0.3.1`

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -24,12 +24,12 @@ Not guaranteed:
 
 ## 1. Public Install And Package Metadata
 
-- [x] Verify the current public PyPI version is visible as `0.12.0`: `python -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/codex-usage-tracking/json'))['info']['version'])"`.
-- [x] Verify public venv install for `0.12.0`: `python -m venv /tmp/codex-usage-pypi-smoke && . /tmp/codex-usage-pypi-smoke/bin/activate && python -m pip install codex-usage-tracking==0.12.0 && codex-usage-tracker --version`.
-- [x] Verify public pipx install path for `0.12.0`: `PIPX_HOME=/tmp/codex-usage-pipx-home PIPX_BIN_DIR=/tmp/codex-usage-pipx-bin pipx install codex-usage-tracking==0.12.0 && /tmp/codex-usage-pipx-bin/codex-usage-tracker --version`.
+- [x] Verify the current public PyPI version is visible as `0.12.1`: `python -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/codex-usage-tracking/json'))['info']['version'])"`.
+- [x] Verify public venv install for `0.12.1`: `python -m venv /tmp/codex-usage-pypi-smoke && . /tmp/codex-usage-pypi-smoke/bin/activate && python -m pip install codex-usage-tracking==0.12.1 && codex-usage-tracker --version`.
+- [x] Verify public pipx install path for `0.12.1`: `PIPX_HOME=/tmp/codex-usage-pipx-home PIPX_BIN_DIR=/tmp/codex-usage-pipx-bin pipx install codex-usage-tracking==0.12.1 && /tmp/codex-usage-pipx-bin/codex-usage-tracker --version`.
 - [x] Verify installed package resources from a built wheel: `python scripts/smoke_installed_package.py`.
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
-- [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.0`.
+- [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.1`.
 - [x] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
 - [x] Add Python 3.14 as an official support target after CI, package classifiers, docs, and installed-package smoke coverage were added. Docker smoke coverage uses `python:3.14-slim` by default. Track this in issue #12.
 
@@ -134,14 +134,14 @@ Not guaranteed:
 
 ## Evidence References
 
-These references are the concrete proof behind completed checklist items. Public package smoke commands are version-specific to `0.12.0`; all repo tests use synthetic or aggregate-only data.
+These references are the concrete proof behind completed checklist items. Public package smoke commands are version-specific to `0.12.1`; all repo tests use synthetic or aggregate-only data.
 
 ### Public Install And Package Metadata
 
 - Public PyPI version, public venv install, and public pipx install are proven by the exact public-install commands in section 1.
 - Built-wheel and installed-resource coverage is proven by `scripts/smoke_installed_package.py` and `tests/test_cli_release.py::test_installed_package_smoke_checks_help_for_stable_commands`.
 - Linux package-resource coverage is proven by `scripts/smoke_installed_package.py --docker`.
-- Public PyPI Docker coverage is proven by `scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.0`.
+- Public PyPI Docker coverage is proven by `scripts/smoke_installed_package.py --docker --from-pypi --version 0.12.1`.
 - PyPI metadata, package/distribution names, package resources, source/wheel member names, Python 3.10-3.14 support metadata, CI workflow requirements, publish workflow safety text, and tracked secret patterns are proven by `scripts/check_release.py`, `scripts/check_release.py --dist`, and `tests/test_cli_release.py::test_release_check_script_passes`.
 
 ### Upgrade And Migration
@@ -219,8 +219,8 @@ These references are the concrete proof behind completed checklist items. Public
 - Publish workflow package name, Trusted Publishing, TestPyPI/PyPI job presence, event guards, no push/PR publishing, no token/password publishing, and manual PyPI main/tag preflight are proven by `scripts/check_release.py::_check_publish_workflow`.
 - The GitHub `pypi` environment gate is proven by `gh api repos/douglasmonsky/codex-usage-tracker/environments/pypi`, which reports a `required_reviewers` protection rule and `can_admins_bypass=false`.
 - Dist filename and wheel/sdist member checks are proven by `python -m build`, `python -m twine check dist/*`, and `python scripts/check_release.py --dist`.
-- TestPyPI publish process is proven by a workflow-dispatch run on `main`, followed by TestPyPI metadata and clean virtualenv install checks for `codex-usage-tracking==0.12.0`.
-- PyPI publish process is proven by a workflow-dispatch run on `main`, protected `pypi` environment approval, PyPI metadata visibility, clean virtualenv install, temporary pipx install, and Docker public-package smoke for `codex-usage-tracking==0.12.0`.
+- TestPyPI publish process is proven by a workflow-dispatch run on `main`, followed by TestPyPI metadata and clean virtualenv install checks for `codex-usage-tracking==0.12.1`.
+- PyPI publish process is proven by a workflow-dispatch run on `main`, protected `pypi` environment approval, PyPI metadata visibility, clean virtualenv install, temporary pipx install, and Docker public-package smoke for `codex-usage-tracking==0.12.1`.
 - Release recovery documentation is proven by `scripts/check_release.py` required-file and docs checks.
 
 ### Known Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codex-usage-tracking"
-version = "0.12.0"
+version = "0.12.1"
 description = "Unofficial local Codex plugin and dashboard for investigating aggregate token usage, costs, caching, and thread patterns."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "codex-usage-tracking==0.12.0",
+    "codex-usage-tracking==0.12.1",
 )
-RUNTIME_VERSION = "0.12.0"
+RUNTIME_VERSION = "0.12.1"
 PACKAGE_SPEC_MARKER = ".codex-usage-tracker-package-spec"
 MODULE_CHECK = (
     "import importlib.metadata; "

--- a/src/codex_usage_tracker/__init__.py
+++ b/src/codex_usage_tracker/__init__.py
@@ -2,6 +2,6 @@
 
 from codex_usage_tracker.core.models import UsageEvent
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = ["UsageEvent", "__version__"]

--- a/src/codex_usage_tracker/cli/__init__.py
+++ b/src/codex_usage_tracker/cli/__init__.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
+from codex_usage_tracker.cli.main import main
+
 _API_MODULE = "codex_usage_tracker.cli.main"
+
+__all__ = ["main"]
 
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)

--- a/tests/cli/test_cli_module_entrypoints.py
+++ b/tests/cli/test_cli_module_entrypoints.py
@@ -8,6 +8,11 @@ import sys
 from pathlib import Path
 
 from codex_usage_tracker import __version__
+from codex_usage_tracker.cli import main as cli_main
+
+
+def test_console_script_target_is_callable() -> None:
+    assert callable(cli_main)
 
 
 def test_cli_package_module_version() -> None:


### PR DESCRIPTION
## Summary
- bump package, plugin, and MCP runtime version pins to 0.12.1
- document the package-domain boundary split, allowance helper split, and CLI module entrypoint fix
- fix the console-script export so installed codex-usage-tracker resolves a callable after the CLI package split

## Validation
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mypy
- .venv/bin/python -m pytest
- .venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing (86%)
- .venv/bin/python -m compileall src
- dashboard JavaScript node --check loop
- .venv/bin/tach check
- .venv/bin/python -m agent_maintainer verify --profile fast (passes with known non-blocking size warnings for server and usage_drain)
- .venv/bin/python scripts/check_release.py
- git diff --check
- clean .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- .venv/bin/python scripts/check_release.py --dist
- .venv/bin/python scripts/smoke_installed_package.py

## Notes
- Build emits the existing MANIFEST warning for a missing previously-excluded docs/usage-drain-research-white-paper.md; distributions still build and pass twine/check_release inspection.