### PR TITLE
perf: avoid full source rescans on append refresh

### DIFF
--- a/src/codex_usage_tracker/parser/jsonl_v1.py
+++ b/src/codex_usage_tracker/parser/jsonl_v1.py
@@ -61,6 +61,7 @@ class ParsedUsageFile:
     events: list[UsageEvent]
     diagnostic_facts: list[DiagnosticFact]
     state: ParserState
+    final_line_number: int = 0
 
 
 @dataclass
@@ -96,11 +97,13 @@ def parse_codex_jsonl_v1(
 
     previous_state = initial_state or ParserState()
     state = _initial_jsonl_parse_state(previous_state, file_session_id, index)
+    final_line_number = start_line
 
     with path.open("rb") as handle:
         if start_byte > 0:
             handle.seek(start_byte)
         for line_number, raw_line in enumerate(handle, start_line + 1):
+            final_line_number = line_number
             _handle_jsonl_line(
                 path=path,
                 index=index,
@@ -123,6 +126,7 @@ def parse_codex_jsonl_v1(
             latest_record_id=state.latest_record_id,
             latest_event_timestamp=state.latest_event_timestamp,
         ),
+        final_line_number=final_line_number,
     )
 
 

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -559,10 +559,11 @@ def record_source_file_metadata(
     with connect(db_path) as conn:
         init_db(conn)
         upsert_source_file_metadata(conn, parsed_files=parsed)
-        sync_source_records(
-            conn,
-            source_files=[str(path) for path, _events, _diagnostics, _state in parsed],
-        )
+        record_ids = [
+            event.record_id for _path, events, *_rest in parsed for event in events
+        ]
+        if record_ids:
+            sync_source_records(conn, record_ids=record_ids)
 
 
 def upsert_usage_events(

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -748,7 +748,11 @@ def _index_content_for_source_file(
     start_byte: int = 0,
     start_line: int = 0,
 ) -> ContentIndexResult:
-    usage_rows = _usage_rows_by_token_line(conn, source_file=str(source_path))
+    usage_rows = _usage_rows_by_token_line(
+        conn,
+        source_file=str(source_path),
+        min_line_number=None if replace_existing else start_line + 1,
+    )
     if not usage_rows:
         return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
 
@@ -853,9 +857,14 @@ def _usage_rows_by_token_line(
     conn: sqlite3.Connection,
     *,
     source_file: str,
+    min_line_number: int | None = None,
 ) -> dict[int, sqlite3.Row]:
+    line_filter = "" if min_line_number is None else "AND u.line_number >= ?"
+    params: list[object] = [source_file]
+    if min_line_number is not None:
+        params.append(min_line_number)
     rows = conn.execute(
-        """
+        f"""
         SELECT
             u.record_id,
             u.session_id,
@@ -870,9 +879,10 @@ def _usage_rows_by_token_line(
         FROM usage_events AS u
         JOIN source_records AS sr ON sr.record_id = u.record_id
         WHERE u.source_file = ?
+          {line_filter}
         ORDER BY u.line_number
         """,
-        (source_file,),
+        params,
     ).fetchall()
     return {int(row["line_number"]): row for row in rows}
 

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -74,7 +74,15 @@ def refresh_usage_index(
         file_events = parsed_file.events
         events.extend(file_events)
         diagnostic_facts.extend(parsed_file.diagnostic_facts)
-        parsed_files.append((plan.path, file_events, file_stats, parsed_file.state))
+        parsed_files.append(
+            (
+                plan.path,
+                file_events,
+                file_stats,
+                parsed_file.state,
+                parsed_file.final_line_number,
+            )
+        )
         for key, value in file_stats.items():
             stats[key] = stats.get(key, 0) + int(value)
     inserted = upsert_usage_events(

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -30,7 +30,10 @@ class SourceParsePlan:
     replace_existing: bool = True
 
 
-ParsedSourceFile = tuple[Path, list[UsageEvent], dict[str, int], ParserState]
+ParsedSourceFile = (
+    tuple[Path, list[UsageEvent], dict[str, int], ParserState]
+    | tuple[Path, list[UsageEvent], dict[str, int], ParserState, int]
+)
 
 
 def source_logs_requiring_parse(
@@ -124,13 +127,17 @@ def upsert_source_file_metadata(
         return
     indexed_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
     rows: list[dict[str, Any]] = []
-    for path, events, diagnostics, parser_state in parsed:
+    for parsed_file in parsed:
+        path, events, diagnostics, parser_state, final_line_number = _parsed_source_file_parts(
+            parsed_file
+        )
         row = _source_file_metadata_row(
             path=path,
             events=events,
             diagnostics=diagnostics,
             parser_state=parser_state,
             indexed_at=indexed_at,
+            final_line_number=final_line_number,
         )
         if row is not None:
             rows.append(row)
@@ -166,6 +173,14 @@ def upsert_source_file_metadata(
     )
 
 
+def _parsed_source_file_parts(
+    parsed_file: ParsedSourceFile,
+) -> tuple[Path, list[UsageEvent], dict[str, int], ParserState, int | None]:
+    path, events, diagnostics, parser_state, *rest = parsed_file
+    final_line_number = rest[0] if rest else None
+    return path, events, diagnostics, parser_state, final_line_number
+
+
 def _source_file_metadata_row(
     *,
     path: Path,
@@ -173,6 +188,7 @@ def _source_file_metadata_row(
     diagnostics: dict[str, int],
     parser_state: ParserState,
     indexed_at: str,
+    final_line_number: int | None = None,
 ) -> dict[str, Any] | None:
     metadata = _source_file_metadata(path)
     if metadata is None:
@@ -185,7 +201,7 @@ def _source_file_metadata_row(
         "is_archived": int(metadata["is_archived"]),
         "size_bytes": int(metadata["size_bytes"]),
         "mtime_ns": int(metadata["mtime_ns"]),
-        "parsed_until_line": _count_lines(path),
+        "parsed_until_line": final_line_number or _count_lines(path),
         "parsed_until_byte": int(metadata["size_bytes"]),
         "latest_record_id": _latest_source_record_id(latest_event, parser_state),
         "latest_event_timestamp": _latest_source_event_timestamp(

--- a/tests/store/test_source_records.py
+++ b/tests/store/test_source_records.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from codex_usage_tracker.parser.state import PARSER_ADAPTER_VERSION, ParserState
 from codex_usage_tracker.reports.api import build_source_coverage_report
+from codex_usage_tracker.store import sources
 from codex_usage_tracker.store.api import (
     connect,
     init_db,
@@ -114,6 +115,53 @@ def test_source_file_metadata_refreshes_source_record_parser_details(
     assert rows[0]["line_number"] == 7
     assert rows[0]["parser_adapter"] == "codex-jsonl"
     assert rows[0]["parser_version"] == "codex-jsonl-v2"
+
+
+def test_source_file_metadata_uses_parser_final_line_number(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    source_path = tmp_path / "sessions" / "fast-metadata.jsonl"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("{}\n", encoding="utf-8")
+    event = replace(
+        _usage_event(
+            record_id="source-fast-metadata",
+            session_id="session-fast-metadata",
+            thread_key="thread:Fast Metadata",
+            event_timestamp="2026-05-17T19:30:00Z",
+            cumulative_total_tokens=350,
+        ),
+        source_file=str(source_path),
+        line_number=7,
+    )
+    upsert_usage_events([event], db_path=db_path)
+
+    def fail_count_lines(_path: Path) -> int:
+        raise AssertionError("final parser line number should avoid recounting source file")
+
+    monkeypatch.setattr(sources, "_count_lines", fail_count_lines)
+
+    record_source_file_metadata(
+        db_path=db_path,
+        parsed_files=[
+            (
+                source_path,
+                [event],
+                {},
+                ParserState(
+                    latest_record_id=event.record_id,
+                    latest_event_timestamp=event.event_timestamp,
+                ),
+                7,
+            )
+        ],
+    )
+
+    rows = query_source_records(db_path=db_path, limit=0)
+    assert len(rows) == 1
+    assert rows[0]["record_id"] == "source-fast-metadata"
+    assert rows[0]["line_number"] == 7
 
 
 def test_reset_usage_database_clears_content_index_tables(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- carry the parser final line number through refresh metadata so append refreshes do not recount entire JSONL files
- sync source-record metadata by parsed record IDs instead of rescanning all rows for parsed source files
- bound content-index token lookup to appended line numbers for append-only plans
- add a regression test proving source metadata uses the parser cursor instead of full line counting

## Timing evidence
Synthetic append simulation against local data, with a copied DB and a large source cursor rewound near EOF:
- before this PR: metadata ~2.76s, total ~5.71s
- after parser cursor metadata: metadata ~0.73s, total ~3.49s
- after record-id source sync and bounded content lookup: metadata ~0.01s, total ~2.48s

Remaining hotspot is usage-event adjacency maintenance for affected large threads (~1.0s in this simulation). That should be a separate PR because it changes link refresh strategy or requires a new expression index.

## First-build parallelism note
Initial full builds can likely parse independent JSONL files in worker processes and merge through one SQLite writer. Chunking within a single JSONL is more delicate because parser state and content flushes cross line boundaries.

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests/store/test_source_records.py tests/store/test_content_index.py::test_refresh_incrementally_indexes_appended_content tests/store/test_store_sources.py tests/cli/test_mcp_integration.py::test_mcp_dogfood_async_job_reports_progress -q --tb=short
- .venv/bin/python -m ruff check .
- .venv/bin/python -m compileall src
- PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short
- python3 scripts/check_release.py
- git diff --check
