### PR TITLE
feat: add agentic MCP investigations

### DIFF
--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -84,6 +84,8 @@ Tracked schema ids:
 | `codex-usage-tracker-repeated-file-rediscovery-v1` | MCP `usage_repeated_file_rediscovery(...)`; repeated safe file identity rediscovery candidates without full paths |
 | `codex-usage-tracker-shell-churn-v1` | MCP `usage_shell_churn(...)`; repeated shell command family diagnostics without raw command output |
 | `codex-usage-tracker-large-low-output-v1` | MCP `usage_large_low_output_calls(...)`; high-token low-output call candidates without raw fragments |
+| `codex-usage-tracker-investigation-suggestions-v1` | MCP `usage_suggest_investigations(...)`; goal-led usage investigation suggestions for agents |
+| `codex-usage-tracker-agentic-investigation-v1` | MCP `usage_investigate(...)`; goal-led aggregate investigation findings and next tools |
 | `codex-usage-tracker-investigation-walk-v1` | MCP `usage_investigation_walk(question=...)`; bounded local hypothesis walk over normalized pattern evidence |
 | `codex-usage-tracker-local-evidence-export-v1` | MCP `usage_local_evidence_export(question=...)`; strict shareable local evidence summary without raw/indexed content |
 | `codex-usage-tracker-export-v1` | CLI `export --json`, MCP `export_usage_csv(...)` |
@@ -1019,6 +1021,34 @@ Ranks high-token calls that produced little output, including token totals, cach
 
 ```json
 {"schema":"codex-usage-tracker-large-low-output-v1","content_mode":"aggregate_with_local_activity","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"min_total_tokens":20000,"max_output_tokens":1000,"limit":20},"row_count":0,"total_candidates":0,"rows":[]}
+```
+
+## Investigation Suggestions
+
+MCP:
+
+- `usage_suggest_investigations(goal="token_waste")`
+
+Schema: `codex-usage-tracker-investigation-suggestions-v1`
+
+Returns a short menu of goal-led investigations an agent can run, including the primary MCP tool, default arguments, follow-up tools, and privacy notes. It does not include raw/indexed content.
+
+```json
+{"schema":"codex-usage-tracker-investigation-suggestions-v1","content_mode":"aggregate_guidance","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","available_goals":["overview","token_waste","allowance_change","cache_failure","workflow_churn"],"filters":{"since":null,"until":null,"thread":null,"include_archived":false,"limit":10},"summary":{"suggestion_count":1,"total_suggestions":1,"top_goal":"token_waste"},"suggestions":[{"goal":"token_waste","label":"Find obvious token-waste candidates","primary_tool":"usage_investigate","default_arguments":{"goal":"token_waste","evidence_limit":5},"follow_up_tools":["usage_large_low_output_calls","usage_shell_churn"],"privacy_notes":"Aggregate-first; no raw prompts, tool output, or full paths."}]}
+```
+
+## Agentic Investigation
+
+MCP:
+
+- `usage_investigate(goal="token_waste")`
+
+Schema: `codex-usage-tracker-agentic-investigation-v1`
+
+Runs a goal-led aggregate investigation over existing tracker reports and returns normalized findings with evidence, confidence, why it matters, recommended action, verification tools, privacy notes, and caveats.
+
+```json
+{"schema":"codex-usage-tracker-agentic-investigation-v1","content_mode":"aggregate_investigation","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"evidence_limit":5},"summary":{"finding_count":1,"top_finding":"No strong local signal at default thresholds","confidence":"insufficient_local_evidence","source_reports":[]},"findings":[{"finding":"No strong local signal at default thresholds","evidence_count":0,"evidence":[],"confidence":"insufficient_local_evidence","recommended_action":"Lower thresholds, widen the time window, include archived sessions, or inspect top aggregate calls.","verify_with":["usage_calls","usage_report_pack"]}],"recommended_next_tools":[],"caveats":["Local Codex logs only; this is not an official OpenAI usage ledger."]}
 ```
 
 ## Investigation Walk

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -82,6 +82,8 @@ The companion skill cannot read your logged-in Codex account plan, native remain
 - `usage_repeated_file_rediscovery`
 - `usage_shell_churn`
 - `usage_large_low_output_calls`
+- `usage_suggest_investigations`
+- `usage_investigate`
 - `usage_context_bloat_scan`
 - `usage_investigation_walk`
 - `usage_local_evidence_export`
@@ -127,6 +129,10 @@ Dashboard recommendations: `usage_dashboard_recommendations(...)` returns the da
 `usage_shell_churn(...)` ranks repeated shell command roots and bounded command labels by failures, adjacent repeats, output bytes, aggregate token totals, and `usage_thread_trace` handles. Use it when the user asks about repeated `sed`, `rg`, `git`, `nl`, test, package, or unknown shell command loops. It does not expose raw command output.
 
 `usage_large_low_output_calls(...)` ranks high-token calls that produced little output, with token totals, cache ratio, context-window percent, nearby tool/command/file counts, and candidate explanations such as cold resume, tool-output pressure, stale thread, or low-value continuation. It stays aggregate-first and does not expose raw fragments, command output, or full file paths.
+
+`usage_suggest_investigations(...)` gives agents a short menu of goal-led investigations such as token waste, allowance change, cache failure, workflow churn, and overview. Use it when the user asks what to look into or wants ideas.
+
+`usage_investigate(...)` runs a compact aggregate-first investigation for one goal and returns normalized findings, evidence, confidence, recommended actions, verification tools, and caveats. Use it as the first stop for broad questions like "look through my usage for token waste" before drilling into lower-level reports.
 
 `usage_investigation_walk(question=...)` runs a bounded local hypothesis walk over those normalized pattern scans, ranks candidate branches, prunes branches without evidence, and returns recommended next MCP tools. It is local-index evidence, not a shareable aggregate-only report.
 

--- a/src/codex_usage_tracker/cli/mcp_server.py
+++ b/src/codex_usage_tracker/cli/mcp_server.py
@@ -44,8 +44,10 @@ from codex_usage_tracker.pricing.api import (
     write_pricing_template,
 )
 from codex_usage_tracker.reports.api import (
+    build_agentic_investigation_report,
     build_content_search_report,
     build_expensive_calls_report,
+    build_investigation_suggestions_report,
     build_investigation_walk_report,
     build_large_low_output_report,
     build_local_evidence_export_report,
@@ -614,6 +616,56 @@ def usage_large_low_output_calls(
         min_total_tokens=min_total_tokens,
         max_output_tokens=max_output_tokens,
         limit=limit,
+        privacy_mode=privacy_mode,
+    ).payload
+
+
+@mcp.tool()
+def usage_suggest_investigations(
+    goal: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    limit: int | None = 10,
+    privacy_mode: str = "normal",
+) -> dict[str, Any]:
+    """Suggest goal-led usage investigations and next MCP tools."""
+
+    return build_investigation_suggestions_report(
+        goal=goal,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        limit=limit,
+        privacy_mode=privacy_mode,
+    ).payload
+
+
+@mcp.tool()
+def usage_investigate(
+    goal: str = "token_waste",
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    evidence_limit: int = 5,
+    privacy_mode: str = "normal",
+) -> dict[str, Any]:
+    """Run a goal-led aggregate usage investigation."""
+
+    return build_agentic_investigation_report(
+        db_path=DEFAULT_DB_PATH,
+        pricing_path=DEFAULT_PRICING_PATH,
+        allowance_path=DEFAULT_ALLOWANCE_PATH,
+        projects_path=DEFAULT_PROJECTS_PATH,
+        goal=goal,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        evidence_limit=evidence_limit,
         privacy_mode=privacy_mode,
     ).payload
 

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -364,6 +364,51 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
+    'codex-usage-tracker-investigation-suggestions-v1': {
+        "required": {
+            "content_mode": str,
+            "includes_indexed_content": bool,
+            "includes_raw_fragments": bool,
+            "privacy_mode": str,
+            "goal": (str, NoneType),
+            "available_goals": list,
+            "filters": dict,
+            "summary": dict,
+            "suggestions": list,
+        },
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "thread": (str, NoneType),
+                "include_archived": bool,
+                "limit": (int, NoneType),
+            }
+        },
+    },
+    'codex-usage-tracker-agentic-investigation-v1': {
+        "required": {
+            "content_mode": str,
+            "includes_indexed_content": bool,
+            "includes_raw_fragments": bool,
+            "privacy_mode": str,
+            "goal": str,
+            "filters": dict,
+            "summary": dict,
+            "findings": list,
+            "recommended_next_tools": list,
+            "caveats": list,
+        },
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "thread": (str, NoneType),
+                "include_archived": bool,
+                "evidence_limit": int,
+            }
+        },
+    },
     'codex-usage-tracker-investigation-walk-v1': {
         "required": {
             "content_mode": str,

--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -185,6 +185,20 @@ class LargeLowOutputReport:
 
 
 @dataclass(frozen=True)
+class InvestigationSuggestionsReport:
+    """Stable machine-readable agentic investigation suggestions."""
+
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgenticInvestigationReport:
+    """Stable machine-readable agentic investigation report."""
+
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
 class InvestigationWalkReport:
     """Stable machine-readable local investigation walk."""
 
@@ -706,6 +720,454 @@ def build_large_low_output_report(
             "rows": rows,
         }
     )
+
+
+AGENTIC_INVESTIGATION_GOALS = (
+    "overview",
+    "token_waste",
+    "allowance_change",
+    "cache_failure",
+    "workflow_churn",
+)
+
+
+def build_investigation_suggestions_report(
+    *,
+    goal: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    limit: int | None = 10,
+    privacy_mode: str = "normal",
+) -> InvestigationSuggestionsReport:
+    """Build intent-led MCP investigation suggestions."""
+
+    privacy_mode = validate_privacy_mode(privacy_mode)
+    normalized_goal = _normalize_agentic_goal(goal)
+    suggestions = _investigation_suggestions(normalized_goal)
+    normalized_limit = None if limit is None or limit <= 0 else limit
+    limited = suggestions if normalized_limit is None else suggestions[:normalized_limit]
+    return InvestigationSuggestionsReport(
+        {
+            "schema": "codex-usage-tracker-investigation-suggestions-v1",
+            "content_mode": "aggregate_guidance",
+            "includes_indexed_content": False,
+            "includes_raw_fragments": False,
+            "privacy_mode": privacy_mode,
+            "goal": normalized_goal,
+            "available_goals": list(AGENTIC_INVESTIGATION_GOALS),
+            "filters": {
+                "since": since,
+                "until": until,
+                "thread": thread,
+                "include_archived": include_archived,
+                "limit": limit,
+            },
+            "summary": {
+                "suggestion_count": len(limited),
+                "total_suggestions": len(suggestions),
+                "top_goal": limited[0]["goal"] if limited else None,
+            },
+            "suggestions": limited,
+        }
+    )
+
+
+def build_agentic_investigation_report(
+    *,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+    projects_path: Path = DEFAULT_PROJECTS_PATH,
+    goal: str = "token_waste",
+    since: str | None = None,
+    until: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    evidence_limit: int = 5,
+    privacy_mode: str = "normal",
+) -> AgenticInvestigationReport:
+    """Build a compact goal-led investigation using existing reports."""
+
+    privacy_mode = validate_privacy_mode(privacy_mode)
+    normalized_goal = _normalize_agentic_goal(goal) or "token_waste"
+    normalized_limit = max(1, evidence_limit)
+    findings: list[dict[str, Any]] = []
+    source_reports: list[str] = []
+    recommended_next_tools: list[dict[str, Any]] = []
+    caveats = [
+        "Local Codex logs only; this is not an official OpenAI usage ledger.",
+        "Archived sessions are excluded unless include_archived is true.",
+    ]
+
+    if normalized_goal in {"token_waste", "cache_failure", "workflow_churn"}:
+        large_low_output = build_large_low_output_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+        source_reports.append(str(large_low_output["schema"]))
+        if large_low_output["rows"]:
+            findings.append(
+                _agentic_finding(
+                    finding="Large calls produced little output",
+                    evidence=large_low_output["rows"][:normalized_limit],
+                    confidence=_count_confidence(int(large_low_output["total_candidates"])),
+                    why_it_matters=(
+                        "Large input/context usage with low output is a strong candidate for "
+                        "cold resumes, stale thread continuation, or low-value continuation."
+                    ),
+                    recommended_action=(
+                        "Open the top calls, check whether a smaller fresh thread or preserved handoff "
+                        "would avoid resending large context."
+                    ),
+                    verify_with=["usage_large_low_output_calls", "usage_call_detail", "usage_thread_trace"],
+                    privacy_notes="Aggregate token/activity counts only; no raw fragments or command output.",
+                )
+            )
+
+    if normalized_goal in {"token_waste", "workflow_churn"}:
+        shell_churn = build_shell_churn_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+        source_reports.append(str(shell_churn["schema"]))
+        if shell_churn["rows"]:
+            findings.append(
+                _agentic_finding(
+                    finding="Repeated shell command churn",
+                    evidence=shell_churn["rows"][:normalized_limit],
+                    confidence=_count_confidence(int(shell_churn["total_candidates"])),
+                    why_it_matters=(
+                        "Repeated shell roots, failures, or adjacent retries can waste turns and "
+                        "inflate tool-output/context pressure."
+                    ),
+                    recommended_action=(
+                        "Turn repeated probes into a small script, narrower command, or targeted test command."
+                    ),
+                    verify_with=["usage_shell_churn", "usage_thread_trace"],
+                    privacy_notes="Command roots and bounded labels only; raw command output is omitted.",
+                )
+            )
+
+        repeated_files = build_repeated_file_rediscovery_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+        source_reports.append(str(repeated_files["schema"]))
+        if repeated_files["rows"]:
+            findings.append(
+                _agentic_finding(
+                    finding="Repeated file rediscovery",
+                    evidence=repeated_files["rows"][:normalized_limit],
+                    confidence=_count_confidence(int(repeated_files["total_candidates"])),
+                    why_it_matters=(
+                        "Repeated safe file identities can indicate the agent keeps rediscovering "
+                        "the same context instead of using a durable summary or targeted helper."
+                    ),
+                    recommended_action=(
+                        "Summarize stable facts into project docs or build a small helper command for recurring lookups."
+                    ),
+                    verify_with=["usage_repeated_file_rediscovery", "usage_thread_trace"],
+                    privacy_notes="Safe path hashes, basenames, and aggregates only; full paths are omitted.",
+                )
+            )
+
+    if normalized_goal in {"overview", "token_waste", "cache_failure"}:
+        recommendations = build_recommendations_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            since=since,
+            until=until,
+            thread=thread,
+            limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+        source_reports.append(str(recommendations["schema"]))
+        if recommendations["rows"]:
+            findings.append(
+                _agentic_finding(
+                    finding="Ranked aggregate usage recommendations",
+                    evidence=recommendations["rows"][:normalized_limit],
+                    confidence="medium",
+                    why_it_matters="Existing recommendation scoring combines aggregate cost, cache, context, and pricing signals.",
+                    recommended_action="Start with the highest recommendation score, then verify with the specific diagnostic tool.",
+                    verify_with=["usage_recommendations", "usage_calls", "usage_call_detail"],
+                    privacy_notes="Aggregate recommendations only; no prompt or tool-output text.",
+                )
+            )
+
+    if normalized_goal == "allowance_change":
+        recommended_next_tools.extend(
+            [
+                {
+                    "tool": "usage_allowance_diagnostics",
+                    "reason": "Run weekly evidence-graded allowance diagnostics before interpreting 5-hour noise.",
+                    "default_arguments": {"window_kind": "weekly", "privacy_mode": "strict"},
+                },
+                {
+                    "tool": "usage_allowance_export",
+                    "reason": "Create strict local evidence bundle when the user wants to share allowance-change evidence.",
+                    "default_arguments": {"window_kind": "weekly"},
+                },
+            ]
+        )
+        caveats.append("Weekly allowance evidence is the primary signal; 5-hour counters are rolling-window context.")
+
+    if normalized_goal == "overview":
+        recommended_next_tools.extend(
+            [
+                {"tool": "usage_status", "reason": "Confirm index freshness and row counts.", "default_arguments": {}},
+                {
+                    "tool": "usage_summary",
+                    "reason": "Rank projects, threads, models, or dates depending on the user's next question.",
+                    "default_arguments": {"group_by": "thread", "limit": 10, "response_format": "json"},
+                },
+                {
+                    "tool": "usage_report_pack",
+                    "reason": "Open dashboard-shaped evidence cards for top aggregate drivers.",
+                    "default_arguments": {"evidence_limit": normalized_limit},
+                },
+            ]
+        )
+
+    if not findings and normalized_goal != "allowance_change":
+        findings.append(
+            _agentic_finding(
+                finding="No strong local signal at default thresholds",
+                evidence=[],
+                confidence="insufficient_local_evidence",
+                why_it_matters="The current aggregate diagnostics did not find a clear candidate at the default threshold.",
+                recommended_action="Lower thresholds, widen the time window, include archived sessions, or inspect top aggregate calls.",
+                verify_with=["usage_calls", "usage_report_pack", "usage_investigation_walk"],
+                privacy_notes="No raw context needed for this follow-up.",
+            )
+        )
+
+    recommended_next_tools.extend(_goal_next_tools(normalized_goal))
+    payload = {
+        "schema": "codex-usage-tracker-agentic-investigation-v1",
+        "content_mode": "aggregate_investigation",
+        "includes_indexed_content": False,
+        "includes_raw_fragments": False,
+        "privacy_mode": privacy_mode,
+        "goal": normalized_goal,
+        "filters": {
+            "since": since,
+            "until": until,
+            "thread": thread,
+            "include_archived": include_archived,
+            "evidence_limit": normalized_limit,
+        },
+        "summary": {
+            "finding_count": len(findings),
+            "top_finding": findings[0]["finding"] if findings else None,
+            "confidence": _overall_agentic_confidence(findings),
+            "source_reports": source_reports,
+        },
+        "findings": findings,
+        "recommended_next_tools": _dedupe_next_tools(recommended_next_tools),
+        "caveats": caveats,
+    }
+    return AgenticInvestigationReport(payload)
+
+
+def _normalize_agentic_goal(goal: str | None) -> str | None:
+    if goal is None:
+        return None
+    normalized = goal.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "waste": "token_waste",
+        "token": "token_waste",
+        "tokens": "token_waste",
+        "usage_waste": "token_waste",
+        "limits": "allowance_change",
+        "limit_change": "allowance_change",
+        "allowance": "allowance_change",
+        "usage_limit": "allowance_change",
+        "cache": "cache_failure",
+        "caching": "cache_failure",
+        "churn": "workflow_churn",
+        "workflow": "workflow_churn",
+        "summary": "overview",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized in AGENTIC_INVESTIGATION_GOALS:
+        return normalized
+    return None
+
+
+def _investigation_suggestions(goal: str | None) -> list[dict[str, Any]]:
+    suggestions = [
+        {
+            "goal": "token_waste",
+            "label": "Find obvious token-waste candidates",
+            "why_it_matters": "Combines large low-output calls, shell churn, repeated file rediscovery, and recommendation scores.",
+            "primary_tool": "usage_investigate",
+            "default_arguments": {"goal": "token_waste", "evidence_limit": 5},
+            "follow_up_tools": [
+                "usage_large_low_output_calls",
+                "usage_shell_churn",
+                "usage_repeated_file_rediscovery",
+                "usage_calls",
+            ],
+            "privacy_notes": "Aggregate-first; no raw prompts, tool output, or full paths.",
+        },
+        {
+            "goal": "allowance_change",
+            "label": "Check whether weekly allowance behavior changed",
+            "why_it_matters": "Separates weekly evidence from noisy 5-hour rolling-window behavior.",
+            "primary_tool": "usage_investigate",
+            "default_arguments": {"goal": "allowance_change", "privacy_mode": "strict"},
+            "follow_up_tools": ["usage_allowance_diagnostics", "usage_allowance_export"],
+            "privacy_notes": "Use strict privacy for shareable evidence bundles.",
+        },
+        {
+            "goal": "cache_failure",
+            "label": "Find cache misses and high-context continuations",
+            "why_it_matters": "Low cache ratio and high context-window use often explain avoidable usage spikes.",
+            "primary_tool": "usage_investigate",
+            "default_arguments": {"goal": "cache_failure", "evidence_limit": 5},
+            "follow_up_tools": ["usage_large_low_output_calls", "usage_calls", "usage_call_detail"],
+            "privacy_notes": "Aggregate token/cache fields only.",
+        },
+        {
+            "goal": "workflow_churn",
+            "label": "Find repeated shell and file rediscovery loops",
+            "why_it_matters": "Repeated probes, command failures, and rereads suggest automation or documentation opportunities.",
+            "primary_tool": "usage_investigate",
+            "default_arguments": {"goal": "workflow_churn", "evidence_limit": 5},
+            "follow_up_tools": ["usage_shell_churn", "usage_repeated_file_rediscovery", "usage_thread_trace"],
+            "privacy_notes": "Uses safe command labels and path identities, not raw command output or full paths.",
+        },
+        {
+            "goal": "overview",
+            "label": "Summarize current usage drivers",
+            "why_it_matters": "Starts with index freshness, thread/model/project summaries, and existing recommendation cards.",
+            "primary_tool": "usage_investigate",
+            "default_arguments": {"goal": "overview", "evidence_limit": 5},
+            "follow_up_tools": ["usage_status", "usage_summary", "usage_report_pack", "usage_recommendations"],
+            "privacy_notes": "Aggregate dashboard/report-pack evidence.",
+        },
+    ]
+    if goal is None:
+        return suggestions
+    return [row for row in suggestions if row["goal"] == goal] or suggestions
+
+
+def _agentic_finding(
+    *,
+    finding: str,
+    evidence: list[dict[str, Any]],
+    confidence: str,
+    why_it_matters: str,
+    recommended_action: str,
+    verify_with: list[str],
+    privacy_notes: str,
+) -> dict[str, Any]:
+    return {
+        "finding": finding,
+        "evidence_count": len(evidence),
+        "evidence": evidence,
+        "confidence": confidence,
+        "why_it_matters": why_it_matters,
+        "recommended_action": recommended_action,
+        "verify_with": verify_with,
+        "privacy_notes": privacy_notes,
+    }
+
+
+def _count_confidence(count: int) -> str:
+    if count >= 5:
+        return "high"
+    if count >= 2:
+        return "medium"
+    if count == 1:
+        return "low"
+    return "insufficient_local_evidence"
+
+
+def _overall_agentic_confidence(findings: list[dict[str, Any]]) -> str:
+    priorities = {
+        "high": 4,
+        "medium": 3,
+        "low": 2,
+        "insufficient_local_evidence": 1,
+    }
+    if not findings:
+        return "insufficient_local_evidence"
+    return max((str(row.get("confidence") or "") for row in findings), key=lambda value: priorities.get(value, 0))
+
+
+def _goal_next_tools(goal: str) -> list[dict[str, Any]]:
+    mapping: dict[str, list[dict[str, Any]]] = {
+        "token_waste": [
+            {
+                "tool": "usage_report_pack",
+                "reason": "Inspect dashboard-shaped evidence rows for top aggregate drivers.",
+                "default_arguments": {"evidence_limit": 10},
+            },
+            {
+                "tool": "usage_calls",
+                "reason": "Open high-token rows and sort/filter the underlying call table.",
+                "default_arguments": {"sort": "tokens", "direction": "desc", "limit": 20},
+            },
+        ],
+        "allowance_change": [
+            {
+                "tool": "usage_allowance_diagnostics",
+                "reason": "Compare observed usage movement against estimated local credits.",
+                "default_arguments": {"window_kind": "weekly", "privacy_mode": "strict"},
+            }
+        ],
+        "cache_failure": [
+            {
+                "tool": "usage_calls",
+                "reason": "Filter high context-window and low-cache calls.",
+                "default_arguments": {"sort": "tokens", "direction": "desc", "limit": 20},
+            }
+        ],
+        "workflow_churn": [
+            {
+                "tool": "usage_shell_churn",
+                "reason": "Inspect repeated command families and failure/retry patterns.",
+                "default_arguments": {"min_occurrences": 3, "limit": 20},
+            }
+        ],
+        "overview": [
+            {"tool": "usage_status", "reason": "Check index freshness.", "default_arguments": {}}
+        ],
+    }
+    return mapping.get(goal, [])
+
+
+def _dedupe_next_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for tool in tools:
+        name = str(tool.get("tool") or "")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        deduped.append(tool)
+    return deduped
 
 
 def build_investigation_walk_report(

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -79,6 +79,8 @@ MCP_TOOL_NAMES = {
     "usage_repeated_file_rediscovery",
     "usage_shell_churn",
     "usage_large_low_output_calls",
+    "usage_suggest_investigations",
+    "usage_investigate",
     "usage_context_bloat_scan",
     "usage_investigation_walk",
     "usage_local_evidence_export",

--- a/tests/cli/test_mcp_integration.py
+++ b/tests/cli/test_mcp_integration.py
@@ -81,6 +81,11 @@ def test_mcp_wrappers_smoke(tmp_path: Path, monkeypatch) -> None:
     command_scan_json = mcp_server.usage_command_loop_scan(min_occurrences=1, limit=2)
     file_scan_json = mcp_server.usage_file_churn_scan(min_occurrences=1, limit=2)
     context_scan_json = mcp_server.usage_context_bloat_scan(min_occurrences=1, limit=2)
+    suggestions_json = mcp_server.usage_suggest_investigations(goal="token_waste", limit=2)
+    agentic_investigation_json = mcp_server.usage_investigate(
+        goal="token_waste",
+        evidence_limit=2,
+    )
     investigation_walk_json = mcp_server.usage_investigation_walk(
         question="Look for local token waste patterns",
         min_occurrences=1,
@@ -140,6 +145,8 @@ def test_mcp_wrappers_smoke(tmp_path: Path, monkeypatch) -> None:
         command_scan_json,
         file_scan_json,
         context_scan_json,
+        suggestions_json,
+        agentic_investigation_json,
         investigation_walk_json,
         local_evidence_export_json,
         session_json,
@@ -211,6 +218,15 @@ def test_mcp_wrappers_smoke(tmp_path: Path, monkeypatch) -> None:
     assert investigation_walk_json["includes_indexed_content"] is True
     assert investigation_walk_json["includes_raw_fragments"] is False
     assert investigation_walk_json["branches"]
+    assert suggestions_json["schema"] == "codex-usage-tracker-investigation-suggestions-v1"
+    assert suggestions_json["content_mode"] == "aggregate_guidance"
+    assert suggestions_json["includes_raw_fragments"] is False
+    assert suggestions_json["suggestions"]
+    assert agentic_investigation_json["schema"] == "codex-usage-tracker-agentic-investigation-v1"
+    assert agentic_investigation_json["content_mode"] == "aggregate_investigation"
+    assert agentic_investigation_json["includes_indexed_content"] is False
+    assert agentic_investigation_json["includes_raw_fragments"] is False
+    assert agentic_investigation_json["findings"]
     assert local_evidence_export_json["schema"] == "codex-usage-tracker-local-evidence-export-v1"
     assert local_evidence_export_json["content_mode"] == "shareable_local_evidence"
     assert local_evidence_export_json["includes_indexed_content"] is False


### PR DESCRIPTION
## Summary
- Add `usage_suggest_investigations(...)` for goal-led investigation suggestions.
- Add `usage_investigate(...)` for aggregate-first token waste, cache, workflow churn, allowance, and overview investigation routing.
- Add stable JSON contracts, MCP docs, schema docs, and MCP smoke coverage.

## Validation
- .venv/bin/python -m ruff check .
- PYTHONPATH=src .venv/bin/python -m mypy
- PYTHONPATH=src .venv/bin/python -m compileall src
- .venv/bin/python scripts/check_release.py
- git diff --check
- PYTHONPATH=src .venv/bin/python -m pytest tests/cli/test_mcp_integration.py tests/cli/test_cli_release.py
- PYTHONPATH=src .venv/bin/python -m pytest
