### PR TITLE
docs: warn about compacted tool output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ Use patch releases for public blockers such as broken PyPI installs, missing pac
 
 Run focused tests first, then broader checks. Run the full local CI gate before opening or updating PRs that touch release, packaging, CLI contracts, MCP behavior, dashboard behavior, privacy behavior, schemas, generated docs/assets, or bundled plugin/skill files.
 
+## Source Inspection And Tool Output
+
+Large command outputs in Codex chat can be visually compacted by the transcript renderer. When inspecting source, especially after broad `rg`, `sed`, `nl`, generated dashboard assets, logs, or workflow output, do not treat a mangled rendered snippet as proof that the file is corrupt. Prefer small targeted file windows, `git diff`, `python -m py_compile`, focused tests, and CI as the source of truth. If exact syntax matters, inspect a narrow range or use a parser/compiler rather than relying on large printed source dumps.
+
 ```bash
 python -m ruff check .
 python -m mypy


### PR DESCRIPTION
## Summary
- document that large command outputs in Codex chat can be visually compacted
- tell agents to trust targeted file windows, git diff, py_compile, tests, and CI over large rendered source dumps

## Validation
- python3 scripts/check_release.py
- git diff --check