### PR TITLE
feat: incrementally index appended content logs

### DIFF
--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -45,6 +45,16 @@ class ContentIndexResult:
 
 
 @dataclass(frozen=True)
+class ContentIndexPlan:
+    """Plan for full or append-only content indexing of a source log."""
+
+    source_path: Path
+    replace_existing: bool = True
+    start_byte: int = 0
+    start_line: int = 0
+
+
+@dataclass(frozen=True)
 class _PendingFragment:
     role: str
     fragment_kind: str
@@ -82,9 +92,32 @@ def index_content_for_source_files(
     """Populate normalized bounded local content rows for source files."""
 
     source_paths = list(dict.fromkeys(source_files))
+    return index_content_for_source_plans(
+        conn,
+        plans=(
+            ContentIndexPlan(source_path=source_path, replace_existing=True)
+            for source_path in source_paths
+        ),
+    )
+
+
+def index_content_for_source_plans(
+    conn: sqlite3.Connection,
+    *,
+    plans: Iterable[ContentIndexPlan],
+) -> ContentIndexResult:
+    """Populate normalized bounded local content rows using refresh parse plans."""
+
+    source_plans = list(_dedupe_content_index_plans(plans))
     totals = ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
-    for source_path in source_paths:
-        result = _index_content_for_source_file(conn, source_path=source_path)
+    for plan in source_plans:
+        result = _index_content_for_source_file(
+            conn,
+            source_path=plan.source_path,
+            replace_existing=plan.replace_existing,
+            start_byte=plan.start_byte,
+            start_line=plan.start_line,
+        )
         totals = ContentIndexResult(
             source_files=totals.source_files + result.source_files,
             conversation_turns=totals.conversation_turns + result.conversation_turns,
@@ -92,6 +125,17 @@ def index_content_for_source_files(
             parse_warnings=totals.parse_warnings + result.parse_warnings,
         )
     return totals
+
+
+def _dedupe_content_index_plans(
+    plans: Iterable[ContentIndexPlan],
+) -> Iterable[ContentIndexPlan]:
+    by_path: dict[Path, ContentIndexPlan] = {}
+    for plan in plans:
+        existing = by_path.get(plan.source_path)
+        if existing is None or plan.replace_existing or plan.start_byte < existing.start_byte:
+            by_path[plan.source_path] = plan
+    return by_path.values()
 
 
 def clear_content_index_rows(conn: sqlite3.Connection) -> None:
@@ -700,16 +744,22 @@ def _index_content_for_source_file(
     conn: sqlite3.Connection,
     *,
     source_path: Path,
+    replace_existing: bool = True,
+    start_byte: int = 0,
+    start_line: int = 0,
 ) -> ContentIndexResult:
     usage_rows = _usage_rows_by_token_line(conn, source_file=str(source_path))
     if not usage_rows:
         return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
 
-    delete_content_index_rows_for_source_files(
-        conn,
-        placeholders="?",
-        source_files_to_replace=[str(source_path)],
-    )
+    if replace_existing:
+        start_byte = 0
+        start_line = 0
+        delete_content_index_rows_for_source_files(
+            conn,
+            placeholders="?",
+            source_files_to_replace=[str(source_path)],
+        )
     pending: list[_PendingFragment] = []
     pending_tool_calls: list[PendingToolCall] = []
     pending_command_runs: list[PendingCommandRun] = []
@@ -719,7 +769,9 @@ def _index_content_for_source_file(
     parse_warnings = 0
     try:
         with source_path.open("rb") as handle:
-            for line_number, raw_line in enumerate(handle, 1):
+            if start_byte > 0:
+                handle.seek(start_byte)
+            for line_number, raw_line in enumerate(handle, start_line + 1):
                 try:
                     envelope = json.loads(raw_line.decode("utf-8"))
                 except (UnicodeDecodeError, json.JSONDecodeError):
@@ -780,7 +832,14 @@ def _index_content_for_source_file(
     except OSError:
         return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
 
-    _rebuild_content_fts(conn)
+    if replace_existing:
+        _rebuild_content_fts(conn)
+    else:
+        _sync_content_fts_for_source_file(
+            conn,
+            source_file=str(source_path),
+            min_line_start=start_line + 1,
+        )
     counts = _content_counts_for_source_file(conn, source_file=str(source_path))
     return ContentIndexResult(
         source_files=1,
@@ -1118,6 +1177,29 @@ def _rebuild_content_fts(conn: sqlite3.Connection) -> None:
             FROM content_fragments
             WHERE fragment_text != ''
             """
+        )
+    except sqlite3.DatabaseError:
+        return
+
+
+def _sync_content_fts_for_source_file(
+    conn: sqlite3.Connection,
+    *,
+    source_file: str,
+    min_line_start: int,
+) -> None:
+    try:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO content_fts(rowid, fragment_text, safe_label, fragment_kind)
+            SELECT cf.fragment_rowid, cf.fragment_text, cf.safe_label, cf.fragment_kind
+            FROM content_fragments cf
+            JOIN usage_events u ON u.record_id = cf.record_id
+            WHERE u.source_file = ?
+              AND cf.line_start >= ?
+              AND cf.fragment_text != ''
+            """,
+            (source_file, min_line_start),
         )
     except sqlite3.DatabaseError:
         return

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -24,7 +24,10 @@ from codex_usage_tracker.store.api import (
     upsert_usage_events,
 )
 from codex_usage_tracker.store.connection import connect
-from codex_usage_tracker.store.content_index import index_content_for_source_files
+from codex_usage_tracker.store.content_index import (
+    ContentIndexPlan,
+    index_content_for_source_plans,
+)
 from codex_usage_tracker.store.sources import ParsedSourceFile, source_logs_requiring_parse
 
 vars(store_facade)["parse_usage_events_from_file_with_state"] = (
@@ -84,9 +87,17 @@ def refresh_usage_index(
     if not aggregate_only:
         with connect(db_path) as conn:
             init_db(conn)
-            index_content_for_source_files(
+            index_content_for_source_plans(
                 conn,
-                source_files=(path for path, _events, _diagnostics, _state in parsed_files),
+                plans=(
+                    ContentIndexPlan(
+                        source_path=plan.path,
+                        replace_existing=plan.replace_existing,
+                        start_byte=plan.start_byte,
+                        start_line=plan.start_line,
+                    )
+                    for plan in parse_plans
+                ),
             )
     skipped_events = stats.get("skipped_events", 0)
     diagnostics = compact_parser_diagnostics(stats)

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -14,6 +14,7 @@ from codex_usage_tracker.reports.api import (
     build_shell_churn_report,
     build_thread_trace_report,
 )
+from codex_usage_tracker.store import content_index
 from codex_usage_tracker.store.api import connect, init_db, refresh_usage_index
 from codex_usage_tracker.store.content_index_events import _command_root_and_label
 from codex_usage_tracker.store.shell_churn import (
@@ -48,6 +49,56 @@ def test_refresh_populates_normalized_content_index_by_default(tmp_path: Path) -
     assert any(row["fragment_kind"] == "reasoning_summary" for row in fragment_rows)
     assert all(row["includes_raw_fragment"] == 1 for row in fragment_rows)
     assert all("SECRET RAW PROMPT" not in row["safe_label"] for row in fragment_rows)
+
+
+def test_refresh_incrementally_indexes_appended_content(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    source_path = next((codex_home / "sessions").glob("**/*.jsonl"))
+
+    def fail_if_rebuild(*args: object, **kwargs: object) -> None:
+        raise AssertionError("append-only content indexing should not rebuild source rows")
+
+    monkeypatch.setattr(
+        content_index,
+        "delete_content_index_rows_for_source_files",
+        fail_if_rebuild,
+    )
+
+    with source_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "APPENDED INCREMENTAL CONTENT SENTINEL",
+                            }
+                        ],
+                    },
+                )
+            )
+            + "\n"
+        )
+        handle.write(json.dumps(_token_event(8_000, 400)) + "\n")
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    report = build_content_search_report(
+        db_path=db_path,
+        query="APPENDED INCREMENTAL CONTENT SENTINEL",
+        limit=5,
+    ).payload
+
+    assert report["total_matched_rows"] == 1
 
 
 def test_refresh_populates_normalized_local_event_tables(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reuse source parse plans for content indexing so append-only refreshes scan only new JSONL bytes
- keep replace_existing/full rebuild behavior available for changed or reset source logs
- route dashboard/CLI/MCP refresh through the same incremental content-index path
- add a regression test proving appended content is searchable without rebuilding existing content rows

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests/store/test_content_index.py::test_refresh_incrementally_indexes_appended_content tests/store/test_content_index.py::test_refresh_populates_normalized_content_index_by_default tests/store/test_store_sources.py tests/cli/test_mcp_integration.py::test_mcp_dogfood_async_job_reports_progress -q --tb=short
- .venv/bin/python -m ruff check .
- .venv/bin/python -m compileall src
- PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short
- python3 scripts/check_release.py
- git diff --check

## Real-data timing
- local refresh with content index: 1.927s after one appended event
- immediate warm refresh: 0.009s with no new rows
