### PR TITLE
test: strengthen installed wheel smoke coverage

### DIFF
--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -177,9 +177,10 @@ def main(argv: list[str] | None = None) -> int:
         _run([str(python), "-c", _import_check_code()])
         _run([str(python), "-c", _resource_check_code()])
         _smoke_plugin_install(command, temp_dir)
+        _smoke_cli_lifecycle(command, temp_dir)
 
-    print("Installed package smoke passed.")
-    return 0
+        print("Installed package smoke passed.")
+        return 0
 
 
 def _run_in_docker(args: argparse.Namespace) -> int:
@@ -340,16 +341,211 @@ def _smoke_plugin_install(command: Path, temp_dir: Path) -> None:
         raise SystemExit("installed-wheel plugin MCP config should not require PYTHONPATH")
 
 
+def _smoke_cli_lifecycle(command: Path, temp_dir: Path) -> None:
+    home_dir = temp_dir / "home"
+    codex_home = home_dir / ".codex"
+    app_dir = home_dir / ".codex-usage-tracker"
+    project_dir = temp_dir / "synthetic-project"
+    plugin_dir = temp_dir / "setup-plugin"
+    marketplace = temp_dir / "setup-marketplace.json"
+    dashboard_path = temp_dir / "dashboard.html"
+    support_path = temp_dir / "support-bundle.json"
+    db_path = app_dir / "usage.sqlite3"
+    pricing_path = app_dir / "pricing.json"
+    allowance_path = app_dir / "allowance.json"
+    rate_card_path = app_dir / "rate-card.json"
+    thresholds_path = app_dir / "thresholds.json"
+    projects_path = app_dir / "projects.json"
+    home_dir.mkdir(parents=True)
+    app_dir.mkdir(parents=True)
+    project_dir.mkdir()
+    _write_synthetic_codex_log(codex_home, project_dir)
+    env = _isolated_home_env(home_dir)
+    global_args = [
+        "--db",
+        str(db_path),
+        "--pricing",
+        str(pricing_path),
+        "--allowance",
+        str(allowance_path),
+        "--rate-card",
+        str(rate_card_path),
+        "--thresholds",
+        str(thresholds_path),
+        "--projects",
+        str(projects_path),
+    ]
+
+    setup_result = _run(
+        [
+            str(command),
+            *global_args,
+            "setup",
+            "--codex-home",
+            str(codex_home),
+            "--plugin-dir",
+            str(plugin_dir),
+            "--marketplace",
+            str(marketplace),
+            "--skip-pricing",
+            "--json",
+        ],
+        capture_output=True,
+        env=env,
+    )
+    setup_payload = json.loads(setup_result.stdout)
+    if setup_payload.get("schema") != "codex-usage-tracker-setup-v1":
+        raise SystemExit("setup JSON schema mismatch")
+    refresh = setup_payload.get("refresh", {})
+    if int(refresh.get("parsed_events", 0)) < 1:
+        raise SystemExit("setup did not parse synthetic usage event")
+    if not db_path.exists():
+        raise SystemExit("setup did not create tracker database")
+
+    doctor_result = _run(
+        [str(command), *global_args, "doctor", "--json"],
+        capture_output=True,
+        env=env,
+    )
+    doctor_payload = json.loads(doctor_result.stdout)
+    if doctor_payload.get("schema") != "codex-usage-tracker-doctor-v1":
+        raise SystemExit("doctor JSON schema mismatch")
+    environment = doctor_payload.get("environment", {})
+    package = environment.get("package", {})
+    if package.get("version") != _installed_version(command):
+        raise SystemExit("doctor environment did not report installed package version")
+    if "dashboard_assets" not in environment:
+        raise SystemExit("doctor environment did not report dashboard asset health")
+
+    dashboard_result = _run(
+        [
+            str(command),
+            *global_args,
+            "dashboard",
+            "--output",
+            str(dashboard_path),
+            "--limit",
+            "0",
+            "--json",
+        ],
+        capture_output=True,
+        env=env,
+    )
+    dashboard_payload = json.loads(dashboard_result.stdout)
+    if dashboard_payload.get("schema") != "codex-usage-tracker-dashboard-v1":
+        raise SystemExit("dashboard JSON schema mismatch")
+    if not dashboard_path.exists():
+        raise SystemExit("dashboard command did not write dashboard HTML")
+    dashboard_html = dashboard_path.read_text(encoding="utf-8")
+    if "<html" not in dashboard_html.lower() or "dashboard" not in dashboard_html.lower():
+        raise SystemExit("dashboard HTML does not look like installed dashboard")
+
+    support_result = _run(
+        [
+            str(command),
+            *global_args,
+            "--privacy-mode",
+            "strict",
+            "support-bundle",
+            "--codex-home",
+            str(codex_home),
+            "--output",
+            str(support_path),
+            "--json",
+        ],
+        capture_output=True,
+        env=env,
+    )
+    support_cli_payload = json.loads(support_result.stdout)
+    if support_cli_payload.get("schema") != "codex-usage-tracker-support-bundle-v1":
+        raise SystemExit("support-bundle CLI JSON schema mismatch")
+    support_bundle = json.loads(support_path.read_text(encoding="utf-8"))
+    if not support_bundle.get("issue_report", {}).get("safe_to_paste_after_review"):
+        raise SystemExit("strict support bundle did not mark issue report as paste-safe")
+    support_text = json.dumps(support_bundle)
+    if str(temp_dir) in support_text or str(home_dir) in support_text:
+        raise SystemExit("strict support bundle leaked local temp paths")
+
+
+def _isolated_home_env(home_dir: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env["HOME"] = str(home_dir)
+    env["USERPROFILE"] = str(home_dir)
+    return env
+
+
+def _write_synthetic_codex_log(codex_home: Path, project_dir: Path) -> None:
+    session_id = "019f0000-0000-7000-8000-000000000001"
+    session_path = codex_home / "sessions" / "2026" / "06" / "30" / f"{session_id}.jsonl"
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "timestamp": "2026-06-30T12:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "timestamp": "2026-06-30T12:00:00.000Z",
+                "cwd": str(project_dir),
+            },
+        },
+        {
+            "timestamp": "2026-06-30T12:00:01.000Z",
+            "type": "turn_context",
+            "payload": {
+                "cwd": str(project_dir),
+                "model": "gpt-5.5-codex",
+                "effort": "medium",
+                "approval_policy": "never",
+                "sandbox_policy": "danger-full-access",
+            },
+        },
+        {
+            "timestamp": "2026-06-30T12:00:02.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 50,
+                        "output_tokens": 40,
+                        "reasoning_output_tokens": 10,
+                        "total_tokens": 300,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 120,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 35,
+                        "reasoning_output_tokens": 5,
+                        "total_tokens": 180,
+                    },
+                    "model_context_window": 258400,
+                },
+            },
+        },
+    ]
+    session_path.write_text(
+        "".join(json.dumps(row, separators=(",", ":")) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
 def _installed_version(command: Path) -> str:
     result = _run([str(command), "--version"], capture_output=True)
     return result.stdout.strip().split()[-1]
 
 
-def _run(command: list[str], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+def _run(
+    command: list[str],
+    *,
+    capture_output: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     print("+ " + " ".join(shlex.quote(part) for part in command), flush=True)
     result = subprocess.run(
         command,
         cwd=REPO_ROOT,
+        env=env,
         text=True,
         capture_output=capture_output,
     )

--- a/src/codex_usage_tracker/reports/support.py
+++ b/src/codex_usage_tracker/reports/support.py
@@ -285,15 +285,18 @@ def _support_path_replacements(
         ("dashboard_path", DEFAULT_DASHBOARD_PATH),
         ("plugin_path", DEFAULT_PLUGIN_LINK),
         ("marketplace_path", DEFAULT_MARKETPLACE_PATH),
+        ("python_executable", Path(sys.executable)),
         ("cwd", Path.cwd()),
         ("home", Path.home()),
     ]
     replacements: dict[str, str] = {}
     for label, path in raw_paths:
-        expanded = _safe_path(path.expanduser())
-        _add_path_replacement(replacements, label, expanded)
-        if label not in {"home", "cwd"}:
-            _add_path_replacement(replacements, f"{label}_dir", expanded.parent)
+        expanded = path.expanduser()
+        candidates = (expanded, _safe_path(expanded))
+        for candidate in candidates:
+            _add_path_replacement(replacements, label, candidate)
+            if label not in {"home", "cwd"}:
+                _add_path_replacement(replacements, f"{label}_dir", candidate.parent)
     return tuple(sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True))
 
 

--- a/tests/reports/test_support.py
+++ b/tests/reports/test_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from codex_usage_tracker.reports.support import build_support_bundle, support_bundle_payload
@@ -113,6 +114,7 @@ def test_support_bundle_strict_mode_redacts_local_paths_and_doctor_text(
         str(fixture["db_path"]),
         str(fixture["pricing_path"]),
         str(fixture["projects_path"]),
+        sys.executable,
     ):
         assert raw_path not in bundle_text
 


### PR DESCRIPTION
## Summary
- expand installed-wheel smoke coverage to exercise setup, doctor, dashboard generation, support-bundle, and bundled dashboard assets from a clean venv
- run lifecycle smoke against synthetic Codex logs and isolated HOME/USERPROFILE paths
- harden strict support-bundle redaction for Python executable paths and macOS /var vs /private/var path forms

## Validation
- + /Users/Monsky/Documents/Codex/2026-06-27/codex-usage-tracker-0.11.4/.venv/bin/python -m build --outdir /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/dist
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/python -m pip install --upgrade pip
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/python -m pip install --no-cache-dir /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/dist/codex_usage_tracking-0.12.1-py3-none-any.whl
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --version
codex-usage-tracker 0.12.1
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker setup --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker doctor --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker install-plugin --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker upgrade-plugin --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker uninstall-plugin --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker refresh --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker inspect-log --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker rebuild-index --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker reset-db --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker summary --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker query --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker recommendations --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker diagnostics --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker session --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker context --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker dashboard --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker open-dashboard --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker serve-dashboard --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker expensive --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker pricing-coverage --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker export --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker init-pricing --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker update-pricing --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker pin-pricing --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker init-allowance --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker parse-allowance --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker update-rate-card --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker init-thresholds --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker init-projects --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker support-bundle --help
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/python -c '
import codex_usage_tracker
print(codex_usage_tracker.__version__)
'
0.12.1
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/python -c '
import json
from importlib import resources

resource_paths = ['"'"'assets/icon.svg'"'"', '"'"'dashboard/dashboard.css'"'"', '"'"'dashboard/dashboard_call.css'"'"', '"'"'dashboard/dashboard_insights.css'"'"', '"'"'dashboard/dashboard_layout.css'"'"', '"'"'dashboard/dashboard_tables.css'"'"', '"'"'dashboard/dashboard_detail.css'"'"', '"'"'dashboard/dashboard_responsive.css'"'"', '"'"'dashboard/dashboard_format.js'"'"', '"'"'dashboard/dashboard_data.js'"'"', '"'"'dashboard/dashboard_analysis.js'"'"', '"'"'dashboard/dashboard_cells.js'"'"', '"'"'dashboard/dashboard_details.js'"'"', '"'"'dashboard/dashboard_insights.js'"'"', '"'"'dashboard/dashboard_tables.js'"'"', '"'"'dashboard/dashboard_filters.js'"'"', '"'"'dashboard/dashboard_status.js'"'"', '"'"'dashboard/dashboard_events.js'"'"', '"'"'dashboard/dashboard_actions.js'"'"', '"'"'dashboard/dashboard_live.js'"'"', '"'"'dashboard/dashboard_diagnostics.js'"'"', '"'"'dashboard/dashboard_call_diagnostics.js'"'"', '"'"'dashboard/dashboard.js'"'"', '"'"'dashboard/dashboard_state.js'"'"', '"'"'dashboard/dashboard_template.html'"'"', '"'"'dashboard/locales/en.json'"'"', '"'"'dashboard/locales/vi.json'"'"', '"'"'dashboard/locales/es.json'"'"', '"'"'dashboard/locales/fr.json'"'"', '"'"'dashboard/locales/de.json'"'"', '"'"'dashboard/locales/pt.json'"'"', '"'"'dashboard/locales/ja.json'"'"', '"'"'dashboard/locales/zh-Hans.json'"'"', '"'"'dashboard/locales/ko.json'"'"', '"'"'dashboard/locales/ru.json'"'"', '"'"'dashboard/locales/it.json'"'"', '"'"'dashboard/locales/ar.json'"'"', '"'"'docs/dashboard-guide.html'"'"', '"'"'docs/assets/dashboard-insights.png'"'"', '"'"'docs/assets/dashboard-calls.png'"'"', '"'"'docs/assets/dashboard-calls-preview.png'"'"', '"'"'docs/assets/dashboard-threads.png'"'"', '"'"'docs/assets/dashboard-diagnostics.png'"'"', '"'"'docs/assets/dashboard-diagnostics-git-expanded.png'"'"', '"'"'docs/assets/dashboard-details.png'"'"', '"'"'docs/assets/dashboard-call-investigator.png'"'"', '"'"'docs/assets/dashboard-call-investigator-preview.png'"'"', '"'"'docs/assets/dashboard-call-investigator-evidence.png'"'"', '"'"'docs/assets/plugin-prompts.png'"'"', '"'"'docs/assets/plugin-thread-leaderboard.png'"'"', '"'"'rate_cards/codex-credit-rates.json'"'"', '"'"'skills/codex-usage-api/SKILL.md'"'"', '"'"'skills/codex-usage-tracker/SKILL.md'"'"']
base = resources.files("codex_usage_tracker.plugin_data")
for resource_path in resource_paths:
    resource = base.joinpath(*resource_path.split("/"))
    if not resource.is_file():
        raise SystemExit(f"missing package resource: {resource_path}")
    size = len(resource.read_bytes())
    if size <= 0:
        raise SystemExit(f"empty package resource: {resource_path}")
rate_card = json.loads(base.joinpath("rate_cards", "codex-credit-rates.json").read_text())
if rate_card.get("schema") != "codex-usage-tracker-codex-rate-card-v1":
    raise SystemExit("bundled rate card schema mismatch")
print(f"validated {len(resource_paths)} package resources")
'
validated 53 package resources
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker install-plugin --plugin-dir /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/plugin --marketplace /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/marketplace.json --force --json
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --version
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --db /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/usage.sqlite3 --pricing /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/pricing.json --allowance /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/allowance.json --rate-card /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/rate-card.json --thresholds /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/thresholds.json --projects /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/projects.json setup --codex-home /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex --plugin-dir /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/setup-plugin --marketplace /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/setup-marketplace.json --skip-pricing --json
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --db /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/usage.sqlite3 --pricing /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/pricing.json --allowance /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/allowance.json --rate-card /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/rate-card.json --thresholds /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/thresholds.json --projects /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/projects.json doctor --json
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --version
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --db /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/usage.sqlite3 --pricing /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/pricing.json --allowance /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/allowance.json --rate-card /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/rate-card.json --thresholds /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/thresholds.json --projects /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/projects.json dashboard --output /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/dashboard.html --limit 0 --json
+ /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/venv/bin/codex-usage-tracker --db /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/usage.sqlite3 --pricing /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/pricing.json --allowance /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/allowance.json --rate-card /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/rate-card.json --thresholds /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/thresholds.json --projects /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex-usage-tracker/projects.json --privacy-mode strict support-bundle --codex-home /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/home/.codex --output /var/folders/8b/wt4vy9ld3_v82nb4hsqpvw880000gp/T/codex-usage-installed-smoke-d7jv3v45/support-bundle.json --json
Installed package smoke passed.
- All checks passed!
- Success: no issues found in 8 source files
- [Tach] 537 tests in 91 files unaffected by changes (~26.4s could be saved). Skip with: pytest --tach
[Tach] To disable: pytest -p no:tach (https://docs.gauge.sh/usage/commands#using-the-pytest-plugin-directly)
........................................................................ [ 13%]
........................................................................ [ 26%]
........................................................................ [ 40%]
........................................................................ [ 53%]
........................................................................ [ 67%]
........................................................................ [ 80%]
........................................................................ [ 93%]
.................................                                        [100%]
537 passed in 27.08s (537 passed)
- Listing 'src'...
Listing 'src/codex_usage_tracker'...
Listing 'src/codex_usage_tracker/cli'...
Listing 'src/codex_usage_tracker/context'...
Listing 'src/codex_usage_tracker/core'...
Listing 'src/codex_usage_tracker/dashboard'...
Listing 'src/codex_usage_tracker/diagnostics'...
Listing 'src/codex_usage_tracker/parser'...
Listing 'src/codex_usage_tracker/plugin_data'...
Listing 'src/codex_usage_tracker/plugin_data/assets'...
Listing 'src/codex_usage_tracker/plugin_data/dashboard'...
Listing 'src/codex_usage_tracker/plugin_data/dashboard/locales'...
Listing 'src/codex_usage_tracker/plugin_data/docs'...
Listing 'src/codex_usage_tracker/plugin_data/docs/assets'...
Listing 'src/codex_usage_tracker/plugin_data/rate_cards'...
Listing 'src/codex_usage_tracker/plugin_data/skills'...
Listing 'src/codex_usage_tracker/plugin_data/skills/codex-usage-api'...
Listing 'src/codex_usage_tracker/plugin_data/skills/codex-usage-tracker'...
Listing 'src/codex_usage_tracker/pricing'...
Listing 'src/codex_usage_tracker/reports'...
Listing 'src/codex_usage_tracker/server'...
Listing 'src/codex_usage_tracker/store'...
Listing 'src/codex_usage_tracker/usage_drain'...
- 
- Release readiness checks passed.
- 