### PR TITLE
feat: improve support bundle issue guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     id: diagnostics
     attributes:
       label: Safe diagnostics
-      description: Prefer a reviewed strict support bundle from `codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json`. If pasting JSON, paste only reviewed strict-mode bundle content or `doctor --json` output.
+      description: Prefer a reviewed strict support bundle from `codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json`. The bundle's `issue_report.safe_fields` list names the safest fields to paste. If pasting JSON, paste only reviewed strict-mode bundle content or `doctor --json` output.
       render: json
   - type: input
     id: version

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -187,6 +187,8 @@ codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage
 
 Support bundles are diagnostic summaries for issues. They include package, platform, doctor, schema, parser, pricing, allowance, threshold, project-config, and privacy metadata. They exclude raw logs, aggregate rows, prompts, assistant messages, tool output, and context text.
 
+Strict support bundles include an `issue_report` section that lists the paste-safe sections and fields for GitHub issues. Review the JSON before posting, and do not add raw JSONL logs, prompts, assistant messages, tool output, command text, patch text, full local paths, secrets, credentials, or private config values.
+
 ## Local Config
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -150,6 +150,6 @@ codex-usage-tracker reset-db --yes
 codex-usage-tracker --privacy-mode strict support-bundle --output ~/.codex-usage-tracker/support-bundle.json
 ```
 
-`support-bundle` writes package, Python, OS/platform, doctor status, database schema, parser diagnostics, pricing status, allowance status, threshold status, project config status, and privacy metadata. It does not include raw logs, prompts, assistant messages, tool output, context text, or aggregate rows.
+`support-bundle` writes package, Python, OS/platform, doctor status, database schema, parser diagnostics, pricing status, allowance status, threshold status, project config status, privacy metadata, and an `issue_report` list of paste-safe issue fields. It does not include raw logs, prompts, assistant messages, tool output, context text, or aggregate rows.
 
 Default `support-bundle` mode keeps local diagnostic paths because they can help troubleshoot setup on your machine. Use `--privacy-mode strict` before sharing: strict mode redacts local diagnostic path strings in the bundle and doctor details while preserving existence flags, counts, parser diagnostics, and status fields.

--- a/src/codex_usage_tracker/cli/main.py
+++ b/src/codex_usage_tracker/cli/main.py
@@ -50,7 +50,10 @@ from codex_usage_tracker.reports.api import (
     build_recommendations_report,
     build_summary_report,
 )
-from codex_usage_tracker.reports.support import build_support_bundle
+from codex_usage_tracker.reports.support import (
+    build_support_bundle,
+    support_bundle_issue_guidance,
+)
 from codex_usage_tracker.store.api import (
     export_usage_csv,
     query_session_usage,
@@ -473,6 +476,7 @@ def _run_support_bundle(args: argparse.Namespace) -> int:
         projects_path=args.projects,
         privacy_mode=args.privacy_mode,
     )
+    issue_guidance = support_bundle_issue_guidance(args.privacy_mode)
     if args.as_json:
         print_json(
             {
@@ -485,11 +489,19 @@ def _run_support_bundle(args: argparse.Namespace) -> int:
                     "contains_tool_output": False,
                     "project_metadata_mode": args.privacy_mode,
                 },
+                "issue_report": issue_guidance,
             }
         )
         return 0
     print(f"Wrote privacy-preserving support bundle to {output}")
     print("Bundle excludes raw logs, prompts, assistant messages, tool output, and context text.")
+    print(
+        "GitHub issue fields safe to paste after review: "
+        + ", ".join(issue_guidance["cli_hint_fields"])
+    )
+    print("Full strict-bundle field list lives in issue_report.safe_fields.")
+    if not issue_guidance["safe_to_paste_after_review"]:
+        print("Use --privacy-mode strict before sharing support bundles publicly.")
     return 0
 
 

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -216,18 +216,29 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "required": {"projects_path": str, **PATH_CREATED_FIELDS}
         },
     'codex-usage-tracker-support-bundle-v1': {
-            "required": {
-                "support_bundle_path": str,
-                "privacy": dict,
-            },
-            "nested": {
-                "privacy": {
-                    "contains_raw_logs": bool,
-                    "contains_prompts": bool,
-                    "contains_assistant_messages": bool,
-                    "contains_tool_output": bool,
-                    "project_metadata_mode": str,
-                }
-            },
+        "required": {
+            "support_bundle_path": str,
+            "privacy": dict,
+            "issue_report": dict,
         },
+        "nested": {
+            "privacy": {
+                "contains_raw_logs": bool,
+                "contains_prompts": bool,
+                "contains_assistant_messages": bool,
+                "contains_tool_output": bool,
+                "project_metadata_mode": str,
+            },
+            "issue_report": {
+                "recommended_privacy_mode": str,
+                "current_privacy_mode": str,
+                "safe_to_paste_after_review": bool,
+                "safe_sections": list,
+                "safe_fields": list,
+                "cli_hint_fields": list,
+                "do_not_add": list,
+                "note": str,
+            }
+        },
+    },
 }

--- a/src/codex_usage_tracker/reports/support.py
+++ b/src/codex_usage_tracker/reports/support.py
@@ -35,6 +35,74 @@ from codex_usage_tracker.pricing.api import load_pricing_config
 from codex_usage_tracker.reports.recommendations import load_threshold_config
 from codex_usage_tracker.store.api import refresh_metadata, schema_state
 
+ISSUE_SAFE_SECTIONS = (
+    "privacy",
+    "package",
+    "paths",
+    "database",
+    "refresh",
+    "pricing",
+    "allowance",
+    "thresholds",
+    "projects",
+    "doctor",
+)
+
+ISSUE_SAFE_FIELDS = (
+    "privacy",
+    "package.name",
+    "package.version",
+    "package.python",
+    "package.platform",
+    "paths.codex_home_exists",
+    "paths.sessions_dir_exists",
+    "database",
+    "refresh",
+    "pricing.loaded",
+    "pricing.error",
+    "pricing.model_count",
+    "pricing.source",
+    "allowance.loaded",
+    "allowance.error",
+    "allowance.window_count",
+    "allowance.credit_rate_count",
+    "thresholds.loaded",
+    "thresholds.error",
+    "thresholds.keys",
+    "projects.loaded",
+    "projects.error",
+    "projects.alias_count",
+    "projects.ignored_path_count",
+    "projects.tag_group_count",
+    "doctor.status",
+    "doctor.checks",
+    "doctor.repair_suggestions",
+    "doctor.environment",
+)
+
+ISSUE_CLI_HINT_FIELDS = (
+    "privacy",
+    "package",
+    "database",
+    "refresh",
+    "doctor.status",
+    "doctor.checks",
+    "doctor.environment",
+    "issue_report.safe_fields",
+)
+
+ISSUE_UNSAFE_ADDITIONS = (
+    "raw Codex JSONL logs",
+    "prompts or conversation text",
+    "assistant messages",
+    "tool output",
+    "command text",
+    "patch text",
+    "full local paths",
+    "secrets or credentials",
+    "private config values",
+)
+
 
 def build_support_bundle(
     *,
@@ -125,6 +193,7 @@ def support_bundle_payload(
             "thresholds_path": _support_path_value("thresholds_path", thresholds_path, privacy_mode),
             "projects_path": _support_path_value("projects_path", projects_path, privacy_mode),
         },
+        "issue_report": support_bundle_issue_guidance(privacy_mode),
         "database": schema_state(db_path),
         "refresh": refresh_metadata(db_path),
         "pricing": {
@@ -167,6 +236,24 @@ def support_bundle_payload(
         redact_paths=redact_paths,
         path_replacements=path_replacements,
     )
+
+
+def support_bundle_issue_guidance(privacy_mode: str) -> dict[str, Any]:
+    """Return reviewer-facing guidance for pasting support data into issues."""
+    privacy_mode = validate_privacy_mode(privacy_mode)
+    return {
+        "recommended_privacy_mode": "strict",
+        "current_privacy_mode": privacy_mode,
+        "safe_to_paste_after_review": privacy_mode == "strict",
+        "safe_sections": list(ISSUE_SAFE_SECTIONS),
+        "safe_fields": list(ISSUE_SAFE_FIELDS),
+        "cli_hint_fields": list(ISSUE_CLI_HINT_FIELDS),
+        "do_not_add": list(ISSUE_UNSAFE_ADDITIONS),
+        "note": (
+            "For public GitHub issues, prefer a reviewed strict support bundle. "
+            "Normal mode may include local diagnostic paths."
+        ),
+    }
 
 
 def _support_path_value(label: str, path: Path, privacy_mode: str) -> str:

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -65,9 +65,12 @@ def test_setup_support_bundle_and_reset_db_cli(tmp_path: Path) -> None:
     bundle = json.loads(support_path.read_text(encoding="utf-8"))
 
     assert support.returncode == 0
+    assert "GitHub issue fields safe to paste after review" in support.stdout
+    assert "doctor.environment" in support.stdout
     assert bundle["privacy"]["contains_raw_logs"] is False
     assert bundle["privacy"]["project_metadata"]["mode"] == "strict"
     assert bundle["privacy"]["project_metadata"]["relative_cwd_hidden"] is True
+    assert bundle["issue_report"]["safe_to_paste_after_review"] is True
     assert bundle["refresh"]["parsed_events"] == "1"
     assert "low_cache_ratio" in bundle["thresholds"]["keys"]
     assert bundle["projects"]["alias_count"] == 0

--- a/tests/reports/test_support.py
+++ b/tests/reports/test_support.py
@@ -90,6 +90,15 @@ def test_support_bundle_strict_mode_redacts_local_paths_and_doctor_text(
     assert bundle["privacy"]["project_metadata"]["mode"] == "strict"
     assert bundle["privacy"]["project_metadata"]["relative_cwd_hidden"] is True
     assert bundle["privacy"]["diagnostic_paths_redacted"] is True
+    issue_report = bundle["issue_report"]
+    assert issue_report["recommended_privacy_mode"] == "strict"
+    assert issue_report["current_privacy_mode"] == "strict"
+    assert issue_report["safe_to_paste_after_review"] is True
+    assert "privacy" in issue_report["safe_sections"]
+    assert "doctor.environment" in issue_report["safe_fields"]
+    assert "issue_report.safe_fields" in issue_report["cli_hint_fields"]
+    assert "raw Codex JSONL logs" in issue_report["do_not_add"]
+    assert "private config values" in issue_report["do_not_add"]
     assert bundle["paths"]["db_path"].startswith("[redacted path:db_path:")
     assert bundle["paths"]["codex_home"].startswith("[redacted path:codex_home:")
     assert "[redacted path:" in bundle_text


### PR DESCRIPTION
## Summary
- add an `issue_report` guidance block to support bundles with paste-safe sections and fields
- print a short support-bundle CLI hint for GitHub issue reports
- update the JSON contract, issue template, docs, and privacy-focused tests

## Validation
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `.venv/bin/python -m pytest -q` (537 passed)
- `.venv/bin/python -m compileall src`
- `.venv/bin/tach check`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`