### PR TITLE
docs: refresh agentic usage skill guidance

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-usage-tracker",
   "version": "0.16.0",
-  "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
+  "description": "Unofficial local Codex usage dashboard and MCP diagnostics from local session logs.",
   "author": {
     "name": "Douglas Monsky"
   },
@@ -19,8 +19,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Codex Usage Tracker",
-    "shortDescription": "Unofficial local aggregate token usage analytics for Codex",
-    "longDescription": "Unofficial independent project, not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. Reads local Codex session logs, aggregates exact token usage counters, and generates summaries, CSV exports, and a hoverable dashboard with optional localhost-only raw context loading.",
+    "shortDescription": "Local Codex usage dashboard, MCP diagnostics, and token-waste investigations",
+    "longDescription": "Unofficial independent project, not made by, affiliated with, endorsed by, sponsored by, or supported by OpenAI. Reads local Codex session logs to power a local dashboard, MCP tools, allowance diagnostics, token-waste investigations, and shareable aggregate reports without uploading logs.",
     "developerName": "Douglas Monsky",
     "category": "Productivity",
     "capabilities": [
@@ -33,8 +33,9 @@
     "termsOfServiceURL": "https://github.com/douglasmonsky/codex-usage-tracker",
     "defaultPrompt": [
       "Open dashboard",
-      "Heaviest thread?",
-      "Thread leaderboard"
+      "Look through my usage for token waste",
+      "Suggest usage investigations",
+      "Check whether my weekly allowance changed"
     ],
     "brandColor": "#2563EB",
     "composerIcon": "./assets/icon.svg",

--- a/docs/examples/remediation-conversation.md
+++ b/docs/examples/remediation-conversation.md
@@ -1,25 +1,25 @@
 # Remediation Planning Conversation
 
-This is a synthetic, aggregate-only example of turning Codex Usage Tracker findings into concrete workflow changes. It is written as an example conversation doc rather than a transcript from private logs.
+This is a synthetic, aggregate-only example turning Codex Usage Tracker findings into concrete workflow changes. It is written as an example conversation document rather than a transcript of private logs.
 
 ## User
 
-Which threads are draining the most, and what can we do so this does not keep happening?
+Which threads are draining the most, and what can we do so it does not keep happening?
 
-## Codex With Codex Usage Tracker
+## Codex
 
-I refreshed the aggregate index, checked `usage_threads`, and pulled supporting Calls rows for the top thread. I did not inspect raw context.
+With Codex Usage Tracker, I refreshed the aggregate index, ran `usage_investigate(goal="workflow_churn")`, then checked `usage_threads` and supporting Calls rows for the top thread. I did not inspect raw context.
 
 ## Evidence
 
-- The top thread has repeated high-token calls after context-heavy investigation turns.
+- The top thread has repeated high-token calls and context-heavy investigation turns.
 - The Calls table shows high context-window percentage and a few low-cache rows.
-- The expensive rows are tied to repeated repository discovery and broad validation.
+- The investigation report recommends checking shell churn and repeated file rediscovery before opening raw context.
 
 ## Recommended Remediation
 
 - Split future work into an investigation thread and an implementation thread once the plan is stable.
-- Preserve reusable findings in a short repo note or roadmap issue, then start a fresh thread from that summary.
+- Preserve reusable findings in a short repo note or roadmap issue, then start a fresh thread with that summary.
 - Ask Codex to use a narrow validation plan first, then broaden only before release.
 - If Headroom is installed, ask it to check context pressure before continuing a long thread.
 - If the pattern repeats, have Codex build a custom local helper command or skill note that captures the exact repo facts it keeps rediscovering.

--- a/docs/examples/token-waste-conversation.md
+++ b/docs/examples/token-waste-conversation.md
@@ -1,20 +1,20 @@
 # Token Waste Review Conversation
 
-This is a synthetic, aggregate-only example of using the Codex Usage Tracker companion skill. It does not include prompts, assistant messages, tool output, pasted secrets, raw transcript text, real thread names, or real usage totals.
+This is a synthetic, aggregate-only example using the Codex Usage Tracker companion skill. It does not include prompts, assistant messages, tool output, pasted secrets, raw transcript text, real thread names, or real usage totals.
 
 ## User
 
 Look through my usage for token waste and recommend what I should change.
 
-## Codex With Codex Usage Tracker
+## Codex
 
-I refreshed the local aggregate index and ranked recent calls by total tokens, context-window pressure, cache ratio, and thread totals.
+I refreshed the local aggregate index and started with `usage_investigate(goal="token_waste")`, then checked the recommended supporting Calls and Threads rows.
 
 ## Evidence
 
 - One long implementation thread accounts for most recent tokens.
-- Several calls have high input tokens with low cached input, which means repeated context was not being reused efficiently.
-- The most expensive rows cluster around broad file discovery plus full test reruns.
+- Several calls have high input tokens and low cached input, which means repeated context was not reused efficiently.
+- The highest-confidence finding points to broad file discovery and repeated validation as the main waste pattern.
 
 ## Likely Waste Pattern
 
@@ -23,6 +23,7 @@ Codex is rediscovering project context and rerunning broad checks in the same wo
 ## Next Actions
 
 - Use Calls to open the top three expensive rows.
+- Follow the investigation report's `recommended_next_tools` before drilling into raw context.
 - If Headroom is available, use it to estimate whether the thread is near context pressure before continuing.
 - Move stable project facts into docs or an `AGENTS.md` note so Codex does not need to infer them repeatedly.
 - Create a repo-specific validation command or test-selection checklist if broad checks are happening every turn.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP And Codex Skills
 
-Codex Usage Tracker can be installed as a local Codex plugin and exposes MCP tools for local usage analysis, aggregate reports, allowance diagnostics, source coverage, and future content-index investigation.
+Codex Usage Tracker can be installed as a local Codex plugin. It exposes MCP tools for local usage analysis, dashboard-shaped aggregate payloads, allowance diagnostics, source coverage, and opt-in local content-index investigations.
 
 ## Local Plugin
 
@@ -16,45 +16,50 @@ For a source checkout:
 codex-usage-tracker install-plugin --python .venv/bin/python
 ```
 
-Restart Codex after registration so it can discover the plugin.
+Restart Codex after registration so the plugin and skills are discovered.
 
-Marketplace installs use the bundled MCP launcher at `skills/codex-usage-tracker/scripts/run_mcp.py`. On first MCP startup it creates a cached runtime under `~/.cache/codex-usage-tracker/mcp-runtime/` and installs the exact pinned Python package, so it does not require a `.venv` inside the plugin directory.
+Marketplace installs use the bundled MCP launcher at `skills/codex-usage-tracker/scripts/run_mcp.py`. On first MCP startup it creates a cached runtime under `~/.cache/codex-usage-tracker/mcp-runtime/` and installs the exact pinned Python package, so the plugin does not need a `.venv` inside its directory.
 
-This is intentional: normal user installs come from the PyPI distribution `codex-usage-tracking`, and the plugin bootstrapper pins an exact reviewed package version so MCP startup does not accidentally track `main`.
-
-The launcher stores the package spec used for that runtime and reinstalls when the bundled package pin changes. Set `CODEX_USAGE_TRACKER_PACKAGE_SPEC` to test a different package version or Git ref, or set `CODEX_USAGE_TRACKER_RUNTIME_DIR` to use a separate cache while debugging plugin startup.
+The launcher intentionally pins a reviewed package version instead of tracking `main`. Set `CODEX_USAGE_TRACKER_PACKAGE_SPEC` to test another package version or Git ref, and set `CODEX_USAGE_TRACKER_RUNTIME_DIR` to use a separate cache while debugging plugin startup.
 
 ## Companion Skills
 
-The plugin installs two companion skills. They are local instruction files that help Codex use this package; they do not create another hosted service or send usage data outside the machine.
+The plugin installs two companion skills:
 
-- `codex-usage-tracker`: operational setup and direct tracker work, including refresh, dashboards, CSV export, doctor checks, and MCP tools.
-- `codex-usage-api`: conversational usage analysis using stable usage APIs first, with content-index tools treated as explicit local investigation tools when they are available.
+- `codex-usage-tracker`: operational setup, dashboard launch, refresh, CSV export, doctor checks, and direct tracker commands.
+- `codex-usage-api`: conversational usage analysis using stable MCP/API payloads first, with content-index tools reserved for explicit local investigation.
 
-Good prompts for the API companion skill:
+Good starter prompts:
 
 ```text
 Open dashboard.
-Use my Codex Usage Tracker data to explain what drove usage this week.
-Heaviest thread?
-Thread leaderboard.
-Look through my usage for token waste and recommend fixes.
-Find low-cache or high-context calls from today and suggest what to inspect next.
+Suggest usage investigations.
 Look through my usage for token waste.
-Find calls where context got bloated.
-Show me where caching failed.
-Find expensive calls worth opening in the investigator.
-Compare usage by project for the last 7 days.
-Show me what is estimated or unpriced before I trust the cost numbers.
+Find high-context, low-cache calls worth opening in investigator.
+Which threads are draining the most, and what would reduce that next time?
+Check whether my weekly allowance changed.
+Explain why the 5-hour counter looks noisy.
+Compare usage by model and effort, then suggest safer defaults.
+Show me what is estimated or unpriced before I trust cost numbers.
 ```
 
-The API skill should refresh the local index, call stable tools such as `usage_status`, `usage_calls`, `usage_call_detail`, `usage_threads`, `usage_report_pack`, `usage_summary`, `usage_query`, `session_usage`, `usage_recommendations`, `most_expensive_usage_calls`, `usage_pricing_coverage`, or `usage_source_coverage`, then explain the answer with the data scope and estimate caveats. Content-aware tools should be used only when the user asks for local content exploration or a diagnostic clearly needs indexed snippets.
+The API skill should refresh the local index, use MCP JSON tools, state scope and caveats, and recommend practical next actions. If MCP tools are unavailable, use the CLI JSON commands documented in [CLI And MCP JSON Schemas](cli-json-schemas.md).
 
-If MCP tools are not available, the same questions can be answered through CLI JSON commands documented in [CLI And MCP JSON Schemas](cli-json-schemas.md).
+## Agentic Investigation Tools
 
-Waste-discovery answers should include remediation ideas when evidence supports them: dashboard rows to inspect, Headroom if available for context/headroom checks, workflow changes such as thread splitting or lower effort for routine work, and small custom local commands or skill updates Codex can build when the same waste pattern keeps recurring.
+Use `usage_suggest_investigations(...)` when the user wants ideas, is unsure what to inspect, or asks what the tracker can help with. It returns goal-led investigation options such as token waste, allowance change, cache failure, workflow churn, and overview.
 
-The companion skill cannot read your logged-in Codex account plan, native remaining allowance, or usage from other agentic surfaces. Remaining allowance context is only as accurate as the values you manually copy into `~/.codex-usage-tracker/allowance.json`.
+Use `usage_investigate(...)` as the first stop for broad requests such as "look through my usage for token waste" or "what should I change?" It returns normalized findings, evidence, confidence, recommended actions, verification tools, and caveats.
+
+Use lower-level diagnostics when the investigation report recommends them:
+
+- `usage_large_low_output_calls(...)`: high-token calls that produced little output, with cache/context clues and likely explanations.
+- `usage_shell_churn(...)`: repeated shell command roots such as `sed`, `rg`, `git`, `nl`, test, and package commands.
+- `usage_repeated_file_rediscovery(...)`: repeated safe file identities using hashes, basenames, extensions, and operation mixes without exposing full paths.
+- `usage_investigation_walk(question=...)`: deeper local hypothesis walk over normalized content/event-index signals.
+- `usage_local_evidence_export(question=...)`: strict shareable summary from the local investigation walk, omitting raw/private records.
+
+Waste-discovery answers should not stop at "interesting." Tie recommendations to evidence and suggest verification in Calls, Threads, Call Investigator, Diagnostics Notebook, or Allowance Intelligence. Mention Headroom only when context pressure or handoff timing is relevant and the tool is available. Suggest custom local commands, scripts, repo notes, or skill updates when the same waste pattern keeps recurring.
 
 ## Tools
 
@@ -68,6 +73,9 @@ The companion skill cannot read your logged-in Codex account plan, native remain
 - `usage_threads`
 - `usage_report_pack`
 - `usage_dashboard_recommendations`
+- `usage_allowance_history`
+- `usage_allowance_diagnostics`
+- `usage_allowance_export`
 - `usage_recommendations`
 - `session_usage`
 - `usage_call_context`
@@ -87,73 +95,45 @@ The companion skill cannot read your logged-in Codex account plan, native remain
 - `usage_context_bloat_scan`
 - `usage_investigation_walk`
 - `usage_local_evidence_export`
-- `usage_allowance_history`
-- `usage_allowance_diagnostics`
-- `usage_allowance_export`
 - `generate_usage_dashboard`
 - `export_usage_csv`
 - `init_usage_pricing_config`
 - `update_usage_pricing_config`
 - `init_usage_allowance_config`
 
+## Tool Notes
+
 `usage_doctor`, `usage_summary`, `usage_recommendations`, `session_usage`, `most_expensive_usage_calls`, `usage_pricing_coverage`, and `usage_source_coverage` accept `response_format="json"` when an agent needs stable structured output instead of markdown.
 
-Dashboard-shaped MCP tools return JSON dictionaries directly and reuse the same aggregate schemas as the local React dashboard API:
+Dashboard-shaped MCP tools return JSON dictionaries that reuse the same aggregate schemas as the local React dashboard API:
 
-Status: `usage_status()` returns `/api/status` freshness, row counts, parser diagnostics, and observed allowance windows.
+- `usage_status()` mirrors `/api/status`.
+- `usage_calls(...)` mirrors `/api/calls`, including filters, pagination, `total_matched_rows`, `has_more`, and `next_offset`.
+- `usage_call_detail(record_id=...)` mirrors `/api/call` for aggregate Call Investigator data without raw transcript context.
+- `usage_threads(...)` mirrors `/api/threads`.
+- `usage_report_pack(...)` mirrors `/api/reports/pack`.
+- `usage_dashboard_recommendations(...)` returns dashboard recommendation payloads.
 
-Calls: `usage_calls(...)` returns `/api/calls` rows with filters, pagination, `total_matched_rows`, `has_more`, and `next_offset`.
+`refresh_usage_index()` indexes aggregate usage rows plus the local content index by default. Use `refresh_usage_index(aggregate_only=True)` when the user wants the older aggregate-only SQLite posture. Use `include_archived=True` only when the user explicitly wants all history; the dashboard defaults to active sessions so older work does not inflate current usage.
 
-Call detail: `usage_call_detail(record_id=...)` returns `/api/call` data for the Call Investigator without raw transcript context.
+## Allowance Intelligence
 
-Threads: `usage_threads(...)` returns `/api/threads` aggregate thread rows.
+- `usage_allowance_history(...)` returns normalized observed weekly and 5-hour allowance snapshots.
+- `usage_allowance_diagnostics(...)` returns evidence grades comparing observed usage movement against estimated local credits. Weekly windows are the primary long-range signal; 5-hour windows are noisy rolling-window context.
+- `usage_allowance_export(...)` returns strict-privacy evidence bundles for manual sharing.
 
-Report pack: `usage_report_pack(...)` returns `/api/reports/pack` report cards and compact evidence rows.
+Use allowance tools when users ask whether limits changed, whether weekly allowance behavior shifted, why the 5-hour counter looks noisy, or how to share aggregate allowance evidence safely. The tracker cannot read the user's logged-in Codex account plan, native remaining allowance, or usage from other agentic surfaces. Remaining allowance context is only as accurate as values manually copied into `~/.codex-usage-tracker/allowance.json`.
 
-Dashboard recommendations: `usage_dashboard_recommendations(...)` returns the dashboard recommendation payload.
-
-`refresh_usage_index`, `usage_query`, `generate_usage_dashboard`, `export_usage_csv`, and config-writing MCP tools return JSON dictionaries directly.
-
-`refresh_usage_index()` indexes aggregate usage rows and the local content index by default. Use `refresh_usage_index(aggregate_only=True)` when the user wants the older aggregate-only SQLite posture.
-
-`refresh_usage_index(include_archived=True)` and `generate_usage_dashboard(include_archived=True)` are explicit all-history opt-ins. The default dashboard view excludes archived session rows so older work does not inflate the current usage picture.
+## Local Content And Raw Context
 
 `usage_content_search(query=...)` searches the explicit local content index and can return indexed snippets. Use it only when the user asks for local content exploration, pattern hunting, or diagnostics that need transcript-level evidence. Its payload marks `content_mode="local_content_index"`, `includes_indexed_content=true`, and `includes_raw_fragments=true`.
 
-`usage_thread_trace(...)` returns a paged call timeline for one thread, thread key, session id, or seed record id, with local indexed fragments attached when present. It is also an explicit local content-index surface and carries the same indexed-content flags.
+`usage_thread_trace(...)` returns a paged call timeline for one thread/session/seed record and may include local indexed fragments. Treat it as an explicit local content-index surface, not a default shareable report.
 
-`usage_repetition_scan(...)`, `usage_command_loop_scan(...)`, `usage_file_churn_scan(...)`, and `usage_context_bloat_scan(...)` run explicit local content/event-index diagnostics over normalized fragment hashes, command roots/labels, file hashes/basenames, and aggregate token rows. These payloads set `includes_indexed_content=true` and `includes_raw_fragments=false`.
-
-`usage_repeated_file_rediscovery(...)` ranks repeated exact safe file identities by path hash/identity, basename, extension, operation mix, adjacent retouches, aggregate token totals, and `usage_thread_trace` handles. Use it when the user asks which files are being rediscovered or reread repeatedly. It does not expose full paths or raw fragments.
-
-`usage_shell_churn(...)` ranks repeated shell command roots and bounded command labels by failures, adjacent repeats, output bytes, aggregate token totals, and `usage_thread_trace` handles. Use it when the user asks about repeated `sed`, `rg`, `git`, `nl`, test, package, or unknown shell command loops. It does not expose raw command output.
-
-`usage_large_low_output_calls(...)` ranks high-token calls that produced little output, with token totals, cache ratio, context-window percent, nearby tool/command/file counts, and candidate explanations such as cold resume, tool-output pressure, stale thread, or low-value continuation. It stays aggregate-first and does not expose raw fragments, command output, or full file paths.
-
-`usage_suggest_investigations(...)` gives agents a short menu of goal-led investigations such as token waste, allowance change, cache failure, workflow churn, and overview. Use it when the user asks what to look into or wants ideas.
-
-`usage_investigate(...)` runs a compact aggregate-first investigation for one goal and returns normalized findings, evidence, confidence, recommended actions, verification tools, and caveats. Use it as the first stop for broad questions like "look through my usage for token waste" before drilling into lower-level reports.
-
-`usage_investigation_walk(question=...)` runs a bounded local hypothesis walk over those normalized pattern scans, ranks candidate branches, prunes branches without evidence, and returns recommended next MCP tools. It is local-index evidence, not a shareable aggregate-only report.
-
-`usage_local_evidence_export(question=...)` returns a strict shareable summary derived from the investigation walk. It omits prompts, indexed snippets, record ids, thread names, raw commands, raw tool output, full paths, file basenames, and command labels.
-
-## Allowance Intelligence MCP Tools
-
-- `usage_allowance_history(...)` returns normalized observed weekly and 5-hour allowance snapshots.
-- `usage_allowance_diagnostics(...)` returns evidence grades comparing observed usage movement against estimated local credits. Weekly candidates include `nonparametric-v1` statistical evidence plus `summary.research_readiness`; weekly windows are primary and 5-hour windows are noisy rolling-window context.
-- `usage_allowance_export(...)` returns a strict-privacy evidence bundle for manual sharing.
-
-Use these when users ask whether limits changed, whether weekly allowance behavior shifted, why the 5-hour counter looks noisy, or how to share aggregate allowance evidence safely.
-
-## Raw Context Guard
-
-`usage_call_context` is disabled by default in MCP server processes. To enable it explicitly:
+`usage_call_context` is disabled by default in MCP server processes. Enable it explicitly only when the user asks to inspect raw local log context:
 
 ```bash
 CODEX_USAGE_TRACKER_ALLOW_RAW_CONTEXT=1
 ```
 
-Normal aggregate tools do not need this variable. Keep raw context disabled unless the user specifically asks to inspect local log context.
-
-When raw context is enabled, `usage_call_context` accepts `max_entries`, `max_chars`, `include_tool_output`, and `include_compaction_history`. Use `0` for either limit only when the user explicitly asks for all matching entries or no character cap for that local context request. Compacted replacement history is transcript-like content; request it only for a specific call investigation, and keep the aggregate tools as the default path.
+Normal aggregate tools do not need that variable. When raw context is enabled, `usage_call_context` accepts `max_entries`, `max_chars`, `include_tool_output`, and `include_compaction_history`. Use `0` limits only when the user explicitly asks for all matching entries or no character cap on local context.

--- a/skills/codex-usage-api/SKILL.md
+++ b/skills/codex-usage-api/SKILL.md
@@ -1,108 +1,55 @@
 ---
 name: codex-usage-api
-description: Use when the user wants to discuss, investigate, compare, or explain Codex usage using the Codex Usage Tracker API or MCP tools.
+description: Use when the user wants to discuss, investigate, compare, explain, or improve Codex usage with Codex Usage Tracker API or MCP tools, including token waste, cache/context problems, allowance or limit changes, pricing confidence, dashboard evidence, and local content-index investigations.
 ---
 
 # Codex Usage API Companion
 
-Use this companion skill as a conversational analyst for Codex Usage Tracker data. Prefer aggregate MCP JSON payloads first, answer from evidence, and keep the user-facing output crisp instead of narrating tool discovery or local file spelunking.
+Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON payloads, answer from structured evidence, and keep the user-facing result concise.
 
-## Privacy Boundary
+## Operating Rules
 
-Normal usage answers should start from aggregate API data. Do not expose prompts, assistant messages, tool output, pasted secrets, or raw transcript snippets.
+- For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `open-dashboard` only when the user explicitly asks for a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
+- Refresh with `refresh_usage_index` unless the user asks for a static historical snapshot.
+- Start with aggregate/shareable tools. Do not expose prompts, assistant messages, raw tool output, pasted secrets, raw commands, full paths, or transcript snippets unless the user explicitly asks for local content or raw context.
+- Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
+- Name the scope: time window, project/thread/model filters, included archived state, row limit, and whether results are estimates.
+- Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
+- For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
 
-When the user plans to share JSON, CSV, dashboards, screenshots, or support bundles, prefer `privacy_mode="strict"` MCP calls or the CLI global option `--privacy-mode strict` before the subcommand. Configured project aliases are explicit display opt-ins.
+## Router
 
-Use `usage_investigation_walk(question=...)` first when user asks for broad local waste discovery; it ranks normalized pattern branches and recommends next tools. Use local pattern scans (`usage_repetition_scan`, `usage_command_loop_scan`, `usage_file_churn_scan`, `usage_context_bloat_scan`) when user asks for recurring waste, command loops, repeated file churn, or context bloat. Use `usage_repeated_file_rediscovery(...)` when user asks which files are rediscovered or reread repeatedly; it ranks safe path hashes/basenames without full paths. Use `usage_shell_churn(...)` when the user asks about repeated shell probing, command loops, failing retries, or repeated sed/rg/git/nl/test/package commands. Use `usage_content_search` only when user asks local content exploration, pattern hunting, diagnostics need indexed snippets; its payload can include local transcript snippets is not default shareable report.
+1. If the user asks what to inspect, wants suggestions, or is unsure where to start, call `usage_suggest_investigations(goal=...)`.
+2. If the user asks broadly to look through usage, find waste, explain expensive usage, improve efficiency, or recommend changes, call `usage_investigate(goal="token_waste")` or `usage_investigate(goal="overview")` first, then drill into its `recommended_next_tools`.
+3. If the user asks whether limits/allowance changed, whether they are throttled, why weekly usage moved, or why the 5-hour counter looks weird, call `usage_investigate(goal="allowance_change")`, then `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")` when evidence is needed. Use `usage_allowance_export(...)` for manually shareable evidence.
+4. If the user asks about cache misses, cold resumes, context bloat, or low-output expensive calls, call `usage_investigate(goal="cache_failure")`, then inspect `usage_large_low_output_calls(...)`, `usage_calls(...)`, `usage_report_pack(...)`, or `usage_context_bloat_scan(...)`.
+5. If the user asks about repeated shell probing, repeated file rediscovery, or workflow churn, call `usage_investigate(goal="workflow_churn")`, then inspect `usage_shell_churn(...)`, `usage_repeated_file_rediscovery(...)`, or `usage_investigation_walk(question=...)`.
+6. If the user asks a precise dashboard/API question, use the direct tool: `usage_calls`, `usage_call_detail`, `usage_threads`, `usage_summary`, `usage_query`, `session_usage`, `usage_report_pack`, `usage_dashboard_recommendations`, `usage_recommendations`, `most_expensive_usage_calls`, `usage_pricing_coverage`, or `usage_source_coverage`.
+7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration or when the user agrees transcript-level indexed snippets are needed.
+8. Use `usage_call_context(...)` only when the user explicitly asks for raw local context and the MCP server has raw context enabled.
 
-Use `usage_large_low_output_calls(...)` when the user asks for obvious token-waste candidates, cold resumes, cache misses, stale high-context continuations, or large calls that produced little output.
+## Tool Stance
 
-Use `usage_call_context` only when the user explicitly asks to inspect actual logged context for one selected record. State that returned text is local, redacted or size-limited when applicable, and not included in default shareable outputs.
+- `usage_suggest_investigations` is the front door for ideas. It should return short, goal-led options and safe defaults.
+- `usage_investigate` is the first stop for broad agentic analysis. It returns normalized findings, confidence, recommended actions, verification tools, and caveats.
+- `usage_allowance_diagnostics` is the main allowance-change evidence tool. Treat weekly windows as the primary signal and 5-hour windows as noisy rolling-window context.
+- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are token-waste diagnostics. They should produce actionable next steps before resorting to raw context.
+- `usage_investigation_walk` and local pattern scans can use the content/event index. They are useful for deeper local diagnosis, but not default shareable reports.
+- If MCP tools are unavailable, use CLI JSON equivalents documented in `docs/cli-json-schemas.md`.
 
-## First Steps
+## Remediation Guidance
 
-1. For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `--no-refresh` only when the user explicitly asks for a cached snapshot. Use `open-dashboard` only for explicit static/offline snapshots or when the environment cannot keep a server alive; say the result is static and Live requires `serve-dashboard`.
-2. For "Heaviest thread?", "Thread leaderboard", or similar ranking requests, refresh aggregate data first, then call `usage_summary(group_by="thread", limit=10, response_format="json")`.
-3. For normal usage questions, start with MCP tools. If MCP tools are unavailable, use the CLI JSON fallback commands below.
-4. Refresh analysis with `refresh_usage_index` unless the user asks for a static historical snapshot. Keep archived sessions excluded unless explicitly requested.
-5. Use `usage_status()` for dashboard/index freshness and row counts. Use `usage_doctor(response_format="json")` when setup, indexing, pricing, MCP discovery, or dashboard freshness is uncertain.
-6. Prefer structured MCP payloads:
-   - `usage_calls(...)`
-   - `usage_call_detail(record_id=...)`
-   - `usage_threads(...)`
-   - `usage_report_pack(...)`
-   - `usage_dashboard_recommendations(...)`
-   - `usage_summary(..., response_format="json")`
-   - `session_usage(..., response_format="json")`
-   - `most_expensive_usage_calls(..., response_format="json")`
-- `usage_recommendations(..., response_format="json")`
-- `usage_pricing_coverage(..., response_format="json")`
-- `usage_source_coverage(..., response_format="json")`
-- `usage_content_search(...)` only for explicit local content-index exploration
-- `usage_thread_trace(...)` only for explicit local content-index thread/session timelines
-- `usage_allowance_diagnostics(..., privacy_mode="strict")`
- - `usage_allowance_history(..., privacy_mode="strict")`
- - `usage_allowance_export(...)`
- - `usage_query(...)`
-7. Check the top-level `schema` field before interpreting structured output. Known schema ids are documented in `docs/cli-json-schemas.md`.
-8. If MCP tools are unavailable, fall back to CLI equivalents: `refresh --json`, `summary --json`, `query`, `session --json`, `expensive --json`, `recommendations --json`, `pricing-coverage --json`, and `source-coverage --json`.
-9. If `codex-usage-tracker` is missing but you are inside the source checkout, use `PYTHONPATH=src .venv/bin/python -m codex_usage_tracker.cli <command>`. Do not use `PYTHONPATH=src` outside that checkout.
+Recommend fixes only when supported by evidence. Useful categories include:
 
-## Routing Questions To API Calls
-
-- "What used most?" Use `usage_summary(group_by="thread", response_format="json")` for thread totals, then `most_expensive_usage_calls(response_format="json")` for supporting calls.
-- "Which project/thread/model is driving usage?" Use `usage_summary` grouped by `project`, `thread`, or `model`.
-- "Show/filter the calls table" Use `usage_calls(...)` with `limit`, `offset`, `search`, `since`, `model`, `effort`, `thread`, `pricing_status`, or `credit_confidence`. Report `row_count`, `total_matched_rows`, and `has_more`.
-- "Search my local usage content for X" Use `usage_content_search(query="X", limit=20)` and state snippets are local indexed content, not public-safe aggregate export.
-- "Trace this thread/session" Use `usage_thread_trace(thread=...)`, `usage_thread_trace(session_id=...)`, or seed with `usage_thread_trace(record_id=...)`; state fragments are local indexed content.
-- "Open/investigate this call" Use `usage_call_detail(record_id=...)` for the aggregate call investigator payload. Use `usage_call_context` only if the user explicitly asks for raw local context.
-- "Show threads" Use `usage_threads(...)`, sorted by token impact by default.
-- "Give me dashboard report evidence" Use `usage_report_pack(...)` for report cards and compact evidence rows. Use `usage_dashboard_recommendations(...)` when the user specifically wants the dashboard recommendation payload.
-- "Is my dashboard/index stale?" Use `usage_status()` first, then `usage_doctor(response_format="json")` if status suggests missing rows, stale refresh, or setup problems.
-- "Can I share this?" Use redacted or strict privacy mode and avoid `usage_call_context`.
-- "Why did usage spike?" Use `usage_recommendations(response_format="json")` for ranked causes, then `usage_query` or `usage_calls` with focused filters for supporting rows.
-- "What is unpriced or estimated?" Use `usage_pricing_coverage(response_format="json")` and `usage_query(pricing_status="unpriced")` or `usage_query(credit_confidence="estimated")`.
-- "How does this affect my allowance?" Use rows from `usage_query` or `usage_calls` and summarize `usage_credits`, `usage_credit_confidence`, and allowance annotations. Explain that remaining allowance is only as accurate as the user's local allowance config.
-- "Did my allowance change?", "Are limits lower?", "Am I being throttled?", or "Why is weekly usage weird?" Use `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")`. Read `change_candidates[].statistical_evidence` and `summary.research_readiness` before answering. Separate local evidence from public claims, and preserve caveats about outside usage and unofficial inference.
-- "What happened in this session?" Use `session_usage(session_id=..., response_format="json")`.
-- "What should I inspect next?" Use `usage_report_pack(...)` or `usage_recommendations(response_format="json")`, then explain the primary recommendation, secondary signals, and row scope.
-
-## Suggested Investigation Ideas
-
-When the user asks what they can look into, offer a short menu of concrete aggregate-only investigations rather than a generic list.
-
-- "Did my Codex allowance or limit change?" Use `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")`. Lead with `primary_evidence_grade`, candidate change count, weekly observation count, and caveat local logs are not OpenAI official ledger.
-- "Why does the 5-hour counter look weird?" Use `usage_allowance_diagnostics(window_kind="five_hour", privacy_mode="strict")` and explain rolling-window noise before claiming allowance changes.
-- "Can I share allowance evidence?" Use `usage_allowance_export(...)`. Do not use raw context, CSV, or non-strict reports for public sharing unless user explicitly wants local-only detail. For local content-pattern evidence, use `usage_local_evidence_export(...)` instead of raw context or content search.
-- "Compare observed usage movement against estimated credits." Use `usage_allowance_diagnostics(privacy_mode="strict")`, then `usage_allowance_history(...)` only when user needs normalized rows.
-
-- "Look through my usage for token waste." Use `usage_report_pack(...)`, then `usage_calls(sort="tokens", direction="desc", limit=10)` and call out high-token calls, low cache ratios, high context-window percent, expensive estimates, or repeated same-thread spikes.
-- "Look through turns for recurring waste patterns." Start with aggregate `usage_report_pack(...)` and `usage_calls(...)`; use `usage_content_search(...)` only if the user wants transcript-level local pattern evidence.
-- "Find calls where context got bloated." Use `usage_calls(...)` sorted by tokens or filtered to recent rows, then rank by `context_window_percent`, `input_tokens`, and low `cache_ratio`.
-- "Show me where caching failed." Use `usage_calls(...)` and `usage_report_pack(...)`; prioritize rows with high `input_tokens`, low `cached_input_tokens`, or low `cache_ratio`.
-- "Which threads are draining the most?" Use `usage_threads(limit=10)` and `usage_summary(group_by="thread", response_format="json")`; include total tokens, estimated cost or credits, and whether archived rows are excluded.
-- "What changed recently?" Use `usage_status()` for freshness, then `usage_calls(since=..., limit=...)` or `usage_summary(group_by="date", response_format="json")` for recent movement.
-- "Find expensive calls worth opening." Use `most_expensive_usage_calls(response_format="json")` or `usage_calls(sort="tokens", direction="desc")`; suggest `usage_call_detail(record_id=...)` for the top few aggregate records.
-- "Check whether model or effort choice is wasting tokens." Use `usage_summary(group_by="model", response_format="json")`, `usage_summary(group_by="effort", response_format="json")`, and supporting `usage_calls(...)` rows.
-- "Can I share this safely?" Use `privacy_mode="strict"` and avoid `usage_call_context`.
-
-## Waste Reduction Recommendations
-
-When user asks to look for token waste, treat answer as diagnosis plus remediation. After ranking aggregate drivers, recommend concrete next steps that can reduce future usage:
-
-- Suggest Headroom when available for context/headroom estimation if evidence shows high context-window pressure, repeated large reads, or long-thread accumulation. Say "if available" unless tool registry confirms it.
-- Suggest dashboard verification steps: open top rows in Calls, inspect selected records in Call Investigator, compare Threads by total tokens, or use Diagnostics Notebook for usage-drain evidence.
-- Suggest custom solutions Codex can build when pattern repeatable: repo-specific test selector, local summary command, prompt checklist, dashboard report preset, or small script extracting exact project facts Codex keeps rediscovering.
-- Suggest workflow changes only when aggregate evidence supports them: split bloated threads, lower reasoning effort for routine edits, reuse one thread for cache-friendly related work, or start fresh thread after compacting needed state into docs.
-
-Structure recommendations as `Evidence`, `Likely waste pattern`, `Next action`, and `How to verify`. Keep privacy boundary explicit and avoid raw context unless user asks.
+- Dashboard inspection: open Calls, Threads, Call Investigator, Diagnostics Notebook, or Allowance Intelligence around specific evidence rows.
+- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, narrow test selection before final gates.
+- Existing tools: suggest Headroom when context pressure or handoff timing is the likely issue and the tool is available.
+- Custom local solutions: suggest a small script, command, repo note, or skill when the same file discovery, shell loop, or validation sequence keeps recurring.
 
 ## Answer Style
 
-- Lead with the direct answer and key metric.
-- Use at most one short progress update such as "Refreshing aggregate usage, then ranking threads."
-- Name data scope, time window, project, thread, model, row count, and whether rows are truncated or paginated.
-- Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, and missing allowance windows.
-- For allowance-change answers, separate weekly evidence from 5-hour counter behavior. Name the evidence grade and say when outside usage could explain movement.
-- Include the next useful investigation when the answer depends on unclear pricing, stale allowance values, or a broad time window.
-- Keep explanations tied to aggregate fields. Do not guess conversation content.
+- Lead with the direct answer and strongest metric.
+- Use at most one short progress update, such as "Refreshing aggregate usage, then ranking likely waste patterns."
+- Keep explanations tied to aggregate fields or clearly labeled local-index evidence.
+- Do not guess conversation content from token patterns.
+- For allowance-change answers, separate local evidence from public claims, quote the evidence grade, and say when outside usage or missing observations could explain movement.

--- a/src/codex_usage_tracker/cli/plugin_installer.py
+++ b/src/codex_usage_tracker/cli/plugin_installer.py
@@ -186,7 +186,7 @@ def plugin_manifest() -> dict[str, Any]:
     return {
         "name": PLUGIN_NAME,
         "version": __version__,
-        "description": "Unofficial local tracker for aggregate Codex token usage from local session logs.",
+        "description": "Unofficial local Codex usage dashboard and MCP diagnostics from local session logs.",
         "author": {"name": "Douglas Monsky"},
         "homepage": "https://github.com/douglasmonsky/codex-usage-tracker",
         "repository": "https://github.com/douglasmonsky/codex-usage-tracker",
@@ -196,13 +196,12 @@ def plugin_manifest() -> dict[str, Any]:
         "mcpServers": "./.mcp.json",
         "interface": {
             "displayName": "Codex Usage Tracker",
-            "shortDescription": "Unofficial local aggregate token usage analytics for Codex",
+            "shortDescription": "Local Codex usage dashboard, MCP diagnostics, and token-waste investigations",
             "longDescription": (
                 "Unofficial independent project, not made by, affiliated with, endorsed by, "
-                "sponsored by, or supported by OpenAI. Reads local Codex session logs, "
-                "aggregates exact token usage counters, and generates summaries, CSV "
-                "exports, and a hoverable dashboard with optional localhost-only raw "
-                "context loading."
+                "sponsored by, or supported by OpenAI. Reads local Codex session logs "
+                "to power a local dashboard, MCP tools, allowance diagnostics, token-waste "
+                "investigations, and shareable aggregate reports without uploading logs."
             ),
             "developerName": "Douglas Monsky",
             "category": "Productivity",
@@ -212,8 +211,9 @@ def plugin_manifest() -> dict[str, Any]:
             "termsOfServiceURL": "https://github.com/douglasmonsky/codex-usage-tracker",
             "defaultPrompt": [
                 "Open dashboard",
-                "Heaviest thread?",
-                "Thread leaderboard",
+                "Look through my usage for token waste",
+                "Suggest usage investigations",
+                "Check whether my weekly allowance changed",
             ],
             "brandColor": "#2563EB",
             "composerIcon": "./assets/icon.svg",

--- a/src/codex_usage_tracker/plugin_data/docs/examples/remediation-conversation.md
+++ b/src/codex_usage_tracker/plugin_data/docs/examples/remediation-conversation.md
@@ -1,25 +1,25 @@
 # Remediation Planning Conversation
 
-This is a synthetic, aggregate-only example of turning Codex Usage Tracker findings into concrete workflow changes. It is written as an example conversation doc rather than a transcript from private logs.
+This is a synthetic, aggregate-only example turning Codex Usage Tracker findings into concrete workflow changes. It is written as an example conversation document rather than a transcript of private logs.
 
 ## User
 
-Which threads are draining the most, and what can we do so this does not keep happening?
+Which threads are draining the most, and what can we do so it does not keep happening?
 
-## Codex With Codex Usage Tracker
+## Codex
 
-I refreshed the aggregate index, checked `usage_threads`, and pulled supporting Calls rows for the top thread. I did not inspect raw context.
+With Codex Usage Tracker, I refreshed the aggregate index, ran `usage_investigate(goal="workflow_churn")`, then checked `usage_threads` and supporting Calls rows for the top thread. I did not inspect raw context.
 
 ## Evidence
 
-- The top thread has repeated high-token calls after context-heavy investigation turns.
+- The top thread has repeated high-token calls and context-heavy investigation turns.
 - The Calls table shows high context-window percentage and a few low-cache rows.
-- The expensive rows are tied to repeated repository discovery and broad validation.
+- The investigation report recommends checking shell churn and repeated file rediscovery before opening raw context.
 
 ## Recommended Remediation
 
 - Split future work into an investigation thread and an implementation thread once the plan is stable.
-- Preserve reusable findings in a short repo note or roadmap issue, then start a fresh thread from that summary.
+- Preserve reusable findings in a short repo note or roadmap issue, then start a fresh thread with that summary.
 - Ask Codex to use a narrow validation plan first, then broaden only before release.
 - If Headroom is installed, ask it to check context pressure before continuing a long thread.
 - If the pattern repeats, have Codex build a custom local helper command or skill note that captures the exact repo facts it keeps rediscovering.

--- a/src/codex_usage_tracker/plugin_data/docs/examples/token-waste-conversation.md
+++ b/src/codex_usage_tracker/plugin_data/docs/examples/token-waste-conversation.md
@@ -1,20 +1,20 @@
 # Token Waste Review Conversation
 
-This is a synthetic, aggregate-only example of using the Codex Usage Tracker companion skill. It does not include prompts, assistant messages, tool output, pasted secrets, raw transcript text, real thread names, or real usage totals.
+This is a synthetic, aggregate-only example using the Codex Usage Tracker companion skill. It does not include prompts, assistant messages, tool output, pasted secrets, raw transcript text, real thread names, or real usage totals.
 
 ## User
 
 Look through my usage for token waste and recommend what I should change.
 
-## Codex With Codex Usage Tracker
+## Codex
 
-I refreshed the local aggregate index and ranked recent calls by total tokens, context-window pressure, cache ratio, and thread totals.
+I refreshed the local aggregate index and started with `usage_investigate(goal="token_waste")`, then checked the recommended supporting Calls and Threads rows.
 
 ## Evidence
 
 - One long implementation thread accounts for most recent tokens.
-- Several calls have high input tokens with low cached input, which means repeated context was not being reused efficiently.
-- The most expensive rows cluster around broad file discovery plus full test reruns.
+- Several calls have high input tokens and low cached input, which means repeated context was not reused efficiently.
+- The highest-confidence finding points to broad file discovery and repeated validation as the main waste pattern.
 
 ## Likely Waste Pattern
 
@@ -23,6 +23,7 @@ Codex is rediscovering project context and rerunning broad checks in the same wo
 ## Next Actions
 
 - Use Calls to open the top three expensive rows.
+- Follow the investigation report's `recommended_next_tools` before drilling into raw context.
 - If Headroom is available, use it to estimate whether the thread is near context pressure before continuing.
 - Move stable project facts into docs or an `AGENTS.md` note so Codex does not need to infer them repeatedly.
 - Create a repo-specific validation command or test-selection checklist if broad checks are happening every turn.

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
@@ -1,108 +1,55 @@
 ---
 name: codex-usage-api
-description: Use when the user wants to discuss, investigate, compare, or explain Codex usage using the Codex Usage Tracker API or MCP tools.
+description: Use when the user wants to discuss, investigate, compare, explain, or improve Codex usage with Codex Usage Tracker API or MCP tools, including token waste, cache/context problems, allowance or limit changes, pricing confidence, dashboard evidence, and local content-index investigations.
 ---
 
 # Codex Usage API Companion
 
-Use this companion skill as a conversational analyst for Codex Usage Tracker data. Prefer aggregate MCP JSON payloads first, answer from evidence, and keep the user-facing output crisp instead of narrating tool discovery or local file spelunking.
+Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON payloads, answer from structured evidence, and keep the user-facing result concise.
 
-## Privacy Boundary
+## Operating Rules
 
-Normal usage answers should start from aggregate API data. Do not expose prompts, assistant messages, tool output, pasted secrets, or raw transcript snippets.
+- For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `open-dashboard` only when the user explicitly asks for a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
+- Refresh with `refresh_usage_index` unless the user asks for a static historical snapshot.
+- Start with aggregate/shareable tools. Do not expose prompts, assistant messages, raw tool output, pasted secrets, raw commands, full paths, or transcript snippets unless the user explicitly asks for local content or raw context.
+- Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
+- Name the scope: time window, project/thread/model filters, included archived state, row limit, and whether results are estimates.
+- Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
+- For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
 
-When the user plans to share JSON, CSV, dashboards, screenshots, or support bundles, prefer `privacy_mode="strict"` MCP calls or the CLI global option `--privacy-mode strict` before the subcommand. Configured project aliases are explicit display opt-ins.
+## Router
 
-Use `usage_investigation_walk(question=...)` first when user asks for broad local waste discovery; it ranks normalized pattern branches and recommends next tools. Use local pattern scans (`usage_repetition_scan`, `usage_command_loop_scan`, `usage_file_churn_scan`, `usage_context_bloat_scan`) when user asks for recurring waste, command loops, repeated file churn, or context bloat. Use `usage_repeated_file_rediscovery(...)` when user asks which files are rediscovered or reread repeatedly; it ranks safe path hashes/basenames without full paths. Use `usage_shell_churn(...)` when the user asks about repeated shell probing, command loops, failing retries, or repeated sed/rg/git/nl/test/package commands. Use `usage_content_search` only when user asks local content exploration, pattern hunting, diagnostics need indexed snippets; its payload can include local transcript snippets is not default shareable report.
+1. If the user asks what to inspect, wants suggestions, or is unsure where to start, call `usage_suggest_investigations(goal=...)`.
+2. If the user asks broadly to look through usage, find waste, explain expensive usage, improve efficiency, or recommend changes, call `usage_investigate(goal="token_waste")` or `usage_investigate(goal="overview")` first, then drill into its `recommended_next_tools`.
+3. If the user asks whether limits/allowance changed, whether they are throttled, why weekly usage moved, or why the 5-hour counter looks weird, call `usage_investigate(goal="allowance_change")`, then `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")` when evidence is needed. Use `usage_allowance_export(...)` for manually shareable evidence.
+4. If the user asks about cache misses, cold resumes, context bloat, or low-output expensive calls, call `usage_investigate(goal="cache_failure")`, then inspect `usage_large_low_output_calls(...)`, `usage_calls(...)`, `usage_report_pack(...)`, or `usage_context_bloat_scan(...)`.
+5. If the user asks about repeated shell probing, repeated file rediscovery, or workflow churn, call `usage_investigate(goal="workflow_churn")`, then inspect `usage_shell_churn(...)`, `usage_repeated_file_rediscovery(...)`, or `usage_investigation_walk(question=...)`.
+6. If the user asks a precise dashboard/API question, use the direct tool: `usage_calls`, `usage_call_detail`, `usage_threads`, `usage_summary`, `usage_query`, `session_usage`, `usage_report_pack`, `usage_dashboard_recommendations`, `usage_recommendations`, `most_expensive_usage_calls`, `usage_pricing_coverage`, or `usage_source_coverage`.
+7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration or when the user agrees transcript-level indexed snippets are needed.
+8. Use `usage_call_context(...)` only when the user explicitly asks for raw local context and the MCP server has raw context enabled.
 
-Use `usage_large_low_output_calls(...)` when the user asks for obvious token-waste candidates, cold resumes, cache misses, stale high-context continuations, or large calls that produced little output.
+## Tool Stance
 
-Use `usage_call_context` only when the user explicitly asks to inspect actual logged context for one selected record. State that returned text is local, redacted or size-limited when applicable, and not included in default shareable outputs.
+- `usage_suggest_investigations` is the front door for ideas. It should return short, goal-led options and safe defaults.
+- `usage_investigate` is the first stop for broad agentic analysis. It returns normalized findings, confidence, recommended actions, verification tools, and caveats.
+- `usage_allowance_diagnostics` is the main allowance-change evidence tool. Treat weekly windows as the primary signal and 5-hour windows as noisy rolling-window context.
+- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are token-waste diagnostics. They should produce actionable next steps before resorting to raw context.
+- `usage_investigation_walk` and local pattern scans can use the content/event index. They are useful for deeper local diagnosis, but not default shareable reports.
+- If MCP tools are unavailable, use CLI JSON equivalents documented in `docs/cli-json-schemas.md`.
 
-## First Steps
+## Remediation Guidance
 
-1. For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `--no-refresh` only when the user explicitly asks for a cached snapshot. Use `open-dashboard` only for explicit static/offline snapshots or when the environment cannot keep a server alive; say the result is static and Live requires `serve-dashboard`.
-2. For "Heaviest thread?", "Thread leaderboard", or similar ranking requests, refresh aggregate data first, then call `usage_summary(group_by="thread", limit=10, response_format="json")`.
-3. For normal usage questions, start with MCP tools. If MCP tools are unavailable, use the CLI JSON fallback commands below.
-4. Refresh analysis with `refresh_usage_index` unless the user asks for a static historical snapshot. Keep archived sessions excluded unless explicitly requested.
-5. Use `usage_status()` for dashboard/index freshness and row counts. Use `usage_doctor(response_format="json")` when setup, indexing, pricing, MCP discovery, or dashboard freshness is uncertain.
-6. Prefer structured MCP payloads:
-   - `usage_calls(...)`
-   - `usage_call_detail(record_id=...)`
-   - `usage_threads(...)`
-   - `usage_report_pack(...)`
-   - `usage_dashboard_recommendations(...)`
-   - `usage_summary(..., response_format="json")`
-   - `session_usage(..., response_format="json")`
-   - `most_expensive_usage_calls(..., response_format="json")`
-- `usage_recommendations(..., response_format="json")`
-- `usage_pricing_coverage(..., response_format="json")`
-- `usage_source_coverage(..., response_format="json")`
-- `usage_content_search(...)` only for explicit local content-index exploration
-- `usage_thread_trace(...)` only for explicit local content-index thread/session timelines
-- `usage_allowance_diagnostics(..., privacy_mode="strict")`
- - `usage_allowance_history(..., privacy_mode="strict")`
- - `usage_allowance_export(...)`
- - `usage_query(...)`
-7. Check the top-level `schema` field before interpreting structured output. Known schema ids are documented in `docs/cli-json-schemas.md`.
-8. If MCP tools are unavailable, fall back to CLI equivalents: `refresh --json`, `summary --json`, `query`, `session --json`, `expensive --json`, `recommendations --json`, `pricing-coverage --json`, and `source-coverage --json`.
-9. If `codex-usage-tracker` is missing but you are inside the source checkout, use `PYTHONPATH=src .venv/bin/python -m codex_usage_tracker.cli <command>`. Do not use `PYTHONPATH=src` outside that checkout.
+Recommend fixes only when supported by evidence. Useful categories include:
 
-## Routing Questions To API Calls
-
-- "What used most?" Use `usage_summary(group_by="thread", response_format="json")` for thread totals, then `most_expensive_usage_calls(response_format="json")` for supporting calls.
-- "Which project/thread/model is driving usage?" Use `usage_summary` grouped by `project`, `thread`, or `model`.
-- "Show/filter the calls table" Use `usage_calls(...)` with `limit`, `offset`, `search`, `since`, `model`, `effort`, `thread`, `pricing_status`, or `credit_confidence`. Report `row_count`, `total_matched_rows`, and `has_more`.
-- "Search my local usage content for X" Use `usage_content_search(query="X", limit=20)` and state snippets are local indexed content, not public-safe aggregate export.
-- "Trace this thread/session" Use `usage_thread_trace(thread=...)`, `usage_thread_trace(session_id=...)`, or seed with `usage_thread_trace(record_id=...)`; state fragments are local indexed content.
-- "Open/investigate this call" Use `usage_call_detail(record_id=...)` for the aggregate call investigator payload. Use `usage_call_context` only if the user explicitly asks for raw local context.
-- "Show threads" Use `usage_threads(...)`, sorted by token impact by default.
-- "Give me dashboard report evidence" Use `usage_report_pack(...)` for report cards and compact evidence rows. Use `usage_dashboard_recommendations(...)` when the user specifically wants the dashboard recommendation payload.
-- "Is my dashboard/index stale?" Use `usage_status()` first, then `usage_doctor(response_format="json")` if status suggests missing rows, stale refresh, or setup problems.
-- "Can I share this?" Use redacted or strict privacy mode and avoid `usage_call_context`.
-- "Why did usage spike?" Use `usage_recommendations(response_format="json")` for ranked causes, then `usage_query` or `usage_calls` with focused filters for supporting rows.
-- "What is unpriced or estimated?" Use `usage_pricing_coverage(response_format="json")` and `usage_query(pricing_status="unpriced")` or `usage_query(credit_confidence="estimated")`.
-- "How does this affect my allowance?" Use rows from `usage_query` or `usage_calls` and summarize `usage_credits`, `usage_credit_confidence`, and allowance annotations. Explain that remaining allowance is only as accurate as the user's local allowance config.
-- "Did my allowance change?", "Are limits lower?", "Am I being throttled?", or "Why is weekly usage weird?" Use `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")`. Read `change_candidates[].statistical_evidence` and `summary.research_readiness` before answering. Separate local evidence from public claims, and preserve caveats about outside usage and unofficial inference.
-- "What happened in this session?" Use `session_usage(session_id=..., response_format="json")`.
-- "What should I inspect next?" Use `usage_report_pack(...)` or `usage_recommendations(response_format="json")`, then explain the primary recommendation, secondary signals, and row scope.
-
-## Suggested Investigation Ideas
-
-When the user asks what they can look into, offer a short menu of concrete aggregate-only investigations rather than a generic list.
-
-- "Did my Codex allowance or limit change?" Use `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")`. Lead with `primary_evidence_grade`, candidate change count, weekly observation count, and caveat local logs are not OpenAI official ledger.
-- "Why does the 5-hour counter look weird?" Use `usage_allowance_diagnostics(window_kind="five_hour", privacy_mode="strict")` and explain rolling-window noise before claiming allowance changes.
-- "Can I share allowance evidence?" Use `usage_allowance_export(...)`. Do not use raw context, CSV, or non-strict reports for public sharing unless user explicitly wants local-only detail. For local content-pattern evidence, use `usage_local_evidence_export(...)` instead of raw context or content search.
-- "Compare observed usage movement against estimated credits." Use `usage_allowance_diagnostics(privacy_mode="strict")`, then `usage_allowance_history(...)` only when user needs normalized rows.
-
-- "Look through my usage for token waste." Use `usage_report_pack(...)`, then `usage_calls(sort="tokens", direction="desc", limit=10)` and call out high-token calls, low cache ratios, high context-window percent, expensive estimates, or repeated same-thread spikes.
-- "Look through turns for recurring waste patterns." Start with aggregate `usage_report_pack(...)` and `usage_calls(...)`; use `usage_content_search(...)` only if the user wants transcript-level local pattern evidence.
-- "Find calls where context got bloated." Use `usage_calls(...)` sorted by tokens or filtered to recent rows, then rank by `context_window_percent`, `input_tokens`, and low `cache_ratio`.
-- "Show me where caching failed." Use `usage_calls(...)` and `usage_report_pack(...)`; prioritize rows with high `input_tokens`, low `cached_input_tokens`, or low `cache_ratio`.
-- "Which threads are draining the most?" Use `usage_threads(limit=10)` and `usage_summary(group_by="thread", response_format="json")`; include total tokens, estimated cost or credits, and whether archived rows are excluded.
-- "What changed recently?" Use `usage_status()` for freshness, then `usage_calls(since=..., limit=...)` or `usage_summary(group_by="date", response_format="json")` for recent movement.
-- "Find expensive calls worth opening." Use `most_expensive_usage_calls(response_format="json")` or `usage_calls(sort="tokens", direction="desc")`; suggest `usage_call_detail(record_id=...)` for the top few aggregate records.
-- "Check whether model or effort choice is wasting tokens." Use `usage_summary(group_by="model", response_format="json")`, `usage_summary(group_by="effort", response_format="json")`, and supporting `usage_calls(...)` rows.
-- "Can I share this safely?" Use `privacy_mode="strict"` and avoid `usage_call_context`.
-
-## Waste Reduction Recommendations
-
-When user asks to look for token waste, treat answer as diagnosis plus remediation. After ranking aggregate drivers, recommend concrete next steps that can reduce future usage:
-
-- Suggest Headroom when available for context/headroom estimation if evidence shows high context-window pressure, repeated large reads, or long-thread accumulation. Say "if available" unless tool registry confirms it.
-- Suggest dashboard verification steps: open top rows in Calls, inspect selected records in Call Investigator, compare Threads by total tokens, or use Diagnostics Notebook for usage-drain evidence.
-- Suggest custom solutions Codex can build when pattern repeatable: repo-specific test selector, local summary command, prompt checklist, dashboard report preset, or small script extracting exact project facts Codex keeps rediscovering.
-- Suggest workflow changes only when aggregate evidence supports them: split bloated threads, lower reasoning effort for routine edits, reuse one thread for cache-friendly related work, or start fresh thread after compacting needed state into docs.
-
-Structure recommendations as `Evidence`, `Likely waste pattern`, `Next action`, and `How to verify`. Keep privacy boundary explicit and avoid raw context unless user asks.
+- Dashboard inspection: open Calls, Threads, Call Investigator, Diagnostics Notebook, or Allowance Intelligence around specific evidence rows.
+- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, narrow test selection before final gates.
+- Existing tools: suggest Headroom when context pressure or handoff timing is the likely issue and the tool is available.
+- Custom local solutions: suggest a small script, command, repo note, or skill when the same file discovery, shell loop, or validation sequence keeps recurring.
 
 ## Answer Style
 
-- Lead with the direct answer and key metric.
-- Use at most one short progress update such as "Refreshing aggregate usage, then ranking threads."
-- Name data scope, time window, project, thread, model, row count, and whether rows are truncated or paginated.
-- Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, and missing allowance windows.
-- For allowance-change answers, separate weekly evidence from 5-hour counter behavior. Name the evidence grade and say when outside usage could explain movement.
-- Include the next useful investigation when the answer depends on unclear pricing, stale allowance values, or a broad time window.
-- Keep explanations tied to aggregate fields. Do not guess conversation content.
+- Lead with the direct answer and strongest metric.
+- Use at most one short progress update, such as "Refreshing aggregate usage, then ranking likely waste patterns."
+- Keep explanations tied to aggregate fields or clearly labeled local-index evidence.
+- Do not guess conversation content from token patterns.
+- For allowance-change answers, separate local evidence from public claims, quote the evidence grade, and say when outside usage or missing observations could explain movement.

--- a/tests/cli/test_plugin_installer.py
+++ b/tests/cli/test_plugin_installer.py
@@ -38,8 +38,8 @@ def test_install_plugin_writes_generated_wrapper_and_marketplace(tmp_path: Path)
     assert manifest["version"] == __version__
     assert manifest["interface"]["defaultPrompt"][:3] == [
         "Open dashboard",
-        "Heaviest thread?",
-        "Thread leaderboard",
+        "Look through my usage for token waste",
+        "Suggest usage investigations",
     ]
     assert (plugin_dir / "assets" / "icon.svg").exists()
     assert (plugin_dir / "skills" / "codex-usage-api" / "SKILL.md").exists()


### PR DESCRIPTION
## Summary
- Refresh the `codex-usage-api` companion skill around the new agentic MCP flow: suggestions, broad investigations, allowance checks, waste remediation, and explicit local-content boundaries.
- Update plugin manifest/default prompts so installed plugin users see token-waste and allowance investigation prompts, not only thread leaderboard prompts.
- Rewrite MCP docs and synthetic conversation examples to lead with `usage_suggest_investigations` / `usage_investigate` and mirror packaged docs examples.

## Validation
- `.venv/bin/python -m ruff check src/codex_usage_tracker/cli/plugin_installer.py tests/cli/test_plugin_installer.py`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/cli/test_plugin_installer.py tests/cli/test_mcp_integration.py tests/cli/test_cli_release.py`
- `PYTHONPATH=src .venv/bin/python -m mypy src/codex_usage_tracker/cli/plugin_installer.py`
- `.venv/bin/python scripts/check_release.py`
- `git diff --check`
