### PR TITLE
Fix hypothesis routing and shell churn labels

### DIFF
--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -1161,19 +1161,80 @@ def _classify_hypothesis_family(hypothesis: str, question: str) -> str:
 
 
 def _classify_hypothesis_text(text: str) -> str | None:
-    if any(term in text for term in ("allowance", "limit", "throttle", "weekly", "5-hour", "5 hour")):
+    if _has_any_phrase(
+        text,
+        (
+            "allowance",
+            "usage allowance",
+            "allowance change",
+            "limit change",
+            "limit changed",
+            "codex limit",
+            "usage limit",
+            "weekly allowance",
+            "weekly limit",
+            "5-hour",
+            "5 hour",
+            "throttle",
+            "throttled",
+        ),
+    ):
         return "allowance_change"
-    if any(term in text for term in ("token waste", "expensive", "cost")):
+    if _has_any_phrase(
+        text,
+        (
+            "token waste",
+            "wasting tokens",
+            "waste",
+            "expensive",
+            "cost",
+            "large low-output",
+            "large low output",
+            "low-output",
+            "low output",
+            "output length",
+            "context pressure",
+            "large call",
+            "large calls",
+            "cleanup target",
+        ),
+    ):
         return "token_waste"
-    if any(term in text for term in ("cache", "cold", "resume", "context")):
+    if _has_any_phrase(text, ("cache", "cold resume", "cold resumes", "cold", "resume")):
         return "cache_failure"
-    if any(term in text for term in ("file", "rediscover", "reread", "path")):
+    if _has_any_phrase(
+        text,
+        (
+            "file",
+            "rediscover",
+            "rediscovery",
+            "reread",
+            "rereads",
+            "re-read",
+            "re-reads",
+            "repeated read",
+            "repeated reads",
+            "path",
+            "content-index",
+            "content index",
+            "thread-trace",
+            "thread trace",
+        ),
+    ):
         return "repeated_file_rediscovery"
     if _has_shell_hypothesis_signal(text):
         return "shell_churn"
-    if any(term in text for term in ("effort", "model", "xhigh", "high", "medium", "gpt")):
+    if _has_any_word(text, ("effort", "model", "xhigh", "high", "medium", "gpt")):
         return "effort_model_choice"
     return None
+
+
+def _has_any_phrase(text: str, phrases: tuple[str, ...]) -> bool:
+    return any(phrase in text for phrase in phrases)
+
+
+def _has_any_word(text: str, words: tuple[str, ...]) -> bool:
+    return any(re.search(rf"(?<![a-z0-9_-]){re.escape(word)}(?![a-z0-9_-])", text) for word in words)
 
 
 def _has_shell_hypothesis_signal(text: str) -> bool:

--- a/src/codex_usage_tracker/store/content_index_events.py
+++ b/src/codex_usage_tracker/store/content_index_events.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from codex_usage_tracker.diagnostics.snapshot_events import command_root_and_child
+
 _SHELL_TOOL_NAMES = {
     "bash",
     "exec_command",
@@ -293,23 +295,23 @@ def _command_from_mapping(mapping: dict[str, Any]) -> str | None:
 
 
 def _command_root_and_label(command: str) -> tuple[str, str]:
-    tokens = _command_tokens(command)
-    if not tokens:
+    root, child = command_root_and_child(command)
+    safe_root = _safe_command_label(root)
+    if safe_root == "unknown_command":
         return "unknown_command", "unknown_command"
-    tokens = _strip_assignment_prefixes(tokens)
-    if not tokens:
-        return "unknown_command", "unknown_command"
-    root = Path(tokens[0]).name
-    if _is_python_root(root) and len(tokens) >= 3 and tokens[1] == "-m":
-        module_root = _safe_command_label(tokens[2])
-        return module_root, f"{root} -m {module_root}"
-    if root == "uv" and len(tokens) >= 3 and tokens[1] == "run":
-        run_root = _safe_command_label(tokens[2])
-        return run_root, f"uv run {run_root}"
-    label = root
-    if root in {"git", "gh"} and len(tokens) >= 2:
-        label = f"{root} {_safe_command_label(tokens[1])}"
-    return _safe_command_label(root), label
+    safe_child = _safe_command_child(safe_root, child)
+    if safe_child is None:
+        return safe_root, safe_root
+    return safe_root, f"{safe_root} {safe_child}"
+
+
+def _safe_command_child(root: str, child: str) -> str | None:
+    if root in _READ_COMMAND_ROOTS:
+        return None
+    if child in {"<none>", "<arg>", "<target>", "unknown"} or child.startswith("-"):
+        return None
+    safe_child = _safe_command_label(child)
+    return None if safe_child == "unknown_command" else safe_child
 
 
 def _command_tokens(command: str) -> list[str]:

--- a/src/codex_usage_tracker/store/shell_churn.py
+++ b/src/codex_usage_tracker/store/shell_churn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from typing import Any
 
@@ -21,6 +22,10 @@ SHELL_CHURN_ROOTS = {
     "python",
     "python3",
     "node",
+    "ruff",
+    "mypy",
+    "eslint",
+    "tsc",
 }
 
 
@@ -152,7 +157,14 @@ def _shell_churn_candidate(
     top_labels: list[dict[str, Any]],
     trace_handles: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    command_root = str(row["command_root"] or "unknown")
+    raw_command_root = str(row["command_root"] or "unknown")
+    sample_command_label = str(row["sample_command_label"] or "")
+    distinct_label_count = int(row["distinct_label_count"] or 0)
+    command_root = _display_command_root(
+        raw_command_root,
+        sample_command_label,
+        distinct_label_count=distinct_label_count,
+    )
     occurrences = int(row["occurrences"] or 0)
     failure_count = int(row["failure_count"] or 0)
     adjacent_root_count = int(row["adjacent_root_repeat_count"] or 0)
@@ -161,7 +173,7 @@ def _shell_churn_candidate(
     output_size_bytes = int(row["output_size_bytes"] or 0)
     return {
         "command_root": command_root,
-        "command_label": row["sample_command_label"],
+        "command_label": _display_command_label(command_root, sample_command_label),
         "command_family": _command_family(command_root),
         "churn_kind": _churn_kind(failure_count, adjacent_root_count),
         "occurrences": occurrences,
@@ -172,7 +184,7 @@ def _shell_churn_candidate(
         "output_size_bytes": output_size_bytes,
         "success_count": int(row["success_count"] or 0),
         "failure_count": failure_count,
-        "distinct_label_count": int(row["distinct_label_count"] or 0),
+        "distinct_label_count": distinct_label_count,
         "adjacent_root_repeat_count": adjacent_root_count,
         "adjacent_label_repeat_count": adjacent_label_count,
         "retry_group_count": int(row["retry_group_count"] or 0),
@@ -321,6 +333,53 @@ def _usage_filters(
     return "WHERE " + " AND ".join(clauses), params
 
 
+def _display_command_root(
+    raw_command_root: str,
+    sample_command_label: str,
+    *,
+    distinct_label_count: int = 1,
+) -> str:
+    command_root = _safe_shell_label(raw_command_root)
+    if command_root not in {"unknown", "unknown_command"}:
+        return command_root
+    if distinct_label_count > 1:
+        return "unclassified_shell_script"
+    label_root = _first_safe_label_part(sample_command_label)
+    if label_root is not None and label_root not in {"unknown", "unknown_command"}:
+        return label_root
+    return "unclassified_shell_script"
+
+
+def _display_command_label(command_root: str, sample_command_label: str) -> str:
+    if command_root == "unclassified_shell_script":
+        return command_root
+    safe_parts = [
+        label_part
+        for label_part in (_safe_shell_label(part.lstrip("$")) for part in sample_command_label.split()[:2])
+        if label_part not in {"unknown", "unknown_command"}
+    ]
+    if not safe_parts:
+        return command_root
+    if safe_parts[0] != command_root:
+        return command_root
+    return " ".join(safe_parts)
+
+
+def _first_safe_label_part(value: str) -> str | None:
+    for part in value.split():
+        label = _safe_shell_label(part.lstrip("$"))
+        if label not in {"unknown", "unknown_command"}:
+            return label
+    return None
+
+
+def _safe_shell_label(value: str) -> str:
+    lowered = value.strip().lower()
+    if re.fullmatch(r"[a-z0-9_.:-]{1,80}", lowered):
+        return lowered
+    return "unknown_command"
+
+
 def _candidate_sort_key(row: dict[str, Any]) -> tuple[int, int, int, int]:
     return (
         int(row["failure_count"]),
@@ -337,13 +396,19 @@ def _command_family(command_root: str) -> str:
         return "vcs"
     if command_root in {"pytest"}:
         return "test"
+    if command_root in {"ruff", "mypy", "eslint", "tsc"}:
+        return "quality"
     if command_root in {"npm", "pnpm", "yarn", "pip"}:
         return "package"
     if command_root in {"python", "python3", "node"}:
         return "runtime"
     if command_root in SHELL_CHURN_ROOTS:
         return "known_shell"
-    return "unknown"
+    if command_root == "unclassified_shell_script":
+        return "unclassified_shell"
+    if command_root in {"unknown", "unknown_command"}:
+        return "unknown"
+    return "custom_command"
 
 
 def _churn_kind(failure_count: int, adjacent_root_repeat_count: int) -> str:

--- a/tests/reports/test_hypothesis_routing.py
+++ b/tests/reports/test_hypothesis_routing.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from codex_usage_tracker.reports.api import _classify_hypothesis_family
+
+
+def test_hypothesis_family_routing_handles_exploratory_usage_phrases() -> None:
+    question = (
+        "Test newer MCP investigation hypotheses around repeated files, shell churn, "
+        "local evidence, and allowance readiness."
+    )
+
+    assert (
+        _classify_hypothesis_family(
+            "Large low-output calls are the highest-leverage near-term cleanup target.",
+            question,
+        )
+        == "token_waste"
+    )
+    assert (
+        _classify_hypothesis_family(
+            "The MCP needs local content-index or thread-trace follow-up to explain intent "
+            "behind repeated reads.",
+            question,
+        )
+        == "repeated_file_rediscovery"
+    )
+    assert (
+        _classify_hypothesis_family(
+            "Allowance-change claims are not ready for public posting without more weekly positive spans.",
+            question,
+        )
+        == "allowance_change"
+    )
+    assert (
+        _classify_hypothesis_family(
+            "High effort is driving a disproportionate share of usage.",
+            question,
+        )
+        == "effort_model_choice"
+    )

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -15,6 +15,12 @@ from codex_usage_tracker.reports.api import (
     build_thread_trace_report,
 )
 from codex_usage_tracker.store.api import connect, init_db, refresh_usage_index
+from codex_usage_tracker.store.content_index_events import _command_root_and_label
+from codex_usage_tracker.store.shell_churn import (
+    _command_family,
+    _display_command_label,
+    _display_command_root,
+)
 from tests.store_dashboard_helpers import _entry, _make_codex_home, _token_event, _write_jsonl
 
 
@@ -372,10 +378,13 @@ def test_shell_churn_detects_repeated_command_families(tmp_path: Path) -> None:
         ("sed -n '41,60p' src/app.py", 0),
         ("rg TODO src", 1),
         ("rg TODO tests", 1),
+        ("bash -lc 'rg TODO wrapped'", 1),
         ("git status --short", 0),
         ("git diff --stat", 0),
         ("nl -ba src/app.py", 0),
         ("nl -ba tests/test_app.py", 0),
+        ("$PWCLI status", 0),
+        ("$PWCLI status --json", 0),
         ("echo one-off", 0),
     ]
     rows: list[dict[str, object]] = [_entry("session_meta", {"id": session_id})]
@@ -426,18 +435,48 @@ def test_shell_churn_detects_repeated_command_families(tmp_path: Path) -> None:
     assert payload["content_mode"] == "local_content_index"
     assert payload["includes_raw_fragments"] is False
     roots = {row["command_root"]: row for row in payload["rows"]}
-    assert {"sed", "rg", "git", "nl"} <= set(roots)
+    assert {"sed", "rg", "git", "nl", "pwcli"} <= set(roots)
     assert "echo" not in roots
+    assert "unknown_command" not in roots
     assert roots["sed"]["churn_kind"] == "successful_loop_churn"
     assert roots["sed"]["success_count"] == 3
     assert roots["sed"]["adjacent_root_repeat_count"] >= 2
     assert roots["rg"]["churn_kind"] == "failure_retry_churn"
-    assert roots["rg"]["failure_count"] == 2
+    assert roots["rg"]["failure_count"] == 3
     assert roots["rg"]["top_labels"][0]["exit_code"] == 1
+    assert roots["pwcli"]["command_family"] == "custom_command"
+    assert roots["pwcli"]["command_label"] == "pwcli status"
     assert roots["sed"]["trace_handles"][0]["next_tool"] == "usage_thread_trace"
     serialized = json.dumps(payload)
     assert "src/app.py" not in serialized
     assert "safe synthetic output" not in serialized
+    assert "$PWCLI" not in serialized
+
+
+def test_command_root_and_label_uses_shared_safe_normalizer() -> None:
+    assert _command_root_and_label("$PWCLI status --json") == ("pwcli", "pwcli status")
+    assert _command_root_and_label("bash -lc 'rg SECRET_TERM src'") == ("rg", "rg")
+    assert _command_root_and_label("poetry run python -m pytest tests/test_private.py") == (
+        "pytest",
+        "pytest",
+    )
+    assert _command_root_and_label("git -C /private/repo status --short") == ("git", "git status")
+
+
+def test_shell_churn_display_labels_repair_legacy_unknown_command_rows() -> None:
+    recovered_root = _display_command_root("unknown_command", "$PWCLI", distinct_label_count=1)
+
+    assert recovered_root == "pwcli"
+    assert _display_command_label(recovered_root, "$PWCLI") == "pwcli"
+    assert _command_family(recovered_root) == "custom_command"
+
+    fallback_root = _display_command_root("unknown_command", "$PWCLI", distinct_label_count=2)
+    assert fallback_root == "unclassified_shell_script"
+
+    fallback_root = _display_command_root("unknown_command", "unknown_command", distinct_label_count=1)
+    assert fallback_root == "unclassified_shell_script"
+    assert _display_command_label(fallback_root, "unknown_command") == "unclassified_shell_script"
+    assert _command_family(fallback_root) == "unclassified_shell"
 
 
 def test_thread_trace_returns_calls_with_indexed_fragments(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route exploratory low-output/context-pressure/repeated-read hypotheses to the correct usage families instead of falling back to broad effort or allowance signals
- reuse the shared command normalizer for content-index command roots so shell wrappers, `$PWCLI`, `poetry run`, `uv run`, `npx`, and `python -m` index consistently
- make shell-churn output less cloudy with `quality`, `custom_command`, and `unclassified_shell` families instead of overusing `unknown`
- add regressions for the exact misrouted hypotheses and shell-churn label cases from the local experiment

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/reports/test_hypothesis_routing.py tests/store/test_content_index.py::test_command_root_and_label_uses_shared_safe_normalizer tests/store/test_content_index.py::test_shell_churn_display_labels_repair_legacy_unknown_command_rows tests/store/test_content_index.py::test_shell_churn_detects_repeated_command_families -q --tb=short`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mypy`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/reports/test_hypothesis_routing.py tests/store/test_content_index.py tests/cli/test_mcp_integration.py -q --tb=short`
- `PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short`
- `PYTHONPATH=src .venv/bin/python -m pytest --cov=codex_usage_tracker --cov-report=term-missing -q`
- `.venv/bin/python -m compileall src`
- `for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file"; done`
- `.venv/bin/python scripts/check_release.py && git diff --check`
- `rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist && git diff --check`
- real-data probe: families now route to `token_waste`, `repeated_file_rediscovery`, `allowance_change`; shell top families show `unclassified_shell`, `quality`, `package`, `test`, `file_discovery` instead of generic `unknown_command`