### PR TITLE
Refresh agentic usage skill guidance

### DIFF
--- a/skills/codex-usage-api/SKILL.md
+++ b/skills/codex-usage-api/SKILL.md
@@ -15,7 +15,19 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 - Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
 - Name scope: time window, project/thread/model filters, included archived state, row limit, detail mode, and whether results are estimates.
 - Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
-- For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
+- For broad asks, give diagnosis plus remediation: `Evidence`, `Hypothesis result`, `Likely waste pattern`, `Next action`, `How to verify`.
+
+## Agentic Investigation Loop
+
+Use this loop for "look through my usage", "make recommendations", "test hypotheses", "what else should I inspect?", and token-waste discovery:
+
+1. Start with `usage_suggest_investigations(goal=...)` when the user needs ideas, otherwise call `usage_investigate(goal=...)` directly.
+2. Convert findings into explicit hypotheses: `I'd like to be able to...`, `I will accomplish it using...`, `I'm missing access to...`, `My hypothesis was true/false/inconclusive because...`.
+3. Drill into recommended tools such as `usage_large_low_output_calls`, `usage_shell_churn`, `usage_repeated_file_rediscovery`, `usage_allowance_diagnostics`, `usage_threads`, or `usage_calls`.
+4. Recommend concrete fixes, not just summaries: shorter handoff, split thread, preserved cache context, lower effort on routine tasks, targeted script, repo note, skill update, or an existing tool such as Headroom when available and relevant.
+5. End with the verification tool/query the user should run after changing behavior.
+
+For maintainer dogfood or plugin-quality checks, use the CLI harness when available: `codex-usage-tracker dogfood-agentic --privacy-mode strict --json`. Treat the output as a compact aggregate QA artifact that must not include raw prompts, raw tool output, full paths, or indexed fragments.
 
 ## Router
 

--- a/skills/codex-usage-tracker/SKILL.md
+++ b/skills/codex-usage-tracker/SKILL.md
@@ -40,6 +40,8 @@ When the user wants ideas, suggest concrete aggregate investigations:
 - Build strict-privacy allowance evidence I can share.
 - Find expensive calls worth opening in the investigator.
 - Check whether model or effort choice is wasting tokens.
+- Test my usage-waste hypotheses and say what was true, false, or inconclusive.
+- Compare repeated file rediscovery, shell churn, and large low-output calls.
 - Build a strict-privacy summary I can share.
 
 Route these through `usage_report_pack`, `usage_calls`, `usage_threads`, `usage_summary`, and `usage_call_detail` before considering raw context.
@@ -56,6 +58,24 @@ When a usage-waste investigation finds clear patterns, do not stop at "interesti
 - Mention dashboard actions that help the user verify the fix: open Calls filtered to the expensive rows, Threads sorted by tokens, Call Investigator for a selected record, or Diagnostics Notebook for usage-drain evidence.
 
 Phrase the final answer as "what happened, why it likely matters, what to try next, how to verify." Avoid implying an external tool is installed unless the current environment or tool registry confirms it.
+
+## Agentic Dogfood
+
+When the maintainer asks whether MCP/skill recommendations are getting more useful, run the aggregate dogfood harness from a source checkout or installed CLI:
+
+```bash
+codex-usage-tracker dogfood-agentic --privacy-mode strict --json
+```
+
+Use it to check old and new hypothesis families, direct reports, suggested goals, investigation findings, and privacy checks. Treat it as compact QA evidence, not as a user-facing raw transcript export.
+
+For experiment-style answers, use this structure:
+
+- `I'd like to be able to...`
+- `I will accomplish it using...`
+- `I'm missing access to...`
+- `My hypothesis was true/false/inconclusive because...`
+- `Next tool or fix...`
 
 ## Common Workflows
 

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-api/SKILL.md
@@ -15,7 +15,19 @@ Act as an evidence-first analyst for Codex Usage Tracker data. Prefer MCP JSON p
 - Check top-level `schema`, `content_mode`, `includes_indexed_content`, `includes_raw_fragments`, row counts, truncation, and caveats before interpreting payloads.
 - Name scope: time window, project/thread/model filters, included archived state, row limit, detail mode, and whether results are estimates.
 - Separate exact facts from estimates. Call out `pricing_estimated`, missing `pricing_model`, `usage_credit_confidence`, missing allowance windows, and outside-usage caveats.
-- For broad asks, give diagnosis plus remediation: `Evidence`, `Likely waste pattern`, `Next action`, `How to verify`.
+- For broad asks, give diagnosis plus remediation: `Evidence`, `Hypothesis result`, `Likely waste pattern`, `Next action`, `How to verify`.
+
+## Agentic Investigation Loop
+
+Use this loop for "look through my usage", "make recommendations", "test hypotheses", "what else should I inspect?", and token-waste discovery:
+
+1. Start with `usage_suggest_investigations(goal=...)` when the user needs ideas, otherwise call `usage_investigate(goal=...)` directly.
+2. Convert findings into explicit hypotheses: `I'd like to be able to...`, `I will accomplish it using...`, `I'm missing access to...`, `My hypothesis was true/false/inconclusive because...`.
+3. Drill into recommended tools such as `usage_large_low_output_calls`, `usage_shell_churn`, `usage_repeated_file_rediscovery`, `usage_allowance_diagnostics`, `usage_threads`, or `usage_calls`.
+4. Recommend concrete fixes, not just summaries: shorter handoff, split thread, preserved cache context, lower effort on routine tasks, targeted script, repo note, skill update, or an existing tool such as Headroom when available and relevant.
+5. End with the verification tool/query the user should run after changing behavior.
+
+For maintainer dogfood or plugin-quality checks, use the CLI harness when available: `codex-usage-tracker dogfood-agentic --privacy-mode strict --json`. Treat the output as a compact aggregate QA artifact that must not include raw prompts, raw tool output, full paths, or indexed fragments.
 
 ## Router
 

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-tracker/SKILL.md
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-tracker/SKILL.md
@@ -40,6 +40,8 @@ When the user wants ideas, suggest concrete aggregate investigations:
 - Build strict-privacy allowance evidence I can share.
 - Find expensive calls worth opening in the investigator.
 - Check whether model or effort choice is wasting tokens.
+- Test my usage-waste hypotheses and say what was true, false, or inconclusive.
+- Compare repeated file rediscovery, shell churn, and large low-output calls.
 - Build a strict-privacy summary I can share.
 
 Route these through `usage_report_pack`, `usage_calls`, `usage_threads`, `usage_summary`, and `usage_call_detail` before considering raw context.
@@ -56,6 +58,24 @@ When a usage-waste investigation finds clear patterns, do not stop at "interesti
 - Mention dashboard actions that help the user verify the fix: open Calls filtered to the expensive rows, Threads sorted by tokens, Call Investigator for a selected record, or Diagnostics Notebook for usage-drain evidence.
 
 Phrase the final answer as "what happened, why it likely matters, what to try next, how to verify." Avoid implying an external tool is installed unless the current environment or tool registry confirms it.
+
+## Agentic Dogfood
+
+When the maintainer asks whether MCP/skill recommendations are getting more useful, run the aggregate dogfood harness from a source checkout or installed CLI:
+
+```bash
+codex-usage-tracker dogfood-agentic --privacy-mode strict --json
+```
+
+Use it to check old and new hypothesis families, direct reports, suggested goals, investigation findings, and privacy checks. Treat it as compact QA evidence, not as a user-facing raw transcript export.
+
+For experiment-style answers, use this structure:
+
+- `I'd like to be able to...`
+- `I will accomplish it using...`
+- `I'm missing access to...`
+- `My hypothesis was true/false/inconclusive because...`
+- `Next tool or fix...`
 
 ## Common Workflows
 


### PR DESCRIPTION
## Summary
- add an explicit agentic investigation loop for usage-waste and hypothesis-testing requests
- teach bundled skills about the dogfood harness for MCP/plugin quality checks
- add suggested prompts for repeated file rediscovery, shell churn, and large low-output calls

## Validation
- diff -u source skills against packaged plugin skills
- .venv/bin/python scripts/check_release.py && git diff --check
- rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info && .venv/bin/python -m build && .venv/bin/python -m twine check dist/* && .venv/bin/python scripts/check_release.py --dist && git diff --check