### PR TITLE
fix: bound agentic dogfood diagnostics

### DIFF
--- a/src/codex_usage_tracker/cli/main.py
+++ b/src/codex_usage_tracker/cli/main.py
@@ -332,6 +332,8 @@ def _run_dogfood_agentic(args: argparse.Namespace) -> int:
         evidence_limit=args.evidence_limit,
         privacy_mode=args.privacy_mode,
         refresh=args.refresh,
+        run_hypotheses=args.hypotheses,
+        run_deep_investigations=args.deep_investigations,
         write_markdown=args.markdown,
     )
     if args.as_json:
@@ -346,6 +348,8 @@ def _run_dogfood_agentic(args: argparse.Namespace) -> int:
         f"old={report['family_checks']['old_passed']} "
         f"new={report['family_checks']['new_passed']}"
     )
+    print(f"Progress: {report['progress']['percent_complete']}%")
+    print(f"Cache keys: {', '.join(report['cache']['cache_keys']) or 'none'}")
     print(f"Privacy checks: {report['privacy_checks']['passed']}")
     return 0
 

--- a/src/codex_usage_tracker/cli/parser.py
+++ b/src/codex_usage_tracker/cli/parser.py
@@ -241,6 +241,16 @@ def _add_dogfood_agentic_parser(
     dogfood.add_argument("--include-archived", action="store_true")
     dogfood.add_argument("--evidence-limit", type=int, default=5)
     dogfood.add_argument(
+        "--hypotheses",
+        action="store_true",
+        help="Run slower full hypothesis evidence scans instead of quick routing checks.",
+    )
+    dogfood.add_argument(
+        "--deep-investigations",
+        action="store_true",
+        help="Also run the slower full usage_investigate dogfood paths instead of reusing action brief findings.",
+    )
+    dogfood.add_argument(
         "--refresh",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/src/codex_usage_tracker/reports/agentic_dogfood.py
+++ b/src/codex_usage_tracker/reports/agentic_dogfood.py
@@ -24,6 +24,7 @@ from codex_usage_tracker.reports.api import (
     build_hypothesis_test_report,
     build_investigation_suggestions_report,
     build_large_low_output_report,
+    build_recommendations_report,
     build_repeated_file_rediscovery_report,
     build_shell_churn_report,
 )
@@ -84,6 +85,8 @@ def build_agentic_dogfood_report(
     evidence_limit: int = 5,
     privacy_mode: str = "strict",
     refresh: bool = True,
+    run_hypotheses: bool = False,
+    run_deep_investigations: bool = False,
     write_markdown: bool = True,
 ) -> dict[str, Any]:
     """Run the repeatable agentic MCP dogfood battery and write compact artifacts."""
@@ -91,6 +94,8 @@ def build_agentic_dogfood_report(
     privacy_mode = validate_privacy_mode(privacy_mode)
     normalized_limit = max(1, evidence_limit)
     output_dir.mkdir(parents=True, exist_ok=True)
+    progress_stages: list[dict[str, Any]] = []
+    report_cache: dict[str, dict[str, Any]] = {}
 
     refresh_payload: dict[str, Any] | None = None
     if refresh:
@@ -104,38 +109,72 @@ def build_agentic_dogfood_report(
             refresh_result,
             schema="codex-usage-tracker-refresh-v1",
         )
+    progress_stages.append(_dogfood_stage("refresh", 10, completed=True, skipped=not refresh))
 
-    old_hypotheses = build_hypothesis_test_report(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        allowance_path=allowance_path,
-        projects_path=projects_path,
-        question="Re-test prior usage-efficiency hypotheses against current local aggregate data.",
-        hypotheses=OLD_AGENTIC_HYPOTHESES,
-        since=since,
-        until=until,
-        thread=thread,
-        include_archived=include_archived,
-        evidence_limit=normalized_limit,
-        privacy_mode=privacy_mode,
-    ).payload
-    new_hypotheses = build_hypothesis_test_report(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        allowance_path=allowance_path,
-        projects_path=projects_path,
-        question=(
-            "Test newer MCP investigation hypotheses around repeated files, shell churn, "
-            "local evidence, and allowance readiness."
-        ),
-        hypotheses=NEW_AGENTIC_HYPOTHESES,
-        since=since,
-        until=until,
-        thread=thread,
-        include_archived=include_archived,
-        evidence_limit=normalized_limit,
-        privacy_mode=privacy_mode,
-    ).payload
+    if run_hypotheses:
+        old_hypotheses = build_hypothesis_test_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            question="Re-test prior usage-efficiency hypotheses against current local aggregate data.",
+            hypotheses=OLD_AGENTIC_HYPOTHESES,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+        new_hypotheses = build_hypothesis_test_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            question=(
+                "Test newer MCP investigation hypotheses around repeated files, shell churn, "
+                "local evidence, and allowance readiness."
+            ),
+            hypotheses=NEW_AGENTIC_HYPOTHESES,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        ).payload
+    else:
+        old_hypotheses = _lightweight_hypothesis_payload(
+            OLD_AGENTIC_HYPOTHESES,
+            EXPECTED_OLD_FAMILIES,
+            question="Re-test prior usage-efficiency hypotheses against current local aggregate data.",
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        )
+        new_hypotheses = _lightweight_hypothesis_payload(
+            NEW_AGENTIC_HYPOTHESES,
+            EXPECTED_NEW_FAMILIES,
+            question=(
+                "Test newer MCP investigation hypotheses around repeated files, shell churn, "
+                "local evidence, and allowance readiness."
+            ),
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            privacy_mode=privacy_mode,
+        )
+    progress_stages.append(
+        _dogfood_stage("old_hypotheses", 25, completed=True, skipped=not run_hypotheses)
+    )
+    progress_stages.append(
+        _dogfood_stage("new_hypotheses", 40, completed=True, skipped=not run_hypotheses)
+    )
 
     large_low_output = build_large_low_output_report(
         db_path=db_path,
@@ -146,6 +185,7 @@ def build_agentic_dogfood_report(
         limit=normalized_limit,
         privacy_mode=privacy_mode,
     ).payload
+    report_cache["large_low_output"] = large_low_output
     shell_churn = build_shell_churn_report(
         db_path=db_path,
         since=since,
@@ -156,6 +196,7 @@ def build_agentic_dogfood_report(
         limit=normalized_limit,
         privacy_mode=privacy_mode,
     ).payload
+    report_cache["shell_churn"] = shell_churn
     repeated_files = build_repeated_file_rediscovery_report(
         db_path=db_path,
         since=since,
@@ -166,6 +207,22 @@ def build_agentic_dogfood_report(
         limit=normalized_limit,
         privacy_mode=privacy_mode,
     ).payload
+    report_cache["repeated_files"] = repeated_files
+    recommendations = build_recommendations_report(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        projects_path=projects_path,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        limit=normalized_limit,
+        source_limit=max(200, normalized_limit * 100),
+        privacy_mode=privacy_mode,
+    ).payload
+    report_cache["recommendations"] = recommendations
+    progress_stages.append(_dogfood_stage("direct_reports", 60, completed=True))
     action_brief = build_action_brief_report(
         db_path=db_path,
         pricing_path=pricing_path,
@@ -178,7 +235,12 @@ def build_agentic_dogfood_report(
         include_archived=include_archived,
         evidence_limit=normalized_limit,
         privacy_mode=privacy_mode,
+        precomputed_reports=report_cache,
     ).payload
+    report_cache["action_brief"] = action_brief
+    progress_stages.append(
+        _dogfood_stage("action_brief", 70, completed=True, cache_keys=sorted(report_cache))
+    )
     allowance = build_allowance_diagnostics_report(
         db_path=db_path,
         allowance_path=allowance_path,
@@ -187,6 +249,7 @@ def build_agentic_dogfood_report(
         limit=50,
         privacy_mode=privacy_mode,
     ).payload
+    progress_stages.append(_dogfood_stage("allowance", 78, completed=True))
     suggestions = build_investigation_suggestions_report(
         goal=None,
         since=since,
@@ -196,38 +259,64 @@ def build_agentic_dogfood_report(
         limit=10,
         privacy_mode=privacy_mode,
     ).payload
-    token_waste = build_agentic_investigation_report(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        allowance_path=allowance_path,
-        projects_path=projects_path,
-        goal="token_waste",
-        since=since,
-        until=until,
-        thread=thread,
-        include_archived=include_archived,
-        evidence_limit=normalized_limit,
-        detail_mode="compact",
-        privacy_mode=privacy_mode,
-    ).payload
-    workflow_churn = build_agentic_investigation_report(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        allowance_path=allowance_path,
-        projects_path=projects_path,
-        goal="workflow_churn",
-        since=since,
-        until=until,
-        thread=thread,
-        include_archived=include_archived,
-        evidence_limit=normalized_limit,
-        detail_mode="compact",
-        privacy_mode=privacy_mode,
-    ).payload
+    progress_stages.append(_dogfood_stage("suggestions", 84, completed=True))
+    if run_deep_investigations:
+        token_waste = build_agentic_investigation_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            goal="token_waste",
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            detail_mode="compact",
+            privacy_mode=privacy_mode,
+        ).payload
+        workflow_churn = build_agentic_investigation_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            goal="workflow_churn",
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=normalized_limit,
+            detail_mode="compact",
+            privacy_mode=privacy_mode,
+        ).payload
+    else:
+        token_waste = _lightweight_investigation_from_action_brief(
+            action_brief,
+            goal="token_waste",
+            families=None,
+        )
+        workflow_churn = _lightweight_investigation_from_action_brief(
+            action_brief,
+            goal="workflow_churn",
+            families={"repeated_file_rediscovery", "shell_churn"},
+        )
+    progress_stages.append(
+        _dogfood_stage(
+            "investigation_findings",
+            92,
+            completed=True,
+            skipped=not run_deep_investigations,
+            source="deep_investigations" if run_deep_investigations else "reused_action_brief",
+        )
+    )
 
     payload = _compact_dogfood_payload(
         refresh=refresh_payload,
         output_dir=output_dir,
+        progress_stages=progress_stages,
+        report_cache=report_cache,
+        run_hypotheses=run_hypotheses,
+        run_deep_investigations=run_deep_investigations,
         old_hypotheses=old_hypotheses,
         new_hypotheses=new_hypotheses,
         large_low_output=large_low_output,
@@ -261,6 +350,10 @@ def _compact_dogfood_payload(
     *,
     refresh: dict[str, Any] | None,
     output_dir: Path,
+    progress_stages: list[dict[str, Any]],
+    report_cache: dict[str, dict[str, Any]],
+    run_hypotheses: bool,
+    run_deep_investigations: bool,
     old_hypotheses: dict[str, Any],
     new_hypotheses: dict[str, Any],
     large_low_output: dict[str, Any],
@@ -295,6 +388,21 @@ def _compact_dogfood_payload(
             "evidence_limit": evidence_limit,
         },
         "refresh": refresh,
+        "progress": {
+            "mode": "synchronous_staged",
+            "percent_complete": 100,
+            "stages": [*progress_stages, _dogfood_stage("write_artifacts", 100, completed=True)],
+            "polling_note": (
+                "This synchronous CLI/MCP payload reports completed stages after return. "
+                "Live percent updates require an async job endpoint."
+            ),
+        },
+        "cache": {
+            "scope": "single_run_shared_reports",
+            "cache_keys": sorted(report_cache),
+            "hypotheses": run_hypotheses,
+            "deep_investigations": run_deep_investigations,
+        },
         "summary": {
             "old_hypothesis_count": len(old_summary),
             "new_hypothesis_count": len(new_summary),
@@ -358,6 +466,142 @@ def _compact_dogfood_payload(
         ],
     }
     return payload
+
+
+def _dogfood_stage(
+    stage: str,
+    percent: int,
+    *,
+    completed: bool,
+    skipped: bool = False,
+    source: str | None = None,
+    cache_keys: list[str] | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "stage": stage,
+        "percent": percent,
+        "status": "skipped" if skipped else "completed" if completed else "pending",
+    }
+    if source is not None:
+        row["source"] = source
+    if cache_keys is not None:
+        row["cache_keys"] = cache_keys
+    return row
+
+
+def _lightweight_hypothesis_payload(
+    hypotheses: list[str],
+    families: list[str],
+    *,
+    question: str,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    evidence_limit: int,
+    privacy_mode: str,
+) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for hypothesis, family in zip(hypotheses, families, strict=True):
+        rows.append(
+            {
+                "hypothesis": hypothesis,
+                "family": family,
+                "status": "skipped_quick_mode",
+                "confidence": "not_evaluated",
+                "row_count": None,
+                "total_tokens": None,
+                "max_total_tokens": None,
+                "candidate_count": None,
+                "evidence_summary": {},
+                "evidence": [],
+                "counter_evidence": [],
+                "i_would_like_to_be_able_to": (
+                    "Keep the agentic dogfood flow fast enough to run on large local datasets."
+                ),
+                "i_will_accomplish_this_using": (
+                    "Family-routing checks plus shared reports instead of full evidence scans."
+                ),
+                "i_am_missing_access_to": (
+                    "Full hypothesis evidence because quick dogfood mode intentionally skipped it."
+                ),
+                "next_action": (
+                    "Run `codex-usage-tracker dogfood-agentic --hypotheses` "
+                    "to evaluate this hypothesis battery."
+                ),
+                "recommended_next_tools": [],
+                "missing_access": (
+                    "Quick dogfood mode skipped expensive hypothesis evidence scans."
+                ),
+            }
+        )
+    return {
+        "schema": "codex-usage-tracker-hypothesis-test-v1",
+        "content_mode": "aggregate_hypothesis_routing_quick_check",
+        "includes_indexed_content": False,
+        "includes_raw_fragments": False,
+        "privacy_mode": privacy_mode,
+        "question": question,
+        "filters": {
+            "since": since,
+            "until": until,
+            "thread": thread,
+            "include_archived": include_archived,
+            "evidence_limit": evidence_limit,
+        },
+        "summary": {
+            "hypothesis_count": len(rows),
+            "status_counts": {"skipped_quick_mode": len(rows)} if rows else {},
+            "top_status": rows[0]["status"] if rows else None,
+        },
+        "hypotheses": rows,
+        "recommended_next_tools": [],
+        "caveats": [
+            "Quick dogfood mode checks hypothesis routing and family coverage only; use --hypotheses for full evidence evaluation."
+        ],
+    }
+
+
+def _lightweight_investigation_from_action_brief(
+    action_brief: dict[str, Any],
+    *,
+    goal: str,
+    families: set[str] | None,
+) -> dict[str, Any]:
+    actions = [
+        action
+        for action in action_brief.get("actions", [])
+        if families is None or str(action.get("family")) in families
+    ]
+    findings = [
+        {
+            "finding": action.get("finding"),
+            "confidence": action.get("confidence"),
+            "evidence_count": action.get("evidence_count"),
+            "recommended_action": action.get("recommended_workflow_change"),
+            "verify_with": action.get("recommended_next_tools"),
+            "source_action_family": action.get("family"),
+        }
+        for action in actions
+    ]
+    return {
+        "schema": "codex-usage-tracker-agentic-investigation-v1",
+        "content_mode": "aggregate_investigation_reused_action_brief",
+        "includes_indexed_content": False,
+        "includes_raw_fragments": False,
+        "privacy_mode": action_brief.get("privacy_mode"),
+        "goal": goal,
+        "summary": {
+            "finding_count": len(findings),
+            "top_finding": findings[0]["finding"] if findings else None,
+            "source_reports": ["codex-usage-tracker-action-brief-v1"],
+        },
+        "findings": findings,
+        "recommended_next_tools": action_brief.get("recommended_next_tools", []),
+        "caveats": [
+            "Reused action brief findings to keep dogfood bounded; run with deep investigations for full investigation payloads."
+        ],
+    }
 
 
 def _compact_hypotheses(payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -1043,11 +1043,13 @@ def build_action_brief_report(
     include_archived: bool = False,
     evidence_limit: int = 5,
     privacy_mode: str = "normal",
+    precomputed_reports: dict[str, dict[str, Any]] | None = None,
 ) -> ActionBriefReport:
     """Build a compact remediation brief from aggregate diagnostics."""
     privacy_mode = validate_privacy_mode(privacy_mode)
     normalized_goal = _normalize_agentic_goal(goal) or "token_waste"
     normalized_limit = max(1, evidence_limit)
+    report_cache = precomputed_reports if precomputed_reports is not None else {}
     actions: list[dict[str, Any]] = []
     source_reports: list[str] = []
     caveats = [
@@ -1057,15 +1059,18 @@ def build_action_brief_report(
     ]
 
     if normalized_goal in {"overview", "token_waste", "cache_failure"}:
-        large_low_output = build_large_low_output_report(
-            db_path=db_path,
-            since=since,
-            until=until,
-            thread=thread,
-            include_archived=include_archived,
-            limit=normalized_limit,
-            privacy_mode=privacy_mode,
-        ).payload
+        large_low_output = report_cache.get("large_low_output")
+        if large_low_output is None:
+            large_low_output = build_large_low_output_report(
+                db_path=db_path,
+                since=since,
+                until=until,
+                thread=thread,
+                include_archived=include_archived,
+                limit=normalized_limit,
+                privacy_mode=privacy_mode,
+            ).payload
+            report_cache["large_low_output"] = large_low_output
         source_reports.append(str(large_low_output["schema"]))
         if large_low_output["rows"]:
             actions.append(
@@ -1103,30 +1108,36 @@ def build_action_brief_report(
                 )
             )
 
-        recommendations = build_recommendations_report(
-            db_path=db_path,
-            pricing_path=pricing_path,
-            allowance_path=allowance_path,
-            projects_path=projects_path,
-            since=since,
-            until=until,
-            thread=thread,
-            include_archived=include_archived,
-            limit=normalized_limit,
-            privacy_mode=privacy_mode,
-        ).payload
+        recommendations = report_cache.get("recommendations")
+        if recommendations is None:
+            recommendations = build_recommendations_report(
+                db_path=db_path,
+                pricing_path=pricing_path,
+                allowance_path=allowance_path,
+                projects_path=projects_path,
+                since=since,
+                until=until,
+                thread=thread,
+                include_archived=include_archived,
+                limit=normalized_limit,
+                privacy_mode=privacy_mode,
+            ).payload
+            report_cache["recommendations"] = recommendations
         source_reports.append(str(recommendations["schema"]))
 
     if normalized_goal in {"overview", "token_waste", "cache_failure", "workflow_churn"}:
-        repeated_files = build_repeated_file_rediscovery_report(
-            db_path=db_path,
-            since=since,
-            until=until,
-            thread=thread,
-            include_archived=include_archived,
-            limit=normalized_limit,
-            privacy_mode=privacy_mode,
-        ).payload
+        repeated_files = report_cache.get("repeated_files")
+        if repeated_files is None:
+            repeated_files = build_repeated_file_rediscovery_report(
+                db_path=db_path,
+                since=since,
+                until=until,
+                thread=thread,
+                include_archived=include_archived,
+                limit=normalized_limit,
+                privacy_mode=privacy_mode,
+            ).payload
+            report_cache["repeated_files"] = repeated_files
         source_reports.append(str(repeated_files["schema"]))
         if repeated_files["rows"]:
             actions.append(
@@ -1160,16 +1171,19 @@ def build_action_brief_report(
                 )
             )
 
-        shell_churn = build_shell_churn_report(
-            db_path=db_path,
-            since=since,
-            until=until,
-            thread=thread,
-            include_archived=include_archived,
-            min_occurrences=2,
-            limit=normalized_limit,
-            privacy_mode=privacy_mode,
-        ).payload
+        shell_churn = report_cache.get("shell_churn")
+        if shell_churn is None:
+            shell_churn = build_shell_churn_report(
+                db_path=db_path,
+                since=since,
+                until=until,
+                thread=thread,
+                include_archived=include_archived,
+                min_occurrences=2,
+                limit=normalized_limit,
+                privacy_mode=privacy_mode,
+            ).payload
+            report_cache["shell_churn"] = shell_churn
         source_reports.append(str(shell_churn["schema"]))
         if shell_churn["rows"]:
             actions.append(
@@ -1266,6 +1280,7 @@ def build_action_brief_report(
             "action_count": len(actions),
             "top_action_family": actions[0]["family"] if actions else None,
             "source_reports": source_reports,
+            "shared_report_cache_keys": sorted(report_cache),
         },
         "actions": actions,
         "recommended_next_tools": _dedupe_action_tools(actions),
@@ -1480,26 +1495,6 @@ def _classify_hypothesis_text(text: str) -> str | None:
     if _has_any_phrase(
         text,
         (
-            "token waste",
-            "wasting tokens",
-            "waste",
-            "expensive",
-            "cost",
-            "large low-output",
-            "large low output",
-            "low-output",
-            "low output",
-            "output length",
-            "context pressure",
-            "large call",
-            "large calls",
-            "cleanup target",
-        ),
-    ):
-        return "token_waste"
-    if _has_any_phrase(
-        text,
-        (
             "file",
             "rediscover",
             "rediscovery",
@@ -1521,6 +1516,26 @@ def _classify_hypothesis_text(text: str) -> str | None:
         return "shell_churn"
     if _has_any_word(text, ("effort", "model", "xhigh", "high", "medium", "gpt")):
         return "effort_model_choice"
+    if _has_any_phrase(
+        text,
+        (
+            "token waste",
+            "wasting tokens",
+            "waste",
+            "expensive",
+            "cost",
+            "large low-output",
+            "large low output",
+            "low-output",
+            "low output",
+            "output length",
+            "context pressure",
+            "large call",
+            "large calls",
+            "cleanup target",
+        ),
+    ):
+        return "token_waste"
     return None
 
 
@@ -2857,6 +2872,7 @@ def build_recommendations_report(
     include_archived: bool = False,
     min_score: float | None = None,
     limit: int = 20,
+    source_limit: int | None = None,
     privacy_mode: str = "normal",
 ) -> RecommendationsReport:
     """Build ranked aggregate recommendations for usage investigations."""
@@ -2870,6 +2886,7 @@ def build_recommendations_report(
         effort=effort,
         thread=thread,
         include_archived=include_archived,
+        source_limit=source_limit,
     )
     rows = _annotated_recommendation_rows(
         rows,
@@ -2901,10 +2918,11 @@ def build_recommendations_report(
                 "thread": thread,
                 "project": project,
                 "include_archived": include_archived,
-                "min_score": min_score,
-                "limit": normalized_limit,
-                "privacy_mode": privacy_mode,
-            },
+            "min_score": min_score,
+            "limit": normalized_limit,
+            "source_limit": source_limit,
+            "privacy_mode": privacy_mode,
+        },
             "row_count": len(private_rows),
             "total_matched_rows": len(scored_rows),
             "truncated": normalized_limit is not None and len(scored_rows) > normalized_limit,
@@ -2923,11 +2941,12 @@ def _recommendation_source_rows(
     effort: str | None,
     thread: str | None,
     include_archived: bool,
+    source_limit: int | None = None,
 ) -> list[dict[str, Any]]:
     return annotate_thread_attachments(
         query_dashboard_events(
             db_path,
-            limit=0,
+            limit=0 if source_limit is None else source_limit,
             since=since,
             until=until,
             model=model,

--- a/src/codex_usage_tracker/store/repeated_files.py
+++ b/src/codex_usage_tracker/store/repeated_files.py
@@ -90,6 +90,8 @@ def query_repeated_file_rediscovery(
         [*params, normalized_min],
     ).fetchall()
 
+    sorted_rows = sorted(rows, key=_candidate_row_sort_key, reverse=True)
+    sliced_rows = sorted_rows if normalized_limit is None else sorted_rows[:normalized_limit]
     candidates = [
         _file_candidate(row, trace_handles=_trace_handles_for_path(
             conn,
@@ -100,13 +102,11 @@ def query_repeated_file_rediscovery(
             include_archived=include_archived,
             limit=normalized_sample_limit,
         ))
-        for row in rows
+        for row in sliced_rows
     ]
-    candidates.sort(key=_candidate_sort_key, reverse=True)
-    sliced = candidates if normalized_limit is None else candidates[:normalized_limit]
     return {
-        "rows": sliced,
-        "total_candidates": len(candidates),
+        "rows": candidates,
+        "total_candidates": len(sorted_rows),
     }
 
 
@@ -247,13 +247,12 @@ def _usage_filters(
     return "WHERE " + " AND ".join(clauses), params
 
 
-def _candidate_sort_key(row: dict[str, Any]) -> tuple[int, int, int, int]:
-    mix = row["operation_mix"]
+def _candidate_row_sort_key(row: sqlite3.Row) -> tuple[int, int, int, int]:
     return (
-        int(mix.get("read") or 0),
-        int(row["adjacent_retouch_count"]),
-        int(row["occurrences"]),
-        int(row["total_tokens"]),
+        int(row["read_count"] or 0),
+        int(row["adjacent_retouch_count"] or 0),
+        int(row["occurrences"] or 0),
+        int(row["total_tokens"] or 0),
     )
 
 

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -707,6 +707,9 @@ def test_dogfood_agentic_cli_writes_compact_artifacts(tmp_path: Path) -> None:
     assert payload["family_checks"]["old_passed"] is True
     assert payload["family_checks"]["new_passed"] is True
     assert payload["privacy_checks"]["passed"] is True
+    assert payload["progress"]["percent_complete"] == 100
+    assert payload["cache"]["hypotheses"] is False
+    assert payload["cache"]["deep_investigations"] is False
     assert Path(payload["artifacts"]["summary_json_path"]).exists()
     assert Path(payload["artifacts"]["summary_markdown_path"]).exists()
     assert "SECRET" not in result.stdout

--- a/tests/reports/test_agentic_dogfood.py
+++ b/tests/reports/test_agentic_dogfood.py
@@ -32,6 +32,13 @@ def test_agentic_dogfood_report_writes_compact_private_artifacts(tmp_path: Path)
     assert payload["family_checks"]["old_passed"] is True
     assert payload["family_checks"]["new_passed"] is True
     assert payload["privacy_checks"]["passed"] is True
+    assert payload["progress"]["percent_complete"] == 100
+    assert payload["progress"]["stages"][-1]["stage"] == "write_artifacts"
+    assert payload["cache"]["scope"] == "single_run_shared_reports"
+    assert payload["cache"]["hypotheses"] is False
+    assert payload["cache"]["deep_investigations"] is False
+    assert "large_low_output" in payload["cache"]["cache_keys"]
+    assert payload["old_hypotheses"][0]["status"] == "skipped_quick_mode"
     assert "action_brief" in payload["direct_reports"]
     assert payload["direct_reports"]["action_brief"]["action_count"] is not None
     assert payload["refresh"]["parsed_events"] > 0

--- a/tests/reports/test_hypothesis_routing.py
+++ b/tests/reports/test_hypothesis_routing.py
@@ -33,6 +33,13 @@ def test_hypothesis_family_routing_handles_exploratory_usage_phrases() -> None:
     )
     assert (
         _classify_hypothesis_family(
+            "Repeated file rediscovery is wasting tokens.",
+            question,
+        )
+        == "repeated_file_rediscovery"
+    )
+    assert (
+        _classify_hypothesis_family(
             "Allowance-change claims are not ready for public posting without more weekly positive spans.",
             question,
         )


### PR DESCRIPTION
## Summary
- make `dogfood-agentic` bounded by default: quick hypothesis routing checks and reused action-brief investigation findings
- add progress/cache metadata to the dogfood payload and CLI output so agents can tell what ran, what was skipped, and which shared reports were reused
- add shared report cache support to action brief and a bounded recommendation source mode for dogfood
- optimize repeated-file rediscovery by slicing ranked candidates before fetching trace samples

## Local evidence
- real local strict dogfood run with `--no-refresh --evidence-limit 3`: ~43s before, ~13s after
- repeated-file rediscovery on local DB: ~22s before, ~0.7s after

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short`
- `.venv/bin/python -m ruff check src/codex_usage_tracker/reports/api.py src/codex_usage_tracker/reports/agentic_dogfood.py src/codex_usage_tracker/store/repeated_files.py src/codex_usage_tracker/cli/parser.py src/codex_usage_tracker/cli/main.py tests/reports/test_action_brief.py tests/reports/test_agentic_dogfood.py tests/cli/test_cli_lifecycle.py tests/store/test_content_index.py tests/cli/test_mcp_integration.py`
- `python3 scripts/check_release.py`
- `git diff --check`

## Note
The returned progress metadata is synchronous staged progress after completion. True live polling percentages should be a follow-up async job endpoint instead of pretending a blocking endpoint can stream status.