### PR TITLE
feat: compact agentic investigation evidence

### DIFF
--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -1027,14 +1027,14 @@ Ranks high-token calls that produced little output, including token totals, cach
 
 MCP:
 
-- `usage_suggest_investigations(goal="token_waste")`
+- `usage_suggest_investigations(goal="token_waste", limit=2)`
 
 Schema: `codex-usage-tracker-investigation-suggestions-v1`
 
-Returns a short menu of goal-led investigations an agent can run, including the primary MCP tool, default arguments, follow-up tools, and privacy notes. It does not include raw/indexed content.
+Returns a short menu of goal-led investigations an agent can run, including the primary MCP tool, default arguments, follow-up tools, and privacy notes. Goal-specific requests include adjacent useful investigations so agents can keep exploring without guessing the next tool. It does not include raw/indexed content.
 
 ```json
-{"schema":"codex-usage-tracker-investigation-suggestions-v1","content_mode":"aggregate_guidance","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","available_goals":["overview","token_waste","allowance_change","cache_failure","workflow_churn"],"filters":{"since":null,"until":null,"thread":null,"include_archived":false,"limit":10},"summary":{"suggestion_count":1,"total_suggestions":1,"top_goal":"token_waste"},"suggestions":[{"goal":"token_waste","label":"Find obvious token-waste candidates","primary_tool":"usage_investigate","default_arguments":{"goal":"token_waste","evidence_limit":5},"follow_up_tools":["usage_large_low_output_calls","usage_shell_churn"],"privacy_notes":"Aggregate-first; no raw prompts, tool output, or full paths."}]}
+{"schema":"codex-usage-tracker-investigation-suggestions-v1","content_mode":"aggregate_guidance","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","available_goals":["overview","token_waste","allowance_change","cache_failure","workflow_churn"],"filters":{"since":null,"until":null,"thread":null,"include_archived":false,"limit":2},"summary":{"suggestion_count":2,"total_suggestions":4,"top_goal":"token_waste"},"suggestions":[{"goal":"token_waste","label":"Find obvious token-waste candidates","primary_tool":"usage_investigate","default_arguments":{"goal":"token_waste","evidence_limit":5},"follow_up_tools":["usage_large_low_output_calls","usage_shell_churn"],"privacy_notes":"Aggregate-first; no raw prompts, tool output, or full paths."},{"goal":"cache_failure","label":"Diagnose cache and context waste","primary_tool":"usage_investigate","default_arguments":{"goal":"cache_failure","evidence_limit":5},"follow_up_tools":["usage_large_low_output_calls","usage_calls","usage_report_pack"],"privacy_notes":"Aggregate-first; no raw prompt or transcript text."}]}
 ```
 
 ## Agentic Investigation
@@ -1045,10 +1045,10 @@ MCP:
 
 Schema: `codex-usage-tracker-agentic-investigation-v1`
 
-Runs a goal-led aggregate investigation over existing tracker reports and returns normalized findings with evidence, confidence, why it matters, recommended action, verification tools, privacy notes, and caveats.
+Runs a goal-led aggregate investigation over existing tracker reports and returns normalized findings with compact evidence, evidence summaries, confidence, why it matters, missing-access notes, recommended action, verification tools, privacy notes, and caveats. `detail_mode="compact"` is the default. Use `detail_mode="full"` only when the full underlying diagnostic rows are needed.
 
 ```json
-{"schema":"codex-usage-tracker-agentic-investigation-v1","content_mode":"aggregate_investigation","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"evidence_limit":5},"summary":{"finding_count":1,"top_finding":"No strong local signal at default thresholds","confidence":"insufficient_local_evidence","source_reports":[]},"findings":[{"finding":"No strong local signal at default thresholds","evidence_count":0,"evidence":[],"confidence":"insufficient_local_evidence","recommended_action":"Lower thresholds, widen the time window, include archived sessions, or inspect top aggregate calls.","verify_with":["usage_calls","usage_report_pack"]}],"recommended_next_tools":[],"caveats":["Local Codex logs only; this is not an official OpenAI usage ledger."]}
+{"schema":"codex-usage-tracker-agentic-investigation-v1","content_mode":"aggregate_investigation","includes_indexed_content":false,"includes_raw_fragments":false,"privacy_mode":"normal","goal":"token_waste","filters":{"since":null,"until":null,"thread":null,"include_archived":false,"evidence_limit":5,"detail_mode":"compact"},"summary":{"finding_count":1,"top_finding":"No strong local signal at default thresholds","confidence":"insufficient_local_evidence","source_reports":[]},"findings":[{"finding":"No strong local signal at default thresholds","evidence_count":0,"evidence_summary":{"row_count":0},"evidence":[],"confidence":"insufficient_local_evidence","recommended_action":"Lower thresholds, widen the time window, include archived sessions, or inspect top aggregate calls.","verify_with":["usage_calls","usage_report_pack"],"missing_access":"No supported aggregate signal was found at the selected thresholds.","privacy_notes":"No raw context needed for this follow-up."}],"recommended_next_tools":[],"caveats":["Local Codex logs only; this is not an official OpenAI usage ledger."]}
 ```
 
 ## Investigation Walk

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,9 +47,9 @@ The API skill should refresh the local index, use MCP JSON tools, state scope an
 
 ## Agentic Investigation Tools
 
-Use `usage_suggest_investigations(...)` when the user wants ideas, is unsure what to inspect, or asks what the tracker can help with. It returns goal-led investigation options such as token waste, allowance change, cache failure, workflow churn, and overview.
+Use `usage_suggest_investigations(...)` when the user wants ideas, is unsure what to inspect, or asks what the tracker can help with. It returns a short menu of related goal-led investigations such as token waste, allowance change, cache failure, workflow churn, and overview. Goal-specific requests still include adjacent useful investigations instead of a one-item answer.
 
-Use `usage_investigate(...)` as the first stop for broad requests such as "look through my usage for token waste" or "what should I change?" It returns normalized findings, evidence, confidence, recommended actions, verification tools, and caveats.
+Use `usage_investigate(...)` as the first stop for broad requests such as "look through my usage for token waste" or "what should I change?" It returns normalized findings with compact evidence, evidence summaries, confidence, missing-access notes, recommended actions, verification tools, and caveats. Compact evidence is the default. Pass `detail_mode="full"` only when the caller needs the full underlying report rows.
 
 Use lower-level diagnostics when the investigation report recommends them:
 

--- a/skills/codex-usage-api/SKILL.md
+++ b/skills/codex-usage-api/SKILL.md
@@ -9,11 +9,11 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 
 ## Operating Rules
 
-- For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `open-dashboard` only when the user explicitly asks for a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
+- For "Open dashboard" style requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands. Use `open-dashboard` only when the user explicitly wants a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
 - Refresh with `refresh_usage_index` unless the user asks for a static historical snapshot.
 - Start with aggregate/shareable tools. Do not expose prompts, assistant messages, raw tool output, pasted secrets, raw commands, full paths, or transcript snippets unless the user explicitly asks for local content or raw context.
 - Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
-- Name the scope: time window, project/thread/model filters, included archived state, row limit, and whether results are estimates.
+- Name scope: time window, project/thread/model filters, included archived state, row limit, detail mode, and whether results are estimates.
 - Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
 - For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
 
@@ -25,16 +25,16 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 4. If the user asks about cache misses, cold resumes, context bloat, or low-output expensive calls, call `usage_investigate(goal="cache_failure")`, then inspect `usage_large_low_output_calls(...)`, `usage_calls(...)`, `usage_report_pack(...)`, or `usage_context_bloat_scan(...)`.
 5. If the user asks about repeated shell probing, repeated file rediscovery, or workflow churn, call `usage_investigate(goal="workflow_churn")`, then inspect `usage_shell_churn(...)`, `usage_repeated_file_rediscovery(...)`, or `usage_investigation_walk(question=...)`.
 6. If the user asks a precise dashboard/API question, use the direct tool: `usage_calls`, `usage_call_detail`, `usage_threads`, `usage_summary`, `usage_query`, `session_usage`, `usage_report_pack`, `usage_dashboard_recommendations`, `usage_recommendations`, `most_expensive_usage_calls`, `usage_pricing_coverage`, or `usage_source_coverage`.
-7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration or when the user agrees transcript-level indexed snippets are needed.
+7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration when the user agrees transcript-level indexed snippets are needed.
 8. Use `usage_call_context(...)` only when the user explicitly asks for raw local context and the MCP server has raw context enabled.
 
 ## Tool Stance
 
-- `usage_suggest_investigations` is the front door for ideas. It should return short, goal-led options and safe defaults.
-- `usage_investigate` is the first stop for broad agentic analysis. It returns normalized findings, confidence, recommended actions, verification tools, and caveats.
+- `usage_suggest_investigations` is the front door for ideas. It should return a short, goal-led menu with adjacent safe next options.
+- `usage_investigate` is the first stop for broad agentic analysis. The default `detail_mode="compact"` returns evidence summaries and compact rows; use `detail_mode="full"` only when full underlying diagnostic rows are necessary.
 - `usage_allowance_diagnostics` is the main allowance-change evidence tool. Treat weekly windows as the primary signal and 5-hour windows as noisy rolling-window context.
-- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are token-waste diagnostics. They should produce actionable next steps before resorting to raw context.
-- `usage_investigation_walk` and local pattern scans can use the content/event index. They are useful for deeper local diagnosis, but not default shareable reports.
+- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are the most actionable token-waste probes. Use them to turn broad findings into concrete next steps.
+- `usage_investigation_walk` can use local content/event-index signals for deeper pattern scans, but it is not the default shareable report.
 - If MCP tools are unavailable, use CLI JSON equivalents documented in `docs/cli-json-schemas.md`.
 
 ## Remediation Guidance
@@ -42,9 +42,9 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 Recommend fixes only when supported by evidence. Useful categories include:
 
 - Dashboard inspection: open Calls, Threads, Call Investigator, Diagnostics Notebook, or Allowance Intelligence around specific evidence rows.
-- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, narrow test selection before final gates.
-- Existing tools: suggest Headroom when context pressure or handoff timing is the likely issue and the tool is available.
-- Custom local solutions: suggest a small script, command, repo note, or skill when the same file discovery, shell loop, or validation sequence keeps recurring.
+- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, and narrow test selection before final gates.
+- Existing tools: suggest Headroom when context pressure or handoff timing appears relevant and the tool is available.
+- Custom local solutions: suggest a small script, command, repo note, or skill update when the same file discovery, shell loop, or validation sequence keeps recurring.
 
 ## Answer Style
 

--- a/src/codex_usage_tracker/cli/mcp_server.py
+++ b/src/codex_usage_tracker/cli/mcp_server.py
@@ -651,6 +651,7 @@ def usage_investigate(
     thread: str | None = None,
     include_archived: bool = False,
     evidence_limit: int = 5,
+    detail_mode: str = "compact",
     privacy_mode: str = "normal",
 ) -> dict[str, Any]:
     """Run a goal-led aggregate usage investigation."""
@@ -666,6 +667,7 @@ def usage_investigate(
         thread=thread,
         include_archived=include_archived,
         evidence_limit=evidence_limit,
+        detail_mode=detail_mode,
         privacy_mode=privacy_mode,
     ).payload
 

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -406,6 +406,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
                 "thread": (str, NoneType),
                 "include_archived": bool,
                 "evidence_limit": int,
+                "detail_mode": str,
             }
         },
     },

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
@@ -9,11 +9,11 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 
 ## Operating Rules
 
-- For "Open dashboard" or similar requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands; use `open-dashboard` only when the user explicitly asks for a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
+- For "Open dashboard" style requests, start the live localhost dashboard with `codex-usage-tracker serve-dashboard --context-api explicit --open`. Refresh is the default for dashboard launch commands. Use `open-dashboard` only when the user explicitly wants a static/offline snapshot or the environment cannot keep a server alive. Say the result is static and Live requires `serve-dashboard`.
 - Refresh with `refresh_usage_index` unless the user asks for a static historical snapshot.
 - Start with aggregate/shareable tools. Do not expose prompts, assistant messages, raw tool output, pasted secrets, raw commands, full paths, or transcript snippets unless the user explicitly asks for local content or raw context.
 - Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
-- Name the scope: time window, project/thread/model filters, included archived state, row limit, and whether results are estimates.
+- Name scope: time window, project/thread/model filters, included archived state, row limit, detail mode, and whether results are estimates.
 - Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
 - For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
 
@@ -25,16 +25,16 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 4. If the user asks about cache misses, cold resumes, context bloat, or low-output expensive calls, call `usage_investigate(goal="cache_failure")`, then inspect `usage_large_low_output_calls(...)`, `usage_calls(...)`, `usage_report_pack(...)`, or `usage_context_bloat_scan(...)`.
 5. If the user asks about repeated shell probing, repeated file rediscovery, or workflow churn, call `usage_investigate(goal="workflow_churn")`, then inspect `usage_shell_churn(...)`, `usage_repeated_file_rediscovery(...)`, or `usage_investigation_walk(question=...)`.
 6. If the user asks a precise dashboard/API question, use the direct tool: `usage_calls`, `usage_call_detail`, `usage_threads`, `usage_summary`, `usage_query`, `session_usage`, `usage_report_pack`, `usage_dashboard_recommendations`, `usage_recommendations`, `most_expensive_usage_calls`, `usage_pricing_coverage`, or `usage_source_coverage`.
-7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration or when the user agrees transcript-level indexed snippets are needed.
+7. Use `usage_content_search(...)` and `usage_thread_trace(...)` only for explicit local content-index exploration when the user agrees transcript-level indexed snippets are needed.
 8. Use `usage_call_context(...)` only when the user explicitly asks for raw local context and the MCP server has raw context enabled.
 
 ## Tool Stance
 
-- `usage_suggest_investigations` is the front door for ideas. It should return short, goal-led options and safe defaults.
-- `usage_investigate` is the first stop for broad agentic analysis. It returns normalized findings, confidence, recommended actions, verification tools, and caveats.
+- `usage_suggest_investigations` is the front door for ideas. It should return a short, goal-led menu with adjacent safe next options.
+- `usage_investigate` is the first stop for broad agentic analysis. The default `detail_mode="compact"` returns evidence summaries and compact rows; use `detail_mode="full"` only when full underlying diagnostic rows are necessary.
 - `usage_allowance_diagnostics` is the main allowance-change evidence tool. Treat weekly windows as the primary signal and 5-hour windows as noisy rolling-window context.
-- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are token-waste diagnostics. They should produce actionable next steps before resorting to raw context.
-- `usage_investigation_walk` and local pattern scans can use the content/event index. They are useful for deeper local diagnosis, but not default shareable reports.
+- `usage_large_low_output_calls`, `usage_shell_churn`, and `usage_repeated_file_rediscovery` are the most actionable token-waste probes. Use them to turn broad findings into concrete next steps.
+- `usage_investigation_walk` can use local content/event-index signals for deeper pattern scans, but it is not the default shareable report.
 - If MCP tools are unavailable, use CLI JSON equivalents documented in `docs/cli-json-schemas.md`.
 
 ## Remediation Guidance
@@ -42,9 +42,9 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 Recommend fixes only when supported by evidence. Useful categories include:
 
 - Dashboard inspection: open Calls, Threads, Call Investigator, Diagnostics Notebook, or Allowance Intelligence around specific evidence rows.
-- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, narrow test selection before final gates.
-- Existing tools: suggest Headroom when context pressure or handoff timing is the likely issue and the tool is available.
-- Custom local solutions: suggest a small script, command, repo note, or skill when the same file discovery, shell loop, or validation sequence keeps recurring.
+- Workflow changes: split long threads after planning, preserve handoff summaries, avoid broad rediscovery, lower effort for routine tasks, and narrow test selection before final gates.
+- Existing tools: suggest Headroom when context pressure or handoff timing appears relevant and the tool is available.
+- Custom local solutions: suggest a small script, command, repo note, or skill update when the same file discovery, shell loop, or validation sequence keeps recurring.
 
 ## Answer Style
 

--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
@@ -786,6 +787,7 @@ def build_agentic_investigation_report(
     thread: str | None = None,
     include_archived: bool = False,
     evidence_limit: int = 5,
+    detail_mode: str = "compact",
     privacy_mode: str = "normal",
 ) -> AgenticInvestigationReport:
     """Build a compact goal-led investigation using existing reports."""
@@ -793,6 +795,7 @@ def build_agentic_investigation_report(
     privacy_mode = validate_privacy_mode(privacy_mode)
     normalized_goal = _normalize_agentic_goal(goal) or "token_waste"
     normalized_limit = max(1, evidence_limit)
+    normalized_detail_mode = _normalize_agentic_detail_mode(detail_mode)
     findings: list[dict[str, Any]] = []
     source_reports: list[str] = []
     recommended_next_tools: list[dict[str, Any]] = []
@@ -817,6 +820,7 @@ def build_agentic_investigation_report(
                 _agentic_finding(
                     finding="Large calls produced little output",
                     evidence=large_low_output["rows"][:normalized_limit],
+                    detail_mode=normalized_detail_mode,
                     confidence=_count_confidence(int(large_low_output["total_candidates"])),
                     why_it_matters=(
                         "Large input/context usage with low output is a strong candidate for "
@@ -828,6 +832,10 @@ def build_agentic_investigation_report(
                     ),
                     verify_with=["usage_large_low_output_calls", "usage_call_detail", "usage_thread_trace"],
                     privacy_notes="Aggregate token/activity counts only; no raw fragments or command output.",
+                    missing_access=(
+                        "The aggregate report cannot prove why output was low without a thread trace "
+                        "or explicit raw-context inspection."
+                    ),
                 )
             )
 
@@ -847,6 +855,7 @@ def build_agentic_investigation_report(
                 _agentic_finding(
                     finding="Repeated shell command churn",
                     evidence=shell_churn["rows"][:normalized_limit],
+                    detail_mode=normalized_detail_mode,
                     confidence=_count_confidence(int(shell_churn["total_candidates"])),
                     why_it_matters=(
                         "Repeated shell roots, failures, or adjacent retries can waste turns and "
@@ -857,6 +866,10 @@ def build_agentic_investigation_report(
                     ),
                     verify_with=["usage_shell_churn", "usage_thread_trace"],
                     privacy_notes="Command roots and bounded labels only; raw command output is omitted.",
+                    missing_access=(
+                        "Strict aggregate evidence cannot always recover the exact shell intent "
+                        "or full command arguments."
+                    ),
                 )
             )
 
@@ -875,6 +888,7 @@ def build_agentic_investigation_report(
                 _agentic_finding(
                     finding="Repeated file rediscovery",
                     evidence=repeated_files["rows"][:normalized_limit],
+                    detail_mode=normalized_detail_mode,
                     confidence=_count_confidence(int(repeated_files["total_candidates"])),
                     why_it_matters=(
                         "Repeated safe file identities can indicate the agent keeps rediscovering "
@@ -885,6 +899,10 @@ def build_agentic_investigation_report(
                     ),
                     verify_with=["usage_repeated_file_rediscovery", "usage_thread_trace"],
                     privacy_notes="Safe path hashes, basenames, and aggregates only; full paths are omitted.",
+                    missing_access=(
+                        "The report can rank repeated safe file identities, but cannot tell whether "
+                        "each reread was necessary without task intent."
+                    ),
                 )
             )
 
@@ -906,11 +924,15 @@ def build_agentic_investigation_report(
                 _agentic_finding(
                     finding="Ranked aggregate usage recommendations",
                     evidence=recommendations["rows"][:normalized_limit],
+                    detail_mode=normalized_detail_mode,
                     confidence="medium",
                     why_it_matters="Existing recommendation scoring combines aggregate cost, cache, context, and pricing signals.",
                     recommended_action="Start with the highest recommendation score, then verify with the specific diagnostic tool.",
                     verify_with=["usage_recommendations", "usage_calls", "usage_call_detail"],
                     privacy_notes="Aggregate recommendations only; no prompt or tool-output text.",
+                    missing_access=(
+                        "Recommendation scores do not know whether an expensive call produced high-value work."
+                    ),
                 )
             )
 
@@ -953,11 +975,13 @@ def build_agentic_investigation_report(
             _agentic_finding(
                 finding="No strong local signal at default thresholds",
                 evidence=[],
+                detail_mode=normalized_detail_mode,
                 confidence="insufficient_local_evidence",
                 why_it_matters="The current aggregate diagnostics did not find a clear candidate at the default threshold.",
                 recommended_action="Lower thresholds, widen the time window, include archived sessions, or inspect top aggregate calls.",
                 verify_with=["usage_calls", "usage_report_pack", "usage_investigation_walk"],
                 privacy_notes="No raw context needed for this follow-up.",
+                missing_access="No supported aggregate signal was found at the selected thresholds.",
             )
         )
 
@@ -975,6 +999,7 @@ def build_agentic_investigation_report(
             "thread": thread,
             "include_archived": include_archived,
             "evidence_limit": normalized_limit,
+            "detail_mode": normalized_detail_mode,
         },
         "summary": {
             "finding_count": len(findings),
@@ -1069,29 +1094,162 @@ def _investigation_suggestions(goal: str | None) -> list[dict[str, Any]]:
     ]
     if goal is None:
         return suggestions
-    return [row for row in suggestions if row["goal"] == goal] or suggestions
+    related_goals = {
+        "overview": ["overview", "token_waste", "cache_failure", "workflow_churn", "allowance_change"],
+        "token_waste": ["token_waste", "cache_failure", "workflow_churn", "overview"],
+        "cache_failure": ["cache_failure", "token_waste", "overview"],
+        "workflow_churn": ["workflow_churn", "token_waste", "cache_failure", "overview"],
+        "allowance_change": ["allowance_change", "overview", "token_waste"],
+    }.get(goal, [goal])
+    by_goal = {row["goal"]: row for row in suggestions}
+    return [by_goal[row_goal] for row_goal in related_goals if row_goal in by_goal] or suggestions
+
+
+def _normalize_agentic_detail_mode(detail_mode: str | None) -> str:
+    normalized = (detail_mode or "compact").strip().lower().replace("-", "_")
+    if normalized in {"full", "verbose", "raw", "rows"}:
+        return "full"
+    return "compact"
 
 
 def _agentic_finding(
     *,
     finding: str,
     evidence: list[dict[str, Any]],
+    detail_mode: str,
     confidence: str,
     why_it_matters: str,
     recommended_action: str,
     verify_with: list[str],
     privacy_notes: str,
+    missing_access: str,
 ) -> dict[str, Any]:
+    evidence_rows = evidence if detail_mode == "full" else [_compact_agentic_evidence_row(row) for row in evidence]
     return {
         "finding": finding,
         "evidence_count": len(evidence),
-        "evidence": evidence,
+        "evidence_summary": _agentic_evidence_summary(evidence),
+        "evidence": evidence_rows,
         "confidence": confidence,
         "why_it_matters": why_it_matters,
         "recommended_action": recommended_action,
         "verify_with": verify_with,
+        "missing_access": missing_access,
         "privacy_notes": privacy_notes,
     }
+
+
+def _compact_agentic_evidence_row(row: dict[str, Any]) -> dict[str, Any]:
+    keep_fields = (
+        "record_id",
+        "session_id",
+        "thread_key",
+        "thread_name",
+        "event_timestamp",
+        "model",
+        "effort",
+        "total_tokens",
+        "input_tokens",
+        "cached_input_tokens",
+        "uncached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "cache_ratio",
+        "context_window_percent",
+        "candidate_explanation",
+        "explanation_reasons",
+        "command_root",
+        "command_label",
+        "command_family",
+        "churn_kind",
+        "occurrences",
+        "call_count",
+        "thread_count",
+        "session_count",
+        "failure_count",
+        "path_hash",
+        "path_identity",
+        "path_basename",
+        "path_extension",
+        "candidate_kind",
+        "operation_mix",
+        "recommendation",
+        "primary_signal",
+        "secondary_signals",
+        "recommended_action",
+        "usage_credits",
+        "estimated_cost_usd",
+        "next_tool",
+    )
+    compact = {key: row[key] for key in keep_fields if key in row and row[key] is not None}
+    if "primary_recommendation" in row and isinstance(row["primary_recommendation"], dict):
+        primary = row["primary_recommendation"]
+        compact["primary_recommendation"] = {
+            key: primary[key]
+            for key in ("key", "severity", "title", "action")
+            if key in primary and primary[key] is not None
+        }
+    if "nearby_activity" in row and isinstance(row["nearby_activity"], dict):
+        compact["nearby_activity"] = {
+            key: row["nearby_activity"].get(key)
+            for key in ("tool_call_count", "command_run_count", "failed_command_count", "file_event_count")
+            if row["nearby_activity"].get(key) is not None
+        }
+    if "trace_handles" in row and isinstance(row["trace_handles"], list):
+        compact["trace_handles"] = [
+            {
+                key: handle.get(key)
+                for key in ("thread_key", "thread", "session_id", "call_count", "total_tokens", "next_tool")
+                if isinstance(handle, dict) and handle.get(key) is not None
+            }
+            for handle in row["trace_handles"][:3]
+            if isinstance(handle, dict)
+        ]
+    return compact
+
+
+def _agentic_evidence_summary(evidence: list[dict[str, Any]]) -> dict[str, Any]:
+    token_values = [int(row["total_tokens"]) for row in evidence if isinstance(row.get("total_tokens"), int | float)]
+    timestamps = [str(row["event_timestamp"]) for row in evidence if row.get("event_timestamp")]
+    threads = _ordered_unique(str(row.get("thread_name") or row.get("thread") or row.get("thread_key")) for row in evidence)
+    models = _ordered_unique(str(row.get("model")) for row in evidence if row.get("model"))
+    efforts = _ordered_unique(str(row.get("effort")) for row in evidence if row.get("effort"))
+    explanations = _ordered_unique(str(row.get("candidate_explanation")) for row in evidence if row.get("candidate_explanation"))
+    recommendations = _ordered_unique(str(row.get("recommendation") or row.get("recommended_action")) for row in evidence if row.get("recommendation") or row.get("recommended_action"))
+    summary: dict[str, Any] = {
+        "row_count": len(evidence),
+        "total_tokens": sum(token_values),
+        "max_total_tokens": max(token_values) if token_values else None,
+        "threads": threads[:5],
+        "models": models[:5],
+        "efforts": efforts[:5],
+        "candidate_explanations": explanations[:5],
+        "recommendations": recommendations[:5],
+    }
+    if timestamps:
+        summary["first_event_timestamp"] = min(timestamps)
+        summary["last_event_timestamp"] = max(timestamps)
+    occurrence_values = [int(row["occurrences"]) for row in evidence if isinstance(row.get("occurrences"), int | float)]
+    call_count_values = [int(row["call_count"]) for row in evidence if isinstance(row.get("call_count"), int | float)]
+    failure_values = [int(row["failure_count"]) for row in evidence if isinstance(row.get("failure_count"), int | float)]
+    if occurrence_values:
+        summary["total_occurrences"] = sum(occurrence_values)
+    if call_count_values:
+        summary["total_call_count"] = sum(call_count_values)
+    if failure_values:
+        summary["total_failure_count"] = sum(failure_values)
+    return {key: value for key, value in summary.items() if value not in (None, [], {})}
+
+
+def _ordered_unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if not value or value == "None" or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
 
 
 def _count_confidence(count: int) -> str:

--- a/tests/cli/test_mcp_integration.py
+++ b/tests/cli/test_mcp_integration.py
@@ -222,11 +222,34 @@ def test_mcp_wrappers_smoke(tmp_path: Path, monkeypatch) -> None:
     assert suggestions_json["content_mode"] == "aggregate_guidance"
     assert suggestions_json["includes_raw_fragments"] is False
     assert suggestions_json["suggestions"]
+    suggestion_goals = [row["goal"] for row in suggestions_json["suggestions"]]
+    assert suggestion_goals == ["token_waste", "cache_failure"]
+    overview_suggestions = mcp_server.usage_suggest_investigations(goal="overview", limit=5)
+    assert [row["goal"] for row in overview_suggestions["suggestions"]] == [
+        "overview",
+        "token_waste",
+        "cache_failure",
+        "workflow_churn",
+        "allowance_change",
+    ]
     assert agentic_investigation_json["schema"] == "codex-usage-tracker-agentic-investigation-v1"
     assert agentic_investigation_json["content_mode"] == "aggregate_investigation"
     assert agentic_investigation_json["includes_indexed_content"] is False
     assert agentic_investigation_json["includes_raw_fragments"] is False
+    assert agentic_investigation_json["filters"]["detail_mode"] == "compact"
     assert agentic_investigation_json["findings"]
+    first_finding = agentic_investigation_json["findings"][0]
+    assert first_finding["evidence_summary"]["row_count"] == first_finding["evidence_count"]
+    assert first_finding["missing_access"]
+    if first_finding["evidence"]:
+        assert "source_file" not in first_finding["evidence"][0]
+    full_investigation_json = mcp_server.usage_investigate(
+        goal="token_waste",
+        evidence_limit=1,
+        detail_mode="full",
+    )
+    assert full_investigation_json["filters"]["detail_mode"] == "full"
+    assert full_investigation_json["findings"][0]["evidence_summary"]["row_count"] == 1
     assert local_evidence_export_json["schema"] == "codex-usage-tracker-local-evidence-export-v1"
     assert local_evidence_export_json["content_mode"] == "shareable_local_evidence"
     assert local_evidence_export_json["includes_indexed_content"] is False


### PR DESCRIPTION
## Summary
- make `usage_investigate` default to compact evidence rows with evidence summaries and explicit missing-access notes
- broaden `usage_suggest_investigations(goal=...)` so goal-specific requests return adjacent useful next investigations
- document the compact/full detail modes and refresh the packaged `codex-usage-api` skill guidance

## Validation
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short` (575 passed)
- `.venv/bin/python -m compileall src`
- `for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file"; done`
- `rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist && git diff --check`
