### PR TITLE
perf: scope refresh rebuilds to affected threads

### DIFF
--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -344,18 +344,24 @@ def upsert_usage_events(
     source_files_to_replace = _source_file_strings(replace_source_files)
     with connect(db_path) as conn:
         init_db(conn)
+        affected_thread_keys = _thread_keys_for_source_files(conn, source_files_to_replace)
         _delete_usage_events_for_source_files(conn, source_files_to_replace)
         if not rows:
             _refresh_after_empty_source_replacement(
                 conn,
                 refresh_links=refresh_links,
-                source_files_to_replace=source_files_to_replace,
+                affected_thread_keys=affected_thread_keys,
             )
             return 0
+        affected_thread_keys.update(_thread_keys_for_usage_rows(rows))
         _delete_diagnostic_facts_for_record_ids(conn, _usage_event_record_ids(rows))
         _insert_usage_event_rows(conn, rows)
         _insert_diagnostic_facts(conn, fact_rows)
-        _refresh_after_usage_event_upsert(conn, refresh_links=refresh_links)
+        _refresh_after_usage_event_upsert(
+            conn,
+            refresh_links=refresh_links,
+            affected_thread_keys=affected_thread_keys,
+        )
         return len(rows)
 
 
@@ -397,15 +403,59 @@ def _delete_usage_events_for_source_files(
     )
 
 
+def _thread_keys_for_source_files(
+    conn: sqlite3.Connection,
+    source_files_to_replace: list[str],
+) -> set[str]:
+    if not source_files_to_replace:
+        return set()
+    placeholders = ", ".join("?" for _source in source_files_to_replace)
+    rows = conn.execute(
+        f"""
+        SELECT thread_key, session_id
+        FROM usage_events
+        WHERE source_file IN ({placeholders})
+        """,
+        source_files_to_replace,
+    ).fetchall()
+    return _thread_keys_for_usage_rows(rows)
+
+
+def _thread_keys_for_usage_rows(
+    rows: Iterable[Mapping[str, object] | sqlite3.Row],
+) -> set[str]:
+    keys: set[str] = set()
+    for row in rows:
+        session_id = _usage_row_value(row, "session_id")
+        thread_key = _usage_row_value(row, "thread_key") or (
+            f"session:{session_id}" if session_id else None
+        )
+        if thread_key:
+            keys.add(str(thread_key))
+    return keys
+
+
+def _usage_row_value(
+    row: Mapping[str, object] | sqlite3.Row,
+    key: str,
+) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    try:
+        return row[key]
+    except (IndexError, KeyError, TypeError):
+        return None
+
+
 def _refresh_after_empty_source_replacement(
     conn: sqlite3.Connection,
     *,
     refresh_links: bool,
-    source_files_to_replace: list[str],
+    affected_thread_keys: set[str],
 ) -> None:
-    if source_files_to_replace and refresh_links:
-        _refresh_usage_event_links(conn)
-        rebuild_thread_summaries(conn)
+    if affected_thread_keys and refresh_links:
+        _refresh_usage_event_links_for_threads(conn, affected_thread_keys)
+        rebuild_thread_summaries(conn, thread_keys=affected_thread_keys)
 
 
 def _usage_event_record_ids(rows: list[dict[str, object]]) -> list[str]:
@@ -440,10 +490,11 @@ def _refresh_after_usage_event_upsert(
     conn: sqlite3.Connection,
     *,
     refresh_links: bool,
+    affected_thread_keys: set[str],
 ) -> None:
-    if refresh_links:
-        _refresh_usage_event_links(conn)
-        rebuild_thread_summaries(conn)
+    if refresh_links and affected_thread_keys:
+        _refresh_usage_event_links_for_threads(conn, affected_thread_keys)
+        rebuild_thread_summaries(conn, thread_keys=affected_thread_keys)
 
 
 def _delete_diagnostic_facts_for_record_ids(
@@ -495,11 +546,38 @@ def refresh_usage_event_links(db_path: Path = DEFAULT_DB_PATH) -> int:
         return changed
 
 
+def _refresh_usage_event_links_for_threads(
+    conn: sqlite3.Connection,
+    affected_thread_keys: Iterable[str],
+) -> int:
+    thread_keys = sorted({key for key in affected_thread_keys if key})
+    if not thread_keys:
+        return 0
+    placeholders = ", ".join("?" for _key in thread_keys)
+    return _refresh_usage_event_links_scoped(
+        conn,
+        where_clause=(
+            "WHERE coalesce(nullif(thread_key, ''), 'session:' || session_id) "
+            f"IN ({placeholders})"
+        ),
+        params=thread_keys,
+    )
+
+
 def _refresh_usage_event_links(conn: sqlite3.Connection) -> int:
+    return _refresh_usage_event_links_scoped(conn)
+
+
+def _refresh_usage_event_links_scoped(
+    conn: sqlite3.Connection,
+    *,
+    where_clause: str = "",
+    params: Iterable[object] = (),
+) -> int:
     before = conn.total_changes
     conn.execute("DROP TABLE IF EXISTS temp_usage_event_links")
     conn.execute(
-        """
+        f"""
         CREATE TEMP TABLE temp_usage_event_links AS
         SELECT
             record_id,
@@ -516,7 +594,9 @@ def _refresh_usage_event_links(conn: sqlite3.Connection) -> int:
                 ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
             ) AS next_id
         FROM usage_events
-        """
+        {where_clause}
+        """,
+        list(params),
     )
     conn.execute(
         "CREATE UNIQUE INDEX temp_usage_event_links_record_id ON temp_usage_event_links(record_id)"

--- a/src/codex_usage_tracker/store/thread_summaries.py
+++ b/src/codex_usage_tracker/store/thread_summaries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -20,23 +21,37 @@ from codex_usage_tracker.store.rows import row_to_dict
 from codex_usage_tracker.store.schema import init_db
 
 
-def rebuild_thread_summaries(conn: sqlite3.Connection) -> int:
+def rebuild_thread_summaries(
+    conn: sqlite3.Connection,
+    *,
+    thread_keys: Iterable[str] | None = None,
+) -> int:
     """Rebuild materialized per-thread aggregate summaries."""
 
     before = conn.total_changes
-    conn.execute("DELETE FROM thread_summaries")
+    normalized_thread_keys = sorted({key for key in thread_keys or [] if key})
+    if normalized_thread_keys:
+        placeholders = ", ".join("?" for _key in normalized_thread_keys)
+        conn.execute(
+            f"DELETE FROM thread_summaries WHERE thread_key IN ({placeholders})",
+            normalized_thread_keys,
+        )
+    else:
+        conn.execute("DELETE FROM thread_summaries")
     updated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     _insert_thread_summary_scope(
         conn,
         scope="active",
         include_archived=False,
         updated_at=updated_at,
+        thread_keys=normalized_thread_keys,
     )
     _insert_thread_summary_scope(
         conn,
         scope="all-history",
         include_archived=True,
         updated_at=updated_at,
+        thread_keys=normalized_thread_keys,
     )
     return conn.total_changes - before
 
@@ -105,9 +120,19 @@ def _insert_thread_summary_scope(
     scope: str,
     include_archived: bool,
     updated_at: str,
+    thread_keys: Iterable[str] | None = None,
 ) -> None:
     where_clause, params = usage_where_clause(include_archived=include_archived)
     thread_key_expr = thread_key_expression()
+    normalized_thread_keys = sorted({key for key in thread_keys or [] if key})
+    if normalized_thread_keys:
+        placeholders = ", ".join("?" for _key in normalized_thread_keys)
+        thread_filter = f"{thread_key_expr} IN ({placeholders})"
+        if where_clause:
+            where_clause = f"{where_clause} AND ({thread_filter})"
+        else:
+            where_clause = f"WHERE {thread_filter}"
+        params.extend(normalized_thread_keys)
     conn.execute(
         f"""
         INSERT INTO thread_summaries (

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+import codex_usage_tracker.store.api as store_api
 from codex_usage_tracker import store as store_module
 from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.diagnostics.reports import build_diagnostics_facts_report
@@ -144,7 +145,7 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
     first = refresh_usage_index(codex_home=codex_home, db_path=db_path)
     with connect(db_path) as conn:
         init_db(conn)
-        source_before = conn.execute(
+        source_before_row = conn.execute(
             """
             SELECT parsed_until_byte, parsed_until_line, parser_state_json
             FROM source_files
@@ -152,10 +153,20 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
             """,
             (str(log_path),),
         ).fetchone()
+        assert source_before_row is not None
+        source_before = dict(source_before_row)
+    target_thread_key = query_session_usage(
+        db_path=db_path,
+        session_id=SESSION_ID,
+    )[0]["thread_key"]
     with log_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(_token_event(650, 350)) + "\n")
     parse_calls: list[dict[str, Any]] = []
     original_parse = store_module.parse_usage_events_from_file_with_state
+    link_scopes: list[set[str]] = []
+    original_refresh_links = store_api._refresh_usage_event_links_for_threads
+    summary_scopes: list[set[str]] = []
+    original_rebuild_summaries = store_api.rebuild_thread_summaries
 
     def tracking_parse(*args: Any, **kwargs: Any):
         parse_calls.append(
@@ -168,10 +179,28 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
         )
         return original_parse(*args, **kwargs)
 
+    def tracking_refresh_links(*args: Any, **kwargs: Any) -> int:
+        link_scopes.append(set(args[1]))
+        return original_refresh_links(*args, **kwargs)
+
+    def tracking_rebuild_summaries(*args: Any, **kwargs: Any) -> int:
+        summary_scopes.append(set(kwargs.get("thread_keys") or []))
+        return original_rebuild_summaries(*args, **kwargs)
+
     monkeypatch.setattr(
         store_module,
         "parse_usage_events_from_file_with_state",
         tracking_parse,
+    )
+    monkeypatch.setattr(
+        store_api,
+        "_refresh_usage_event_links_for_threads",
+        tracking_refresh_links,
+    )
+    monkeypatch.setattr(
+        store_api,
+        "rebuild_thread_summaries",
+        tracking_rebuild_summaries,
     )
     second = refresh_usage_index(codex_home=codex_home, db_path=db_path)
     third = refresh_usage_index(codex_home=codex_home, db_path=db_path)
@@ -190,6 +219,8 @@ def test_refresh_indexes_only_appended_token_events_when_source_grows(
     assert second.parsed_events == 1
     assert second.inserted_or_updated_events == 1
     assert third.parsed_events == 0
+    assert link_scopes == [{target_thread_key}]
+    assert summary_scopes == [{target_thread_key}]
     assert [row["cumulative_total_tokens"] for row in rows] == [100, 300, 650]
     assert metadata["parsed_source_files"] == "0"
     assert metadata["skipped_source_files"] == "3"


### PR DESCRIPTION
## Summary
- collect affected thread keys before replacing source rows
- refresh usage-event adjacency only for changed thread partitions
- allow thread summaries to rebuild only the affected thread rows
- extend the append-cursor store test to assert scoped link and summary rebuild calls

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests/store/test_store_dashboard_mcp.py::test_refresh_indexes_only_appended_token_events_when_source_grows -q
- PYTHONPATH=src .venv/bin/python -m pytest tests/store/test_store_dashboard_mcp.py -q
- PYTHONPATH=src .venv/bin/python -m pytest tests/store -q
- PYTHONPATH=src .venv/bin/python -m ruff check .
- PYTHONPATH=src .venv/bin/python -m mypy
- PYTHONPATH=src .venv/bin/python -m compileall src
- PYTHONPATH=src .venv/bin/python -m pytest -q
- PYTHONPATH=src .venv/bin/python scripts/check_release.py
- git diff --check