### PR TITLE
feat: add doctor first-run environment report

### DIFF
--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -37,6 +37,7 @@ Tracked schema ids:
 | --- | --- |
 | `codex-usage-tracker-setup-v1` | CLI `setup --json` |
 | `codex-usage-tracker-doctor-v1` | CLI `doctor --json`, MCP `usage_doctor(response_format="json")` |
+| | Includes an `environment` object with package and Python versions, important local paths, lightweight Codex log discovery counts, and packaged dashboard asset health. Support bundles sanitize this payload according to the selected privacy mode. |
 | `codex-usage-tracker-plugin-install-v1` | CLI `install-plugin --json`, setup plugin payload |
 | `codex-usage-tracker-plugin-upgrade-v1` | CLI `upgrade-plugin --json` |
 | `codex-usage-tracker-plugin-uninstall-v1` | CLI `uninstall-plugin --json` |

--- a/src/codex_usage_tracker/core/formatting.py
+++ b/src/codex_usage_tracker/core/formatting.py
@@ -180,6 +180,47 @@ def format_doctor(report: dict[str, Any]) -> str:
         f"Failures: {report.get('failures', 0)} | warnings: {report.get('warnings', 0)}",
         "",
     ]
+    environment = report.get("environment")
+    if isinstance(environment, dict):
+        lines.extend(["Environment:"])
+        package = environment.get("package")
+        if isinstance(package, dict):
+            lines.append(
+                "Package: "
+                f"{package.get('name', 'unknown')} "
+                f"{package.get('version', 'unknown')}"
+            )
+        python = environment.get("python")
+        if isinstance(python, dict):
+            lines.append(
+                "Python: "
+                f"{python.get('version', 'unknown')} "
+                f"({python.get('implementation', 'unknown')})"
+            )
+        paths = environment.get("paths")
+        if isinstance(paths, dict):
+            lines.append(f"Codex home: {paths.get('codex_home', 'unknown')}")
+            lines.append(f"Database: {paths.get('db_path', 'unknown')}")
+            lines.append(f"Dashboard: {paths.get('dashboard_path', 'unknown')}")
+        codex_logs = environment.get("codex_logs")
+        if isinstance(codex_logs, dict):
+            sessions_status = "found" if codex_logs.get("sessions_dir_exists") else "missing"
+            lines.append(
+                "Codex logs: "
+                f"{sessions_status}, "
+                f"{_fmt_int(codex_logs.get('jsonl_files'))} JSONL files"
+            )
+        assets = environment.get("dashboard_assets")
+        if isinstance(assets, dict):
+            asset_status = "available" if assets.get("available") else "missing"
+            missing = assets.get("missing")
+            suffix = (
+                f" ({len(missing)} missing)"
+                if isinstance(missing, list) and missing
+                else ""
+            )
+            lines.append(f"Dashboard assets: {asset_status}{suffix}")
+        lines.append("")
     for check in report.get("checks", []):
         status = str(check.get("status", "unknown")).upper()
         lines.append(f"- [{status}] {check.get('name')}: {check.get('detail')}")

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -26,13 +26,14 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     'codex-usage-tracker-doctor-v1': {
-            "required": {
-                "status": str,
-                "failures": int,
-                "warnings": int,
-                "checks": list,
-            }
-        },
+        "required": {
+            "status": str,
+            "failures": int,
+            "warnings": int,
+            "environment": dict,
+            "checks": list,
+        }
+    },
     'codex-usage-tracker-plugin-install-v1': {"required": PLUGIN_INSTALL_FIELDS},
     'codex-usage-tracker-plugin-upgrade-v1': {"required": PLUGIN_INSTALL_FIELDS},
     'codex-usage-tracker-plugin-uninstall-v1': {

--- a/src/codex_usage_tracker/diagnostics/api.py
+++ b/src/codex_usage_tracker/diagnostics/api.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import platform
+import sys
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
+from codex_usage_tracker import __version__
 from codex_usage_tracker.core.paths import (
     DEFAULT_CODEX_HOME,
     DEFAULT_DASHBOARD_PATH,
@@ -26,6 +30,13 @@ from codex_usage_tracker.pricing.api import load_pricing_config
 from codex_usage_tracker.store.api import SchemaMigrationError, refresh_metadata, schema_state
 
 PLUGIN_NAME = "codex-usage-tracker"
+DASHBOARD_REQUIRED_ASSETS = (
+    "dashboard_data.js",
+    "dashboard_live.js",
+    "dashboard_tables.js",
+    "dashboard_responsive.css",
+    "locales/en.json",
+)
 
 
 def run_doctor(
@@ -41,6 +52,15 @@ def run_doctor(
 ) -> dict[str, Any]:
     """Run read-only checks and return a structured report."""
     root = repo_root or _resolve_plugin_root(plugin_link) or find_project_root()
+    environment = _doctor_environment(
+        codex_home=codex_home,
+        db_path=db_path,
+        dashboard_path=dashboard_path,
+        pricing_path=pricing_path,
+        plugin_link=plugin_link,
+        marketplace_path=marketplace_path,
+        root=root,
+    )
     checks = _doctor_checks(
         codex_home=codex_home,
         db_path=db_path,
@@ -50,7 +70,11 @@ def run_doctor(
         marketplace_path=marketplace_path,
         root=root,
     )
-    return _doctor_report(checks, suggest_repair=suggest_repair)
+    return _doctor_report(
+        checks,
+        suggest_repair=suggest_repair,
+        environment=environment,
+    )
 
 
 def _doctor_checks(
@@ -80,7 +104,12 @@ def _doctor_checks(
     ]
 
 
-def _doctor_report(checks: list[DoctorCheck], *, suggest_repair: bool) -> dict[str, Any]:
+def _doctor_report(
+    checks: list[DoctorCheck],
+    *,
+    suggest_repair: bool,
+    environment: dict[str, Any],
+) -> dict[str, Any]:
     fail_count = _count_check_status(checks, "fail")
     warn_count = _count_check_status(checks, "warn")
     report: dict[str, Any] = {
@@ -88,11 +117,92 @@ def _doctor_report(checks: list[DoctorCheck], *, suggest_repair: bool) -> dict[s
         "status": _doctor_status(fail_count=fail_count, warn_count=warn_count),
         "failures": fail_count,
         "warnings": warn_count,
+        "environment": environment,
         "checks": [check.to_dict() for check in checks],
     }
     if suggest_repair:
         report["repair_suggestions"] = _doctor_repair_suggestions(checks)
     return report
+
+
+def _doctor_environment(
+    *,
+    codex_home: Path,
+    db_path: Path,
+    dashboard_path: Path,
+    pricing_path: Path,
+    plugin_link: Path,
+    marketplace_path: Path,
+    root: Path | None,
+) -> dict[str, Any]:
+    return {
+        "package": {
+            "name": "codex-usage-tracker",
+            "version": __version__,
+        },
+        "python": {
+            "version": sys.version.split()[0],
+            "executable": sys.executable,
+            "implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+        },
+        "paths": {
+            "codex_home": str(codex_home.expanduser()),
+            "codex_sessions": str(codex_home.expanduser() / "sessions"),
+            "db_path": str(db_path.expanduser()),
+            "dashboard_path": str(dashboard_path.expanduser()),
+            "pricing_path": str(pricing_path.expanduser()),
+            "plugin_link": str(plugin_link.expanduser()),
+            "marketplace_path": str(marketplace_path.expanduser()),
+            "plugin_root": str(root) if root else None,
+        },
+        "codex_logs": _codex_log_environment(codex_home),
+        "dashboard_assets": _dashboard_asset_environment(),
+    }
+
+
+def _codex_log_environment(codex_home: Path) -> dict[str, Any]:
+    expanded_home = codex_home.expanduser()
+    sessions_dir = expanded_home / "sessions"
+    jsonl_count = 0
+    latest_mtime: float | None = None
+    if sessions_dir.is_dir():
+        for log_path in sessions_dir.rglob("*.jsonl"):
+            jsonl_count += 1
+            try:
+                mtime = log_path.stat().st_mtime
+            except OSError:
+                continue
+            latest_mtime = mtime if latest_mtime is None else max(latest_mtime, mtime)
+    return {
+        "codex_home_exists": expanded_home.exists(),
+        "sessions_dir": str(sessions_dir),
+        "sessions_dir_exists": sessions_dir.is_dir(),
+        "jsonl_files": jsonl_count,
+        "latest_jsonl_mtime": latest_mtime,
+    }
+
+
+def _dashboard_asset_environment() -> dict[str, Any]:
+    try:
+        dashboard_root = files("codex_usage_tracker.plugin_data").joinpath("dashboard")
+        missing = [
+            asset
+            for asset in DASHBOARD_REQUIRED_ASSETS
+            if not dashboard_root.joinpath(asset).is_file()
+        ]
+    except (AttributeError, FileNotFoundError, ModuleNotFoundError, TypeError) as exc:
+        return {
+            "available": False,
+            "checked": list(DASHBOARD_REQUIRED_ASSETS),
+            "missing": list(DASHBOARD_REQUIRED_ASSETS),
+            "error": str(exc),
+        }
+    return {
+        "available": not missing,
+        "checked": list(DASHBOARD_REQUIRED_ASSETS),
+        "missing": missing,
+    }
 
 
 def _count_check_status(checks: list[DoctorCheck], status: str) -> int:

--- a/tests/diagnostics/test_doctor_first_run.py
+++ b/tests/diagnostics/test_doctor_first_run.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from codex_usage_tracker.core.formatting import format_doctor
+from codex_usage_tracker.diagnostics.api import run_doctor
+
+
+def test_doctor_reports_first_run_environment(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    sessions_dir = codex_home / "sessions" / "2026" / "06"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "session.jsonl").write_text("{}\n", encoding="utf-8")
+
+    report = run_doctor(
+        codex_home=codex_home,
+        db_path=tmp_path / "usage.sqlite3",
+        dashboard_path=tmp_path / "dashboard.html",
+        pricing_path=tmp_path / "pricing.json",
+        plugin_link=tmp_path / "plugins" / "codex-usage-tracker",
+        marketplace_path=tmp_path / "marketplace.json",
+        repo_root=None,
+    )
+
+    environment = report["environment"]
+
+    assert environment["package"]["version"]
+    assert environment["python"]["version"] == sys.version.split()[0]
+    assert environment["paths"]["codex_home"] == str(codex_home)
+    assert environment["paths"]["db_path"] == str(tmp_path / "usage.sqlite3")
+    assert environment["codex_logs"]["sessions_dir_exists"] is True
+    assert environment["codex_logs"]["jsonl_files"] == 1
+    assert environment["dashboard_assets"]["available"] is True
+    assert environment["dashboard_assets"]["missing"] == []
+
+    text = format_doctor(report)
+
+    assert "Environment:" in text
+    assert "Package: codex-usage-tracker" in text
+    assert "Codex logs:" in text
+    assert "Dashboard assets: available" in text


### PR DESCRIPTION
## Summary
- add a structured `environment` block to `doctor --json` with package/Python versions, key paths, lightweight Codex log discovery counts, and packaged dashboard asset health
- render those first-run facts in the human-readable `doctor` output before the existing check list
- document the new doctor payload field in CLI JSON schema docs and require it in the JSON contract

## Checks
- `.venv/bin/python -m pytest tests/diagnostics/test_doctor_first_run.py -q`
- `.venv/bin/python -m pytest tests/cli/test_plugin_installer.py tests/store/test_store_migrations.py::test_doctor_reports_malformed_legacy_schema_without_traceback tests/reports/test_support.py::test_support_bundle_strict_mode_redacts_local_paths_and_doctor_text -q`
- `.venv/bin/python -m pytest tests/core/test_json_contracts.py tests/diagnostics/test_doctor_first_run.py -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall src`
- `.venv/bin/tach check`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
- `PYTHONPATH=src .venv/bin/python -m codex_usage_tracker.cli --db /tmp/codex-doctor-first-run.sqlite3 doctor --json`
- `PYTHONPATH=src .venv/bin/python -m codex_usage_tracker.cli --db /tmp/codex-doctor-first-run.sqlite3 doctor`