### PR TITLE
docs: fix downloads badge colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Local-first dashboard, Codex plugin, and companion skill for understanding where
 
 [![CI](https://github.com/douglasmonsky/codex-usage-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/douglasmonsky/codex-usage-tracker/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/codex-usage-tracking.svg)](https://pypi.org/project/codex-usage-tracking/)
-[![PyPI Downloads](https://static.pepy.tech/personalized-badge/codex-usage-tracking?period=total&units=INTERNATIONAL_SYSTEM&left_color=555&right_color=BLUE&left_text=downloads)](https://pepy.tech/projects/codex-usage-tracking)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/codex-usage-tracking?period=total&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=RED&left_text=downloads)](https://pepy.tech/projects/codex-usage-tracking)
 ![Python 3.10-3.14](https://img.shields.io/badge/python-3.10--3.14-blue)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- update the Pepy downloads badge to use the supported `GREY` left color and `RED` right color
- fixes the broken badge URL introduced by numeric `555` color

## Checks
- `curl -I -L` against the final Pepy badge URL returned `200` with `content-type: image/svg+xml`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`