### PR TITLE
feat: add large low-output usage diagnostic

### DIFF
--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -83,6 +83,7 @@ Tracked schema ids:
 | `codex-usage-tracker-pattern-scan-v1` | MCP `usage_repetition_scan(...)`, `usage_command_loop_scan(...)`, `usage_file_churn_scan(...)`, `usage_context_bloat_scan(...)`; explicit local content/event-index pattern diagnostics |
 | `codex-usage-tracker-repeated-file-rediscovery-v1` | MCP `usage_repeated_file_rediscovery(...)`; repeated safe file identity rediscovery candidates without full paths |
 | `codex-usage-tracker-shell-churn-v1` | MCP `usage_shell_churn(...)`; repeated shell command family diagnostics without raw command output |
+| `codex-usage-tracker-large-low-output-v1` | MCP `usage_large_low_output_calls(...)`; high-token low-output call candidates without raw fragments |
 | `codex-usage-tracker-investigation-walk-v1` | MCP `usage_investigation_walk(question=...)`; bounded local hypothesis walk over normalized pattern evidence |
 | `codex-usage-tracker-local-evidence-export-v1` | MCP `usage_local_evidence_export(question=...)`; strict shareable local evidence summary without raw/indexed content |
 | `codex-usage-tracker-export-v1` | CLI `export --json`, MCP `export_usage_csv(...)` |
@@ -1006,6 +1007,20 @@ Ranks repeated shell command roots and bounded command labels by failures, adjac
 {"schema":"codex-usage-tracker-shell-churn-v1","content_mode":"local_content_index","includes_indexed_content":true,"includes_raw_fragments":false,"privacy_mode":"normal","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_occurrences":3,"limit":20,"sample_limit":3},"row_count":0,"total_candidates":0,"rows":[]}
 ```
 
+## Large Low-Output Calls
+
+MCP:
+
+- `usage_large_low_output_calls(min_total_tokens=20000,max_output_tokens=1000)`
+
+Schema: `codex-usage-tracker-large-low-output-v1`
+
+Ranks high-token calls that produced little output, including token totals, cache ratio, context-window percent, nearby activity counts, candidate explanations, and `usage_thread_trace` handles. It omits raw fragments, command output, and full file paths.
+
+```json
+{"schema":"codex-usage-tracker-large-low-output-v1","content_mode":"aggregate_with_local_activity","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_total_tokens":20000,"max_output_tokens":1000,"limit":20},"row_count":0,"total_candidates":0,"rows":[]}
+```
+
 ## Investigation Walk
 
 MCP:
@@ -1017,7 +1032,7 @@ Schema: `codex-usage-tracker-investigation-walk-v1`
 Runs a bounded local hypothesis walk over normalized pattern scans, ranks candidate branches, prunes branches without evidence, and returns recommended next MCP tools. Does not include raw fragments.
 
 ```json
-{"schema":"codex-usage-tracker-investigation-walk-v1","content_mode":"local_content_index","includes_indexed_content":true,"includes_raw_fragments":false,"privacy_mode":"normal","question":"look for token waste","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_occurrences":2,"evidence_limit":5},"summary":{"branch_count":4,"supported_branch_count":0,"top_hypothesis":null,"confidence":"insufficient_local_evidence"},"branches":[],"recommended_next_tools":[]}
+{"schema":"codex-usage-tracker-investigation-walk-v1","content_mode":"local_content_index","includes_indexed_content":true,"includes_raw_fragments":false,"privacy_mode":"normal","question":"look for token waste","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_occurrences":2,"evidence_limit":5},"summary":{"branch_count":5,"supported_branch_count":0,"top_hypothesis":null,"confidence":"insufficient_local_evidence"},"branches":[],"recommended_next_tools":[]}
 ```
 
 ## Local Evidence Export
@@ -1031,7 +1046,7 @@ Schema: `codex-usage-tracker-local-evidence-export-v1`
 Strict shareable summary derived from local investigation evidence. It omits raw fragments, snippets, record ids, thread names, command labels, file basenames, full paths, raw commands, and raw tool output.
 
 ```json
-{"schema":"codex-usage-tracker-local-evidence-export-v1","content_mode":"shareable_local_evidence","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"strict","question":"share token waste evidence","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_occurrences":2,"evidence_limit":5},"summary":{"branch_count":4,"supported_branch_count":0,"top_hypothesis":null,"confidence":"insufficient_local_evidence","export_branch_count":0},"branches":[],"omitted_fields":["record_id","session_id","thread_name","raw_fragment","snippet","raw_command","raw_tool_output","full_path","path_basename","command_label"],"caveats":["Local evidence only; not an official OpenAI ledger."]}
+{"schema":"codex-usage-tracker-local-evidence-export-v1","content_mode":"shareable_local_evidence","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"strict","question":"share token waste evidence","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_occurrences":2,"evidence_limit":5},"summary":{"branch_count":5,"supported_branch_count":0,"top_hypothesis":null,"confidence":"insufficient_local_evidence","export_branch_count":0},"branches":[],"omitted_fields":["record_id","session_id","thread_name","raw_fragment","snippet","raw_command","raw_tool_output","full_path","path_basename","command_label"],"caveats":["Local evidence only; not an official OpenAI ledger."]}
 ```
 
 ## Lifecycle Commands

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -81,6 +81,7 @@ The companion skill cannot read your logged-in Codex account plan, native remain
 - `usage_file_churn_scan`
 - `usage_repeated_file_rediscovery`
 - `usage_shell_churn`
+- `usage_large_low_output_calls`
 - `usage_context_bloat_scan`
 - `usage_investigation_walk`
 - `usage_local_evidence_export`
@@ -124,6 +125,8 @@ Dashboard recommendations: `usage_dashboard_recommendations(...)` returns the da
 `usage_repeated_file_rediscovery(...)` ranks repeated exact safe file identities by path hash/identity, basename, extension, operation mix, adjacent retouches, aggregate token totals, and `usage_thread_trace` handles. Use it when the user asks which files are being rediscovered or reread repeatedly. It does not expose full paths or raw fragments.
 
 `usage_shell_churn(...)` ranks repeated shell command roots and bounded command labels by failures, adjacent repeats, output bytes, aggregate token totals, and `usage_thread_trace` handles. Use it when the user asks about repeated `sed`, `rg`, `git`, `nl`, test, package, or unknown shell command loops. It does not expose raw command output.
+
+`usage_large_low_output_calls(...)` ranks high-token calls that produced little output, with token totals, cache ratio, context-window percent, nearby tool/command/file counts, and candidate explanations such as cold resume, tool-output pressure, stale thread, or low-value continuation. It stays aggregate-first and does not expose raw fragments, command output, or full file paths.
 
 `usage_investigation_walk(question=...)` runs a bounded local hypothesis walk over those normalized pattern scans, ranks candidate branches, prunes branches without evidence, and returns recommended next MCP tools. It is local-index evidence, not a shareable aggregate-only report.
 

--- a/skills/codex-usage-api/SKILL.md
+++ b/skills/codex-usage-api/SKILL.md
@@ -15,6 +15,8 @@ When the user plans to share JSON, CSV, dashboards, screenshots, or support bund
 
 Use `usage_investigation_walk(question=...)` first when user asks for broad local waste discovery; it ranks normalized pattern branches and recommends next tools. Use local pattern scans (`usage_repetition_scan`, `usage_command_loop_scan`, `usage_file_churn_scan`, `usage_context_bloat_scan`) when user asks for recurring waste, command loops, repeated file churn, or context bloat. Use `usage_repeated_file_rediscovery(...)` when user asks which files are rediscovered or reread repeatedly; it ranks safe path hashes/basenames without full paths. Use `usage_shell_churn(...)` when the user asks about repeated shell probing, command loops, failing retries, or repeated sed/rg/git/nl/test/package commands. Use `usage_content_search` only when user asks local content exploration, pattern hunting, diagnostics need indexed snippets; its payload can include local transcript snippets is not default shareable report.
 
+Use `usage_large_low_output_calls(...)` when the user asks for obvious token-waste candidates, cold resumes, cache misses, stale high-context continuations, or large calls that produced little output.
+
 Use `usage_call_context` only when the user explicitly asks to inspect actual logged context for one selected record. State that returned text is local, redacted or size-limited when applicable, and not included in default shareable outputs.
 
 ## First Steps

--- a/src/codex_usage_tracker/cli/mcp_server.py
+++ b/src/codex_usage_tracker/cli/mcp_server.py
@@ -47,6 +47,7 @@ from codex_usage_tracker.reports.api import (
     build_content_search_report,
     build_expensive_calls_report,
     build_investigation_walk_report,
+    build_large_low_output_report,
     build_local_evidence_export_report,
     build_pattern_scan_report,
     build_pricing_coverage_report,
@@ -587,6 +588,32 @@ def usage_shell_churn(
         min_occurrences=min_occurrences,
         limit=limit,
         sample_limit=sample_limit,
+        privacy_mode=privacy_mode,
+    ).payload
+
+
+@mcp.tool()
+def usage_large_low_output_calls(
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_total_tokens: int = 20_000,
+    max_output_tokens: int = 1_000,
+    limit: int | None = 20,
+    privacy_mode: str = "normal",
+) -> dict[str, Any]:
+    """Find high-token calls with low output as token-waste candidates."""
+
+    return build_large_low_output_report(
+        db_path=DEFAULT_DB_PATH,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        min_total_tokens=min_total_tokens,
+        max_output_tokens=max_output_tokens,
+        limit=limit,
         privacy_mode=privacy_mode,
     ).payload
 

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -341,6 +341,29 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
+    'codex-usage-tracker-large-low-output-v1': {
+        "required": {
+            "content_mode": str,
+            "includes_indexed_content": bool,
+            "includes_raw_fragments": bool,
+            "privacy_mode": str,
+            "filters": dict,
+            "row_count": int,
+            "total_candidates": int,
+            "rows": list,
+        },
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "thread": (str, NoneType),
+                "include_archived": bool,
+                "min_total_tokens": int,
+                "max_output_tokens": int,
+                "limit": (int, NoneType),
+            }
+        },
+    },
     'codex-usage-tracker-investigation-walk-v1': {
         "required": {
             "content_mode": str,

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
@@ -15,6 +15,8 @@ When the user plans to share JSON, CSV, dashboards, screenshots, or support bund
 
 Use `usage_investigation_walk(question=...)` first when user asks for broad local waste discovery; it ranks normalized pattern branches and recommends next tools. Use local pattern scans (`usage_repetition_scan`, `usage_command_loop_scan`, `usage_file_churn_scan`, `usage_context_bloat_scan`) when user asks for recurring waste, command loops, repeated file churn, or context bloat. Use `usage_repeated_file_rediscovery(...)` when user asks which files are rediscovered or reread repeatedly; it ranks safe path hashes/basenames without full paths. Use `usage_shell_churn(...)` when the user asks about repeated shell probing, command loops, failing retries, or repeated sed/rg/git/nl/test/package commands. Use `usage_content_search` only when user asks local content exploration, pattern hunting, diagnostics need indexed snippets; its payload can include local transcript snippets is not default shareable report.
 
+Use `usage_large_low_output_calls(...)` when the user asks for obvious token-waste candidates, cold resumes, cache misses, stale high-context continuations, or large calls that produced little output.
+
 Use `usage_call_context` only when the user explicitly asks to inspect actual logged context for one selected record. State that returned text is local, redacted or size-limited when applicable, and not included in default shareable outputs.
 
 ## First Steps

--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -43,6 +43,7 @@ from codex_usage_tracker.reports.recommendations import annotate_rows_with_recom
 from codex_usage_tracker.store.api import (
     query_content_search,
     query_dashboard_events,
+    query_large_low_output_calls,
     query_most_expensive_calls,
     query_pattern_scan,
     query_repeated_file_rediscovery,
@@ -172,6 +173,13 @@ class RepeatedFileRediscoveryReport:
 @dataclass(frozen=True)
 class ShellChurnReport:
     """Stable machine-readable repeated shell command churn report."""
+
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class LargeLowOutputReport:
+    """Stable machine-readable large low-output call report."""
 
     payload: dict[str, Any]
 
@@ -649,6 +657,57 @@ def build_shell_churn_report(
     )
 
 
+def build_large_low_output_report(
+    *,
+    db_path: Path,
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_total_tokens: int = 20_000,
+    max_output_tokens: int = 1_000,
+    limit: int | None = 20,
+    privacy_mode: str = "normal",
+) -> LargeLowOutputReport:
+    """Build aggregate-first large low-output call payload."""
+
+    privacy_mode = validate_privacy_mode(privacy_mode)
+    normalized_min_total = max(0, min_total_tokens)
+    normalized_max_output = max(0, max_output_tokens)
+    result = query_large_low_output_calls(
+        db_path=db_path,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        min_total_tokens=normalized_min_total,
+        max_output_tokens=normalized_max_output,
+        limit=limit,
+    )
+    rows = result["rows"]
+    return LargeLowOutputReport(
+        {
+            "schema": "codex-usage-tracker-large-low-output-v1",
+            "content_mode": "aggregate_with_local_activity",
+            "includes_indexed_content": False,
+            "includes_raw_fragments": False,
+            "privacy_mode": privacy_mode,
+            "filters": {
+                "since": since,
+                "until": until,
+                "thread": thread,
+                "include_archived": include_archived,
+                "min_total_tokens": normalized_min_total,
+                "max_output_tokens": normalized_max_output,
+                "limit": limit,
+            },
+            "row_count": len(rows),
+            "total_candidates": int(result["total_candidates"]),
+            "rows": rows,
+        }
+    )
+
+
 def build_investigation_walk_report(
     *,
     db_path: Path,
@@ -675,8 +734,25 @@ def build_investigation_walk_report(
         min_occurrences=min_occurrences,
         limit=normalized_evidence_limit * 4,
     )
+    large_low_output_result = query_large_low_output_calls(
+        db_path=db_path,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        min_total_tokens=20_000,
+        max_output_tokens=1_000,
+        limit=normalized_evidence_limit,
+    )
     patterns = pattern_result["patterns"]
     branches = _investigation_branches(patterns=patterns, evidence_limit=normalized_evidence_limit)
+    branches.append(
+        _large_low_output_branch(
+            rows=large_low_output_result["rows"],
+            evidence_limit=normalized_evidence_limit,
+        )
+    )
+    branches.sort(key=lambda branch: (-int(branch["score"]), str(branch["scan_type"])))
     supported = [branch for branch in branches if branch["status"] != "no_evidence"]
     payload = {
         "schema": "codex-usage-tracker-investigation-walk-v1",
@@ -755,6 +831,28 @@ def _investigation_branches(
     return branches
 
 
+def _large_low_output_branch(
+    *,
+    rows: list[dict[str, Any]],
+    evidence_limit: int,
+) -> dict[str, Any]:
+    selected = [dict(row, scan_type="large_low_output") for row in rows[:evidence_limit]]
+    score = _branch_score(selected)
+    return {
+        "scan_type": "large_low_output",
+        "hypothesis": "Large calls with little output",
+        "rationale": (
+            "Large input/context usage with low output can indicate cold resumes, "
+            "tool-output pressure, stale thread continuation, or low-value continuation."
+        ),
+        "status": _branch_status(score, selected),
+        "score": score,
+        "evidence_count": len(selected),
+        "evidence": selected,
+        "pruned_reason": None if selected else "No calls matched large low-output thresholds.",
+    }
+
+
 def _branch_score(evidence: list[dict[str, Any]]) -> int:
     total = 0
     for row in evidence:
@@ -817,11 +915,27 @@ def _recommended_investigation_tools(supported: list[dict[str, Any]]) -> list[di
                 "reason": "Inspect repeated file path hashes and linked aggregate calls.",
             }
         )
+    elif top_scan == "large_low_output":
+        tools.append(
+            {
+                "tool": "usage_large_low_output_calls",
+                "reason": "Inspect large input/context calls that produced little output.",
+            }
+        )
     else:
         tools.append(
             {
                 "tool": "usage_content_search",
                 "reason": "Use explicit local snippet search only when transcript-level evidence is needed.",
+            }
+        )
+    if any(str(branch["scan_type"]) == "large_low_output" for branch in supported) and all(
+        tool["tool"] != "usage_large_low_output_calls" for tool in tools
+    ):
+        tools.append(
+            {
+                "tool": "usage_large_low_output_calls",
+                "reason": "Inspect large input/context calls that produced little output.",
             }
         )
     return tools

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -60,6 +60,9 @@ from codex_usage_tracker.store.diagnostic_queries import (
 )
 from codex_usage_tracker.store.exports import export_usage_csv as export_usage_csv
 from codex_usage_tracker.store.investigation_runs import insert_investigation_run
+from codex_usage_tracker.store.large_low_output import (
+    query_large_low_output_calls as query_large_low_output_calls_rows,
+)
 from codex_usage_tracker.store.repeated_files import (
     query_repeated_file_rediscovery as query_repeated_file_rediscovery_rows,
 )
@@ -323,7 +326,34 @@ def query_shell_churn(
             include_archived=include_archived,
             min_occurrences=min_occurrences,
             limit=limit,
-            sample_limit=sample_limit,
+        sample_limit=sample_limit,
+    )
+
+
+def query_large_low_output_calls(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_total_tokens: int = 20_000,
+    max_output_tokens: int = 1_000,
+    limit: int | None = 20,
+) -> dict[str, Any]:
+    """Return large aggregate-token calls that produced little output."""
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        return query_large_low_output_calls_rows(
+            conn,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            min_total_tokens=min_total_tokens,
+            max_output_tokens=max_output_tokens,
+            limit=limit,
         )
 
 

--- a/src/codex_usage_tracker/store/large_low_output.py
+++ b/src/codex_usage_tracker/store/large_low_output.py
@@ -1,0 +1,255 @@
+"""Large low-output call diagnostics over aggregate usage rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def query_large_low_output_calls(
+    conn: sqlite3.Connection,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_total_tokens: int = 20_000,
+    max_output_tokens: int = 1_000,
+    limit: int | None = 20,
+) -> dict[str, Any]:
+    """Return large aggregate-token calls that produced little output."""
+
+    normalized_min_total = max(0, min_total_tokens)
+    normalized_max_output = max(0, max_output_tokens)
+    normalized_limit = _normalize_limit(limit)
+    where_sql, params = _usage_filters(
+        "u",
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        extra_clauses=[
+            "u.total_tokens >= ?",
+            "u.output_tokens <= ?",
+        ],
+        extra_params=[normalized_min_total, normalized_max_output],
+    )
+
+    rows = conn.execute(
+        f"""
+        WITH tool_counts AS (
+            SELECT
+                record_id,
+                COUNT(*) AS tool_call_count,
+                COALESCE(SUM(output_size_bytes), 0) AS tool_output_size_bytes
+            FROM tool_calls
+            GROUP BY record_id
+        ),
+        command_counts AS (
+            SELECT
+                record_id,
+                COUNT(*) AS command_run_count,
+                COALESCE(SUM(output_size_bytes), 0) AS command_output_size_bytes,
+                SUM(CASE WHEN status != 'completed' THEN 1 ELSE 0 END) AS failed_command_count
+            FROM command_runs
+            GROUP BY record_id
+        ),
+        file_counts AS (
+            SELECT
+                record_id,
+                COUNT(*) AS file_event_count,
+                SUM(CASE WHEN operation = 'read' THEN 1 ELSE 0 END) AS file_read_count,
+                SUM(CASE WHEN operation IN ('modify', 'edit', 'write') THEN 1 ELSE 0 END) AS file_write_count
+            FROM file_events
+            GROUP BY record_id
+        )
+        SELECT
+            u.record_id,
+            u.session_id,
+            u.thread_key,
+            u.thread_name,
+            u.parent_thread_name,
+            u.event_timestamp,
+            u.model,
+            u.effort,
+            u.call_initiator,
+            u.call_initiator_confidence,
+            u.total_tokens,
+            u.input_tokens,
+            u.cached_input_tokens,
+            u.uncached_input_tokens,
+            u.output_tokens,
+            u.reasoning_output_tokens,
+            u.model_context_window,
+            u.context_window_percent,
+            COALESCE(tc.tool_call_count, 0) AS tool_call_count,
+            COALESCE(tc.tool_output_size_bytes, 0) AS tool_output_size_bytes,
+            COALESCE(cc.command_run_count, 0) AS command_run_count,
+            COALESCE(cc.command_output_size_bytes, 0) AS command_output_size_bytes,
+            COALESCE(cc.failed_command_count, 0) AS failed_command_count,
+            COALESCE(fc.file_event_count, 0) AS file_event_count,
+            COALESCE(fc.file_read_count, 0) AS file_read_count,
+            COALESCE(fc.file_write_count, 0) AS file_write_count
+        FROM usage_events u
+        LEFT JOIN tool_counts tc ON tc.record_id = u.record_id
+        LEFT JOIN command_counts cc ON cc.record_id = u.record_id
+        LEFT JOIN file_counts fc ON fc.record_id = u.record_id
+        {where_sql}
+        ORDER BY u.total_tokens DESC, u.uncached_input_tokens DESC, u.event_timestamp DESC, u.record_id ASC
+        """,
+        params,
+    ).fetchall()
+
+    candidates = [_candidate(row) for row in rows]
+    sliced = candidates if normalized_limit is None else candidates[:normalized_limit]
+    return {
+        "rows": sliced,
+        "total_candidates": len(candidates),
+    }
+
+
+def _candidate(row: sqlite3.Row) -> dict[str, Any]:
+    input_tokens = int(row["input_tokens"] or 0)
+    cached_input_tokens = int(row["cached_input_tokens"] or 0)
+    uncached_input_tokens = int(row["uncached_input_tokens"] or 0)
+    output_tokens = int(row["output_tokens"] or 0)
+    total_tokens = int(row["total_tokens"] or 0)
+    context_window_percent = float(row["context_window_percent"] or 0.0)
+    tool_output_size_bytes = int(row["tool_output_size_bytes"] or 0)
+    command_output_size_bytes = int(row["command_output_size_bytes"] or 0)
+    tool_call_count = int(row["tool_call_count"] or 0)
+    command_run_count = int(row["command_run_count"] or 0)
+    file_event_count = int(row["file_event_count"] or 0)
+    explanation, reasons = _candidate_explanation(
+        input_tokens=input_tokens,
+        cached_input_tokens=cached_input_tokens,
+        uncached_input_tokens=uncached_input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        context_window_percent=context_window_percent,
+        tool_output_size_bytes=tool_output_size_bytes,
+        command_output_size_bytes=command_output_size_bytes,
+        tool_call_count=tool_call_count,
+        command_run_count=command_run_count,
+        file_event_count=file_event_count,
+    )
+    return {
+        "record_id": row["record_id"],
+        "session_id": row["session_id"],
+        "thread_key": row["thread_key"],
+        "thread_name": row["thread_name"],
+        "parent_thread_name": row["parent_thread_name"],
+        "event_timestamp": row["event_timestamp"],
+        "model": row["model"],
+        "effort": row["effort"],
+        "call_initiator": row["call_initiator"],
+        "call_initiator_confidence": row["call_initiator_confidence"],
+        "total_tokens": total_tokens,
+        "input_tokens": input_tokens,
+        "cached_input_tokens": cached_input_tokens,
+        "uncached_input_tokens": uncached_input_tokens,
+        "output_tokens": output_tokens,
+        "reasoning_output_tokens": int(row["reasoning_output_tokens"] or 0),
+        "cache_ratio": _ratio(cached_input_tokens, input_tokens),
+        "uncached_input_ratio": _ratio(uncached_input_tokens, input_tokens),
+        "model_context_window": row["model_context_window"],
+        "context_window_percent": context_window_percent,
+        "tool_call_count": tool_call_count,
+        "command_run_count": command_run_count,
+        "file_event_count": file_event_count,
+        "nearby_activity": {
+            "tool_call_count": tool_call_count,
+            "command_run_count": command_run_count,
+            "failed_command_count": int(row["failed_command_count"] or 0),
+            "file_event_count": file_event_count,
+            "file_read_count": int(row["file_read_count"] or 0),
+            "file_write_count": int(row["file_write_count"] or 0),
+            "tool_output_size_bytes": tool_output_size_bytes,
+            "command_output_size_bytes": command_output_size_bytes,
+        },
+        "candidate_explanation": explanation,
+        "explanation_reasons": reasons,
+        "next_tool": "usage_thread_trace",
+    }
+
+
+def _candidate_explanation(
+    *,
+    input_tokens: int,
+    cached_input_tokens: int,
+    uncached_input_tokens: int,
+    output_tokens: int,
+    total_tokens: int,
+    context_window_percent: float,
+    tool_output_size_bytes: int,
+    command_output_size_bytes: int,
+    tool_call_count: int,
+    command_run_count: int,
+    file_event_count: int,
+) -> tuple[str, list[str]]:
+    cache_ratio = _ratio(cached_input_tokens, input_tokens)
+    uncached_ratio = _ratio(uncached_input_tokens, input_tokens)
+    activity_count = tool_call_count + command_run_count + file_event_count
+    output_bytes = tool_output_size_bytes + command_output_size_bytes
+    reasons: list[str] = []
+
+    if input_tokens and uncached_input_tokens >= 10_000 and uncached_ratio >= 0.65 and cache_ratio <= 0.35:
+        reasons.append("large_uncached_input")
+    if context_window_percent >= 0.60:
+        reasons.append("high_context_window_share")
+    if output_bytes >= 50_000 or activity_count >= 8:
+        reasons.append("tool_or_file_activity_pressure")
+    if total_tokens and output_tokens <= max(250, int(total_tokens * 0.02)):
+        reasons.append("very_low_output_share")
+
+    if "large_uncached_input" in reasons:
+        return "cold_resume_or_cache_miss", reasons
+    if "tool_or_file_activity_pressure" in reasons:
+        return "tool_output_pressure", reasons
+    if "high_context_window_share" in reasons:
+        return "stale_thread_low_value_continuation", reasons
+    return "large_context_low_output", reasons
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def _normalize_limit(limit: int | None) -> int | None:
+    if limit is None or limit <= 0:
+        return None
+    return limit
+
+
+def _usage_filters(
+    alias: str,
+    *,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    extra_clauses: list[str] | None = None,
+    extra_params: list[object] | None = None,
+) -> tuple[str, list[object]]:
+    clauses: list[str] = []
+    params: list[object] = []
+    if not include_archived:
+        clauses.append(f"{alias}.is_archived = 0")
+    if since:
+        clauses.append(f"{alias}.event_timestamp >= ?")
+        params.append(since)
+    if until:
+        clauses.append(f"{alias}.event_timestamp <= ?")
+        params.append(until)
+    if thread:
+        clauses.append(f"({alias}.thread_name = ? OR {alias}.thread_key = ? OR {alias}.session_id = ?)")
+        params.extend([thread, thread, thread])
+    if extra_clauses:
+        clauses.extend(extra_clauses)
+    if extra_params:
+        params.extend(extra_params)
+    if not clauses:
+        return "", params
+    return "WHERE " + " AND ".join(clauses), params

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -78,6 +78,7 @@ MCP_TOOL_NAMES = {
     "usage_file_churn_scan",
     "usage_repeated_file_rediscovery",
     "usage_shell_churn",
+    "usage_large_low_output_calls",
     "usage_context_bloat_scan",
     "usage_investigation_walk",
     "usage_local_evidence_export",

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -7,6 +7,7 @@ from codex_usage_tracker.core.json_contracts import validate_json_payload_contra
 from codex_usage_tracker.reports.api import (
     build_content_search_report,
     build_investigation_walk_report,
+    build_large_low_output_report,
     build_local_evidence_export_report,
     build_pattern_scan_report,
     build_repeated_file_rediscovery_report,
@@ -461,6 +462,139 @@ def test_thread_trace_returns_calls_with_indexed_fragments(tmp_path: Path) -> No
         "SECRET" in fragment["snippet"]
         for call in payload["calls"]
         for fragment in call["fragments"]
+    )
+
+
+def test_large_low_output_calls_flags_cold_resume_candidates(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_id = "019e3911-c0de-7777-8afe-333333333333"
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "20"
+        / f"rollout-2026-05-20T10-00-00-{session_id}.jsonl"
+    )
+    rows = [
+        _entry("session_meta", {"id": session_id}),
+        _entry("turn_context", {"turn_id": "turn-cold", "model": "gpt-5.5"}),
+        _entry(
+            "response_item",
+            {
+                "type": "function_call",
+                "call_id": "call-cold-rg",
+                "name": "exec_command",
+                "arguments": json.dumps({"cmd": "rg TODO src/private_low_output.py"}),
+            },
+        ),
+        _entry(
+            "response_item",
+            {
+                "type": "function_call_output",
+                "call_id": "call-cold-rg",
+                "output": (
+                    "Chunk ID: abc123\n"
+                    "Wall time: 0.0000 seconds\n"
+                    "Process exited with code 0\n"
+                    "Original token count: 4\n"
+                    "Output:\n"
+                    "PRIVATE LOW OUTPUT MATCH"
+                ),
+            },
+        ),
+        _custom_token_event(
+            50_100,
+            last_input_tokens=50_000,
+            last_cached_input_tokens=500,
+            last_output_tokens=100,
+            last_reasoning_output_tokens=20,
+        ),
+        _entry("turn_context", {"turn_id": "turn-high-output", "model": "gpt-5.5"}),
+        _custom_token_event(
+            108_100,
+            last_input_tokens=50_000,
+            last_cached_input_tokens=45_000,
+            last_output_tokens=8_000,
+            last_reasoning_output_tokens=200,
+        ),
+        _entry("turn_context", {"turn_id": "turn-small", "model": "gpt-5.5"}),
+        _custom_token_event(
+            109_000,
+            last_input_tokens=850,
+            last_cached_input_tokens=0,
+            last_output_tokens=50,
+        ),
+    ]
+    _write_jsonl(log_path, rows)
+
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    payload = build_large_low_output_report(
+        db_path=db_path,
+        min_total_tokens=20_000,
+        max_output_tokens=500,
+        limit=None,
+    ).payload
+
+    assert validate_json_payload_contract(payload) == []
+    assert payload["schema"] == "codex-usage-tracker-large-low-output-v1"
+    assert payload["content_mode"] == "aggregate_with_local_activity"
+    assert payload["includes_indexed_content"] is False
+    assert payload["includes_raw_fragments"] is False
+    assert payload["row_count"] == 1
+    candidate = payload["rows"][0]
+    assert candidate["total_tokens"] == 50_100
+    assert candidate["output_tokens"] == 100
+    assert candidate["cache_ratio"] < 0.02
+    assert candidate["command_run_count"] == 1
+    assert candidate["candidate_explanation"] == "cold_resume_or_cache_miss"
+    assert "large_uncached_input" in candidate["explanation_reasons"]
+    serialized = json.dumps(payload)
+    assert "src/private_low_output.py" not in serialized
+    assert "PRIVATE LOW OUTPUT MATCH" not in serialized
+
+    walk = build_investigation_walk_report(
+        db_path=db_path,
+        question="look for token waste",
+        min_occurrences=1,
+    ).payload
+    assert validate_json_payload_contract(walk) == []
+    assert any(branch["scan_type"] == "large_low_output" for branch in walk["branches"])
+    assert any(tool["tool"] == "usage_large_low_output_calls" for tool in walk["recommended_next_tools"])
+
+
+def _custom_token_event(
+    cumulative_total: int,
+    *,
+    last_input_tokens: int,
+    last_cached_input_tokens: int,
+    last_output_tokens: int,
+    last_reasoning_output_tokens: int = 0,
+) -> dict[str, object]:
+    return _entry(
+        "event_msg",
+        {
+            "type": "token_count",
+            "info": {
+                "total_token_usage": {
+                    "input_tokens": max(cumulative_total - last_output_tokens, 0),
+                    "cached_input_tokens": last_cached_input_tokens,
+                    "output_tokens": last_output_tokens,
+                    "reasoning_output_tokens": last_reasoning_output_tokens,
+                    "total_tokens": cumulative_total,
+                },
+                "last_token_usage": {
+                    "input_tokens": last_input_tokens,
+                    "cached_input_tokens": last_cached_input_tokens,
+                    "output_tokens": last_output_tokens,
+                    "reasoning_output_tokens": last_reasoning_output_tokens,
+                    "total_tokens": last_input_tokens + last_output_tokens,
+                },
+                "model_context_window": 100_000,
+            },
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- Add an aggregate-first large low-output calls diagnostic for high-token calls that produce little output.
- Expose it through the store API, report builder, MCP tool, JSON contract, docs, and bundled skill guidance.
- Add the signal as a first-class investigation-walk branch with recommended next-tool routing.

## Validation
- .venv/bin/python -m ruff check .
- .venv/bin/python -m pytest tests/store/test_content_index.py tests/cli/test_cli_release.py
- .venv/bin/python -m pytest tests/cli/test_mcp_integration.py
- .venv/bin/python -m compileall src
- .venv/bin/python -m mypy
- .venv/bin/python scripts/check_release.py
- git diff --check
- .venv/bin/python -m pytest
