### PR TITLE
perf: batch content FTS rebuilds

### DIFF
--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -110,6 +110,8 @@ def index_content_for_source_plans(
 
     source_plans = list(_dedupe_content_index_plans(plans))
     totals = ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
+    defer_full_fts_rebuild = any(plan.replace_existing for plan in source_plans)
+    needs_full_fts_rebuild = False
     for plan in source_plans:
         result = _index_content_for_source_file(
             conn,
@@ -117,6 +119,10 @@ def index_content_for_source_plans(
             replace_existing=plan.replace_existing,
             start_byte=plan.start_byte,
             start_line=plan.start_line,
+            sync_fts=not defer_full_fts_rebuild,
+        )
+        needs_full_fts_rebuild = needs_full_fts_rebuild or (
+            plan.replace_existing and result.source_files > 0
         )
         totals = ContentIndexResult(
             source_files=totals.source_files + result.source_files,
@@ -124,6 +130,8 @@ def index_content_for_source_plans(
             content_fragments=totals.content_fragments + result.content_fragments,
             parse_warnings=totals.parse_warnings + result.parse_warnings,
         )
+    if needs_full_fts_rebuild:
+        _rebuild_content_fts(conn)
     return totals
 
 
@@ -151,19 +159,22 @@ def delete_content_index_rows_for_source_files(
     *,
     placeholders: str,
     source_files_to_replace: list[str],
+    sync_fts: bool = True,
 ) -> None:
     """Delete normalized content rows linked to source files."""
 
     record_subquery = (
         "SELECT record_id FROM usage_events " f"WHERE source_file IN ({placeholders})"
     )
-    _clear_content_fts(conn)
+    if sync_fts:
+        _clear_content_fts(conn)
     for table_name in CONTENT_INDEX_TABLES:
         conn.execute(
             f"DELETE FROM {table_name} WHERE record_id IN ({record_subquery})",
             source_files_to_replace,
         )
-    _rebuild_content_fts(conn)
+    if sync_fts:
+        _rebuild_content_fts(conn)
 
 
 def search_content_fragments(
@@ -747,6 +758,7 @@ def _index_content_for_source_file(
     replace_existing: bool = True,
     start_byte: int = 0,
     start_line: int = 0,
+    sync_fts: bool = True,
 ) -> ContentIndexResult:
     usage_rows = _usage_rows_by_token_line(
         conn,
@@ -763,6 +775,7 @@ def _index_content_for_source_file(
             conn,
             placeholders="?",
             source_files_to_replace=[str(source_path)],
+            sync_fts=sync_fts,
         )
     pending: list[_PendingFragment] = []
     pending_tool_calls: list[PendingToolCall] = []
@@ -836,14 +849,15 @@ def _index_content_for_source_file(
     except OSError:
         return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
 
-    if replace_existing:
-        _rebuild_content_fts(conn)
-    else:
-        _sync_content_fts_for_source_file(
-            conn,
-            source_file=str(source_path),
-            min_line_start=start_line + 1,
-        )
+    if sync_fts:
+        if replace_existing:
+            _rebuild_content_fts(conn)
+        else:
+            _sync_content_fts_for_source_file(
+                conn,
+                source_file=str(source_path),
+                min_line_start=start_line + 1,
+            )
     counts = _content_counts_for_source_file(conn, source_file=str(source_path))
     return ContentIndexResult(
         source_files=1,

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -101,6 +101,36 @@ def test_refresh_incrementally_indexes_appended_content(
     assert report["total_matched_rows"] == 1
 
 
+def test_refresh_batches_full_content_fts_rebuild(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path, aggregate_only=True)
+    source_paths = sorted((codex_home / "sessions").glob("**/*.jsonl"))
+    rebuild_calls = 0
+    original_rebuild = content_index._rebuild_content_fts
+
+    def counting_rebuild(conn) -> None:
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        original_rebuild(conn)
+
+    monkeypatch.setattr(content_index, "_rebuild_content_fts", counting_rebuild)
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        content_index.index_content_for_source_plans(
+            conn,
+            plans=(
+                content_index.ContentIndexPlan(source_path=source_path)
+                for source_path in source_paths
+            ),
+        )
+
+    assert rebuild_calls == 1
+
+
 def test_refresh_populates_normalized_local_event_tables(tmp_path: Path) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"


### PR DESCRIPTION
## Summary
- defer full content FTS rebuilds while processing a batch of full-replace content-index plans
- keep append-only plans syncing only their appended rows
- add a regression test proving a full content-index batch performs one FTS rebuild instead of rebuilding per source

## Benchmark
Mirrored real local logs, empty temporary SQLite DB, automatic refresh workers:
- before: full rebuild 141.138s; content indexing 114.567s
- after: full rebuild 109.373s; content indexing 81.849s

This is a material improvement, but content indexing is still the dominant first-build cost. The next major reductions likely require content extraction batching/parallelism or combining aggregate parse and content extraction to avoid a second full JSONL pass.

## Validation
- PYTHONPATH=src .venv/bin/python -m pytest tests/store/test_content_index.py::test_refresh_batches_full_content_fts_rebuild tests/store/test_content_index.py::test_refresh_incrementally_indexes_appended_content tests/store/test_content_index.py::test_refresh_populates_normalized_content_index_by_default -q --tb=short
- .venv/bin/python -m ruff check src/codex_usage_tracker/store/content_index.py tests/store/test_content_index.py
- .venv/bin/python -m ruff check .
- .venv/bin/python -m compileall src
- PYTHONPATH=src .venv/bin/python -m pytest -q --tb=short
- python3 scripts/check_release.py
- git diff --check
