### PR TITLE
Normalize Python formatting

### DIFF
--- a/scripts/benchmark_synthetic_history.py
+++ b/scripts/benchmark_synthetic_history.py
@@ -179,9 +179,11 @@ def main() -> int:
                 )
                 for failure in result["threshold_failures"]:
                     print(f"  FAIL {failure}")
-        return 1 if args.enforce_thresholds and any(
-            result["threshold_failures"] for result in results
-        ) else 0
+        return (
+            1
+            if args.enforce_thresholds and any(result["threshold_failures"] for result in results)
+            else 0
+        )
     finally:
         if temp_dir and not args.keep_dbs:
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -251,6 +253,7 @@ def benchmark_size(
             min_tokens=9_000,
         )
     )
+
     def payload_action() -> dict[str, Any]:
         return dashboard_payload(
             db_path=db_path,
@@ -333,9 +336,7 @@ def benchmark_size(
     }
     context_metrics: dict[str, Any] = {}
     if source_bundle:
-        timings["dashboard_payload_with_source_logs_seconds"] = (
-            dashboard_payload_active_seconds
-        )
+        timings["dashboard_payload_with_source_logs_seconds"] = dashboard_payload_active_seconds
         context_metrics = _benchmark_context_loads(
             db_path=db_path,
             row_count=row_count,
@@ -495,7 +496,9 @@ def _benchmark_context_loads(
         )
         timing_name = f"context_load_{label}_line_seconds"
         timings[timing_name] = elapsed
-        diagnostics = payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
+        diagnostics = (
+            payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
+        )
         loads[label] = {
             "record_id": record_id,
             "seconds": elapsed,
@@ -534,10 +537,7 @@ def _evaluate_thresholds(
         if threshold is None:
             continue
         limit = round(
-            (
-                threshold["base_seconds"]
-                + threshold["per_10k_seconds"] * (row_count / 10_000)
-            )
+            (threshold["base_seconds"] + threshold["per_10k_seconds"] * (row_count / 10_000))
             * threshold_scale,
             6,
         )
@@ -818,9 +818,15 @@ def _synthetic_events(
             subagent_type="guardian" if is_review else "thread_spawn" if is_subagent else None,
             agent_role="reviewer" if is_review else "worker" if is_subagent else None,
             agent_nickname=None,
-            parent_session_id=f"session-{(index - 1) % 2500:04d}" if is_subagent or is_review else None,
-            parent_thread_name=_synthetic_thread_name(index - 1) if is_subagent or is_review else None,
-            parent_session_updated_at=f"2026-05-{day:02d}T22:00:00Z" if is_subagent or is_review else None,
+            parent_session_id=f"session-{(index - 1) % 2500:04d}"
+            if is_subagent or is_review
+            else None,
+            parent_thread_name=_synthetic_thread_name(index - 1)
+            if is_subagent or is_review
+            else None,
+            parent_session_updated_at=f"2026-05-{day:02d}T22:00:00Z"
+            if is_subagent or is_review
+            else None,
             model_context_window=200_000,
             input_tokens=metrics["input_tokens"],
             cached_input_tokens=metrics["cached_input_tokens"],

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -266,10 +266,7 @@ def main() -> int:
 
 def _check_required_files() -> list[str]:
     failures: list[str] = []
-    tracked_files = {
-        path.relative_to(REPO_ROOT).as_posix()
-        for path in _tracked_files()
-    }
+    tracked_files = {path.relative_to(REPO_ROOT).as_posix() for path in _tracked_files()}
     for path in REQUIRED_FILES:
         if not (REPO_ROOT / path).exists():
             failures.append(f"missing required file: {path}")
@@ -337,7 +334,9 @@ def _check_package_naming_docs() -> list[str]:
     for relative_path in PACKAGE_NAMING_DOCS:
         text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
         if DISTRIBUTION_NAME not in text:
-            failures.append(f"{relative_path} must name the public PyPI package {DISTRIBUTION_NAME}")
+            failures.append(
+                f"{relative_path} must name the public PyPI package {DISTRIBUTION_NAME}"
+            )
         if relative_path in {"README.md", "docs/install.md"} and old_name_warning not in text:
             failures.append(
                 f"{relative_path} must warn that {OLD_PYPI_DISTRIBUTION_NAME} "
@@ -406,9 +405,11 @@ def _check_packaging_metadata() -> list[str]:
     failures: list[str] = []
     manifest = json.loads((REPO_ROOT / ".codex-plugin/plugin.json").read_text(encoding="utf-8"))
     if manifest != plugin_manifest():
-        failures.append(".codex-plugin/plugin.json does not match plugin_installer.plugin_manifest()")
+        failures.append(
+            ".codex-plugin/plugin.json does not match plugin_installer.plugin_manifest()"
+        )
     if project.get("license") != "MIT":
-        failures.append("pyproject.toml should use SPDX license = \"MIT\"")
+        failures.append('pyproject.toml should use SPDX license = "MIT"')
     if "license-files" not in project:
         failures.append("pyproject.toml should include license-files")
     if "urls" not in project:
@@ -427,7 +428,9 @@ def _check_packaging_metadata() -> list[str]:
     if mcp_server.get("args") != ["./skills/codex-usage-tracker/scripts/run_mcp.py"]:
         failures.append(".mcp.json should point at the bundled MCP bootstrap launcher")
     if mcp_server.get("startup_timeout_sec") != 120:
-        failures.append(".mcp.json should allow enough startup time for first-run runtime bootstrap")
+        failures.append(
+            ".mcp.json should allow enough startup time for first-run runtime bootstrap"
+        )
     manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
     if "recursive-include skills *.md *.py" not in manifest:
         failures.append("MANIFEST.in should include Codex skill scripts in the source distribution")
@@ -453,7 +456,9 @@ def _check_packaging_metadata() -> list[str]:
     if "importlib.metadata.version('codex-usage-tracking')" not in launcher:
         failures.append("MCP runtime launcher must check the codex-usage-tracking distribution")
     if "PACKAGE_SPEC_MARKER" not in launcher:
-        failures.append("MCP runtime launcher should invalidate cached runtimes when package spec changes")
+        failures.append(
+            "MCP runtime launcher should invalidate cached runtimes when package spec changes"
+        )
     failures.extend(_check_python_support_metadata(project))
     failures.extend(_check_ci_workflow())
     failures.extend(_check_publish_workflow())
@@ -506,8 +511,8 @@ def _check_publish_workflow() -> list[str]:
         "python -m twine check dist/*",
         "if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'",
         "if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')",
-        "echo \"ref=$GITHUB_REF\"",
-        "echo \"sha=$GITHUB_SHA\"",
+        'echo "ref=$GITHUB_REF"',
+        'echo "sha=$GITHUB_SHA"',
         "refs/heads/main|refs/tags/*",
         "Manual PyPI publishing must run from main or a tag ref.",
         "name: testpypi",
@@ -518,7 +523,9 @@ def _check_publish_workflow() -> list[str]:
         "codex-usage-tracking {version} already exists on {index_name}; skipping upload.",
     ]:
         if required not in workflow:
-            failures.append(f"publish workflow is missing required Trusted Publishing text: {required}")
+            failures.append(
+                f"publish workflow is missing required Trusted Publishing text: {required}"
+            )
     if re.search(r"(?m)^\s*push\s*:", workflow):
         failures.append("publish workflow must not publish on ordinary pushes")
     if re.search(r"(?m)^\s*pull_request\s*:", workflow):
@@ -532,9 +539,9 @@ def _check_publish_workflow() -> list[str]:
             continue
         for required in [
             "Verify PyPI publish ref",
-            "echo \"event=$GITHUB_EVENT_NAME\"",
-            "echo \"ref=$GITHUB_REF\"",
-            "echo \"sha=$GITHUB_SHA\"",
+            'echo "event=$GITHUB_EVENT_NAME"',
+            'echo "ref=$GITHUB_REF"',
+            'echo "sha=$GITHUB_SHA"',
             "refs/heads/main|refs/tags/*",
             "Manual PyPI publishing must run from main or a tag ref.",
             "Check target package version",
@@ -578,7 +585,9 @@ def _check_ci_workflow() -> list[str]:
 def _check_skill_packaging() -> list[str]:
     failures: list[str] = []
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    package_data = set(pyproject["tool"]["setuptools"]["package-data"]["codex_usage_tracker.plugin_data"])
+    package_data = set(
+        pyproject["tool"]["setuptools"]["package-data"]["codex_usage_tracker.plugin_data"]
+    )
     if "dashboard/locales/*" not in package_data:
         failures.append("pyproject.toml package data is missing dashboard locale catalogs")
     for source_skill in sorted((REPO_ROOT / "skills").glob("*/SKILL.md")):

--- a/scripts/generate_social_preview.py
+++ b/scripts/generate_social_preview.py
@@ -50,7 +50,9 @@ def paste_rounded(base: Image.Image, image: Image.Image, xy: tuple[int, int], ra
     base.paste(image, xy, rounded_mask(image.size, radius))
 
 
-def draw_soft_shadow(base: Image.Image, box: tuple[int, int, int, int], radius: int, alpha: int = 44) -> None:
+def draw_soft_shadow(
+    base: Image.Image, box: tuple[int, int, int, int], radius: int, alpha: int = 44
+) -> None:
     x0, y0, x1, y1 = box
     shadow = Image.new("RGBA", base.size, (0, 0, 0, 0))
     draw = ImageDraw.Draw(shadow)
@@ -62,7 +64,9 @@ def cover_crop(path: Path, size: tuple[int, int], focus_y: float = 0.35) -> Imag
     src = Image.open(path).convert("RGBA")
     target_w, target_h = size
     scale = max(target_w / src.width, target_h / src.height)
-    resized = src.resize((int(src.width * scale), int(src.height * scale)), Image.Resampling.LANCZOS)
+    resized = src.resize(
+        (int(src.width * scale), int(src.height * scale)), Image.Resampling.LANCZOS
+    )
     left = max(0, (resized.width - target_w) // 2)
     top = int(max(0, resized.height - target_h) * focus_y)
     return resized.crop((left, top, left + target_w, top + target_h))
@@ -103,7 +107,9 @@ def draw_dashboard_stack(base: Image.Image, *, x: int, y: int) -> None:
     draw = ImageDraw.Draw(base)
     card_box = (x, y, x + 536, y + 436)
     draw_soft_shadow(base, card_box, 30, 72)
-    draw.rounded_rectangle(card_box, radius=30, fill=(255, 255, 255, 246), outline=(202, 213, 232), width=2)
+    draw.rounded_rectangle(
+        card_box, radius=30, fill=(255, 255, 255, 246), outline=(202, 213, 232), width=2
+    )
 
     overview = cover_crop(ASSETS / "dashboard-insights.png", (486, 178), 0.20)
     calls = cover_crop(ASSETS / "dashboard-calls.png", (232, 174), 0.56)
@@ -112,9 +118,15 @@ def draw_dashboard_stack(base: Image.Image, *, x: int, y: int) -> None:
     paste_rounded(base, overview, (x + 25, y + 32), 20)
     paste_rounded(base, calls, (x + 25, y + 232), 18)
     paste_rounded(base, investigator, (x + 279, y + 232), 18)
-    draw.rounded_rectangle((x + 25, y + 32, x + 511, y + 210), radius=20, outline=(213, 224, 240), width=2)
-    draw.rounded_rectangle((x + 25, y + 232, x + 257, y + 406), radius=18, outline=(213, 224, 240), width=2)
-    draw.rounded_rectangle((x + 279, y + 232, x + 511, y + 406), radius=18, outline=(213, 224, 240), width=2)
+    draw.rounded_rectangle(
+        (x + 25, y + 32, x + 511, y + 210), radius=20, outline=(213, 224, 240), width=2
+    )
+    draw.rounded_rectangle(
+        (x + 25, y + 232, x + 257, y + 406), radius=18, outline=(213, 224, 240), width=2
+    )
+    draw.rounded_rectangle(
+        (x + 279, y + 232, x + 511, y + 406), radius=18, outline=(213, 224, 240), width=2
+    )
 
     draw.rounded_rectangle((x + 34, y + 44, x + 178, y + 72), radius=14, fill=(37, 99, 235, 232))
     draw.text((x + 52, y + 49), "Overview", font=font(16, "bold"), fill=(255, 255, 255))
@@ -135,8 +147,16 @@ def draw_stat_badge(
     x, y = xy
     label_font = font(18, "bold")
     value_font = font(30, "black")
-    width = max(int(draw.textlength(label, font=label_font)), int(draw.textlength(value, font=value_font))) + 54
-    draw.rounded_rectangle((x, y, x + width, y + 96), radius=22, fill=fill, outline=outline, width=2)
+    width = (
+        max(
+            int(draw.textlength(label, font=label_font)),
+            int(draw.textlength(value, font=value_font)),
+        )
+        + 54
+    )
+    draw.rounded_rectangle(
+        (x, y, x + width, y + 96), radius=22, fill=fill, outline=outline, width=2
+    )
     draw.text((x + 26, y + 18), label, font=label_font, fill=(72, 83, 104))
     draw.text((x + 26, y + 44), value, font=value_font, fill=(18, 28, 45))
     return width
@@ -145,8 +165,15 @@ def draw_stat_badge(
 def draw_title(draw: ImageDraw.ImageDraw, *, x: int, y: int) -> None:
     draw.text((x, y), "Codex Usage", font=font(76, "black"), fill=(15, 23, 42))
     draw.text((x, y + 76), "Tracker", font=font(86, "black"), fill=(37, 99, 235))
-    draw.text((x + 6, y + 176), "Unofficial local analytics for Codex tokens,", font=font(28, "bold"), fill=(53, 65, 85))
-    draw.text((x + 6, y + 212), "cache, threads, and spend.", font=font(28, "bold"), fill=(53, 65, 85))
+    draw.text(
+        (x + 6, y + 176),
+        "Unofficial local analytics for Codex tokens,",
+        font=font(28, "bold"),
+        fill=(53, 65, 85),
+    )
+    draw.text(
+        (x + 6, y + 212), "cache, threads, and spend.", font=font(28, "bold"), fill=(53, 65, 85)
+    )
 
 
 def draw_social_preview() -> Image.Image:
@@ -154,9 +181,13 @@ def draw_social_preview() -> Image.Image:
     draw = ImageDraw.Draw(base)
     draw_dashboard_stack(base, x=662, y=82)
 
-    draw.rounded_rectangle((72, 70, 206, 112), radius=21, fill=(238, 246, 255), outline=(177, 199, 232), width=2)
+    draw.rounded_rectangle(
+        (72, 70, 206, 112), radius=21, fill=(238, 246, 255), outline=(177, 199, 232), width=2
+    )
     draw.text((94, 82), "MIT License", font=font(17, "bold"), fill=(31, 55, 88))
-    draw.rounded_rectangle((224, 70, 394, 112), radius=21, fill=(238, 253, 246), outline=(161, 218, 195), width=2)
+    draw.rounded_rectangle(
+        (224, 70, 394, 112), radius=21, fill=(238, 253, 246), outline=(161, 218, 195), width=2
+    )
     draw.text((246, 82), "10K+ downloads", font=font(17, "bold"), fill=(20, 83, 45))
 
     draw_title(draw, x=72, y=150)
@@ -167,7 +198,9 @@ def draw_social_preview() -> Image.Image:
     draw_stat_badge(draw, (x, 414), "LICENSE", "MIT", (239, 246, 255), (147, 197, 253))
 
     draw.line((80, 558, 1188, 558), fill=(203, 213, 225), width=2)
-    draw.text((82, 582), "douglasmonsky/codex-usage-tracker", font=font(22, "bold"), fill=(30, 41, 59))
+    draw.text(
+        (82, 582), "douglasmonsky/codex-usage-tracker", font=font(22, "bold"), fill=(30, 41, 59)
+    )
     draw.text((825, 582), "Local dashboard + MCP tools", font=font(22, "bold"), fill=(71, 85, 105))
     return base
 
@@ -177,7 +210,9 @@ def draw_readme_hero() -> Image.Image:
     draw = ImageDraw.Draw(base)
     draw_dashboard_stack(base, x=662, y=82)
 
-    draw.rounded_rectangle((72, 76, 324, 118), radius=21, fill=(238, 246, 255), outline=(177, 199, 232), width=2)
+    draw.rounded_rectangle(
+        (72, 76, 324, 118), radius=21, fill=(238, 246, 255), outline=(177, 199, 232), width=2
+    )
     draw.text((96, 88), "Local-first Codex analytics", font=font(17, "bold"), fill=(31, 55, 88))
 
     draw_title(draw, x=72, y=158)
@@ -193,7 +228,9 @@ def draw_readme_hero() -> Image.Image:
         draw.text((110, bullet_y), text, font=font(24, "bold"), fill=(30, 41, 59))
 
     draw.line((80, 580, 1188, 580), fill=(203, 213, 225), width=2)
-    draw.text((82, 602), "douglasmonsky/codex-usage-tracker", font=font(22, "bold"), fill=(30, 41, 59))
+    draw.text(
+        (82, 602), "douglasmonsky/codex-usage-tracker", font=font(22, "bold"), fill=(30, 41, 59)
+    )
     draw.text((832, 602), "Private logs stay local", font=font(22, "bold"), fill=(71, 85, 105))
     return base
 

--- a/scripts/install_local_plugin.py
+++ b/scripts/install_local_plugin.py
@@ -26,7 +26,9 @@ def main() -> int:
     )
     parser.add_argument("--plugin-dir", type=Path, default=DEFAULT_PLUGIN_LINK)
     parser.add_argument("--marketplace", type=Path, default=DEFAULT_MARKETPLACE_PATH)
-    parser.add_argument("--python", type=Path, default=Path(sys.executable), dest="python_executable")
+    parser.add_argument(
+        "--python", type=Path, default=Path(sys.executable), dest="python_executable"
+    )
     parser.add_argument(
         "--force",
         action="store_true",

--- a/scripts/model_usage_drain.py
+++ b/scripts/model_usage_drain.py
@@ -36,10 +36,7 @@ def main() -> int:
         "--plan-type",
         action="append",
         dest="plan_types",
-        help=(
-            "Filter rows to one rate_limit_plan_type. Repeat to include multiple "
-            "plan types."
-        ),
+        help=("Filter rows to one rate_limit_plan_type. Repeat to include multiple plan types."),
     )
     parser.add_argument("--thread")
     parser.add_argument("--include-archived", action="store_true")
@@ -159,8 +156,7 @@ def main() -> int:
                 best_mae = _best_metric_model(models, "mae")
                 best_rmse = _best_metric_model(models, "rmse")
                 print(
-                    "walk-forward {scope}: n={n} best_mae={best_mae} "
-                    "best_rmse={best_rmse}".format(
+                    "walk-forward {scope}: n={n} best_mae={best_mae} best_rmse={best_rmse}".format(
                         scope=scope_name,
                         n=actual.get("n"),
                         best_mae=best_mae,
@@ -168,9 +164,7 @@ def main() -> int:
                     )
                 )
                 state_models = {
-                    name: values
-                    for name, values in models.items()
-                    if name.startswith("empirical_")
+                    name: values for name, values in models.items() if name.startswith("empirical_")
                 }
                 best_state = _best_metric_model(state_models, "mae")
                 if best_state:
@@ -189,16 +183,14 @@ def main() -> int:
                     )
                 ambiguity = (
                     (
-                        ((walk_forward.get("state_ambiguity") or {}).get("scopes") or {})
-                        .get(scope_name)
+                        ((walk_forward.get("state_ambiguity") or {}).get("scopes") or {}).get(
+                            scope_name
+                        )
                         or {}
-                    )
-                    .get("signatures")
+                    ).get("signatures")
                     or {}
                 ).get("full_bucket_state") or {}
-                repeated_metrics = (
-                    ambiguity.get("repeated_oracle_mode_metrics") or {}
-                )
+                repeated_metrics = ambiguity.get("repeated_oracle_mode_metrics") or {}
                 if ambiguity:
                     print(
                         "state ambiguity {scope}: full_state_ambiguous={ambiguous} "
@@ -213,8 +205,7 @@ def main() -> int:
                     "adaptive_mae_transition_gate_history_state_mode"
                 ) or {}
                 transition_gate_model = (
-                    models.get("adaptive_mae_transition_gate_history_state_mode")
-                    or {}
+                    models.get("adaptive_mae_transition_gate_history_state_mode") or {}
                 )
                 if transition_gate_model:
                     print(
@@ -227,10 +218,8 @@ def main() -> int:
                         )
                     )
                 transition_scope = (
-                    ((walk_forward.get("transition_risk") or {}).get("scopes") or {})
-                    .get(scope_name)
-                    or {}
-                )
+                    (walk_forward.get("transition_risk") or {}).get("scopes") or {}
+                ).get(scope_name) or {}
                 transition_target = transition_scope.get("non_one_percent_delta") or {}
                 transition_models = transition_target.get("models") or {}
                 best_transition = _best_metric_model(transition_models, "brier")
@@ -267,9 +256,7 @@ def main() -> int:
                     best=longest.get("best_by_mae"),
                 )
             )
-        adaptation = (
-            (segments.get("adaptation_by_position") or {}).get("all_segments") or {}
-        )
+        adaptation = (segments.get("adaptation_by_position") or {}).get("all_segments") or {}
         if adaptation:
             first = adaptation.get("first_span") or {}
             second = adaptation.get("second_span") or {}
@@ -284,12 +271,9 @@ def main() -> int:
         boundary = segments.get("boundary_diagnostics") or {}
         if boundary:
             long_one_percent = boundary.get("after_long_one_percent_run") or {}
-            position_rows = (
-                (boundary.get("by_context") or {}).get(
-                    "previous_segment_position_bucket"
-                )
-                or []
-            )
+            position_rows = (boundary.get("by_context") or {}).get(
+                "previous_segment_position_bucket"
+            ) or []
             position_rates = {
                 row.get("previous_segment_position_bucket"): row.get("boundary_rate")
                 for row in position_rows
@@ -311,11 +295,8 @@ def main() -> int:
                 )
             )
             boundary_risk_scope = (
-                ((boundary.get("walk_forward_risk") or {}).get("scopes") or {}).get(
-                    "all_after_10"
-                )
-                or {}
-            )
+                (boundary.get("walk_forward_risk") or {}).get("scopes") or {}
+            ).get("all_after_10") or {}
             best_boundary_risk = _best_metric_model(
                 boundary_risk_scope.get("models") or {},
                 "brier",
@@ -328,12 +309,8 @@ def main() -> int:
                     )
                 )
             boundary_delta_scope = (
-                (
-                    (boundary.get("walk_forward_delta_prediction") or {}).get("scopes")
-                    or {}
-                ).get("all_after_10")
-                or {}
-            )
+                (boundary.get("walk_forward_delta_prediction") or {}).get("scopes") or {}
+            ).get("all_after_10") or {}
             best_boundary_delta = _best_metric_model(
                 boundary_delta_scope.get("models") or {},
                 "mae",
@@ -342,37 +319,22 @@ def main() -> int:
                 boundary_delta_scope.get("models") or {},
                 "rmse",
             )
-            gate_diagnostics = (
-                (boundary_delta_scope.get("risk_gate_diagnostics") or {}).get(
-                    "risk_gated_label_segment_age_mode"
-                )
-                or {}
-            )
+            gate_diagnostics = (boundary_delta_scope.get("risk_gate_diagnostics") or {}).get(
+                "risk_gated_label_segment_age_mode"
+            ) or {}
             adaptive_gate_diagnostics = (
-                (boundary_delta_scope.get("risk_gate_diagnostics") or {}).get(
-                    "adaptive_mae_gate_label_segment_age_mode"
-                )
-                or {}
-            )
+                boundary_delta_scope.get("risk_gate_diagnostics") or {}
+            ).get("adaptive_mae_gate_label_segment_age_mode") or {}
             if best_boundary_delta:
                 previous_delta_residuals = (
-                    (boundary_delta_scope.get("residual_diagnostics") or {}).get(
-                        "previous_delta"
-                    )
-                    or {}
-                )
+                    boundary_delta_scope.get("residual_diagnostics") or {}
+                ).get("previous_delta") or {}
                 boundary_state_errors = (
-                    (previous_delta_residuals.get("top_error_groups") or {}).get(
-                        "boundary_state"
-                    )
-                    or []
-                )
-                transition_errors = (
-                    (previous_delta_residuals.get("top_error_groups") or {}).get(
-                        "transition"
-                    )
-                    or []
-                )
+                    previous_delta_residuals.get("top_error_groups") or {}
+                ).get("boundary_state") or []
+                transition_errors = (previous_delta_residuals.get("top_error_groups") or {}).get(
+                    "transition"
+                ) or []
                 top_boundary_error = boundary_state_errors[0] if boundary_state_errors else {}
                 top_transition_error = transition_errors[0] if transition_errors else {}
                 print(
@@ -384,12 +346,8 @@ def main() -> int:
                         best=best_boundary_delta,
                         best_rmse=best_boundary_delta_rmse,
                         override=gate_diagnostics.get("override_share"),
-                        adaptive_override=adaptive_gate_diagnostics.get(
-                            "override_share"
-                        ),
-                        adaptive_threshold=adaptive_gate_diagnostics.get(
-                            "mean_threshold"
-                        ),
+                        adaptive_override=adaptive_gate_diagnostics.get("override_share"),
+                        adaptive_threshold=adaptive_gate_diagnostics.get("mean_threshold"),
                     )
                 )
                 print(
@@ -406,15 +364,9 @@ def main() -> int:
         variants = components.get("variants") or {}
         for variant_name in ("unweighted", "high_medium_fast_weighted"):
             variant = variants.get(variant_name) or {}
-            visible = (
-                (variant.get("visible_drain") or {})
-                .get("with_intercept", {})
-                .get("all", {})
-            )
+            visible = (variant.get("visible_drain") or {}).get("with_intercept", {}).get("all", {})
             credits = (
-                (variant.get("credit_accounting") or {})
-                .get("no_intercept", {})
-                .get("all", {})
+                (variant.get("credit_accounting") or {}).get("no_intercept", {}).get("all", {})
             )
             if visible or credits:
                 print(
@@ -456,8 +408,7 @@ def main() -> int:
                 if holdout:
                     diagnostics = model.get("holdout_error_diagnostics") or {}
                     print(
-                        "  {name}: r2={r2} mae={mae} within10={within10} "
-                        "large={large}".format(
+                        "  {name}: r2={r2} mae={mae} within10={within10} large={large}".format(
                             name=model_name,
                             r2=holdout.get("r2"),
                             mae=holdout.get("mae"),
@@ -478,15 +429,13 @@ def main() -> int:
                 sequence_name="same_span_capacity_controls",
                 validation="interleaved_every_5th",
             )
-            capacity_components = (
-                (capacity.get("token_component_regression") or {}).get("variants") or {}
-            )
+            capacity_components = (capacity.get("token_component_regression") or {}).get(
+                "variants"
+            ) or {}
             for variant_name in ("unweighted", "high_medium_fast_weighted"):
                 variant = capacity_components.get(variant_name) or {}
                 credits = (
-                    (variant.get("capacity_credits") or {})
-                    .get("no_intercept", {})
-                    .get("all", {})
+                    (variant.get("capacity_credits") or {}).get("no_intercept", {}).get("all", {})
                 )
                 if credits:
                     print(
@@ -500,48 +449,25 @@ def main() -> int:
                     )
         breakpoints = summary.get("allowance_breakpoint_analysis") or {}
         if breakpoints.get("span_count"):
-            global_fit = (
-                (breakpoints.get("global_credit_to_delta_fit") or {}).get("metrics")
-                or {}
-            )
-            piecewise_models = (
-                (breakpoints.get("piecewise_credit_to_delta_fit") or {}).get("models")
-                or {}
-            )
-            piecewise_fit = (
-                (
-                    piecewise_models.get("piecewise_mean_capacity_denominator")
-                    or {}
-                ).get("metrics")
-                or {}
-            )
+            global_fit = (breakpoints.get("global_credit_to_delta_fit") or {}).get("metrics") or {}
+            piecewise_models = (breakpoints.get("piecewise_credit_to_delta_fit") or {}).get(
+                "models"
+            ) or {}
+            piecewise_fit = (piecewise_models.get("piecewise_mean_capacity_denominator") or {}).get(
+                "metrics"
+            ) or {}
             ceiling_fit = (
-                (
-                    piecewise_models.get(
-                        "piecewise_ceiling_mean_capacity_denominator"
-                    )
-                    or {}
-                ).get("metrics")
-                or {}
-            )
-            online_models = (
-                (breakpoints.get("online_capacity_credit_to_delta_fit") or {}).get(
-                    "models"
-                )
-                or {}
-            )
-            online_previous = (
-                (online_models.get("previous_capacity_denominator") or {}).get(
-                    "metrics"
-                )
-                or {}
-            )
-            online_previous_errors = (
-                (
-                    online_models.get("previous_capacity_denominator") or {}
-                ).get("known_breakpoint_diagnostics")
-                or {}
-            )
+                piecewise_models.get("piecewise_ceiling_mean_capacity_denominator") or {}
+            ).get("metrics") or {}
+            online_models = (breakpoints.get("online_capacity_credit_to_delta_fit") or {}).get(
+                "models"
+            ) or {}
+            online_previous = (online_models.get("previous_capacity_denominator") or {}).get(
+                "metrics"
+            ) or {}
+            online_previous_errors = (online_models.get("previous_capacity_denominator") or {}).get(
+                "known_breakpoint_diagnostics"
+            ) or {}
             online_metric_models = {
                 name: (row.get("metrics") or {})
                 for name, row in online_models.items()
@@ -573,9 +499,7 @@ def main() -> int:
                         best=best_online,
                         r2=online_previous.get("r2"),
                         mae=online_previous.get("mae"),
-                        error_share=online_previous_errors.get(
-                            "known_breakpoint_abs_error_share"
-                        ),
+                        error_share=online_previous_errors.get("known_breakpoint_abs_error_share"),
                     )
                 )
     return 0
@@ -590,9 +514,7 @@ def _filter_rows_by_plan_type(
     if not allowed:
         return rows
     return [
-        row
-        for row in rows
-        if str(row.get("rate_limit_plan_type") or "").strip().lower() in allowed
+        row for row in rows if str(row.get("rate_limit_plan_type") or "").strip().lower() in allowed
     ]
 
 
@@ -603,17 +525,8 @@ def _print_feature_attribution(
     sequence_name: str,
     validation: str,
 ) -> None:
-    rows = (
-        ((attribution.get("sequences") or {}).get(sequence_name) or {}).get(
-            validation
-        )
-        or []
-    )
-    improvements = [
-        row
-        for row in rows
-        if row.get("mae_improvement_vs_previous") is not None
-    ]
+    rows = ((attribution.get("sequences") or {}).get(sequence_name) or {}).get(validation) or []
+    improvements = [row for row in rows if row.get("mae_improvement_vs_previous") is not None]
     if not improvements:
         return
     improvements.sort(

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -333,7 +333,9 @@ def _smoke_plugin_install(command: Path, temp_dir: Path) -> None:
     ]
     missing = [path for path in required_files if not path.exists()]
     if missing:
-        raise SystemExit("plugin install missing files: " + ", ".join(str(path) for path in missing))
+        raise SystemExit(
+            "plugin install missing files: " + ", ".join(str(path) for path in missing)
+        )
     manifest = json.loads((plugin_dir / ".codex-plugin" / "plugin.json").read_text())
     if manifest.get("name") != "codex-usage-tracker":
         raise SystemExit("plugin manifest name mismatch")
@@ -521,7 +523,9 @@ def _smoke_served_dashboard(
     try:
         react_html = _read_url_when_ready(react_url, process)
         legacy_html = _read_url(legacy_url)
-        react_js = _read_url(f"{root_url}/codex-usage-tracker-assets/react/assets/dashboard-react.js")
+        react_js = _read_url(
+            f"{root_url}/codex-usage-tracker-assets/react/assets/dashboard-react.js"
+        )
         react_css = _read_url(f"{root_url}/codex-usage-tracker-assets/react/assets/index.css")
     finally:
         process_output = _stop_process(process)
@@ -544,7 +548,9 @@ def _smoke_served_dashboard(
         raise SystemExit("served React CSS asset did not include dashboard shell styles")
 
 
-def _read_url_when_ready(url: str, process: subprocess.Popen[str], timeout_seconds: float = 15.0) -> str:
+def _read_url_when_ready(
+    url: str, process: subprocess.Popen[str], timeout_seconds: float = 15.0
+) -> str:
     deadline = time.monotonic() + timeout_seconds
     last_error: Exception | None = None
     while time.monotonic() < deadline:

--- a/src/codex_usage_tracker/allowance_intelligence/model.py
+++ b/src/codex_usage_tracker/allowance_intelligence/model.py
@@ -179,9 +179,7 @@ def _change_candidate(window_kind: str, spans: list[dict[str, Any]]) -> dict[str
         return None
 
     best: dict[str, Any] | None = None
-    for split in range(
-        _MIN_BASELINE_CHANGE_SPANS, len(spans) - _MIN_RECENT_CHANGE_SPANS + 1
-    ):
+    for split in range(_MIN_BASELINE_CHANGE_SPANS, len(spans) - _MIN_RECENT_CHANGE_SPANS + 1):
         previous = spans[:split]
         recent = spans[split:]
         previous_median = _median_credits_per_percent(previous)

--- a/src/codex_usage_tracker/allowance_intelligence/reports.py
+++ b/src/codex_usage_tracker/allowance_intelligence/reports.py
@@ -139,9 +139,7 @@ def build_allowance_export_report(
         "privacy_mode": "strict",
         "include_archived": include_archived,
         "summary": diagnostics["summary"],
-        "windows": [
-            _export_window(window) for window in diagnostics.get("windows", [])
-        ],
+        "windows": [_export_window(window) for window in diagnostics.get("windows", [])],
         "change_candidates": diagnostics.get("change_candidates", []),
         "notes": [
             *_privacy_notes(),
@@ -197,9 +195,7 @@ def _history_row(row: dict[str, Any], *, privacy_mode: str) -> dict[str, Any]:
     return payload
 
 
-def _privacy_filtered_analysis(
-    analysis: dict[str, Any], *, privacy_mode: str
-) -> dict[str, Any]:
+def _privacy_filtered_analysis(analysis: dict[str, Any], *, privacy_mode: str) -> dict[str, Any]:
     return {
         "summary": analysis["summary"],
         "windows": [
@@ -207,17 +203,14 @@ def _privacy_filtered_analysis(
             for window in analysis["windows"]
         ],
         "spans": [
-            _privacy_filtered_span(span, privacy_mode=privacy_mode)
-            for span in analysis["spans"]
+            _privacy_filtered_span(span, privacy_mode=privacy_mode) for span in analysis["spans"]
         ],
         "change_candidates": analysis["change_candidates"],
         "notes": [*analysis["notes"], *_privacy_notes()],
     }
 
 
-def _privacy_filtered_window(
-    window: dict[str, Any], *, privacy_mode: str
-) -> dict[str, Any]:
+def _privacy_filtered_window(window: dict[str, Any], *, privacy_mode: str) -> dict[str, Any]:
     return {
         "window_kind": window.get("window_kind"),
         "plan_type": window.get("plan_type"),
@@ -234,9 +227,7 @@ def _privacy_filtered_window(
     }
 
 
-def _privacy_filtered_span(
-    span: dict[str, Any], *, privacy_mode: str
-) -> dict[str, Any]:
+def _privacy_filtered_span(span: dict[str, Any], *, privacy_mode: str) -> dict[str, Any]:
     payload = dict(span)
     payload["start_observed_date"] = _date_bucket(payload.get("start_observed_at"))
     payload["end_observed_date"] = _date_bucket(payload.get("end_observed_at"))

--- a/src/codex_usage_tracker/cli/__init__.py
+++ b/src/codex_usage_tracker/cli/__init__.py
@@ -11,6 +11,7 @@ _API_MODULE = "codex_usage_tracker.cli.main"
 
 __all__ = ["main"]
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/cli/dashboard.py
+++ b/src/codex_usage_tracker/cli/dashboard.py
@@ -67,7 +67,9 @@ def run_serve_dashboard(args: argparse.Namespace) -> int:
                 "port": args.port,
                 "dashboard_path": path_payload(args.output),
                 "dashboard_url": _served_dashboard_url(args.host, args.port),
-                "legacy_dashboard_url": _served_legacy_dashboard_url(args.host, args.port, args.output.name),
+                "legacy_dashboard_url": _served_legacy_dashboard_url(
+                    args.host, args.port, args.output.name
+                ),
                 "limit": _limit_value(args),
                 "since": args.since,
                 "context_api": _context_api(args),

--- a/src/codex_usage_tracker/cli/main.py
+++ b/src/codex_usage_tracker/cli/main.py
@@ -76,7 +76,14 @@ def main() -> int:
         return _main()
     except BrokenPipeError:
         return 1
-    except (FileExistsError, FileNotFoundError, PermissionError, RuntimeError, ValueError, OSError) as exc:
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        PermissionError,
+        RuntimeError,
+        ValueError,
+        OSError,
+    ) as exc:
         print(f"Error: [{error_code(exc)}] {exc}", file=sys.stderr)
         return 1
 

--- a/src/codex_usage_tracker/cli/mcp_server.py
+++ b/src/codex_usage_tracker/cli/mcp_server.py
@@ -255,11 +255,15 @@ def _prune_dogfood_result_cache() -> None:
         _DOGFOOD_RESULT_CACHE.items(),
         key=lambda item: str(item[1].get("stored_at") or ""),
     )
-    for cache_key, _entry in removable[: max(0, len(_DOGFOOD_RESULT_CACHE) - _DOGFOOD_MAX_RESULT_CACHE)]:
+    for cache_key, _entry in removable[
+        : max(0, len(_DOGFOOD_RESULT_CACHE) - _DOGFOOD_MAX_RESULT_CACHE)
+    ]:
         _DOGFOOD_RESULT_CACHE.pop(cache_key, None)
 
 
-def _load_cached_dogfood_result(params: dict[str, Any], cache_key: str) -> tuple[dict[str, Any] | None, str]:
+def _load_cached_dogfood_result(
+    params: dict[str, Any], cache_key: str
+) -> tuple[dict[str, Any] | None, str]:
     cached = _DOGFOOD_RESULT_CACHE.get(cache_key)
     if cached is not None:
         return _copy_jsonable(cached["result"]), "memory"
@@ -295,11 +299,7 @@ def _prune_dogfood_jobs() -> None:
     if len(_DOGFOOD_JOBS) <= _DOGFOOD_MAX_JOBS:
         return
     removable = sorted(
-        (
-            job
-            for job in _DOGFOOD_JOBS.values()
-            if job.get("status") not in {"queued", "running"}
-        ),
+        (job for job in _DOGFOOD_JOBS.values() if job.get("status") not in {"queued", "running"}),
         key=lambda row: str(row.get("updated_at") or row.get("created_at") or ""),
     )
     for job in removable[: max(0, len(_DOGFOOD_JOBS) - _DOGFOOD_MAX_JOBS)]:
@@ -510,6 +510,7 @@ def refresh_usage_index(
     )
     return refresh_result_payload(result, schema="codex-usage-tracker-refresh-v1")
 
+
 @mcp.tool()
 def usage_refresh_start(
     include_archived: bool = False,
@@ -531,7 +532,6 @@ def usage_refresh_status(job_id: str) -> dict[str, Any]:
     """Poll an async local usage refresh job for phase progress and result."""
 
     return _REFRESH_JOB_REGISTRY.status(job_id)
-
 
 
 @mcp.tool()
@@ -1165,42 +1165,44 @@ def usage_dogfood_start(
             _prune_dogfood_jobs()
         else:
             _DOGFOOD_JOBS[job_id] = {
-            "job_id": job_id,
-            "job_type": "agentic_dogfood",
-            "status": "queued",
-            "percent_complete": 0,
-            "current_stage": "queued",
-            "stages": [],
-            "created_at": now,
-            "updated_at": now,
-            "started_at": None,
-            "completed_at": None,
-            "error": None,
-            "filters": {
-                "since": since,
-                "until": until,
-                "thread": thread,
-                "include_archived": include_archived,
-                "evidence_limit": max(1, evidence_limit),
-                "privacy_mode": privacy_mode,
-                "refresh": refresh,
-                "run_hypotheses": run_hypotheses,
-                "run_deep_investigations": run_deep_investigations,
-                "use_cache": use_cache,
-            },
-            "cache": {},
-            "result_cache": {
-                "enabled": use_cache,
-                "cacheable": True,
-                "hit": False,
-                "source": cache_source if use_cache and not refresh else None,
-                "cache_key": cache_key,
-                "miss_reason": cache_source
-                if use_cache and not refresh
-                else "refresh_requested" if use_cache else "disabled",
-            },
-            "artifacts": {},
-            "result": None,
+                "job_id": job_id,
+                "job_type": "agentic_dogfood",
+                "status": "queued",
+                "percent_complete": 0,
+                "current_stage": "queued",
+                "stages": [],
+                "created_at": now,
+                "updated_at": now,
+                "started_at": None,
+                "completed_at": None,
+                "error": None,
+                "filters": {
+                    "since": since,
+                    "until": until,
+                    "thread": thread,
+                    "include_archived": include_archived,
+                    "evidence_limit": max(1, evidence_limit),
+                    "privacy_mode": privacy_mode,
+                    "refresh": refresh,
+                    "run_hypotheses": run_hypotheses,
+                    "run_deep_investigations": run_deep_investigations,
+                    "use_cache": use_cache,
+                },
+                "cache": {},
+                "result_cache": {
+                    "enabled": use_cache,
+                    "cacheable": True,
+                    "hit": False,
+                    "source": cache_source if use_cache and not refresh else None,
+                    "cache_key": cache_key,
+                    "miss_reason": cache_source
+                    if use_cache and not refresh
+                    else "refresh_requested"
+                    if use_cache
+                    else "disabled",
+                },
+                "artifacts": {},
+                "result": None,
             }
         _prune_dogfood_jobs()
     if cache_hit_payload is not None:
@@ -1386,10 +1388,7 @@ def usage_calls(
             include_archived_default=include_archived,
             thread_key=thread_key,
         ),
-        live_call_rows=lambda *,
-        query_params,
-        pricing_status,
-        credit_confidence: _live_call_rows(
+        live_call_rows=lambda *, query_params, pricing_status, credit_confidence: _live_call_rows(
             query_params=query_params,
             pricing_status=pricing_status,
             credit_confidence=credit_confidence,
@@ -1519,10 +1518,7 @@ def usage_report_pack(
             include_archived_default=include_archived,
             thread_key=thread_key,
         ),
-        live_call_rows=lambda *,
-        query_params,
-        pricing_status,
-        credit_confidence: _live_call_rows(
+        live_call_rows=lambda *, query_params, pricing_status, credit_confidence: _live_call_rows(
             query_params=query_params,
             pricing_status=pricing_status,
             credit_confidence=credit_confidence,
@@ -1697,6 +1693,7 @@ def update_usage_pricing_config(
         "estimated_model_count": result.estimated_model_count,
         "backup_path": str(result.backup_path) if result.backup_path else None,
     }
+
 
 if __name__ == "__main__":
     mcp.run()

--- a/src/codex_usage_tracker/cli/parser.py
+++ b/src/codex_usage_tracker/cli/parser.py
@@ -199,7 +199,9 @@ def _add_refresh_parser(subparsers: argparse._SubParsersAction[argparse.Argument
     refresh.add_argument("--json", action="store_true", dest="as_json")
 
 
-def _add_inspect_log_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+def _add_inspect_log_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
     inspect = subparsers.add_parser(
         "inspect-log",
         help="Inspect one Codex JSONL log through the parser without writing to SQLite",
@@ -310,7 +312,9 @@ def _add_query_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPa
     query.add_argument("--credit-confidence", choices=QUERY_CREDIT_CONFIDENCE_CHOICES)
     query.add_argument("--min-tokens", type=int)
     query.add_argument("--min-credits", type=float)
-    query.add_argument("--limit", type=int, default=100, help="Maximum rows to return; use 0 for all")
+    query.add_argument(
+        "--limit", type=int, default=100, help="Maximum rows to return; use 0 for all"
+    )
     query.add_argument(
         "--json",
         action="store_true",
@@ -326,17 +330,21 @@ def _add_recommendations_parser(
         "recommendations",
         help="Rank aggregate usage rows and threads by action recommendation severity",
     )
-    recommendations.add_argument("--since", help="Only include calls at or after this ISO date/time")
-    recommendations.add_argument("--until", help="Only include calls at or before this ISO date/time")
+    recommendations.add_argument(
+        "--since", help="Only include calls at or after this ISO date/time"
+    )
+    recommendations.add_argument(
+        "--until", help="Only include calls at or before this ISO date/time"
+    )
     recommendations.add_argument("--model")
     recommendations.add_argument("--effort")
     recommendations.add_argument("--thread")
     recommendations.add_argument("--project")
     recommendations.add_argument("--min-score", type=float)
-    recommendations.add_argument("--limit", type=int, default=20, help="Maximum rows to return; use 0 for all")
+    recommendations.add_argument(
+        "--limit", type=int, default=20, help="Maximum rows to return; use 0 for all"
+    )
     recommendations.add_argument("--json", action="store_true", dest="as_json")
-
-
 
 
 def _add_action_brief_parser(
@@ -403,7 +411,9 @@ def _add_dashboard_parsers(
 ) -> None:
     dashboard = subparsers.add_parser("dashboard", help="Generate static dashboard")
     dashboard.add_argument("--output", type=Path, default=DEFAULT_DASHBOARD_PATH)
-    dashboard.add_argument("--limit", type=int, default=5000, help="Maximum calls to load; use 0 for all")
+    dashboard.add_argument(
+        "--limit", type=int, default=5000, help="Maximum calls to load; use 0 for all"
+    )
     dashboard.add_argument("--since", help="Only include calls at or after this ISO date/time")
     dashboard.add_argument(
         "--include-archived",
@@ -417,7 +427,9 @@ def _add_dashboard_parsers(
         "open-dashboard", help="Generate the default dashboard and open it"
     )
     open_dashboard.add_argument("--output", type=Path, default=DEFAULT_DASHBOARD_PATH)
-    open_dashboard.add_argument("--limit", type=int, default=5000, help="Maximum calls to load; use 0 for all")
+    open_dashboard.add_argument(
+        "--limit", type=int, default=5000, help="Maximum calls to load; use 0 for all"
+    )
     open_dashboard.add_argument("--since", help="Only include calls at or after this ISO date/time")
     open_dashboard.add_argument(
         "--include-archived",
@@ -441,7 +453,9 @@ def _add_dashboard_parsers(
         help="Serve dashboard with lazy localhost context loading",
     )
     serve.add_argument("--output", type=Path, default=DEFAULT_DASHBOARD_PATH)
-    serve.add_argument("--limit", type=int, default=5000, help="Initial maximum calls to load; use 0 for all")
+    serve.add_argument(
+        "--limit", type=int, default=5000, help="Initial maximum calls to load; use 0 for all"
+    )
     serve.add_argument("--since", help="Only include calls at or after this ISO date/time")
     serve.add_argument("--host", default="127.0.0.1")
     serve.add_argument("--port", type=int, default=8765)
@@ -495,7 +509,9 @@ def _add_pricing_coverage_parser(
     pricing_coverage = subparsers.add_parser(
         "pricing-coverage", help="Show priced, estimated, and unpriced token coverage"
     )
-    pricing_coverage.add_argument("--since", help="Only include calls at or after this ISO date/time")
+    pricing_coverage.add_argument(
+        "--since", help="Only include calls at or after this ISO date/time"
+    )
     pricing_coverage.add_argument("--limit", type=int, default=20)
     pricing_coverage.add_argument(
         "--json",

--- a/src/codex_usage_tracker/cli/parser_diagnostics.py
+++ b/src/codex_usage_tracker/cli/parser_diagnostics.py
@@ -207,7 +207,9 @@ def _add_diagnostics_fact_sort(
     *,
     default_limit: int,
 ) -> None:
-    parser.add_argument("--limit", type=int, default=default_limit, help="Maximum rows; use 0 for all")
+    parser.add_argument(
+        "--limit", type=int, default=default_limit, help="Maximum rows; use 0 for all"
+    )
     parser.add_argument("--sort", choices=DIAGNOSTIC_FACT_SORT_CHOICES, default="uncached")
     parser.add_argument("--direction", choices=DIAGNOSTIC_DIRECTION_CHOICES, default="desc")
     parser.add_argument("--json", action="store_true", dest="as_json")

--- a/src/codex_usage_tracker/context/__init__.py
+++ b/src/codex_usage_tracker/context/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.context.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/context/api.py
+++ b/src/codex_usage_tracker/context/api.py
@@ -63,9 +63,7 @@ def load_call_context(
         record_id=record_id,
         diagnostic_payload=diagnostic_payload,
     )
-    source_file, source_file_bytes, line_number = context_source_location(
-        row, record_id=record_id
-    )
+    source_file, source_file_bytes, line_number = context_source_location(row, record_id=record_id)
     loaded = _read_context_for_usage_record(
         row=row,
         source_file=source_file,

--- a/src/codex_usage_tracker/context/loader.py
+++ b/src/codex_usage_tracker/context/loader.py
@@ -42,9 +42,7 @@ def load_context_usage_record(
     return row
 
 
-def context_source_location(
-    row: dict[str, Any], *, record_id: str
-) -> tuple[Path, int, int]:
+def context_source_location(row: dict[str, Any], *, record_id: str) -> tuple[Path, int, int]:
     source_file = Path(str(row.get("source_file") or ""))
     if not source_file.exists():
         raise FileNotFoundError(f"Source log not found: {source_file}")
@@ -125,9 +123,7 @@ def attach_context_diagnostics(
     diagnostic_payload["serialized_estimate_ms"] = loaded.serialized_estimate_ms
     diagnostic_payload["source_file_bytes"] = source_file_bytes
     diagnostic_payload["source_line_number"] = line_number
-    diagnostic_payload["entries_before_limit"] = int(
-        loaded.omitted.get("total_entries") or 0
-    )
+    diagnostic_payload["entries_before_limit"] = int(loaded.omitted.get("total_entries") or 0)
     diagnostic_payload["entries_returned"] = len(loaded.entries)
     payload["diagnostics"] = diagnostic_payload
     diagnostic_payload["json_bytes"] = json_byte_count(payload)

--- a/src/codex_usage_tracker/context/reader.py
+++ b/src/codex_usage_tracker/context/reader.py
@@ -88,8 +88,7 @@ def _normalize_context_mode(mode: str) -> str:
     normalized = str(mode or CONTEXT_MODE_QUICK).strip().lower()
     if normalized not in CONTEXT_MODES:
         raise ValueError(
-            f"Unsupported context mode: {mode}. Expected one of: "
-            f"{', '.join(sorted(CONTEXT_MODES))}"
+            f"Unsupported context mode: {mode}. Expected one of: {', '.join(sorted(CONTEXT_MODES))}"
         )
     return normalized
 
@@ -208,13 +207,19 @@ def _scan_context_line(
     if _pending_summary_handled(state, line_number, timestamp, entry_type, summarized):
         return False
     if summarized is not None:
-        state.candidates.append(_summarized_context_entry(line_number, timestamp, entry_type, summarized))
+        state.candidates.append(
+            _summarized_context_entry(line_number, timestamp, entry_type, summarized)
+        )
     return _is_token_count_boundary(line_number, token_line, entry_type, payload)
 
 
 def _context_envelope_parts(envelope: dict[str, Any]) -> tuple[str, dict[str, Any], str | None]:
     payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else {}
-    return optional_str(envelope.get("type")) or "unknown", payload, optional_str(envelope.get("timestamp"))
+    return (
+        optional_str(envelope.get("type")) or "unknown",
+        payload,
+        optional_str(envelope.get("timestamp")),
+    )
 
 
 def _is_token_count_boundary(
@@ -223,7 +228,11 @@ def _is_token_count_boundary(
     entry_type: str,
     payload: dict[str, Any],
 ) -> bool:
-    return line_number >= token_line and entry_type == "event_msg" and payload.get("type") == "token_count"
+    return (
+        line_number >= token_line
+        and entry_type == "event_msg"
+        and payload.get("type") == "token_count"
+    )
 
 
 def _start_turn_context(
@@ -371,7 +380,6 @@ def _summarized_context_entry(
         else None,
         action_duration_ms=nonnegative_float(summarized.get("action_duration_ms")),
     )
-
 
 
 def _context_entry(

--- a/src/codex_usage_tracker/core/call_origin.py
+++ b/src/codex_usage_tracker/core/call_origin.py
@@ -18,12 +18,7 @@ class CallOriginFlags:
 
     @property
     def has_signal(self) -> bool:
-        return (
-            self.user_message
-            or self.compaction
-            or self.tool_result
-            or self.codex_activity
-        )
+        return self.user_message or self.compaction or self.tool_result or self.codex_activity
 
 
 def event_flags_from_envelope(envelope: object) -> CallOriginFlags:
@@ -49,9 +44,7 @@ def _payload_mapping(envelope: Mapping[str, Any]) -> Mapping[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _is_user_message_event(
-    entry_type: object, payload_type: object, role: object
-) -> bool:
+def _is_user_message_event(entry_type: object, payload_type: object, role: object) -> bool:
     return (
         entry_type == "event_msg"
         and payload_type == "user_message"
@@ -73,9 +66,7 @@ def _is_tool_result_event(entry_type: object, payload_type: object) -> bool:
     )
 
 
-def _is_codex_activity_event(
-    entry_type: object, payload_type: object, role: object
-) -> bool:
+def _is_codex_activity_event(entry_type: object, payload_type: object, role: object) -> bool:
     return (
         entry_type == "event_msg"
         and payload_type in {"agent_message", "mcp_tool_call_begin"}

--- a/src/codex_usage_tracker/core/formatting.py
+++ b/src/codex_usage_tracker/core/formatting.py
@@ -186,9 +186,7 @@ def format_doctor(report: dict[str, Any]) -> str:
         package = environment.get("package")
         if isinstance(package, dict):
             lines.append(
-                "Package: "
-                f"{package.get('name', 'unknown')} "
-                f"{package.get('version', 'unknown')}"
+                f"Package: {package.get('name', 'unknown')} {package.get('version', 'unknown')}"
             )
         python = environment.get("python")
         if isinstance(python, dict):
@@ -214,11 +212,7 @@ def format_doctor(report: dict[str, Any]) -> str:
         if isinstance(assets, dict):
             asset_status = "available" if assets.get("available") else "missing"
             missing = assets.get("missing")
-            suffix = (
-                f" ({len(missing)} missing)"
-                if isinstance(missing, list) and missing
-                else ""
-            )
+            suffix = f" ({len(missing)} missing)" if isinstance(missing, list) and missing else ""
             lines.append(f"Dashboard assets: {asset_status}{suffix}")
         lines.append("")
     for check in report.get("checks", []):
@@ -259,8 +253,7 @@ def format_pricing_coverage(report: dict[str, Any], limit: int = 20) -> str:
         elif row.get("priced_as"):
             status = f"priced as {row.get('priced_as')}"
         lines.append(
-            f"- {model}: {status}; {_fmt_int(row.get('total_tokens'))} tokens"
-            f"{_cost_suffix(row)}"
+            f"- {model}: {status}; {_fmt_int(row.get('total_tokens'))} tokens{_cost_suffix(row)}"
         )
     return "\n".join(lines)
 

--- a/src/codex_usage_tracker/core/i18n.py
+++ b/src/codex_usage_tracker/core/i18n.py
@@ -160,9 +160,8 @@ def dashboard_i18n_payload(language: str | None = None) -> dict[str, object]:
 def _cached_raw_catalog(language: str) -> dict[str, str]:
     if language not in SUPPORTED_LANGUAGES:
         language = DEFAULT_LANGUAGE
-    resource = (
-        resources.files("codex_usage_tracker.plugin_data")
-        .joinpath("dashboard", "locales", f"{language}.json")
+    resource = resources.files("codex_usage_tracker.plugin_data").joinpath(
+        "dashboard", "locales", f"{language}.json"
     )
     try:
         data = json.loads(resource.read_text(encoding="utf-8"))
@@ -177,6 +176,8 @@ def _cached_raw_catalog(language: str) -> dict[str, str]:
         if not isinstance(key, str) or not key:
             raise ValueError(f"dashboard locale catalog contains an invalid key: {language}")
         if not isinstance(value, str) or not value.strip():
-            raise ValueError(f"dashboard locale catalog contains an invalid value for {key!r}: {language}")
+            raise ValueError(
+                f"dashboard locale catalog contains an invalid value for {key!r}: {language}"
+            )
         catalog[key] = value
     return catalog

--- a/src/codex_usage_tracker/core/json_contract_cli.py
+++ b/src/codex_usage_tracker/core/json_contract_cli.py
@@ -14,18 +14,18 @@ NoneType = type(None)
 Number = (int, float)
 
 CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
-    'codex-usage-tracker-setup-v1': {
-            "required": {
-                "codex_home": str,
-                "codex_home_exists": bool,
-                "plugin": dict,
-                "pricing": dict,
-                "refresh": dict,
-                "doctor": dict,
-                "restart_required": bool,
-            }
-        },
-    'codex-usage-tracker-doctor-v1': {
+    "codex-usage-tracker-setup-v1": {
+        "required": {
+            "codex_home": str,
+            "codex_home_exists": bool,
+            "plugin": dict,
+            "pricing": dict,
+            "refresh": dict,
+            "doctor": dict,
+            "restart_required": bool,
+        }
+    },
+    "codex-usage-tracker-doctor-v1": {
         "required": {
             "status": str,
             "failures": int,
@@ -34,80 +34,80 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "checks": list,
         }
     },
-    'codex-usage-tracker-plugin-install-v1': {"required": PLUGIN_INSTALL_FIELDS},
-    'codex-usage-tracker-plugin-upgrade-v1': {"required": PLUGIN_INSTALL_FIELDS},
-    'codex-usage-tracker-plugin-uninstall-v1': {
-            "required": {
-                "plugin_dir": str,
-                "marketplace_path": str,
-                "removed_plugin_path": bool,
-                "removed_marketplace_entry": bool,
-                "restart_required": bool,
-            }
-        },
-    'codex-usage-tracker-refresh-v1': {"required": REFRESH_RESULT_FIELDS},
-    'codex-usage-tracker-rebuild-index-v1': {"required": REFRESH_RESULT_FIELDS},
-    'codex-usage-tracker-reset-db-v1': {
-            "required": {
-                "db_path": str,
-                "deleted_usage_events": int,
-            }
-        },
-    'codex-usage-tracker-summary-v1': {
-            "required": {
-                "group_by": str,
-                "is_expensive": bool,
-                "privacy_mode": str,
-                "row_count": int,
-                "rows": list,
-            }
-        },
-    'codex-usage-tracker-query-v1': {
-            "required": {
-                "filters": dict,
-                "row_count": int,
-                "total_matched_rows": int,
-                "truncated": bool,
-                "rows": list,
-            },
-            "nested": {
-                "filters": {
-                    "since": (str, NoneType),
-                    "until": (str, NoneType),
-                    "model": (str, NoneType),
-                    "effort": (str, NoneType),
-                    "thread": (str, NoneType),
-                    "project": (str, NoneType),
-                    "pricing_status": (str, NoneType),
-                    "credit_confidence": (str, NoneType),
-                    "min_tokens": (int, NoneType),
-                    "min_credits": (int, float, NoneType),
-                    "limit": (int, NoneType),
-                    "privacy_mode": str,
-                }
-            },
-        },
-    'codex-usage-tracker-recommendations-v1': {
+    "codex-usage-tracker-plugin-install-v1": {"required": PLUGIN_INSTALL_FIELDS},
+    "codex-usage-tracker-plugin-upgrade-v1": {"required": PLUGIN_INSTALL_FIELDS},
+    "codex-usage-tracker-plugin-uninstall-v1": {
+        "required": {
+            "plugin_dir": str,
+            "marketplace_path": str,
+            "removed_plugin_path": bool,
+            "removed_marketplace_entry": bool,
+            "restart_required": bool,
+        }
+    },
+    "codex-usage-tracker-refresh-v1": {"required": REFRESH_RESULT_FIELDS},
+    "codex-usage-tracker-rebuild-index-v1": {"required": REFRESH_RESULT_FIELDS},
+    "codex-usage-tracker-reset-db-v1": {
+        "required": {
+            "db_path": str,
+            "deleted_usage_events": int,
+        }
+    },
+    "codex-usage-tracker-summary-v1": {
+        "required": {
+            "group_by": str,
+            "is_expensive": bool,
+            "privacy_mode": str,
+            "row_count": int,
+            "rows": list,
+        }
+    },
+    "codex-usage-tracker-query-v1": {
         "required": {
             "filters": dict,
-                "row_count": int,
-                "total_matched_rows": int,
-                "truncated": bool,
-                "threads": list,
-                "rows": list,
-            },
-            "nested": {
-                "filters": {
-                    "since": (str, NoneType),
-                    "until": (str, NoneType),
-                    "model": (str, NoneType),
-                    "effort": (str, NoneType),
-                    "thread": (str, NoneType),
-                    "project": (str, NoneType),
-                    "include_archived": bool,
-                    "min_score": (int, float, NoneType),
-                    "limit": (int, NoneType),
-                    "privacy_mode": str,
+            "row_count": int,
+            "total_matched_rows": int,
+            "truncated": bool,
+            "rows": list,
+        },
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "model": (str, NoneType),
+                "effort": (str, NoneType),
+                "thread": (str, NoneType),
+                "project": (str, NoneType),
+                "pricing_status": (str, NoneType),
+                "credit_confidence": (str, NoneType),
+                "min_tokens": (int, NoneType),
+                "min_credits": (int, float, NoneType),
+                "limit": (int, NoneType),
+                "privacy_mode": str,
+            }
+        },
+    },
+    "codex-usage-tracker-recommendations-v1": {
+        "required": {
+            "filters": dict,
+            "row_count": int,
+            "total_matched_rows": int,
+            "truncated": bool,
+            "threads": list,
+            "rows": list,
+        },
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "model": (str, NoneType),
+                "effort": (str, NoneType),
+                "thread": (str, NoneType),
+                "project": (str, NoneType),
+                "include_archived": bool,
+                "min_score": (int, float, NoneType),
+                "limit": (int, NoneType),
+                "privacy_mode": str,
             }
         },
     },
@@ -146,61 +146,61 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "notes": list,
         },
     },
-    'codex-usage-tracker-dashboard-v1': {
+    "codex-usage-tracker-dashboard-v1": {
         "required": {
             "dashboard_path": str,
-                "file_url": str,
-                "opened": bool,
-                "limit": (int, NoneType),
-                "since": (str, NoneType),
-                "privacy_mode": str,
-                "include_archived": bool,
-            }
-        },
-    'codex-usage-tracker-open-dashboard-v1': {
-            "required": {
-                "dashboard_path": str,
-                "file_url": str,
-                "opened": bool,
-                "limit": (int, NoneType),
-                "since": (str, NoneType),
-                "refresh": (dict, NoneType),
-                "privacy_mode": str,
-                "include_archived": bool,
-            }
-        },
-    'codex-usage-tracker-serve-dashboard-v1': {
-            "required": {
-                "host": str,
-                "port": int,
-                "dashboard_path": str,
-                "dashboard_url": str,
-                "legacy_dashboard_url": str,
-                "limit": (int, NoneType),
-                "since": (str, NoneType),
-                "context_api": str,
-                "refresh_before_start": bool,
-                "privacy_mode": str,
-                "include_archived": bool,
-            }
-        },
-    'codex-usage-tracker-pricing-coverage-v1': {
+            "file_url": str,
+            "opened": bool,
+            "limit": (int, NoneType),
+            "since": (str, NoneType),
+            "privacy_mode": str,
+            "include_archived": bool,
+        }
+    },
+    "codex-usage-tracker-open-dashboard-v1": {
+        "required": {
+            "dashboard_path": str,
+            "file_url": str,
+            "opened": bool,
+            "limit": (int, NoneType),
+            "since": (str, NoneType),
+            "refresh": (dict, NoneType),
+            "privacy_mode": str,
+            "include_archived": bool,
+        }
+    },
+    "codex-usage-tracker-serve-dashboard-v1": {
+        "required": {
+            "host": str,
+            "port": int,
+            "dashboard_path": str,
+            "dashboard_url": str,
+            "legacy_dashboard_url": str,
+            "limit": (int, NoneType),
+            "since": (str, NoneType),
+            "context_api": str,
+            "refresh_before_start": bool,
+            "privacy_mode": str,
+            "include_archived": bool,
+        }
+    },
+    "codex-usage-tracker-pricing-coverage-v1": {
         "required": {
             "model_count": int,
-                "priced_model_count": int,
-                "unpriced_model_count": int,
-                "total_tokens": Number,
-                "priced_tokens": Number,
-                "unpriced_tokens": Number,
-                "estimated_cost_usd": Number,
-                "priced_token_ratio": Number,
-                "pricing_loaded": bool,
-                "pricing_path": str,
-                "pricing_source": (dict, NoneType),
+            "priced_model_count": int,
+            "unpriced_model_count": int,
+            "total_tokens": Number,
+            "priced_tokens": Number,
+            "unpriced_tokens": Number,
+            "estimated_cost_usd": Number,
+            "priced_token_ratio": Number,
+            "pricing_loaded": bool,
+            "pricing_path": str,
+            "pricing_source": (dict, NoneType),
             "rows": list,
         }
     },
-    'codex-usage-tracker-source-coverage-v1': {
+    "codex-usage-tracker-source-coverage-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -213,7 +213,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "rows": list,
         }
     },
-    'codex-usage-tracker-content-search-v1': {
+    "codex-usage-tracker-content-search-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -243,7 +243,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-thread-trace-v1': {
+    "codex-usage-tracker-thread-trace-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -272,7 +272,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-pattern-scan-v1': {
+    "codex-usage-tracker-pattern-scan-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -296,7 +296,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-repeated-file-rediscovery-v1': {
+    "codex-usage-tracker-repeated-file-rediscovery-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -319,7 +319,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-shell-churn-v1': {
+    "codex-usage-tracker-shell-churn-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -342,7 +342,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-large-low-output-v1': {
+    "codex-usage-tracker-large-low-output-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -365,7 +365,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-investigation-suggestions-v1': {
+    "codex-usage-tracker-investigation-suggestions-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -387,7 +387,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-agentic-investigation-v1': {
+    "codex-usage-tracker-agentic-investigation-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -411,7 +411,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-action-brief-v1': {
+    "codex-usage-tracker-action-brief-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -434,7 +434,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-hypothesis-test-v1': {
+    "codex-usage-tracker-hypothesis-test-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -457,7 +457,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-investigation-walk-v1': {
+    "codex-usage-tracker-investigation-walk-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -480,7 +480,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-local-evidence-export-v1': {
+    "codex-usage-tracker-local-evidence-export-v1": {
         "required": {
             "content_mode": str,
             "includes_indexed_content": bool,
@@ -504,60 +504,60 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             }
         },
     },
-    'codex-usage-tracker-export-v1': {
+    "codex-usage-tracker-export-v1": {
         "required": {
             "rows": int,
-                "csv_path": str,
-                "limit": (int, NoneType),
-                "privacy_mode": str,
-            }
-        },
-    'codex-usage-tracker-init-pricing-v1': {
-            "required": {"pricing_path": str, **PATH_CREATED_FIELDS}
-        },
-    'codex-usage-tracker-update-pricing-v1': {
-            "required": {
-                "pricing_path": str,
-                "source_url": str,
-                "tier": str,
-                "fetched_at": str,
-                "model_count": int,
-                "estimated_model_count": int,
-                "backup_path": (str, NoneType),
-            }
-        },
-    'codex-usage-tracker-pin-pricing-v1': {
-            "required": {
-                "pricing_path": str,
-                "source_pricing_path": str,
-            }
-        },
-    'codex-usage-tracker-init-allowance-v1': {
-            "required": {"allowance_path": str, **PATH_CREATED_FIELDS}
-        },
-    'codex-usage-tracker-parse-allowance-v1': {
-            "required": {
-                "allowance_path": str,
-                "updated": bool,
-            }
-        },
-    'codex-usage-tracker-update-rate-card-v1': {
-            "required": {
-                "rate_card_path": str,
-                "source_url": (str, NoneType),
-                "fetched_at": (str, NoneType),
-                "model_count": int,
-                "alias_count": int,
-                "backup_path": (str, NoneType),
-            }
-        },
-    'codex-usage-tracker-init-thresholds-v1': {
-            "required": {"thresholds_path": str, **PATH_CREATED_FIELDS}
-        },
-    'codex-usage-tracker-init-projects-v1': {
-            "required": {"projects_path": str, **PATH_CREATED_FIELDS}
-        },
-    'codex-usage-tracker-support-bundle-v1': {
+            "csv_path": str,
+            "limit": (int, NoneType),
+            "privacy_mode": str,
+        }
+    },
+    "codex-usage-tracker-init-pricing-v1": {
+        "required": {"pricing_path": str, **PATH_CREATED_FIELDS}
+    },
+    "codex-usage-tracker-update-pricing-v1": {
+        "required": {
+            "pricing_path": str,
+            "source_url": str,
+            "tier": str,
+            "fetched_at": str,
+            "model_count": int,
+            "estimated_model_count": int,
+            "backup_path": (str, NoneType),
+        }
+    },
+    "codex-usage-tracker-pin-pricing-v1": {
+        "required": {
+            "pricing_path": str,
+            "source_pricing_path": str,
+        }
+    },
+    "codex-usage-tracker-init-allowance-v1": {
+        "required": {"allowance_path": str, **PATH_CREATED_FIELDS}
+    },
+    "codex-usage-tracker-parse-allowance-v1": {
+        "required": {
+            "allowance_path": str,
+            "updated": bool,
+        }
+    },
+    "codex-usage-tracker-update-rate-card-v1": {
+        "required": {
+            "rate_card_path": str,
+            "source_url": (str, NoneType),
+            "fetched_at": (str, NoneType),
+            "model_count": int,
+            "alias_count": int,
+            "backup_path": (str, NoneType),
+        }
+    },
+    "codex-usage-tracker-init-thresholds-v1": {
+        "required": {"thresholds_path": str, **PATH_CREATED_FIELDS}
+    },
+    "codex-usage-tracker-init-projects-v1": {
+        "required": {"projects_path": str, **PATH_CREATED_FIELDS}
+    },
+    "codex-usage-tracker-support-bundle-v1": {
         "required": {
             "support_bundle_path": str,
             "privacy": dict,
@@ -580,7 +580,7 @@ CLI_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
                 "cli_hint_fields": list,
                 "do_not_add": list,
                 "note": str,
-            }
+            },
         },
     },
 }

--- a/src/codex_usage_tracker/core/json_contract_diagnostics.py
+++ b/src/codex_usage_tracker/core/json_contract_diagnostics.py
@@ -8,149 +8,149 @@ NoneType = type(None)
 Number = (int, float)
 
 DIAGNOSTIC_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
-    'codex-usage-tracker-diagnostics-v1': {
-            "required": {
-                "view": str,
-                "filters": dict,
-                "row_count": int,
-                "total_matched_rows": int,
-                "truncated": bool,
-                "raw_context_included": bool,
-                "rows": list,
-                "notes": list,
-            },
-            "nested": {
-                "filters": {
-                    "since": (str, NoneType),
-                    "until": (str, NoneType),
-                    "model": (str, NoneType),
-                    "effort": (str, NoneType),
-                    "thread": (str, NoneType),
-                    "min_tokens": (int, NoneType),
-                    "fact_type": (str, NoneType),
-                    "fact_name": (str, NoneType),
-                    "fact_category": (str, NoneType),
-                    "fact_group": (str, NoneType),
-                    "include_archived": bool,
-                    "sort": str,
-                    "direction": str,
-                    "limit": (int, NoneType),
-                    "offset": int,
-                    "privacy_mode": str,
-                }
-            },
+    "codex-usage-tracker-diagnostics-v1": {
+        "required": {
+            "view": str,
+            "filters": dict,
+            "row_count": int,
+            "total_matched_rows": int,
+            "truncated": bool,
+            "raw_context_included": bool,
+            "rows": list,
+            "notes": list,
         },
-    'codex-usage-tracker-diagnostic-overview-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "overview": (dict, NoneType),
-                "notes": list,
+        "nested": {
+            "filters": {
+                "since": (str, NoneType),
+                "until": (str, NoneType),
+                "model": (str, NoneType),
+                "effort": (str, NoneType),
+                "thread": (str, NoneType),
+                "min_tokens": (int, NoneType),
+                "fact_type": (str, NoneType),
+                "fact_name": (str, NoneType),
+                "fact_category": (str, NoneType),
+                "fact_group": (str, NoneType),
+                "include_archived": bool,
+                "sort": str,
+                "direction": str,
+                "limit": (int, NoneType),
+                "offset": int,
+                "privacy_mode": str,
             }
         },
-    'codex-usage-tracker-diagnostic-tool-output-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "functions": list,
-                "command_roots": list,
-                "missing_reasons": list,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-commands-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "commands": list,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-git-interactions-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "interactions": list,
-                "categories": list,
-                "mutability": list,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-file-reads-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "by_reader": list,
-                "top_paths": list,
-                "largest_read_commands": list,
-                "path_privacy": dict,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-file-modifications-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "top_paths": list,
-                "by_extension": list,
-                "largest_events": list,
-                "path_privacy": dict,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-read-productivity-v1': {
-            "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "by_reader": list,
-                "top_modified_paths": list,
-                "path_privacy": dict,
-                "notes": list,
-            }
-        },
-    'codex-usage-tracker-diagnostic-concentration-v1': {
+    },
+    "codex-usage-tracker-diagnostic-overview-v1": {
         "required": {
             "section": str,
             "status": str,
             "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "metrics": list,
-                "dimensions": list,
-                "largest_impact_rows": list,
-                "privacy": dict,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "overview": (dict, NoneType),
             "notes": list,
         }
     },
-    'codex-usage-tracker-diagnostic-guided-summary-v1': {
+    "codex-usage-tracker-diagnostic-tool-output-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "functions": list,
+            "command_roots": list,
+            "missing_reasons": list,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-commands-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "commands": list,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-git-interactions-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "interactions": list,
+            "categories": list,
+            "mutability": list,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-file-reads-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "by_reader": list,
+            "top_paths": list,
+            "largest_read_commands": list,
+            "path_privacy": dict,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-file-modifications-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "top_paths": list,
+            "by_extension": list,
+            "largest_events": list,
+            "path_privacy": dict,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-read-productivity-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "by_reader": list,
+            "top_modified_paths": list,
+            "path_privacy": dict,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-concentration-v1": {
+        "required": {
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "metrics": list,
+            "dimensions": list,
+            "largest_impact_rows": list,
+            "privacy": dict,
+            "notes": list,
+        }
+    },
+    "codex-usage-tracker-diagnostic-guided-summary-v1": {
         "required": {
             "section": str,
             "status": str,
@@ -167,19 +167,19 @@ DIAGNOSTIC_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "notes": list,
         }
     },
-    'codex-usage-tracker-diagnostic-usage-drain-v1': {
+    "codex-usage-tracker-diagnostic-usage-drain-v1": {
         "required": {
-                "section": str,
-                "status": str,
-                "refreshed": bool,
-                "raw_context_included": bool,
-                "snapshot": (dict, NoneType),
-                "summary": (dict, NoneType),
-                "thread_cost_curves": dict,
-                "time_series": dict,
-                "model_highlights": dict,
-                "pricing": dict,
-                "notes": list,
-            }
-        },
+            "section": str,
+            "status": str,
+            "refreshed": bool,
+            "raw_context_included": bool,
+            "snapshot": (dict, NoneType),
+            "summary": (dict, NoneType),
+            "thread_cost_curves": dict,
+            "time_series": dict,
+            "model_highlights": dict,
+            "pricing": dict,
+            "notes": list,
+        }
+    },
 }

--- a/src/codex_usage_tracker/core/json_contract_server.py
+++ b/src/codex_usage_tracker/core/json_contract_server.py
@@ -8,48 +8,48 @@ NoneType = type(None)
 Number = (int, float)
 
 SERVER_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
-    'codex-usage-tracker-session-v1': {
-            "required": {
-                "requested_session_id": (str, NoneType),
-                "resolved_session_id": (str, NoneType),
-                "limit": int,
-                "privacy_mode": str,
-                "row_count": int,
-                "rows": list,
-            }
-        },
-    'codex-usage-tracker-context-v1': {
-            "required": {
-                "loaded_on_demand": bool,
-                "raw_context_persisted": bool,
-                "include_tool_output": bool,
-                "record": dict,
-                "source": dict,
-                "entries": list,
-                "omitted": dict,
-            }
-        },
-    'codex-usage-tracker-context-disabled-v1': {
-            "required": {
-                "error": str,
-                "raw_context_enabled": bool,
-                "record_id": str,
-            }
-        },
-    'codex-usage-tracker-context-settings-v1': {
-            "required": {
-                "context_api_enabled": bool,
-                "raw_context_persisted": bool,
-            }
-        },
-    'codex-usage-tracker-open-investigator-v1': {
-            "required": {
-                "opened": bool,
-                "url": str,
-            }
-        },
-    'codex-usage-tracker-live-api-v1': {"required": {}},
-    'codex-usage-tracker-async-job-status-v1': {
+    "codex-usage-tracker-session-v1": {
+        "required": {
+            "requested_session_id": (str, NoneType),
+            "resolved_session_id": (str, NoneType),
+            "limit": int,
+            "privacy_mode": str,
+            "row_count": int,
+            "rows": list,
+        }
+    },
+    "codex-usage-tracker-context-v1": {
+        "required": {
+            "loaded_on_demand": bool,
+            "raw_context_persisted": bool,
+            "include_tool_output": bool,
+            "record": dict,
+            "source": dict,
+            "entries": list,
+            "omitted": dict,
+        }
+    },
+    "codex-usage-tracker-context-disabled-v1": {
+        "required": {
+            "error": str,
+            "raw_context_enabled": bool,
+            "record_id": str,
+        }
+    },
+    "codex-usage-tracker-context-settings-v1": {
+        "required": {
+            "context_api_enabled": bool,
+            "raw_context_persisted": bool,
+        }
+    },
+    "codex-usage-tracker-open-investigator-v1": {
+        "required": {
+            "opened": bool,
+            "url": str,
+        }
+    },
+    "codex-usage-tracker-live-api-v1": {"required": {}},
+    "codex-usage-tracker-async-job-status-v1": {
         "required": {
             "job_id": str,
             "job_type": str,
@@ -57,61 +57,61 @@ SERVER_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
             "percent_complete": int,
         }
     },
-    'codex-usage-tracker-status-v1': {
+    "codex-usage-tracker-status-v1": {
         "required": {
-                "payload_schema": str,
-                "latest_refresh_at": (str, NoneType),
-                "include_archived": bool,
-                "row_counts": dict,
-                "max_event_timestamp": (str, NoneType),
-                "parser_diagnostics": dict,
-            }
-        },
-    'codex-usage-tracker-calls-v1': {
-            "required": {
-                "rows": list,
-                "row_count": int,
-                "total_matched_rows": int,
-                "limit": (int, NoneType),
-                "offset": int,
-                "has_more": bool,
-                "next_offset": (int, NoneType),
-                "filters": dict,
-                "raw_context_included": bool,
-            }
-        },
-    'codex-usage-tracker-call-v1': {
-            "required": {
-                "record": dict,
-                "previous_record_id": (str, NoneType),
-                "next_record_id": (str, NoneType),
-                "raw_context_included": bool,
-            }
-        },
-    'codex-usage-tracker-threads-v1': {
-            "required": {
-                "rows": list,
-                "row_count": int,
-                "limit": (int, NoneType),
-                "offset": int,
-                "include_archived": bool,
-                "raw_context_included": bool,
-            }
-        },
-    'codex-usage-tracker-thread-calls-v1': {
+            "payload_schema": str,
+            "latest_refresh_at": (str, NoneType),
+            "include_archived": bool,
+            "row_counts": dict,
+            "max_event_timestamp": (str, NoneType),
+            "parser_diagnostics": dict,
+        }
+    },
+    "codex-usage-tracker-calls-v1": {
         "required": {
-            "thread_key": str,
             "rows": list,
-                "row_count": int,
-                "total_matched_rows": int,
-                "limit": (int, NoneType),
-                "offset": int,
-                "has_more": bool,
-                "next_offset": (int, NoneType),
+            "row_count": int,
+            "total_matched_rows": int,
+            "limit": (int, NoneType),
+            "offset": int,
+            "has_more": bool,
+            "next_offset": (int, NoneType),
+            "filters": dict,
             "raw_context_included": bool,
         }
     },
-    'codex-usage-tracker-reports-pack-v1': {
+    "codex-usage-tracker-call-v1": {
+        "required": {
+            "record": dict,
+            "previous_record_id": (str, NoneType),
+            "next_record_id": (str, NoneType),
+            "raw_context_included": bool,
+        }
+    },
+    "codex-usage-tracker-threads-v1": {
+        "required": {
+            "rows": list,
+            "row_count": int,
+            "limit": (int, NoneType),
+            "offset": int,
+            "include_archived": bool,
+            "raw_context_included": bool,
+        }
+    },
+    "codex-usage-tracker-thread-calls-v1": {
+        "required": {
+            "thread_key": str,
+            "rows": list,
+            "row_count": int,
+            "total_matched_rows": int,
+            "limit": (int, NoneType),
+            "offset": int,
+            "has_more": bool,
+            "next_offset": (int, NoneType),
+            "raw_context_included": bool,
+        }
+    },
+    "codex-usage-tracker-reports-pack-v1": {
         "required": {
             "reports": list,
             "evidence": dict,

--- a/src/codex_usage_tracker/core/json_contract_validation.py
+++ b/src/codex_usage_tracker/core/json_contract_validation.py
@@ -78,10 +78,7 @@ def _validate_contract_field(
 
 
 def _contract_type_error(field_path: str, value: object, expected: object) -> str:
-    return (
-        f"{field_path} must be {_describe_type(expected)}, "
-        f"got {type(value).__name__}"
-    )
+    return f"{field_path} must be {_describe_type(expected)}, got {type(value).__name__}"
 
 
 def _matches_type(value: object, expected: object) -> bool:

--- a/src/codex_usage_tracker/core/projects.py
+++ b/src/codex_usage_tracker/core/projects.py
@@ -71,9 +71,7 @@ def _project_aliases(payload: dict[str, Any]) -> dict[str, str]:
 
 def _project_ignored_paths(payload: dict[str, Any]) -> list[str]:
     return [
-        str(value)
-        for value in _list_section(payload, "ignored_paths")
-        if isinstance(value, str)
+        str(value) for value in _list_section(payload, "ignored_paths") if isinstance(value, str)
     ]
 
 
@@ -353,7 +351,11 @@ def _apply_project_privacy_to_row(row: dict[str, Any], mode: str) -> dict[str, A
 
 def _redacted_cwd_label(value: object) -> str:
     key = str(value or "unknown")
-    digest = key[:8] if len(key) >= 8 and all(ch in "0123456789abcdef" for ch in key[:8].lower()) else _stable_hash(key)[:8]
+    digest = (
+        key[:8]
+        if len(key) >= 8 and all(ch in "0123456789abcdef" for ch in key[:8].lower())
+        else _stable_hash(key)[:8]
+    )
     return f"[redacted cwd:{digest}]"
 
 

--- a/src/codex_usage_tracker/core/schema.py
+++ b/src/codex_usage_tracker/core/schema.py
@@ -86,9 +86,7 @@ USAGE_EVENT_SCHEMA_CHECKSUM = hashlib.sha256(
     )
 ).hexdigest()
 USAGE_EVENT_REPAIR_COLUMNS = {
-    column.name: column.alter_type
-    for column in USAGE_EVENT_COLUMNS
-    if column.repairable
+    column.name: column.alter_type for column in USAGE_EVENT_COLUMNS if column.repairable
 }
 
 DIAGNOSTIC_FACT_COLUMN_NAMES = (

--- a/src/codex_usage_tracker/dashboard/__init__.py
+++ b/src/codex_usage_tracker/dashboard/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.dashboard.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/dashboard/api.py
+++ b/src/codex_usage_tracker/dashboard/api.py
@@ -376,9 +376,7 @@ def render_dashboard_html(
         "call_investigator_script_src": call_investigator_script_src,
         "script_src": script_src,
     }
-    script_srcs.update(
-        {key: value for key, value in script_overrides.items() if value is not None}
-    )
+    script_srcs.update({key: value for key, value in script_overrides.items() if value is not None})
     return render_dashboard_template(
         payload,
         guide_href=guide_href,
@@ -535,22 +533,6 @@ def _previous_dashboard_payload(output_path: Path) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return raw if isinstance(raw, dict) else None
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def _safe_int(value: object) -> int:

--- a/src/codex_usage_tracker/dashboard/assets.py
+++ b/src/codex_usage_tracker/dashboard/assets.py
@@ -69,6 +69,7 @@ DEFAULT_DASHBOARD_SCRIPT_SRCS = {
     for key, _placeholder, filename in DASHBOARD_SCRIPT_ASSETS
 }
 
+
 def dashboard_guide_href(output_path: Path) -> str | None:
     override = os.environ.get("CODEX_USAGE_TRACKER_DOCS_URL")
     if override:
@@ -83,6 +84,7 @@ def dashboard_guide_href(output_path: Path) -> str | None:
         return None
     return "codex-usage-tracker-guide/dashboard-guide.html"
 
+
 def dashboard_assets_href(output_path: Path) -> str:
     assets_source = resources.files("codex_usage_tracker.plugin_data").joinpath("dashboard")
     assets_target = output_path.parent / "codex-usage-tracker-assets"
@@ -90,6 +92,7 @@ def dashboard_assets_href(output_path: Path) -> str:
         shutil.rmtree(assets_target)
     _copy_dashboard_resource_tree(assets_source, assets_target)
     return "codex-usage-tracker-assets"
+
 
 def versioned_asset_href(output_path: Path, asset_base: str, filename: str) -> str:
     asset_path = output_path.parent / asset_base / filename
@@ -99,11 +102,13 @@ def versioned_asset_href(output_path: Path, asset_base: str, filename: str) -> s
         return f"{asset_base}/{filename}"
     return f"{asset_base}/{filename}?v={digest}"
 
+
 def dashboard_script_srcs(output_path: Path, asset_base: str) -> dict[str, str]:
     return {
         key: versioned_asset_href(output_path, asset_base, filename)
         for key, _placeholder, filename in DASHBOARD_SCRIPT_ASSETS
     }
+
 
 def _copy_dashboard_resource_tree(source: Any, target: Path) -> None:
     target.mkdir(parents=True, exist_ok=True)
@@ -113,6 +118,7 @@ def _copy_dashboard_resource_tree(source: Any, target: Path) -> None:
             _copy_dashboard_resource_tree(child, destination)
         else:
             destination.write_bytes(child.read_bytes())
+
 
 def render_dashboard_template(
     payload: str,
@@ -154,6 +160,7 @@ def render_dashboard_template(
         )
     return rendered
 
+
 def format_body_attrs(attrs: dict[str, str] | None) -> str:
     if not attrs:
         return ""
@@ -163,6 +170,7 @@ def format_body_attrs(attrs: dict[str, str] | None) -> str:
             continue
         rendered.append(f'{html.escape(key, quote=True)}="{html.escape(str(value), quote=True)}"')
     return " " + " ".join(rendered) if rendered else ""
+
 
 def _read_dashboard_asset(name: str) -> str:
     asset = resources.files("codex_usage_tracker.plugin_data").joinpath("dashboard", name)

--- a/src/codex_usage_tracker/diagnostics/__init__.py
+++ b/src/codex_usage_tracker/diagnostics/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.diagnostics.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/diagnostics/action_hints.py
+++ b/src/codex_usage_tracker/diagnostics/action_hints.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-_DEFAULT_ACTION_HINT = (
-    "Open associated high-cost calls when the pattern needs more context."
-)
+_DEFAULT_ACTION_HINT = "Open associated high-cost calls when the pattern needs more context."
 _COMMAND_FAMILY_HINT = (
     "Review repeated validation or command loops when associated uncached input is high."
 )
 _UNKNOWN_COMMAND_HINT = (
     "Open associated calls when shell activity is high; command text is intentionally not stored."
 )
-_COMPACTION_HINT = (
-    "Review associated calls to see whether compaction reduced context or a fresh handoff would be cleaner."
-)
+_COMPACTION_HINT = "Review associated calls to see whether compaction reduced context or a fresh handoff would be cleaner."
 _FACT_TYPE_ACTION_HINTS = {
     "mcp_server": (
         "Inspect repeated MCP activity and narrow tool result scope when associated costs are high."
@@ -27,9 +23,7 @@ _FACT_TYPE_ACTION_HINTS = {
     "function": (
         "Check whether repeated function calls are carrying more context forward than needed."
     ),
-    "tool": (
-        "Check whether repeated tool activity is carrying forward more context than needed."
-    ),
+    "tool": ("Check whether repeated tool activity is carrying forward more context than needed."),
 }
 _FACT_NAME_ACTION_HINTS = {
     "search_read_command": (
@@ -44,15 +38,9 @@ _FACT_NAME_ACTION_HINTS = {
     "function_call_output": (
         "Inspect repeated large tool results when associated uncached input is high."
     ),
-    "patch_applied": (
-        "Likely productive work; verify tests or commit state captured the change."
-    ),
-    "task_complete": (
-        "Consider archiving or writing a handoff before reviving the thread later."
-    ),
-    "turn_aborted": (
-        "Inspect associated calls for interrupted work or retry loops."
-    ),
+    "patch_applied": ("Likely productive work; verify tests or commit state captured the change."),
+    "task_complete": ("Consider archiving or writing a handoff before reviving the thread later."),
+    "turn_aborted": ("Inspect associated calls for interrupted work or retry loops."),
 }
 
 

--- a/src/codex_usage_tracker/diagnostics/api.py
+++ b/src/codex_usage_tracker/diagnostics/api.py
@@ -483,7 +483,11 @@ def _check_plugin_link(plugin_link: Path, repo_root: Path | None) -> DoctorCheck
     if plugin_link.is_symlink():
         target = plugin_link.resolve()
         if _looks_like_plugin_root(target):
-            kind = "source checkout" if repo_root and target == repo_root.resolve() else "plugin wrapper"
+            kind = (
+                "source checkout"
+                if repo_root and target == repo_root.resolve()
+                else "plugin wrapper"
+            )
             return DoctorCheck(
                 "Plugin registration",
                 "pass",
@@ -549,24 +553,6 @@ def _check_marketplace(marketplace_path: Path) -> DoctorCheck:
         f"No {PLUGIN_NAME} entry found in {marketplace_path}.",
         "Run: codex-usage-tracker install-plugin",
     )
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 def _safe_int(value: object) -> int:

--- a/src/codex_usage_tracker/diagnostics/fact_classifiers.py
+++ b/src/codex_usage_tracker/diagnostics/fact_classifiers.py
@@ -54,6 +54,7 @@ SEARCH_READ_COMMANDS = frozenset(
     }
 )
 
+
 def structured_tool_and_skill_facts(
     *,
     entry_type: object,
@@ -247,8 +248,6 @@ def _command_activity_facts(
             )
         )
     return tuple(facts)
-
-
 
 
 def _skill_label(payload: dict[str, Any]) -> str | None:

--- a/src/codex_usage_tracker/diagnostics/facts.py
+++ b/src/codex_usage_tracker/diagnostics/facts.py
@@ -108,8 +108,6 @@ def diagnostic_facts_from_envelope(
     return ()
 
 
-
-
 def _with_derived_loop_facts(
     segment: tuple[DiagnosticFact, ...],
 ) -> tuple[DiagnosticFact, ...]:
@@ -151,9 +149,7 @@ def _derived_loop_specs(
     )
 
 
-def _loop_source_facts(
-    segment: tuple[DiagnosticFact, ...], *, kind: str
-) -> list[DiagnosticFact]:
+def _loop_source_facts(segment: tuple[DiagnosticFact, ...], *, kind: str) -> list[DiagnosticFact]:
     if kind == "search_read":
         return [fact for fact in segment if _is_search_read_fact(fact)]
     if kind == "retry":
@@ -178,8 +174,6 @@ def _fact_event_total(facts: list[DiagnosticFact]) -> int:
     return sum(fact.event_count for fact in facts)
 
 
-
-
 def _derived_loop_fact(
     *,
     fact_name: str,
@@ -187,9 +181,7 @@ def _derived_loop_fact(
     event_count: int,
     source_facts: list[DiagnosticFact],
 ) -> DiagnosticFact:
-    first_source_line = _min_optional_int(
-        *[fact.first_source_line for fact in source_facts]
-    )
+    first_source_line = _min_optional_int(*[fact.first_source_line for fact in source_facts])
     last_source_line = _max_optional_int(*[fact.last_source_line for fact in source_facts])
     return DiagnosticFact(
         record_id=None,

--- a/src/codex_usage_tracker/diagnostics/mcp.py
+++ b/src/codex_usage_tracker/diagnostics/mcp.py
@@ -249,11 +249,14 @@ def _mcp_import_failure(command: str, result: subprocess.CompletedProcess[str]) 
         ),
     )
 
+
 def _uses_direct_mcp_module(args: list[str]) -> bool:
     return "-m" in args and "codex_usage_tracker.mcp_server" in args
 
+
 def _uses_bootstrap_launcher(args: list[str]) -> bool:
     return any(arg.endswith("skills/codex-usage-tracker/scripts/run_mcp.py") for arg in args)
+
 
 def _check_mcp_launcher(repo_root: Path, args: list[str]) -> DoctorCheck:
     script_args = [
@@ -282,6 +285,7 @@ def _check_mcp_launcher(repo_root: Path, args: list[str]) -> DoctorCheck:
         "MCP bootstrap launcher is present; it validates or installs the runtime on startup.",
     )
 
+
 def _resolve_mcp_command(command: object, repo_root: Path) -> str | None:
     if not isinstance(command, str) or not command:
         return None
@@ -293,11 +297,13 @@ def _resolve_mcp_command(command: object, repo_root: Path) -> str | None:
         return str(resolved) if resolved.exists() else None
     return shutil.which(command)
 
+
 def _resolve_mcp_cwd(cwd: object, repo_root: Path) -> Path:
     if not isinstance(cwd, str) or not cwd:
         return repo_root
     cwd_path = Path(cwd)
     return cwd_path if cwd_path.is_absolute() else (repo_root / cwd_path).resolve()
+
 
 def _first_error_line(text: str) -> str:
     for line in text.splitlines():
@@ -305,6 +311,7 @@ def _first_error_line(text: str) -> str:
         if stripped:
             return stripped
     return ""
+
 
 def check_mcp_import() -> DoctorCheck:
     module_spec = importlib.util.find_spec("codex_usage_tracker.mcp_server")

--- a/src/codex_usage_tracker/diagnostics/reports.py
+++ b/src/codex_usage_tracker/diagnostics/reports.py
@@ -448,9 +448,7 @@ def _filter_fact_group(
         return rows
     if fact_group == "tools":
         return [
-            row
-            for row in rows
-            if str(row.get("fact_type") or "") in DIAGNOSTIC_TOOL_FACT_TYPES
+            row for row in rows if str(row.get("fact_type") or "") in DIAGNOSTIC_TOOL_FACT_TYPES
         ]
     raise ValueError(f"unknown diagnostic fact group: {fact_group}")
 

--- a/src/codex_usage_tracker/diagnostics/snapshot_analysis.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_analysis.py
@@ -62,7 +62,9 @@ def analyze_indexed_source_logs(
     meta["usage_rows_scanned"] = usage_rows_scanned
 
     for source_log in source_logs:
-        _scan_source_log(source_log, counters=counters, meta=meta, source_record_index=source_record_index)
+        _scan_source_log(
+            source_log, counters=counters, meta=meta, source_record_index=source_record_index
+        )
 
     return _analysis_payload(counters=counters, meta=meta)
 
@@ -231,7 +233,9 @@ def _source_log_line_may_have_diagnostic_payload(line: str) -> bool:
     return '"response_item"' in line or '"patch_apply_end"' in line
 
 
-def _record_id_for_order(source_log: Path, order: int, source_record_index: SourceRecordIndex) -> str | None:
+def _record_id_for_order(
+    source_log: Path, order: int, source_record_index: SourceRecordIndex
+) -> str | None:
     rows = source_record_index.get(str(source_log))
     if not rows:
         return None
@@ -371,7 +375,9 @@ def _tool_output_payload(counters: dict[str, Any]) -> dict[str, Any]:
             "function_calls": int(sum(counters["function_calls"].values())),
             "function_outputs": int(sum(counters["function_outputs"].values())),
             "outputs_with_original_token_count": int(sum(counters["output_with_count"].values())),
-            "outputs_missing_original_token_count": int(sum(counters["output_missing_count"].values())),
+            "outputs_missing_original_token_count": int(
+                sum(counters["output_missing_count"].values())
+            ),
             "original_token_sum": int(sum(counters["output_token_sum"].values())),
         },
         "functions": function_rows(
@@ -431,7 +437,9 @@ def _git_interactions_payload(counters: dict[str, Any]) -> dict[str, Any]:
             git_interaction_token_sum=counters["git_interaction_token_sum"],
         ),
         "categories": simple_rows(counters["git_interactions_by_category"], key_name="category"),
-        "mutability": simple_rows(counters["git_interactions_by_mutability"], key_name="mutability"),
+        "mutability": simple_rows(
+            counters["git_interactions_by_mutability"], key_name="mutability"
+        ),
     }
 
 
@@ -441,8 +449,12 @@ def _file_reads_payload(counters: dict[str, Any]) -> dict[str, Any]:
             "read_commands": counters["read_command_count"],
             "read_events": len(counters["read_events"]),
             "unique_paths_read": len(counters["read_path_refs"]),
-            "read_events_with_output_count": int(sum(counters["read_events_with_count_by_reader"].values())),
-            "read_events_missing_output_count": int(sum(counters["read_events_missing_count_by_reader"].values())),
+            "read_events_with_output_count": int(
+                sum(counters["read_events_with_count_by_reader"].values())
+            ),
+            "read_events_missing_output_count": int(
+                sum(counters["read_events_missing_count_by_reader"].values())
+            ),
             "allocated_output_token_sum": int(sum(counters["read_tokens_by_reader"].values())),
         },
         "by_reader": read_reader_rows(
@@ -495,7 +507,9 @@ def _read_productivity_payload(counters: dict[str, Any]) -> dict[str, Any]:
         "summary": {
             "read_events": len(counters["read_events"]),
             "read_events_modified_later": read_modified_count,
-            "read_events_modified_later_pct": ratio(read_modified_count, len(counters["read_events"])),
+            "read_events_modified_later_pct": ratio(
+                read_modified_count, len(counters["read_events"])
+            ),
             "unique_paths_read": len(counters["read_path_refs"]),
             "unique_paths_modified_later": len(counters["read_modified_by_path"]),
             "unique_path_modified_later_pct": ratio(

--- a/src/codex_usage_tracker/diagnostics/snapshot_concentration.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_concentration.py
@@ -109,7 +109,6 @@ def compute_concentration(
     }
 
 
-
 def _add_concentration_row(
     groups: dict[str, dict[str, Any]],
     *,
@@ -148,7 +147,10 @@ def _concentration_dimension(
     *,
     total_tokens: int,
 ) -> dict[str, Any]:
-    rows = [_concentration_group_row(dimension, group, total_tokens=total_tokens) for group in groups.values()]
+    rows = [
+        _concentration_group_row(dimension, group, total_tokens=total_tokens)
+        for group in groups.values()
+    ]
     rows = sorted(
         rows,
         key=lambda row: (-int(row["total_tokens"]), -int(row["usage_rows"]), row["label"]),
@@ -209,7 +211,12 @@ def _largest_impact_rows(dimensions: list[dict[str, Any]]) -> list[dict[str, Any
             rows.append(dict(row))
     return sorted(
         rows,
-        key=lambda row: (-float(row["share"]), -int(row["total_tokens"]), row["dimension"], row["label"]),
+        key=lambda row: (
+            -float(row["share"]),
+            -int(row["total_tokens"]),
+            row["dimension"],
+            row["label"],
+        ),
     )[:15]
 
 
@@ -264,8 +271,6 @@ def _day_label(value: object) -> str:
     return "unknown_day"
 
 
-
-
 def concentration_privacy_metadata() -> dict[str, str]:
     return {
         "source_log_label_policy": "session_id_prefix_or_source_hash",
@@ -291,7 +296,11 @@ def _path_ref_from_token(token: str) -> dict[str, str] | None:
 
 def _safe_path_label(token: str) -> str | None:
     normalized = token.rstrip("/")
-    label = normalized if normalized in {".", ".."} else normalized.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    label = (
+        normalized
+        if normalized in {".", ".."}
+        else normalized.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    )
     if not label:
         return None
     lowered = label.lower()

--- a/src/codex_usage_tracker/diagnostics/snapshot_events.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_events.py
@@ -99,9 +99,7 @@ ORIGINAL_OUTPUT_RE = re.compile(
 def shell_command_from_payload(payload: dict[str, Any], *, function_name: str) -> str | None:
     if not is_shell_tool(function_name):
         return None
-    return _shell_command_from_arguments(payload.get("arguments")) or _command_from_mapping(
-        payload
-    )
+    return _shell_command_from_arguments(payload.get("arguments")) or _command_from_mapping(payload)
 
 
 def _shell_command_from_arguments(arguments: object) -> str | None:

--- a/src/codex_usage_tracker/diagnostics/snapshot_report.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_report.py
@@ -227,9 +227,7 @@ def _signal_lines(signals: object) -> list[str]:
     if not rows:
         return ["- No signals available."]
     return [
-        f"- {row.get('title')}: {row.get('finding')}"
-        for row in rows
-        if isinstance(row, dict)
+        f"- {row.get('title')}: {row.get('finding')}" for row in rows if isinstance(row, dict)
     ] or ["- No signals available."]
 
 

--- a/src/codex_usage_tracker/diagnostics/snapshot_rows.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_rows.py
@@ -17,7 +17,9 @@ def function_rows(
     output_missing_count: Counter[str],
     output_token_sum: Counter[str],
 ) -> list[dict[str, Any]]:
-    names = set(function_calls) | set(function_outputs) | set(output_with_count) | set(output_token_sum)
+    names = (
+        set(function_calls) | set(function_outputs) | set(output_with_count) | set(output_token_sum)
+    )
     rows = [
         {
             "function": name,
@@ -30,7 +32,9 @@ def function_rows(
         }
         for name in names
     ]
-    return sorted(rows, key=lambda row: (-int(row["original_token_sum"]), -int(row["calls"]), row["function"]))
+    return sorted(
+        rows, key=lambda row: (-int(row["original_token_sum"]), -int(row["calls"]), row["function"])
+    )
 
 
 def command_output_rows(
@@ -52,7 +56,9 @@ def command_output_rows(
         }
         for root in set(command_calls) | set(command_token_sum)
     ]
-    return sorted(rows, key=lambda row: (-int(row["original_token_sum"]), -int(row["calls"]), row["root"]))
+    return sorted(
+        rows, key=lambda row: (-int(row["original_token_sum"]), -int(row["calls"]), row["root"])
+    )
 
 
 def command_rows(
@@ -137,7 +143,11 @@ def read_reader_rows(
     ]
     return sorted(
         rows,
-        key=lambda row: (-int(row["allocated_output_token_sum"]), -int(row["read_events"]), row["reader"]),
+        key=lambda row: (
+            -int(row["allocated_output_token_sum"]),
+            -int(row["read_events"]),
+            row["reader"],
+        ),
     )
 
 

--- a/src/codex_usage_tracker/diagnostics/snapshot_source_scan.py
+++ b/src/codex_usage_tracker/diagnostics/snapshot_source_scan.py
@@ -51,7 +51,9 @@ def record_function_call(
         call_roots[call_id] = root
         if representative_record_id:
             call_record_ids[call_id] = representative_record_id
-    _set_representative_record_id(counters["function_record_ids"], function_name, representative_record_id)
+    _set_representative_record_id(
+        counters["function_record_ids"], function_name, representative_record_id
+    )
     _set_representative_record_id(counters["command_record_ids"], root, representative_record_id)
     _record_git_command_interaction(
         command,
@@ -96,7 +98,9 @@ def _record_missing_shell_command(
         meta["missing_command"] += 1
 
 
-def _set_representative_record_id(mapping: dict[object, str], key: object, record_id: str | None) -> None:
+def _set_representative_record_id(
+    mapping: dict[object, str], key: object, record_id: str | None
+) -> None:
     if record_id and key not in mapping:
         mapping[key] = record_id
 
@@ -133,7 +137,9 @@ def _record_git_command_interaction(
     counters["git_interactions_by_root"][interaction["root"]] += 1
     if call_id:
         call_git_interactions[call_id] = interaction_key
-    _set_representative_record_id(counters["git_interaction_record_ids"], interaction_key, representative_record_id)
+    _set_representative_record_id(
+        counters["git_interaction_record_ids"], interaction_key, representative_record_id
+    )
 
 
 def _record_read_command(
@@ -195,8 +201,12 @@ def record_read_refs(
         indexes.append(event_index)
         counters["read_events_by_reader"][reader] += 1
         counters["read_events_by_path"][path_key] += 1
-        _set_representative_record_id(counters["read_reader_record_ids"], reader, representative_record_id)
-        _set_representative_record_id(counters["read_path_record_ids"], path_key, representative_record_id)
+        _set_representative_record_id(
+            counters["read_reader_record_ids"], reader, representative_record_id
+        )
+        _set_representative_record_id(
+            counters["read_path_record_ids"], path_key, representative_record_id
+        )
     return indexes
 
 
@@ -256,8 +266,8 @@ def record_function_output(
             output,
             counters=counters,
             function_name=function_name,
-        root=call_roots.get(call_id or ""),
-        git_interaction=git_interaction,
+            root=call_roots.get(call_id or ""),
+            git_interaction=git_interaction,
             read_indexes=read_indexes,
             representative_record_id=output_record_id,
         )
@@ -288,7 +298,9 @@ def record_missing_output_count(
     counters["missing_reasons"][missing_reason] += 1
     if root:
         counters["command_missing_count"][root] += 1
-        _set_representative_record_id(counters["command_record_ids"], root, representative_record_id)
+        _set_representative_record_id(
+            counters["command_record_ids"], root, representative_record_id
+        )
     if git_interaction:
         counters["git_interaction_missing_count"][git_interaction] += 1
         _set_representative_record_id(
@@ -316,7 +328,9 @@ def record_output_count(
     if root:
         counters["command_with_count"][root] += 1
         counters["command_token_sum"][root] += count
-        _set_representative_record_id(counters["command_record_ids"], root, representative_record_id)
+        _set_representative_record_id(
+            counters["command_record_ids"], root, representative_record_id
+        )
     if git_interaction:
         counters["git_interaction_with_count"][git_interaction] += 1
         counters["git_interaction_token_sum"][git_interaction] += count

--- a/src/codex_usage_tracker/parser/__init__.py
+++ b/src/codex_usage_tracker/parser/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.parser.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/parser/api.py
+++ b/src/codex_usage_tracker/parser/api.py
@@ -25,6 +25,7 @@ from codex_usage_tracker.parser.state import (
 
 PARSER_DIAGNOSTIC_KEYS = _parser_state.PARSER_DIAGNOSTIC_KEYS
 
+
 @dataclass(frozen=True)
 class ParserAdapter:
     """Versioned parser adapter for one Codex log format family."""

--- a/src/codex_usage_tracker/parser/jsonl_v1.py
+++ b/src/codex_usage_tracker/parser/jsonl_v1.py
@@ -55,9 +55,11 @@ KNOWN_NON_TOKEN_EVENT_MSG_TYPES = frozenset(
     }
 )
 
+
 @dataclass(frozen=True)
 class ParsedUsageFile:
     """Parsed aggregate usage events plus the final parser cursor."""
+
     events: list[UsageEvent]
     diagnostic_facts: list[DiagnosticFact]
     state: ParserState
@@ -183,16 +185,14 @@ def _handle_jsonl_line(
         return
 
     payload_type = payload.get("type")
-    skipped, state.call_origin_segment, state.diagnostic_facts_segment = (
-        _handle_non_token_event(
-            envelope=envelope,
-            entry_type=entry_type,
-            payload_type=payload_type,
-            line_number=line_number,
-            call_origin_segment=state.call_origin_segment,
-            diagnostic_facts_segment=state.diagnostic_facts_segment,
-            stats=stats,
-        )
+    skipped, state.call_origin_segment, state.diagnostic_facts_segment = _handle_non_token_event(
+        envelope=envelope,
+        entry_type=entry_type,
+        payload_type=payload_type,
+        line_number=line_number,
+        call_origin_segment=state.call_origin_segment,
+        diagnostic_facts_segment=state.diagnostic_facts_segment,
+        stats=stats,
     )
     if skipped:
         return

--- a/src/codex_usage_tracker/parser/jsonl_values.py
+++ b/src/codex_usage_tracker/parser/jsonl_values.py
@@ -15,6 +15,7 @@ SESSION_ID_RE = re.compile(
     r"rollout-[^-]+-[0-9T:-]+-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$"
 )
 
+
 def build_usage_event(
     path: Path,
     line_number: int,
@@ -33,9 +34,7 @@ def build_usage_event(
     input_tokens = required_usage_int(last_usage, "input_tokens", stats=stats)
     cached_input_tokens = required_usage_int(last_usage, "cached_input_tokens", stats=stats)
     output_tokens = required_usage_int(last_usage, "output_tokens", stats=stats)
-    reasoning_output_tokens = required_usage_int(
-        last_usage, "reasoning_output_tokens", stats=stats
-    )
+    reasoning_output_tokens = required_usage_int(last_usage, "reasoning_output_tokens", stats=stats)
     total_tokens = required_usage_int(last_usage, "total_tokens", stats=stats)
     cumulative_total_tokens = required_usage_int(
         total_usage,

--- a/src/codex_usage_tracker/parser/state.py
+++ b/src/codex_usage_tracker/parser/state.py
@@ -122,8 +122,7 @@ def parser_state_to_json(state: ParserState) -> str:
                 for flags in state.call_origin_segment
             ],
             "diagnostic_facts_segment": [
-                diagnostic_fact_to_json(fact)
-                for fact in state.diagnostic_facts_segment
+                diagnostic_fact_to_json(fact) for fact in state.diagnostic_facts_segment
             ],
             "latest_record_id": state.latest_record_id,
             "latest_event_timestamp": state.latest_event_timestamp,
@@ -141,11 +140,7 @@ def empty_parser_diagnostics() -> dict[str, int]:
 def compact_parser_diagnostics(stats: MutableMapping[str, int]) -> dict[str, int]:
     """Return non-zero parser diagnostics in stable key order."""
 
-    return {
-        key: int(stats.get(key, 0))
-        for key in PARSER_DIAGNOSTIC_KEYS
-        if stats.get(key, 0)
-    }
+    return {key: int(stats.get(key, 0)) for key in PARSER_DIAGNOSTIC_KEYS if stats.get(key, 0)}
 
 
 def optional_str(value: object) -> str | None:

--- a/src/codex_usage_tracker/pricing/__init__.py
+++ b/src/codex_usage_tracker/pricing/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.pricing.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/pricing/allowance_config.py
+++ b/src/codex_usage_tracker/pricing/allowance_config.py
@@ -69,6 +69,7 @@ ALLOWANCE_TEMPLATE = {
     "aliases": {},
 }
 
+
 @dataclass(frozen=True)
 class AllowanceWindow:
     """One configured usage-limit window from the user's local allowance file."""
@@ -98,6 +99,7 @@ class UsageAllowanceConfig:
     source: dict[str, Any]
     error: str | None = None
     rate_card_error: str | None = None
+
 
 def load_allowance_config(
     path: Path = DEFAULT_ALLOWANCE_PATH,
@@ -198,9 +200,7 @@ def load_allowance_config(
     )
 
 
-def write_allowance_template(
-    path: Path = DEFAULT_ALLOWANCE_PATH, force: bool = False
-) -> Path:
+def write_allowance_template(path: Path = DEFAULT_ALLOWANCE_PATH, force: bool = False) -> Path:
     """Write a local template for optional allowance-window settings."""
 
     if path.exists() and not force:
@@ -266,6 +266,7 @@ def write_allowance_from_text(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
 
 def parse_windows(raw: object) -> list[AllowanceWindow]:
     windows: list[AllowanceWindow] = []

--- a/src/codex_usage_tracker/pricing/allowance_rate_card.py
+++ b/src/codex_usage_tracker/pricing/allowance_rate_card.py
@@ -27,6 +27,7 @@ DEFAULT_SOURCE = {
     "tier": "standard",
 }
 
+
 @dataclass(frozen=True)
 class RateCardUpdateResult:
     """Result from writing a local Codex credit rate-card snapshot."""
@@ -37,6 +38,7 @@ class RateCardUpdateResult:
     model_count: int
     alias_count: int
     backup_path: Path | None = None
+
 
 def load_bundled_rate_card() -> dict[str, Any]:
     """Load the package-bundled Codex credit rate-card snapshot."""
@@ -51,6 +53,7 @@ def load_bundled_rate_card() -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ValueError("bundled Codex rate card must be a JSON object")
     return raw
+
 
 def update_rate_card(
     path: Path = DEFAULT_RATE_CARD_PATH,
@@ -86,6 +89,7 @@ def update_rate_card(
         backup_path=backup_path,
     )
 
+
 def parse_credit_rates(raw: object) -> dict[str, dict[str, float]]:
     if not isinstance(raw, dict):
         return {}
@@ -102,6 +106,7 @@ def parse_credit_rates(raw: object) -> dict[str, dict[str, float]]:
             "output_per_million": _required_rate(rates, "output_per_million", normalized),
         }
     return parsed
+
 
 def parse_aliases(raw: object) -> dict[str, dict[str, str]]:
     if not isinstance(raw, dict):
@@ -136,6 +141,7 @@ def _parse_alias_entry(source_model: str, target: object) -> dict[str, str] | No
         or f"Mapped from {source_model} by local allowance config.",
     }
 
+
 def parse_rate_card_source(raw: object) -> dict[str, Any]:
     if not isinstance(raw, dict):
         return dict(DEFAULT_SOURCE)
@@ -143,6 +149,7 @@ def parse_rate_card_source(raw: object) -> dict[str, Any]:
     if not isinstance(source, dict):
         return dict(DEFAULT_SOURCE)
     return {**DEFAULT_SOURCE, **source}
+
 
 def parse_credit_rate_metadata(
     raw: object,
@@ -176,10 +183,12 @@ def _credit_rate_metadata_entry(
         or optional_str(source.get("name"))
         or "Codex credit rates",
         "source_url": optional_str(rates.get("source_url")) or optional_str(source.get("url")),
-        "fetched_at": optional_str(rates.get("fetched_at")) or optional_str(source.get("fetched_at")),
+        "fetched_at": optional_str(rates.get("fetched_at"))
+        or optional_str(source.get("fetched_at")),
         "tier": optional_str(rates.get("tier")) or optional_str(source.get("tier")),
         "note": optional_str(rates.get("note")),
     }
+
 
 def parse_alias_metadata(raw: object, *, source: dict[str, Any]) -> dict[str, dict[str, Any]]:
     if not isinstance(raw, dict):
@@ -227,17 +236,20 @@ def _mapping_alias_metadata(target: dict[str, Any], source: dict[str, Any]) -> d
         or optional_str(source.get("name"))
         or "Codex credit rates",
         "source_url": optional_str(target.get("source_url")) or optional_str(source.get("url")),
-        "fetched_at": optional_str(target.get("fetched_at")) or optional_str(source.get("fetched_at")),
+        "fetched_at": optional_str(target.get("fetched_at"))
+        or optional_str(source.get("fetched_at")),
         "tier": optional_str(target.get("tier")) or optional_str(source.get("tier")),
         "note": optional_str(target.get("note")),
         "alias_reason": optional_str(target.get("alias_reason")),
     }
+
 
 def load_json_file(path: Path) -> dict[str, Any]:
     raw = json.loads(path.expanduser().read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise ValueError(f"JSON config must be an object: {path}")
     return raw
+
 
 def _backup_existing_rate_card(path: Path) -> Path | None:
     if not path.exists():
@@ -247,16 +259,19 @@ def _backup_existing_rate_card(path: Path) -> Path | None:
     shutil.copy2(path, backup_path)
     return backup_path
 
+
 def normalize_model(value: object) -> str | None:
     if not isinstance(value, str) or not value.strip():
         return None
     return value.strip().lower().replace("_", "-")
+
 
 def _required_rate(raw: dict[str, Any], key: str, model: str) -> float:
     parsed = optional_positive_number(raw.get(key))
     if parsed is None:
         raise ValueError(f"missing {key} for Codex credit model {model}")
     return parsed
+
 
 def optional_positive_number(value: object) -> float | None:
     if value is None or value == "":
@@ -266,8 +281,10 @@ def optional_positive_number(value: object) -> float | None:
         raise ValueError("allowance values cannot be negative")
     return number
 
+
 def optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value.strip() else None
+
 
 def number_value(value: object) -> float:
     if isinstance(value, bool):

--- a/src/codex_usage_tracker/pricing/allowance_usage.py
+++ b/src/codex_usage_tracker/pricing/allowance_usage.py
@@ -25,6 +25,7 @@ __all__ = (
     "summarize_allowance_usage",
 )
 
+
 def annotate_rows_with_allowance(
     rows: list[dict[str, Any]],
     config: UsageAllowanceConfig | None = None,
@@ -176,8 +177,10 @@ def _resolve_alias_credit_rate(
         return None
     metadata = {**config.rate_metadata.get(target, {}), **config.alias_metadata.get(model, {})}
     confidence = alias.get("confidence") or optional_str(metadata.get("confidence")) or "estimated"
-    note = alias.get("note") or optional_str(metadata.get("note")) or (
-        f"Mapped from {model} to {target} by local alias."
+    note = (
+        alias.get("note")
+        or optional_str(metadata.get("note"))
+        or (f"Mapped from {model} to {target} by local alias.")
     )
     return target, rates, confidence, note, metadata
 
@@ -194,7 +197,5 @@ def estimate_usage_credits(row: dict[str, Any], rates: dict[str, float]) -> floa
         uncached_input = max(number_value(row.get("input_tokens")) - cached_input, 0.0)
     output_tokens = number_value(row.get("output_tokens"))
     return (
-        (uncached_input * input_rate)
-        + (cached_input * cached_rate)
-        + (output_tokens * output_rate)
+        (uncached_input * input_rate) + (cached_input * cached_rate) + (output_tokens * output_rate)
     ) / 1_000_000

--- a/src/codex_usage_tracker/pricing/costing.py
+++ b/src/codex_usage_tracker/pricing/costing.py
@@ -61,9 +61,7 @@ def summarize_pricing_coverage(
         coverage_rows.append(copy)
 
     total_tokens = totals["total_tokens"]
-    totals["priced_token_ratio"] = (
-        totals["priced_tokens"] / total_tokens if total_tokens else 0.0
-    )
+    totals["priced_token_ratio"] = totals["priced_tokens"] / total_tokens if total_tokens else 0.0
     coverage_rows.sort(
         key=lambda row: (
             0 if row.get("priced") is False else 1,
@@ -132,9 +130,7 @@ def estimate_cost_usd(
     output_tokens = _number(row.get("output_tokens"))
 
     return (
-        (uncached_input * input_rate)
-        + (cached_input * cached_rate)
-        + (output_tokens * output_rate)
+        (uncached_input * input_rate) + (cached_input * cached_rate) + (output_tokens * output_rate)
     ) / 1_000_000
 
 

--- a/src/codex_usage_tracker/pricing/openai.py
+++ b/src/codex_usage_tracker/pricing/openai.py
@@ -242,11 +242,7 @@ def _parse_openai_price_value(value: str) -> float | None:
     normalized = value.strip()
     if normalized in {"", "null", "undefined", "-", '""', "''", '"-"', "'-'"}:
         return None
-    if (
-        len(normalized) >= 2
-        and normalized[0] == normalized[-1]
-        and normalized[0] in {'"', "'"}
-    ):
+    if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {'"', "'"}:
         normalized = normalized[1:-1].strip()
     if normalized in {"", "-", "Free"}:
         return None

--- a/src/codex_usage_tracker/reports/__init__.py
+++ b/src/codex_usage_tracker/reports/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.reports.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/reports/agentic_dogfood.py
+++ b/src/codex_usage_tracker/reports/agentic_dogfood.py
@@ -449,11 +449,11 @@ def _compact_dogfood_payload(
             [
                 old_hypotheses,
                 new_hypotheses,
-            large_low_output,
-            shell_churn,
-            repeated_files,
-            action_brief,
-            allowance,
+                large_low_output,
+                shell_churn,
+                repeated_files,
+                action_brief,
+                allowance,
                 suggestions,
                 token_waste,
                 workflow_churn,
@@ -806,6 +806,5 @@ def render_agentic_dogfood_markdown(payload: dict[str, Any]) -> str:
 
 def _hypothesis_lines(rows: list[dict[str, Any]]) -> list[str]:
     return [
-        f"- **{row.get('family')}**: {row.get('status')} ({row.get('confidence')})"
-        for row in rows
+        f"- **{row.get('family')}**: {row.get('status')} ({row.get('confidence')})" for row in rows
     ]

--- a/src/codex_usage_tracker/reports/api.py
+++ b/src/codex_usage_tracker/reports/api.py
@@ -285,9 +285,7 @@ def build_summary_report(
         rows = query_most_expensive_calls(db_path, limit=limit, since=since_filter)
         return SummaryReport(
             rows=apply_project_privacy_to_rows(
-                annotate_rows_with_recommendations(
-                    annotate_rows_with_efficiency(rows, pricing)
-                ),
+                annotate_rows_with_recommendations(annotate_rows_with_efficiency(rows, pricing)),
                 privacy_mode=privacy_mode,
             ),
             group_by=resolved_group_by,
@@ -431,11 +429,7 @@ def build_content_search_report(
     normalized_limit = None if limit is None or limit <= 0 else limit
     normalized_offset = max(0, offset)
     total_matched = int(result["total_matched_rows"])
-    has_more = (
-        False
-        if normalized_limit is None
-        else normalized_offset + len(rows) < total_matched
-    )
+    has_more = False if normalized_limit is None else normalized_offset + len(rows) < total_matched
     return ContentSearchReport(
         {
             "schema": "codex-usage-tracker-content-search-v1",
@@ -460,9 +454,7 @@ def build_content_search_report(
             "total_matched_rows": total_matched,
             "truncated": has_more,
             "has_more": has_more,
-            "next_offset": (
-                normalized_offset + len(rows) if has_more else None
-            ),
+            "next_offset": (normalized_offset + len(rows) if has_more else None),
             "rows": rows,
         }
     )
@@ -503,11 +495,7 @@ def build_thread_trace_report(
     normalized_limit = None if limit is None or limit <= 0 else limit
     normalized_offset = max(0, offset)
     total_matched = int(result["total_matched_calls"])
-    has_more = (
-        False
-        if normalized_limit is None
-        else normalized_offset + len(calls) < total_matched
-    )
+    has_more = False if normalized_limit is None else normalized_offset + len(calls) < total_matched
     return ThreadTraceReport(
         {
             "schema": "codex-usage-tracker-thread-trace-v1",
@@ -531,9 +519,7 @@ def build_thread_trace_report(
             "total_matched_calls": total_matched,
             "truncated": has_more,
             "has_more": has_more,
-            "next_offset": (
-                normalized_offset + len(calls) if has_more else None
-            ),
+            "next_offset": (normalized_offset + len(calls) if has_more else None),
             "calls": calls,
         }
     )
@@ -845,7 +831,11 @@ def build_agentic_investigation_report(
                         "Open the top calls, check whether a smaller fresh thread or preserved handoff "
                         "would avoid resending large context."
                     ),
-                    verify_with=["usage_large_low_output_calls", "usage_call_detail", "usage_thread_trace"],
+                    verify_with=[
+                        "usage_large_low_output_calls",
+                        "usage_call_detail",
+                        "usage_thread_trace",
+                    ],
                     privacy_notes="Aggregate token/activity counts only; no raw fragments or command output.",
                     missing_access=(
                         "The aggregate report cannot prove why output was low without a thread trace "
@@ -967,16 +957,26 @@ def build_agentic_investigation_report(
                 },
             ]
         )
-        caveats.append("Weekly allowance evidence is the primary signal; 5-hour counters are rolling-window context.")
+        caveats.append(
+            "Weekly allowance evidence is the primary signal; 5-hour counters are rolling-window context."
+        )
 
     if normalized_goal == "overview":
         recommended_next_tools.extend(
             [
-                {"tool": "usage_status", "reason": "Confirm index freshness and row counts.", "default_arguments": {}},
+                {
+                    "tool": "usage_status",
+                    "reason": "Confirm index freshness and row counts.",
+                    "default_arguments": {},
+                },
                 {
                     "tool": "usage_summary",
                     "reason": "Rank projects, threads, models, or dates depending on the user's next question.",
-                    "default_arguments": {"group_by": "thread", "limit": 10, "response_format": "json"},
+                    "default_arguments": {
+                        "group_by": "thread",
+                        "limit": 10,
+                        "response_format": "json",
+                    },
                 },
                 {
                     "tool": "usage_report_pack",
@@ -1234,8 +1234,8 @@ def build_action_brief_report(
                     "Keep a local strict evidence export for Reddit/issues rather than sharing screenshots or raw logs."
                 ),
                 how_to_verify=(
-                    "Run `usage_allowance_diagnostics(window_kind=\"weekly\", privacy_mode=\"strict\")` and "
-                    "`usage_allowance_export(window_kind=\"weekly\")`."
+                    'Run `usage_allowance_diagnostics(window_kind="weekly", privacy_mode="strict")` and '
+                    '`usage_allowance_export(window_kind="weekly")`.'
                 ),
                 recommended_next_tools=["usage_allowance_diagnostics", "usage_allowance_export"],
                 missing_access="OpenAI's internal ledger and other-surface account usage are not available locally.",
@@ -1257,7 +1257,11 @@ def build_action_brief_report(
                 recommended_existing_tool=None,
                 recommended_custom_solution="Create a narrower hypothesis and test it with direct aggregate tools.",
                 how_to_verify="Run `usage_suggest_investigations` or `usage_investigate` with a more specific goal.",
-                recommended_next_tools=["usage_suggest_investigations", "usage_investigate", "usage_calls"],
+                recommended_next_tools=[
+                    "usage_suggest_investigations",
+                    "usage_investigate",
+                    "usage_calls",
+                ],
                 missing_access="The brief needs stronger aggregate signals or a narrower user question.",
             )
         )
@@ -1544,7 +1548,9 @@ def _has_any_phrase(text: str, phrases: tuple[str, ...]) -> bool:
 
 
 def _has_any_word(text: str, words: tuple[str, ...]) -> bool:
-    return any(re.search(rf"(?<![a-z0-9_-]){re.escape(word)}(?![a-z0-9_-])", text) for word in words)
+    return any(
+        re.search(rf"(?<![a-z0-9_-]){re.escape(word)}(?![a-z0-9_-])", text) for word in words
+    )
 
 
 def _has_shell_hypothesis_signal(text: str) -> bool:
@@ -1700,7 +1706,9 @@ def _evaluate_token_waste_hypothesis(
                 "large_low_output_candidate_count": large_count,
             },
         ),
-        evidence=[_compact_agentic_evidence_row(row) for row in large.get("rows", [])[:evidence_limit]],
+        evidence=[
+            _compact_agentic_evidence_row(row) for row in large.get("rows", [])[:evidence_limit]
+        ],
         counter_evidence=(
             []
             if large_count
@@ -1708,7 +1716,9 @@ def _evaluate_token_waste_hypothesis(
         ),
         next_action="Inspect the largest low-output rows, then verify whether a shorter handoff or smaller context would have avoided them.",
         recommended_next_tools=[
-            _next_tool("usage_large_low_output_calls", "Inspect the highest-token low-output calls."),
+            _next_tool(
+                "usage_large_low_output_calls", "Inspect the highest-token low-output calls."
+            ),
             _next_tool("usage_recommendations", "Compare aggregate recommendation scoring."),
             _next_tool("usage_calls", "Open the underlying aggregate call rows."),
         ],
@@ -1754,7 +1764,9 @@ def _evaluate_cache_failure_hypothesis(
         i_will_accomplish_this_using="Look for large low-output calls with low cache ratios, high context-window use, or cache/context explanations.",
         i_am_missing_access_to="The exact task intent and raw turn context unless the user explicitly enables raw context inspection.",
         evidence_summary=_agentic_evidence_summary(signal_rows or rows),
-        evidence=[_compact_agentic_evidence_row(row) for row in (signal_rows or rows)[:evidence_limit]],
+        evidence=[
+            _compact_agentic_evidence_row(row) for row in (signal_rows or rows)[:evidence_limit]
+        ],
         counter_evidence=(
             []
             if signal_rows
@@ -1762,9 +1774,14 @@ def _evaluate_cache_failure_hypothesis(
         ),
         next_action="Verify the candidate rows in Call Investigator and compare nearby thread traces before changing workflow.",
         recommended_next_tools=[
-            _next_tool("usage_large_low_output_calls", "Check cache ratio and context-window percent."),
+            _next_tool(
+                "usage_large_low_output_calls", "Check cache ratio and context-window percent."
+            ),
             _next_tool("usage_call_detail", "Inspect one aggregate call in Call Investigator."),
-            _next_tool("usage_thread_trace", "Trace local indexed thread activity if deeper context is needed."),
+            _next_tool(
+                "usage_thread_trace",
+                "Trace local indexed thread activity if deeper context is needed.",
+            ),
         ],
     )
 
@@ -1804,11 +1821,15 @@ def _evaluate_repeated_file_hypothesis(
         i_am_missing_access_to="Whether each reread was necessary for task correctness without task-level intent.",
         evidence_summary=_agentic_evidence_summary(rows),
         evidence=[_compact_agentic_evidence_row(row) for row in rows[:evidence_limit]],
-        counter_evidence=[] if total else ["No repeated file rediscovery candidates crossed the threshold."],
+        counter_evidence=[]
+        if total
+        else ["No repeated file rediscovery candidates crossed the threshold."],
         next_action="Turn recurring lookups into a durable project note, helper command, or narrower read path.",
         recommended_next_tools=[
             _next_tool("usage_repeated_file_rediscovery", "Rank repeated safe file identities."),
-            _next_tool("usage_thread_trace", "Check whether the same thread repeats the rediscovery loop."),
+            _next_tool(
+                "usage_thread_trace", "Check whether the same thread repeats the rediscovery loop."
+            ),
         ],
     )
 
@@ -1840,11 +1861,15 @@ def _evaluate_shell_churn_hypothesis(
         context["shell_churn"] = report
     rows = report.get("rows", [])
     total = int(report["total_candidates"])
-    unknown_count = sum(1 for row in rows if str(row.get("command_root") or "").startswith("unknown"))
+    unknown_count = sum(
+        1 for row in rows if str(row.get("command_root") or "").startswith("unknown")
+    )
     status = "true" if total >= 3 else "partially_true" if total else "false"
     counter_evidence = []
     if unknown_count:
-        counter_evidence.append("Some shell rows still have cloudy command labels; normalization needs more hardening.")
+        counter_evidence.append(
+            "Some shell rows still have cloudy command labels; normalization needs more hardening."
+        )
     if not total:
         counter_evidence.append("No repeated shell churn candidates crossed the threshold.")
     return _hypothesis_result(
@@ -1918,12 +1943,16 @@ def _evaluate_effort_model_hypothesis(
             "top_models": _top_token_totals(model_totals),
         },
         evidence=[],
-        counter_evidence=[] if high_effort_ratio else ["No high-effort token share found in the selected scope."],
+        counter_evidence=[]
+        if high_effort_ratio
+        else ["No high-effort token share found in the selected scope."],
         next_action="Compare high-effort calls against task type, then use lower effort for routine edits and reserve higher effort for uncertain design work.",
         recommended_next_tools=[
             _next_tool("usage_summary", "Summarize usage by model or effort."),
             _next_tool("usage_calls", "Filter calls by effort and inspect outliers."),
-            _next_tool("usage_recommendations", "Compare effort choices with aggregate recommendations."),
+            _next_tool(
+                "usage_recommendations", "Compare effort choices with aggregate recommendations."
+            ),
         ],
     )
 
@@ -1977,8 +2006,12 @@ def _evaluate_allowance_hypothesis(
         ],
         next_action="Run full weekly allowance diagnostics and export strict evidence before making any public claim.",
         recommended_next_tools=[
-            _next_tool("usage_allowance_diagnostics", "Run evidence-graded weekly allowance diagnostics."),
-            _next_tool("usage_allowance_export", "Create a strict local evidence bundle for sharing."),
+            _next_tool(
+                "usage_allowance_diagnostics", "Run evidence-graded weekly allowance diagnostics."
+            ),
+            _next_tool(
+                "usage_allowance_export", "Create a strict local evidence bundle for sharing."
+            ),
         ],
     )
 
@@ -2060,7 +2093,9 @@ def _merge_evidence_summaries(base: dict[str, Any], extra: dict[str, Any]) -> di
     return {**base, **extra}
 
 
-def _next_tool(tool: str, reason: str, default_arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+def _next_tool(
+    tool: str, reason: str, default_arguments: dict[str, Any] | None = None
+) -> dict[str, Any]:
     return {
         "tool": tool,
         "reason": reason,
@@ -2163,7 +2198,11 @@ def _investigation_suggestions(goal: str | None) -> list[dict[str, Any]]:
             "why_it_matters": "Repeated probes, command failures, and rereads suggest automation or documentation opportunities.",
             "primary_tool": "usage_investigate",
             "default_arguments": {"goal": "workflow_churn", "evidence_limit": 5},
-            "follow_up_tools": ["usage_shell_churn", "usage_repeated_file_rediscovery", "usage_thread_trace"],
+            "follow_up_tools": [
+                "usage_shell_churn",
+                "usage_repeated_file_rediscovery",
+                "usage_thread_trace",
+            ],
             "privacy_notes": "Uses safe command labels and path identities, not raw command output or full paths.",
         },
         {
@@ -2172,14 +2211,25 @@ def _investigation_suggestions(goal: str | None) -> list[dict[str, Any]]:
             "why_it_matters": "Starts with index freshness, thread/model/project summaries, and existing recommendation cards.",
             "primary_tool": "usage_investigate",
             "default_arguments": {"goal": "overview", "evidence_limit": 5},
-            "follow_up_tools": ["usage_status", "usage_summary", "usage_report_pack", "usage_recommendations"],
+            "follow_up_tools": [
+                "usage_status",
+                "usage_summary",
+                "usage_report_pack",
+                "usage_recommendations",
+            ],
             "privacy_notes": "Aggregate dashboard/report-pack evidence.",
         },
     ]
     if goal is None:
         return suggestions
     related_goals = {
-        "overview": ["overview", "token_waste", "cache_failure", "workflow_churn", "allowance_change"],
+        "overview": [
+            "overview",
+            "token_waste",
+            "cache_failure",
+            "workflow_churn",
+            "allowance_change",
+        ],
         "token_waste": ["token_waste", "cache_failure", "workflow_churn", "overview"],
         "cache_failure": ["cache_failure", "token_waste", "overview"],
         "workflow_churn": ["workflow_churn", "token_waste", "cache_failure", "overview"],
@@ -2208,7 +2258,11 @@ def _agentic_finding(
     privacy_notes: str,
     missing_access: str,
 ) -> dict[str, Any]:
-    evidence_rows = evidence if detail_mode == "full" else [_compact_agentic_evidence_row(row) for row in evidence]
+    evidence_rows = (
+        evidence
+        if detail_mode == "full"
+        else [_compact_agentic_evidence_row(row) for row in evidence]
+    )
     return {
         "finding": finding,
         "evidence_count": len(evidence),
@@ -2276,14 +2330,26 @@ def _compact_agentic_evidence_row(row: dict[str, Any]) -> dict[str, Any]:
     if "nearby_activity" in row and isinstance(row["nearby_activity"], dict):
         compact["nearby_activity"] = {
             key: row["nearby_activity"].get(key)
-            for key in ("tool_call_count", "command_run_count", "failed_command_count", "file_event_count")
+            for key in (
+                "tool_call_count",
+                "command_run_count",
+                "failed_command_count",
+                "file_event_count",
+            )
             if row["nearby_activity"].get(key) is not None
         }
     if "trace_handles" in row and isinstance(row["trace_handles"], list):
         compact["trace_handles"] = [
             {
                 key: handle.get(key)
-                for key in ("thread_key", "thread", "session_id", "call_count", "total_tokens", "next_tool")
+                for key in (
+                    "thread_key",
+                    "thread",
+                    "session_id",
+                    "call_count",
+                    "total_tokens",
+                    "next_tool",
+                )
                 if isinstance(handle, dict) and handle.get(key) is not None
             }
             for handle in row["trace_handles"][:3]
@@ -2293,13 +2359,28 @@ def _compact_agentic_evidence_row(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _agentic_evidence_summary(evidence: list[dict[str, Any]]) -> dict[str, Any]:
-    token_values = [int(row["total_tokens"]) for row in evidence if isinstance(row.get("total_tokens"), int | float)]
+    token_values = [
+        int(row["total_tokens"])
+        for row in evidence
+        if isinstance(row.get("total_tokens"), int | float)
+    ]
     timestamps = [str(row["event_timestamp"]) for row in evidence if row.get("event_timestamp")]
-    threads = _ordered_unique(str(row.get("thread_name") or row.get("thread") or row.get("thread_key")) for row in evidence)
+    threads = _ordered_unique(
+        str(row.get("thread_name") or row.get("thread") or row.get("thread_key"))
+        for row in evidence
+    )
     models = _ordered_unique(str(row.get("model")) for row in evidence if row.get("model"))
     efforts = _ordered_unique(str(row.get("effort")) for row in evidence if row.get("effort"))
-    explanations = _ordered_unique(str(row.get("candidate_explanation")) for row in evidence if row.get("candidate_explanation"))
-    recommendations = _ordered_unique(str(row.get("recommendation") or row.get("recommended_action")) for row in evidence if row.get("recommendation") or row.get("recommended_action"))
+    explanations = _ordered_unique(
+        str(row.get("candidate_explanation"))
+        for row in evidence
+        if row.get("candidate_explanation")
+    )
+    recommendations = _ordered_unique(
+        str(row.get("recommendation") or row.get("recommended_action"))
+        for row in evidence
+        if row.get("recommendation") or row.get("recommended_action")
+    )
     summary: dict[str, Any] = {
         "row_count": len(evidence),
         "total_tokens": sum(token_values),
@@ -2313,9 +2394,19 @@ def _agentic_evidence_summary(evidence: list[dict[str, Any]]) -> dict[str, Any]:
     if timestamps:
         summary["first_event_timestamp"] = min(timestamps)
         summary["last_event_timestamp"] = max(timestamps)
-    occurrence_values = [int(row["occurrences"]) for row in evidence if isinstance(row.get("occurrences"), int | float)]
-    call_count_values = [int(row["call_count"]) for row in evidence if isinstance(row.get("call_count"), int | float)]
-    failure_values = [int(row["failure_count"]) for row in evidence if isinstance(row.get("failure_count"), int | float)]
+    occurrence_values = [
+        int(row["occurrences"])
+        for row in evidence
+        if isinstance(row.get("occurrences"), int | float)
+    ]
+    call_count_values = [
+        int(row["call_count"]) for row in evidence if isinstance(row.get("call_count"), int | float)
+    ]
+    failure_values = [
+        int(row["failure_count"])
+        for row in evidence
+        if isinstance(row.get("failure_count"), int | float)
+    ]
     if occurrence_values:
         summary["total_occurrences"] = sum(occurrence_values)
     if call_count_values:
@@ -2355,7 +2446,10 @@ def _overall_agentic_confidence(findings: list[dict[str, Any]]) -> str:
     }
     if not findings:
         return "insufficient_local_evidence"
-    return max((str(row.get("confidence") or "") for row in findings), key=lambda value: priorities.get(value, 0))
+    return max(
+        (str(row.get("confidence") or "") for row in findings),
+        key=lambda value: priorities.get(value, 0),
+    )
 
 
 def _goal_next_tools(goal: str) -> list[dict[str, Any]]:
@@ -2516,7 +2610,9 @@ def _investigation_branches(
     branches: list[dict[str, Any]] = []
     for scan_type, hypothesis, rationale in specs:
         evidence = [row for row in patterns if row.get("scan_type") == scan_type]
-        evidence.sort(key=lambda row: (-int(row.get("total_tokens") or 0), -int(row.get("occurrences") or 0)))
+        evidence.sort(
+            key=lambda row: (-int(row.get("total_tokens") or 0), -int(row.get("occurrences") or 0))
+        )
         selected = evidence[:evidence_limit]
         score = _branch_score(selected)
         branches.append(
@@ -2528,7 +2624,9 @@ def _investigation_branches(
                 "score": score,
                 "evidence_count": len(selected),
                 "evidence": selected,
-                "pruned_reason": None if selected else "No matching normalized local evidence at this threshold.",
+                "pruned_reason": None
+                if selected
+                else "No matching normalized local evidence at this threshold.",
             }
         )
     branches.sort(key=lambda branch: (-int(branch["score"]), str(branch["scan_type"])))
@@ -2918,11 +3016,11 @@ def build_recommendations_report(
                 "thread": thread,
                 "project": project,
                 "include_archived": include_archived,
-            "min_score": min_score,
-            "limit": normalized_limit,
-            "source_limit": source_limit,
-            "privacy_mode": privacy_mode,
-        },
+                "min_score": min_score,
+                "limit": normalized_limit,
+                "source_limit": source_limit,
+                "privacy_mode": privacy_mode,
+            },
             "row_count": len(private_rows),
             "total_matched_rows": len(scored_rows),
             "truncated": normalized_limit is not None and len(scored_rows) > normalized_limit,

--- a/src/codex_usage_tracker/reports/recommendations.py
+++ b/src/codex_usage_tracker/reports/recommendations.py
@@ -68,7 +68,9 @@ def write_threshold_template(path: Path = DEFAULT_THRESHOLDS_PATH, force: bool =
     if path.exists() and not force:
         raise FileExistsError(f"{path} already exists. Use --force to replace it.")
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(DEFAULT_THRESHOLDS, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(DEFAULT_THRESHOLDS, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     return path
 
 
@@ -97,12 +99,12 @@ def annotate_rows_with_recommendations(
             else "No aggregate action is flagged; continue monitoring usage patterns."
         )
         copy["recommended_action_key"] = (
-            recommendations[0]["action_key"]
-            if recommendations
-            else "recommendation.none.action"
+            recommendations[0]["action_key"] if recommendations else "recommendation.none.action"
         )
         copy["flag_explanations"] = [recommendation["why"] for recommendation in recommendations]
-        copy["flag_explanation_keys"] = [recommendation["why_key"] for recommendation in recommendations]
+        copy["flag_explanation_keys"] = [
+            recommendation["why_key"] for recommendation in recommendations
+        ]
         annotated.append(copy)
     return annotated
 
@@ -124,11 +126,7 @@ def action_recommendations(
         _large_thread_recommendation(row, limits),
         _subagent_recommendation(row),
     ]
-    return [
-        recommendation
-        for recommendation in candidates
-        if recommendation is not None
-    ]
+    return [recommendation for recommendation in candidates if recommendation is not None]
 
 
 def _pricing_recommendation(row: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/codex_usage_tracker/reports/support.py
+++ b/src/codex_usage_tracker/reports/support.py
@@ -190,7 +190,9 @@ def support_bundle_payload(
             "pricing_path": _support_path_value("pricing_path", pricing_path, privacy_mode),
             "allowance_path": _support_path_value("allowance_path", allowance_path, privacy_mode),
             "rate_card_path": _support_path_value("rate_card_path", rate_card_path, privacy_mode),
-            "thresholds_path": _support_path_value("thresholds_path", thresholds_path, privacy_mode),
+            "thresholds_path": _support_path_value(
+                "thresholds_path", thresholds_path, privacy_mode
+            ),
             "projects_path": _support_path_value("projects_path", projects_path, privacy_mode),
         },
         "issue_report": support_bundle_issue_guidance(privacy_mode),

--- a/src/codex_usage_tracker/server/__init__.py
+++ b/src/codex_usage_tracker/server/__init__.py
@@ -12,6 +12,7 @@ _COMPAT_MODULES = {
     "server_utils": "codex_usage_tracker.server.utils",
 }
 
+
 def __getattr__(name: str) -> Any:
     if name in _COMPAT_MODULES:
         return import_module(_COMPAT_MODULES[name])

--- a/src/codex_usage_tracker/server/allowance.py
+++ b/src/codex_usage_tracker/server/allowance.py
@@ -188,9 +188,7 @@ def allowance_export_payload(
     return report.payload
 
 
-def _include_archived(
-    params: dict[str, list[str]], include_archived_default: bool
-) -> bool:
+def _include_archived(params: dict[str, list[str]], include_archived_default: bool) -> bool:
     return parse_bool_query_value(
         first_query_value(params.get("include_archived")),
         include_archived_default,

--- a/src/codex_usage_tracker/server/api.py
+++ b/src/codex_usage_tracker/server/api.py
@@ -46,7 +46,6 @@ _validate_context_api_mode = server_utils.validate_context_api_mode
 _validate_loopback_host = server_utils.validate_loopback_host
 
 
-
 def serve_dashboard(
     db_path: Path,
     output_path: Path = DEFAULT_DASHBOARD_PATH,

--- a/src/codex_usage_tracker/server/call_detail.py
+++ b/src/codex_usage_tracker/server/call_detail.py
@@ -75,9 +75,7 @@ def call_detail_payload(
         "previous_record": previous_record,
         "next_record": next_record,
         "adjacent_records": [
-            candidate
-            for candidate in (previous_record, selected_row, next_record)
-            if candidate
+            candidate for candidate in (previous_record, selected_row, next_record) if candidate
         ],
         "previous_record_id": row.get("previous_record_id"),
         "next_record_id": row.get("next_record_id"),
@@ -87,7 +85,9 @@ def call_detail_payload(
 
 def _required_record_id(query: str) -> str:
     params = parse_qs(query)
-    record_id = first_query_value(params.get("record_id")) or first_query_value(params.get("record"))
+    record_id = first_query_value(params.get("record_id")) or first_query_value(
+        params.get("record")
+    )
     if not record_id:
         raise MissingRecordIdError("record_id required")
     return record_id

--- a/src/codex_usage_tracker/server/call_lists.py
+++ b/src/codex_usage_tracker/server/call_lists.py
@@ -125,7 +125,9 @@ def thread_calls_payload(
 ) -> dict[str, object]:
     """Build the thread-scoped calls API payload."""
     params = parse_qs(query)
-    thread_key = first_query_value(params.get("thread_key")) or first_query_value(params.get("thread"))
+    thread_key = first_query_value(params.get("thread_key")) or first_query_value(
+        params.get("thread")
+    )
     if not thread_key:
         raise MissingThreadKeyError("thread_key required")
     query_params = live_query_params(params, thread_key=thread_key)

--- a/src/codex_usage_tracker/server/context.py
+++ b/src/codex_usage_tracker/server/context.py
@@ -116,7 +116,9 @@ def context_payload(
             first_query_value(params.get("max_entries")),
             DEFAULT_CONTEXT_ENTRIES,
         ),
-        include_tool_output=truthy_query_value(first_query_value(params.get("include_tool_output"))),
+        include_tool_output=truthy_query_value(
+            first_query_value(params.get("include_tool_output"))
+        ),
         include_compaction_history=truthy_query_value(
             first_query_value(params.get("include_compaction_history")),
         ),

--- a/src/codex_usage_tracker/server/handler.py
+++ b/src/codex_usage_tracker/server/handler.py
@@ -92,9 +92,12 @@ _DASHBOARD_ASSET_MIME_TYPES = {
 }
 _REACT_DASHBOARD_PATH = "/react-dashboard.html"
 _REACT_DASHBOARD_INDEX_PATH = "/codex-usage-tracker-assets/react/index.html"
+
+
 def _optional_int_query(params: dict[str, list[str]], key: str) -> int | None:
     value = _first(params.get(key))
     return None if value is None else _safe_int(value)
+
 
 class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
     def __init__(
@@ -228,7 +231,9 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
         usage_data = json.dumps(payload, ensure_ascii=True).replace("</", "<\\/")
         usage_script = f'<script id="usage-data" type="application/json">{usage_data}</script>'
         if '<div id="root"></div>' in html:
-            html = html.replace('<div id="root"></div>', f'<div id="root"></div>\n    {usage_script}', 1)
+            html = html.replace(
+                '<div id="root"></div>', f'<div id="root"></div>\n    {usage_script}', 1
+            )
         elif "</head>" in html:
             html = html.replace("</head>", f"  {usage_script}\n</head>", 1)
         else:
@@ -311,11 +316,11 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
                 privacy_mode=self._privacy_mode,
                 since=self._since,
                 api_token=self._api_token,
-            context_api_enabled=self._context_api_state.enabled,
-            include_archived_default=self._include_archived,
-            language_default=self._language,
-            limit_default=self._limit,
-        )
+                context_api_enabled=self._context_api_state.enabled,
+                include_archived_default=self._include_archived,
+                language_default=self._language,
+                limit_default=self._limit,
+            )
         except sqlite3.Error as exc:
             self._send_exception("Database error while preparing dashboard shell", exc)
             return None
@@ -350,6 +355,7 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
             return
         payload = context_settings_payload(query, context_api_state=self._context_api_state)
         self._send_json(HTTPStatus.OK, payload)
+
     def _handle_open_investigator(self, query: str) -> None:
         params = parse_qs(query)
         if not self._has_valid_api_token(params):
@@ -367,6 +373,7 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, str(exc))
             return
         self._send_json(HTTPStatus.OK, payload)
+
     def _handle_status(self, query: str) -> None:
         handle_status_request(
             query,
@@ -577,6 +584,7 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
             send_exception=self._send_exception,
             send_json=self._send_json,
         )
+
     def _request_origin_allowed(self) -> bool:
         return request_origin_allowed(self.headers, self.server.server_port)
 

--- a/src/codex_usage_tracker/server/open_investigator.py
+++ b/src/codex_usage_tracker/server/open_investigator.py
@@ -31,7 +31,9 @@ def open_investigator_payload(
 
     parsed_target = urlparse(target)
     if parsed_target.scheme:
-        _validate_absolute_target(parsed_target.scheme, parsed_target.hostname, parsed_target.port, server_port)
+        _validate_absolute_target(
+            parsed_target.scheme, parsed_target.hostname, parsed_target.port, server_port
+        )
     allowed_paths = {f"/{dashboard_name}", REACT_DASHBOARD_PATH}
     if parsed_target.path not in allowed_paths:
         raise OpenInvestigatorRequestError("Only dashboard investigator URLs can be opened")

--- a/src/codex_usage_tracker/server/recommendations.py
+++ b/src/codex_usage_tracker/server/recommendations.py
@@ -73,7 +73,8 @@ def recommendations_payload(
         effort=first_query_value(params.get("effort")),
         thread=first_query_value(params.get("thread")),
         project=first_query_value(params.get("project")),
-        include_archived=first_query_value(params.get("include_archived")) in {"1", "true", "yes", "on"},
+        include_archived=first_query_value(params.get("include_archived"))
+        in {"1", "true", "yes", "on"},
         min_score=parse_optional_float(first_query_value(params.get("min_score")), "min_score"),
         limit=parse_report_limit(first_query_value(params.get("limit")), 20),
         privacy_mode=privacy_mode,

--- a/src/codex_usage_tracker/server/reports.py
+++ b/src/codex_usage_tracker/server/reports.py
@@ -151,14 +151,20 @@ def _report_evidence_rows(
     if report_key == "fast-mode-proxy":
         return sorted(
             [row for row in rows if _is_fast_candidate(row)],
-            key=lambda row: (_duration_seconds(row), -_usage_credits(row), -_number(row, "total_tokens")),
+            key=lambda row: (
+                _duration_seconds(row),
+                -_usage_credits(row),
+                -_number(row, "total_tokens"),
+            ),
         )[:evidence_limit]
     if report_key == "cost-curves":
         return sorted(
             rows,
             key=lambda row: (-_number(row, "estimated_cost_usd"), -_number(row, "total_tokens")),
         )[:evidence_limit]
-    return sorted(rows, key=lambda row: (-_usage_credits(row), -_number(row, "total_tokens")))[:evidence_limit]
+    return sorted(rows, key=lambda row: (-_usage_credits(row), -_number(row, "total_tokens")))[
+        :evidence_limit
+    ]
 
 
 def _is_fast_candidate(row: dict[str, Any]) -> bool:

--- a/src/codex_usage_tracker/server/request_guards.py
+++ b/src/codex_usage_tracker/server/request_guards.py
@@ -41,5 +41,7 @@ def has_valid_api_token(
     api_token: str,
 ) -> bool:
     """Validate API token from header first, then query string fallback."""
-    provided = headers.get("X-Codex-Usage-Token") or first_query_value(params.get("api_token")) or ""
+    provided = (
+        headers.get("X-Codex-Usage-Token") or first_query_value(params.get("api_token")) or ""
+    )
     return hmac.compare_digest(str(provided), api_token)

--- a/src/codex_usage_tracker/server/routes.py
+++ b/src/codex_usage_tracker/server/routes.py
@@ -5,57 +5,63 @@ from __future__ import annotations
 from collections.abc import Mapping
 from types import MappingProxyType
 
-GET_ROUTE_METHODS: Mapping[str, str] = MappingProxyType({
-    "/api/context": "_handle_context",
-    "/api/context-settings": "_handle_context_settings",
-    "/api/open-investigator": "_handle_open_investigator",
-    "/api/status": "_handle_status",
-    "/api/calls": "_handle_calls",
-    "/api/call": "_handle_call",
-    "/api/threads": "_handle_threads",
-    "/api/thread-calls": "_handle_thread_calls",
-    "/api/summary": "_handle_summary",
-    "/api/recommendations": "_handle_recommendations",
-    "/api/allowance/history": "_handle_allowance_history",
-    "/api/allowance/diagnostics": "_handle_allowance_diagnostics",
-    "/api/allowance/export": "_handle_allowance_export",
-    "/api/reports/pack": "_handle_reports_pack",
-    "/api/diagnostics/summary": "_handle_diagnostics_summary",
-    "/api/diagnostics/facts": "_handle_diagnostics_facts",
-    "/api/diagnostics/fact-calls": "_handle_diagnostics_fact_calls",
-    "/api/diagnostics/overview": "_handle_diagnostics_overview",
-    "/api/diagnostics/tool-output": "_handle_diagnostics_tool_output",
-    "/api/diagnostics/commands": "_handle_diagnostics_commands",
-    "/api/diagnostics/git-interactions": "_handle_diagnostics_git_interactions",
-    "/api/diagnostics/file-reads": "_handle_diagnostics_file_reads",
-    "/api/diagnostics/file-modifications": "_handle_diagnostics_file_modifications",
-    "/api/diagnostics/read-productivity": "_handle_diagnostics_read_productivity",
-    "/api/diagnostics/concentration": "_handle_diagnostics_concentration",
-    "/api/diagnostics/guided-summary": "_handle_diagnostics_guided_summary",
-    "/api/diagnostics/usage-drain": "_handle_diagnostics_usage_drain",
-    "/api/usage": "_handle_usage",
-    "/api/refresh/start": "_handle_refresh_start",
-    "/api/refresh/status": "_handle_refresh_status",
-})
+GET_ROUTE_METHODS: Mapping[str, str] = MappingProxyType(
+    {
+        "/api/context": "_handle_context",
+        "/api/context-settings": "_handle_context_settings",
+        "/api/open-investigator": "_handle_open_investigator",
+        "/api/status": "_handle_status",
+        "/api/calls": "_handle_calls",
+        "/api/call": "_handle_call",
+        "/api/threads": "_handle_threads",
+        "/api/thread-calls": "_handle_thread_calls",
+        "/api/summary": "_handle_summary",
+        "/api/recommendations": "_handle_recommendations",
+        "/api/allowance/history": "_handle_allowance_history",
+        "/api/allowance/diagnostics": "_handle_allowance_diagnostics",
+        "/api/allowance/export": "_handle_allowance_export",
+        "/api/reports/pack": "_handle_reports_pack",
+        "/api/diagnostics/summary": "_handle_diagnostics_summary",
+        "/api/diagnostics/facts": "_handle_diagnostics_facts",
+        "/api/diagnostics/fact-calls": "_handle_diagnostics_fact_calls",
+        "/api/diagnostics/overview": "_handle_diagnostics_overview",
+        "/api/diagnostics/tool-output": "_handle_diagnostics_tool_output",
+        "/api/diagnostics/commands": "_handle_diagnostics_commands",
+        "/api/diagnostics/git-interactions": "_handle_diagnostics_git_interactions",
+        "/api/diagnostics/file-reads": "_handle_diagnostics_file_reads",
+        "/api/diagnostics/file-modifications": "_handle_diagnostics_file_modifications",
+        "/api/diagnostics/read-productivity": "_handle_diagnostics_read_productivity",
+        "/api/diagnostics/concentration": "_handle_diagnostics_concentration",
+        "/api/diagnostics/guided-summary": "_handle_diagnostics_guided_summary",
+        "/api/diagnostics/usage-drain": "_handle_diagnostics_usage_drain",
+        "/api/usage": "_handle_usage",
+        "/api/refresh/start": "_handle_refresh_start",
+        "/api/refresh/status": "_handle_refresh_status",
+    }
+)
 
-GET_DIAGNOSTIC_FACT_ROUTES: Mapping[str, Mapping[str, str]] = MappingProxyType({
-    "/api/diagnostics/compactions": MappingProxyType({"fact_type": "compaction"}),
-    "/api/diagnostics/tools": MappingProxyType({"fact_group": "tools"}),
-})
+GET_DIAGNOSTIC_FACT_ROUTES: Mapping[str, Mapping[str, str]] = MappingProxyType(
+    {
+        "/api/diagnostics/compactions": MappingProxyType({"fact_type": "compaction"}),
+        "/api/diagnostics/tools": MappingProxyType({"fact_group": "tools"}),
+    }
+)
 
-POST_ROUTE_METHODS: Mapping[str, str] = MappingProxyType({
-    "/api/diagnostics/refresh": "_handle_diagnostics_refresh",
-    "/api/diagnostics/overview/refresh": "_handle_diagnostics_overview_refresh",
-    "/api/diagnostics/tool-output/refresh": "_handle_diagnostics_tool_output_refresh",
-    "/api/diagnostics/commands/refresh": "_handle_diagnostics_commands_refresh",
-    "/api/diagnostics/git-interactions/refresh": "_handle_diagnostics_git_interactions_refresh",
-    "/api/diagnostics/file-reads/refresh": "_handle_diagnostics_file_reads_refresh",
-    "/api/diagnostics/file-modifications/refresh": "_handle_diagnostics_file_modifications_refresh",
-    "/api/diagnostics/read-productivity/refresh": "_handle_diagnostics_read_productivity_refresh",
-    "/api/diagnostics/concentration/refresh": "_handle_diagnostics_concentration_refresh",
-    "/api/diagnostics/guided-summary/refresh": "_handle_diagnostics_guided_summary_refresh",
-    "/api/diagnostics/usage-drain/refresh": "_handle_diagnostics_usage_drain_refresh",
-})
+POST_ROUTE_METHODS: Mapping[str, str] = MappingProxyType(
+    {
+        "/api/diagnostics/refresh": "_handle_diagnostics_refresh",
+        "/api/diagnostics/overview/refresh": "_handle_diagnostics_overview_refresh",
+        "/api/diagnostics/tool-output/refresh": "_handle_diagnostics_tool_output_refresh",
+        "/api/diagnostics/commands/refresh": "_handle_diagnostics_commands_refresh",
+        "/api/diagnostics/git-interactions/refresh": "_handle_diagnostics_git_interactions_refresh",
+        "/api/diagnostics/file-reads/refresh": "_handle_diagnostics_file_reads_refresh",
+        "/api/diagnostics/file-modifications/refresh": "_handle_diagnostics_file_modifications_refresh",
+        "/api/diagnostics/read-productivity/refresh": "_handle_diagnostics_read_productivity_refresh",
+        "/api/diagnostics/concentration/refresh": "_handle_diagnostics_concentration_refresh",
+        "/api/diagnostics/guided-summary/refresh": "_handle_diagnostics_guided_summary_refresh",
+        "/api/diagnostics/usage-drain/refresh": "_handle_diagnostics_usage_drain_refresh",
+    }
+)
 
 
 def is_dashboard_shell_path(path: str, dashboard_name: str) -> bool:

--- a/src/codex_usage_tracker/server/usage_refresh.py
+++ b/src/codex_usage_tracker/server/usage_refresh.py
@@ -325,7 +325,9 @@ def usage_payload(
         include_archived_default,
     )
     language = normalize_language(first_query_value(params.get("lang")) or language_default)
-    diagnostics_enabled = parse_bool_query_value(first_query_value(params.get("diagnostics")), False)
+    diagnostics_enabled = parse_bool_query_value(
+        first_query_value(params.get("diagnostics")), False
+    )
     shell_only = parse_bool_query_value(first_query_value(params.get("shell")), False)
     refresh_result = None
     refresh_ms: float | None = None

--- a/src/codex_usage_tracker/server/utils.py
+++ b/src/codex_usage_tracker/server/utils.py
@@ -132,11 +132,7 @@ def next_row_offset(
     row_count: int,
     total_matched: int,
 ) -> int | None:
-    return (
-        offset + row_count
-        if has_more_rows(limit, offset, row_count, total_matched)
-        else None
-    )
+    return offset + row_count if has_more_rows(limit, offset, row_count, total_matched) else None
 
 
 def parse_context_limit(value: str | None, default: int) -> int:
@@ -187,9 +183,7 @@ def validate_loopback_host(host: str) -> None:
     try:
         address = ip_address(host)
     except ValueError as exc:
-        raise ValueError(
-            "serve-dashboard --host must be localhost, 127.0.0.1, or ::1"
-        ) from exc
+        raise ValueError("serve-dashboard --host must be localhost, 127.0.0.1, or ::1") from exc
     if not address.is_loopback:
         raise ValueError("serve-dashboard refuses to expose raw context off localhost")
 

--- a/src/codex_usage_tracker/store/__init__.py
+++ b/src/codex_usage_tracker/store/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 _API_MODULE = "codex_usage_tracker.store.api"
 
+
 def __getattr__(name: str) -> Any:
     module = import_module(_API_MODULE)
     try:

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -117,6 +117,8 @@ DIAGNOSTIC_FACT_COLUMNS = list(DIAGNOSTIC_FACT_COLUMN_NAMES)
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 SQLITE_VARIABLE_BATCH_SIZE = 500
 RefreshProgressCallback = Callable[[dict[str, object]], None]
+
+
 def refresh_usage_index(
     codex_home: Path = DEFAULT_CODEX_HOME,
     db_path: Path = DEFAULT_DB_PATH,
@@ -275,8 +277,8 @@ def query_pattern_scan(
             thread=thread,
             include_archived=include_archived,
             min_occurrences=min_occurrences,
-        limit=limit,
-    )
+            limit=limit,
+        )
 
 
 def query_repeated_file_rediscovery(
@@ -329,8 +331,8 @@ def query_shell_churn(
             include_archived=include_archived,
             min_occurrences=min_occurrences,
             limit=limit,
-        sample_limit=sample_limit,
-    )
+            sample_limit=sample_limit,
+        )
 
 
 def query_large_low_output_calls(
@@ -562,9 +564,7 @@ def record_source_file_metadata(
     with connect(db_path) as conn:
         init_db(conn)
         upsert_source_file_metadata(conn, parsed_files=parsed)
-        record_ids = [
-            event.record_id for _path, events, *_rest in parsed for event in events
-        ]
+        record_ids = [event.record_id for _path, events, *_rest in parsed for event in events]
         if record_ids:
             sync_source_records(conn, record_ids=record_ids)
 
@@ -720,9 +720,7 @@ def _usage_event_record_ids(rows: list[dict[str, object]]) -> list[str]:
 def _usage_event_upsert_sql() -> str:
     placeholders = ", ".join("?" for _column in EVENT_COLUMNS)
     update_clause = ", ".join(
-        f"{column}=excluded.{column}"
-        for column in EVENT_COLUMNS
-        if column != "record_id"
+        f"{column}=excluded.{column}" for column in EVENT_COLUMNS if column != "record_id"
     )
     return (
         f"INSERT INTO usage_events ({', '.join(EVENT_COLUMNS)}) "
@@ -812,8 +810,7 @@ def _refresh_usage_event_links_for_threads(
     return _refresh_usage_event_links_scoped(
         conn,
         where_clause=(
-            "WHERE coalesce(nullif(thread_key, ''), 'session:' || session_id) "
-            f"IN ({placeholders})"
+            f"WHERE coalesce(nullif(thread_key, ''), 'session:' || session_id) IN ({placeholders})"
         ),
         params=thread_keys,
     )

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -296,6 +296,7 @@ def _emit_content_index_progress(
     payload.update(extra)
     progress_callback(payload)
 
+
 def _dedupe_content_index_plans(
     plans: Iterable[ContentIndexPlan],
 ) -> Iterable[ContentIndexPlan]:
@@ -324,9 +325,7 @@ def delete_content_index_rows_for_source_files(
 ) -> None:
     """Delete normalized content rows linked to source files."""
 
-    record_subquery = (
-        "SELECT record_id FROM usage_events " f"WHERE source_file IN ({placeholders})"
-    )
+    record_subquery = f"SELECT record_id FROM usage_events WHERE source_file IN ({placeholders})"
     if sync_fts:
         _clear_content_fts(conn)
     for table_name in CONTENT_INDEX_TABLES:
@@ -538,9 +537,7 @@ def _trace_calls(
         if row["fragment_id"] is not None:
             fragments = call["fragments"]
             assert isinstance(fragments, list)
-            fragments.append(
-                _trace_fragment_row(row, max_snippet_chars=max_snippet_chars)
-            )
+            fragments.append(_trace_fragment_row(row, max_snippet_chars=max_snippet_chars))
     for call in calls_by_id.values():
         fragments = call["fragments"]
         assert isinstance(fragments, list)
@@ -706,8 +703,7 @@ def _search_content_like(
     )
     terms = _search_terms(query) or [query]
     like_clauses = [
-        "(lower(cf.fragment_text) LIKE ? OR lower(cf.safe_label) LIKE ?)"
-        for _term in terms
+        "(lower(cf.fragment_text) LIKE ? OR lower(cf.safe_label) LIKE ?)" for _term in terms
     ]
     like_params: list[object] = []
     for term in terms:
@@ -716,7 +712,7 @@ def _search_content_like(
     from_sql = f"""
         FROM content_fragments AS cf
         JOIN usage_events AS u ON u.record_id = cf.record_id
-        WHERE {' AND '.join(like_clauses)}
+        WHERE {" AND ".join(like_clauses)}
         {usage_clause}
     """
     params = [*like_params, *usage_params]
@@ -912,7 +908,6 @@ def _limit_params(limit: int | None, offset: int) -> list[int]:
     return [limit, offset]
 
 
-
 def _content_usage_rows_for_plans(
     conn: sqlite3.Connection,
     *,
@@ -1095,6 +1090,7 @@ def _configured_parallel_content_index_workers() -> int | None:
     except ValueError:
         return None
 
+
 def _index_content_for_source_file(
     conn: sqlite3.Connection,
     *,
@@ -1171,15 +1167,15 @@ def _index_content_for_source_file(
                         pending_file_events = []
                     continue
                 pending.extend(
-                        _extract_pending_fragments(
-                            envelope=envelope,
-                            payload=payload,
-                            line_number=line_number,
-                            timestamp=timestamp,
-                            turn_id=turn_id,
-                            turn_index=turn_index,
-                        )
+                    _extract_pending_fragments(
+                        envelope=envelope,
+                        payload=payload,
+                        line_number=line_number,
+                        timestamp=timestamp,
+                        turn_id=turn_id,
+                        turn_index=turn_index,
                     )
+                )
                 events = extract_pending_local_events(
                     envelope=envelope,
                     payload=payload,

--- a/src/codex_usage_tracker/store/content_index_event_store.py
+++ b/src/codex_usage_tracker/store/content_index_event_store.py
@@ -194,7 +194,9 @@ def _merge_command_run_row(existing: dict[str, object], row: dict[str, object]) 
         existing["command_root"] = row["command_root"]
         existing["command_label"] = row["command_label"]
     existing["status"] = _merged_status(existing.get("status"), row.get("status"))
-    existing["exit_code"] = row.get("exit_code") if row.get("exit_code") is not None else existing.get("exit_code")
+    existing["exit_code"] = (
+        row.get("exit_code") if row.get("exit_code") is not None else existing.get("exit_code")
+    )
     existing["output_size_bytes"] = max(
         _int_value(existing.get("output_size_bytes")),
         _int_value(row.get("output_size_bytes")),
@@ -309,7 +311,9 @@ def _upsert_file_event_rows(conn: sqlite3.Connection, rows: list[dict[str, objec
 
 def _upsert_sql(table_name: str, columns: tuple[str, ...], primary_key: str) -> str:
     placeholders = ", ".join("?" for _column in columns)
-    update_clause = ", ".join(f"{column}=excluded.{column}" for column in columns if column != primary_key)
+    update_clause = ", ".join(
+        f"{column}=excluded.{column}" for column in columns if column != primary_key
+    )
     return (
         f"INSERT INTO {table_name} ({', '.join(columns)}) "
         f"VALUES ({placeholders}) "

--- a/src/codex_usage_tracker/store/content_index_events.py
+++ b/src/codex_usage_tracker/store/content_index_events.py
@@ -119,7 +119,9 @@ def _response_item_events(
     if payload_type == "function_call":
         return _function_call_events(payload=payload, line_number=line_number, timestamp=timestamp)
     if payload_type == "function_call_output":
-        return _function_output_events(payload=payload, line_number=line_number, timestamp=timestamp)
+        return _function_output_events(
+            payload=payload, line_number=line_number, timestamp=timestamp
+        )
     return PendingLocalEvents(tool_calls=[], command_runs=[], file_events=[])
 
 
@@ -188,9 +190,15 @@ def _function_call_events(
                 line_end=line_number,
             )
         )
-        file_events.extend(_file_events_from_command(command, root=command_root, line_number=line_number))
-    file_events.extend(_file_events_from_payload(payload=payload, operation="modify", line_number=line_number))
-    return PendingLocalEvents(tool_calls=[tool_call], command_runs=command_runs, file_events=file_events)
+        file_events.extend(
+            _file_events_from_command(command, root=command_root, line_number=line_number)
+        )
+    file_events.extend(
+        _file_events_from_payload(payload=payload, operation="modify", line_number=line_number)
+    )
+    return PendingLocalEvents(
+        tool_calls=[tool_call], command_runs=command_runs, file_events=file_events
+    )
 
 
 def _function_output_events(
@@ -323,7 +331,11 @@ def _command_tokens(command: str) -> list[str]:
 
 def _strip_assignment_prefixes(tokens: list[str]) -> list[str]:
     index = 0
-    while index < len(tokens) and "=" in tokens[index] and not tokens[index].startswith(("-", "./", "/")):
+    while (
+        index < len(tokens)
+        and "=" in tokens[index]
+        and not tokens[index].startswith(("-", "./", "/"))
+    ):
         index += 1
     return tokens[index:]
 

--- a/src/codex_usage_tracker/store/dashboard_queries.py
+++ b/src/codex_usage_tracker/store/dashboard_queries.py
@@ -223,9 +223,7 @@ def query_usage_status(
         "total_rows": int(total_row["count"] if total_row is not None else 0),
         "active_rows": int(active_row["count"] if active_row is not None else 0),
         "scoped_rows": int(scoped_row["count"] if scoped_row is not None else 0),
-        "max_event_timestamp": (
-            max_row["max_event_timestamp"] if max_row is not None else None
-        ),
+        "max_event_timestamp": (max_row["max_event_timestamp"] if max_row is not None else None),
     }
 
 
@@ -242,9 +240,7 @@ def query_latest_observed_usage(
         "OR rate_limit_secondary_used_percent IS NOT NULL"
     )
     scoped_where = (
-        f"{where_clause} AND ({observed_clause})"
-        if where_clause
-        else f"WHERE {observed_clause}"
+        f"{where_clause} AND ({observed_clause})" if where_clause else f"WHERE {observed_clause}"
     )
     with connect(db_path) as conn:
         init_db(conn)
@@ -313,9 +309,7 @@ def observed_usage_reconciliation(
         scoped_where=scoped_where,
         params=params,
     )
-    consecutive_alternate_rows, latest_alternate = _alternate_usage_limit_streak(
-        recent_rows
-    )
+    consecutive_alternate_rows, latest_alternate = _alternate_usage_limit_streak(recent_rows)
     selected = row_to_dict(selected_row) if selected_row is not None else {}
     recommended = _observed_usage_reconciliation_recommended(
         consecutive_alternate_rows=consecutive_alternate_rows,
@@ -399,9 +393,7 @@ def _observed_usage_reconciliation_payload(
         "latest_plan_type": latest_alternate.get("rate_limit_plan_type")
         if latest_alternate
         else None,
-        "latest_observed_at": latest_alternate.get("event_timestamp")
-        if latest_alternate
-        else None,
+        "latest_observed_at": latest_alternate.get("event_timestamp") if latest_alternate else None,
         "selected_observed_at": selected.get("event_timestamp"),
         "selected_limit_id": selected.get("rate_limit_limit_id"),
     }

--- a/src/codex_usage_tracker/store/large_low_output.py
+++ b/src/codex_usage_tracker/store/large_low_output.py
@@ -193,7 +193,12 @@ def _candidate_explanation(
     output_bytes = tool_output_size_bytes + command_output_size_bytes
     reasons: list[str] = []
 
-    if input_tokens and uncached_input_tokens >= 10_000 and uncached_ratio >= 0.65 and cache_ratio <= 0.35:
+    if (
+        input_tokens
+        and uncached_input_tokens >= 10_000
+        and uncached_ratio >= 0.65
+        and cache_ratio <= 0.35
+    ):
         reasons.append("large_uncached_input")
     if context_window_percent >= 0.60:
         reasons.append("high_context_window_share")
@@ -244,7 +249,9 @@ def _usage_filters(
         clauses.append(f"{alias}.event_timestamp <= ?")
         params.append(until)
     if thread:
-        clauses.append(f"({alias}.thread_name = ? OR {alias}.thread_key = ? OR {alias}.session_id = ?)")
+        clauses.append(
+            f"({alias}.thread_name = ? OR {alias}.thread_key = ? OR {alias}.session_id = ?)"
+        )
         params.extend([thread, thread, thread])
     if extra_clauses:
         clauses.extend(extra_clauses)

--- a/src/codex_usage_tracker/store/query_sql.py
+++ b/src/codex_usage_tracker/store/query_sql.py
@@ -145,11 +145,7 @@ def _extend_thread_filter(
     if not thread:
         return
     clauses.append(
-        "("
-        f"{prefix}thread_name = ? OR "
-        f"{prefix}parent_thread_name = ? OR "
-        f"{prefix}session_id = ?"
-        ")"
+        f"({prefix}thread_name = ? OR {prefix}parent_thread_name = ? OR {prefix}session_id = ?)"
     )
     params.extend([thread, thread, thread])
 
@@ -179,9 +175,7 @@ def _extend_archive_filter(
     archived_path_clause = " OR ".join(
         f"{prefix}source_file LIKE ?" for _pattern in _ARCHIVED_SOURCE_PATTERNS
     )
-    clauses.append(
-        f"(coalesce({prefix}is_archived, 0) = 0 AND NOT ({archived_path_clause}))"
-    )
+    clauses.append(f"(coalesce({prefix}is_archived, 0) = 0 AND NOT ({archived_path_clause}))")
     params.extend(_ARCHIVED_SOURCE_PATTERNS)
 
 

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -240,7 +240,6 @@ def refresh_usage_index(
     return result
 
 
-
 def _emit_refresh_progress(
     progress_callback: RefreshProgressCallback | None,
     *,
@@ -273,6 +272,7 @@ def _refresh_progress_percent(completed: int, total: int) -> float:
         return 100.0
     return round(min(100.0, max(0.0, (completed / total) * 100.0)), 1)
 
+
 def _parse_refresh_plans(
     parse_plans: list[SourceParsePlan],
     session_index: dict[str, Any],
@@ -299,7 +299,6 @@ def _parse_refresh_plans(
             session_index=session_index,
             progress_callback=progress_callback,
         )
-
 
 
 def _parse_refresh_plans_serial(
@@ -331,6 +330,7 @@ def _parse_refresh_plans_serial(
             parsed_events=sum(len(result.events) for result in results),
         )
     return results
+
 
 def _parse_refresh_plans_parallel(
     parse_plans: list[SourceParsePlan],

--- a/src/codex_usage_tracker/store/repeated_files.py
+++ b/src/codex_usage_tracker/store/repeated_files.py
@@ -93,15 +93,18 @@ def query_repeated_file_rediscovery(
     sorted_rows = sorted(rows, key=_candidate_row_sort_key, reverse=True)
     sliced_rows = sorted_rows if normalized_limit is None else sorted_rows[:normalized_limit]
     candidates = [
-        _file_candidate(row, trace_handles=_trace_handles_for_path(
-            conn,
-            path_hash=str(row["path_hash"]),
-            since=since,
-            until=until,
-            thread=thread,
-            include_archived=include_archived,
-            limit=normalized_sample_limit,
-        ))
+        _file_candidate(
+            row,
+            trace_handles=_trace_handles_for_path(
+                conn,
+                path_hash=str(row["path_hash"]),
+                since=since,
+                until=until,
+                thread=thread,
+                include_archived=include_archived,
+                limit=normalized_sample_limit,
+            ),
+        )
         for row in sliced_rows
     ]
     return {
@@ -275,7 +278,9 @@ def _recommendation(
                 f"{adjacent_retouch_count} adjacent retouches and {operation_mix} suggest rediscovery."
             )
         return f"Use thread handoff notes for {file_label}; operation mix is {operation_mix}."
-    return f"Batch edits for {file_label} or inspect thread trace; operation mix is {operation_mix}."
+    return (
+        f"Batch edits for {file_label} or inspect thread trace; operation mix is {operation_mix}."
+    )
 
 
 def _normalize_limit(limit: int | None) -> int | None:

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -564,8 +564,7 @@ def _backfill_source_records(conn: sqlite3.Connection) -> None:
 
 def _source_record_backfill_columns_available(conn: sqlite3.Connection) -> bool:
     existing = {
-        str(row["name"])
-        for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
+        str(row["name"]) for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
     }
     required = {"record_id", "source_file", "line_number", "event_timestamp"}
     return required.issubset(existing)
@@ -620,9 +619,7 @@ def _backfill_allowance_observations(conn: sqlite3.Connection) -> None:
     _backfill_allowance_observation_window(conn, "secondary")
 
 
-def _backfill_allowance_observation_window(
-    conn: sqlite3.Connection, window_key: str
-) -> None:
+def _backfill_allowance_observation_window(conn: sqlite3.Connection, window_key: str) -> None:
     used_col = f"rate_limit_{window_key}_used_percent"
     minutes_col = f"rate_limit_{window_key}_window_minutes"
     resets_col = f"rate_limit_{window_key}_resets_at"
@@ -738,8 +735,7 @@ def _ensure_table_columns(
     columns: dict[str, str],
 ) -> None:
     existing = {
-        str(row["name"])
-        for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
     }
     for column, column_type in columns.items():
         if column not in existing:
@@ -752,8 +748,7 @@ def _ensure_table_columns(
 
 def _validate_usage_events_schema(conn: sqlite3.Connection) -> None:
     existing = {
-        str(row["name"])
-        for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
+        str(row["name"]) for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
     }
     missing = [column for column in REQUIRED_USAGE_EVENT_COLUMNS if column not in existing]
     if missing:

--- a/src/codex_usage_tracker/store/shell_churn.py
+++ b/src/codex_usage_tracker/store/shell_churn.py
@@ -355,7 +355,9 @@ def _display_command_label(command_root: str, sample_command_label: str) -> str:
         return command_root
     safe_parts = [
         label_part
-        for label_part in (_safe_shell_label(part.lstrip("$")) for part in sample_command_label.split()[:2])
+        for label_part in (
+            _safe_shell_label(part.lstrip("$")) for part in sample_command_label.split()[:2]
+        )
         if label_part not in {"unknown", "unknown_command"}
     ]
     if not safe_parts:

--- a/src/codex_usage_tracker/store/source_records.py
+++ b/src/codex_usage_tracker/store/source_records.py
@@ -254,9 +254,7 @@ def _source_record_payload(row: sqlite3.Row) -> dict[str, object]:
 def _source_record_upsert_sql() -> str:
     placeholders = ", ".join("?" for _column in SOURCE_RECORD_COLUMNS)
     update_clause = ", ".join(
-        f"{column}=excluded.{column}"
-        for column in SOURCE_RECORD_COLUMNS
-        if column != "record_id"
+        f"{column}=excluded.{column}" for column in SOURCE_RECORD_COLUMNS if column != "record_id"
     )
     return (
         f"INSERT INTO source_records ({', '.join(SOURCE_RECORD_COLUMNS)}) "

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -43,16 +43,10 @@ def source_logs_requiring_parse(
     paths = list(logs)
     if not paths:
         return []
-    return [
-        plan
-        for plan in (_source_parse_plan(conn, path) for path in paths)
-        if plan is not None
-    ]
+    return [plan for plan in (_source_parse_plan(conn, path) for path in paths) if plan is not None]
 
 
-def _source_parse_plan(
-    conn: sqlite3.Connection, path: Path
-) -> SourceParsePlan | None:
+def _source_parse_plan(conn: sqlite3.Connection, path: Path) -> SourceParsePlan | None:
     metadata = _source_file_metadata(path)
     if metadata is None:
         return None
@@ -93,9 +87,7 @@ def _source_parse_plan_from_row(
     return SourceParsePlan(path=path)
 
 
-def _requires_full_source_parse(
-    row: sqlite3.Row, previous_state: ParserState | None
-) -> bool:
+def _requires_full_source_parse(row: sqlite3.Row, previous_state: ParserState | None) -> bool:
     previous_adapter = str(row["parser_adapter"] or "")
     return previous_adapter != PARSER_ADAPTER_VERSION or previous_state is None
 
@@ -107,9 +99,7 @@ def _source_metadata_matches(row: sqlite3.Row, metadata: dict[str, int]) -> bool
     )
 
 
-def _can_incrementally_parse_source(
-    metadata: dict[str, int], row: sqlite3.Row
-) -> bool:
+def _can_incrementally_parse_source(metadata: dict[str, int], row: sqlite3.Row) -> bool:
     previous_size = int(row["size_bytes"])
     previous_byte = int(row["parsed_until_byte"])
     return metadata["size_bytes"] > previous_size and 0 < previous_byte <= previous_size
@@ -204,9 +194,7 @@ def _source_file_metadata_row(
         "parsed_until_line": final_line_number or _count_lines(path),
         "parsed_until_byte": int(metadata["size_bytes"]),
         "latest_record_id": _latest_source_record_id(latest_event, parser_state),
-        "latest_event_timestamp": _latest_source_event_timestamp(
-            latest_event, parser_state
-        ),
+        "latest_event_timestamp": _latest_source_event_timestamp(latest_event, parser_state),
         "parser_adapter": PARSER_ADAPTER_VERSION,
         "parser_diagnostics_json": json.dumps(
             compact_parser_diagnostics(diagnostics),
@@ -226,11 +214,7 @@ def _latest_source_record_id(
 def _latest_source_event_timestamp(
     latest_event: UsageEvent | None, parser_state: ParserState
 ) -> str | None:
-    return (
-        latest_event.event_timestamp
-        if latest_event
-        else parser_state.latest_event_timestamp
-    )
+    return latest_event.event_timestamp if latest_event else parser_state.latest_event_timestamp
 
 
 def _latest_source_usage_event(events: list[UsageEvent]) -> UsageEvent | None:

--- a/src/codex_usage_tracker/usage_drain/allowance_breakpoints.py
+++ b/src/codex_usage_tracker/usage_drain/allowance_breakpoints.py
@@ -49,9 +49,7 @@ def allowance_breakpoint_analysis(spans: list[UsageDeltaSpan]) -> dict[str, Any]
 
     global_sse = _allowance_capacity_sse(rows, 0, len(rows))
     segments = _allowance_capacity_segments(rows)
-    piecewise_sse = sum(
-        _allowance_capacity_sse(rows, start, end) for start, end in segments
-    )
+    piecewise_sse = sum(_allowance_capacity_sse(rows, start, end) for start, end in segments)
     return {
         "target": "standard_usage_credits_per_visible_percent",
         "target_description": (
@@ -125,9 +123,7 @@ def _allowance_breakpoint_rows(spans: list[UsageDeltaSpan]) -> list[dict[str, An
 
 
 def _allowance_capacity_distribution(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    return _value_distribution(
-        [_number(row.get("credits_per_visible_percent")) for row in rows]
-    )
+    return _value_distribution([_number(row.get("credits_per_visible_percent")) for row in rows])
 
 
 def _allowance_capacity_segments(rows: list[dict[str, Any]]) -> list[tuple[int, int]]:
@@ -152,10 +148,7 @@ def _allowance_capacity_segments(rows: list[dict[str, Any]]) -> list[tuple[int, 
             candidates,
             key=lambda item: _number(item[1].get("sse_reduction")),
         )
-        if (
-            _number(split.get("sse_reduction_share"))
-            < ALLOWANCE_BREAKPOINT_MIN_REDUCTION_SHARE
-        ):
+        if _number(split.get("sse_reduction_share")) < ALLOWANCE_BREAKPOINT_MIN_REDUCTION_SHARE:
             break
         start, end = segments[segment_index]
         split_index = int(split["split_index"])
@@ -198,9 +191,7 @@ def _best_allowance_capacity_split(
 
 
 def _allowance_capacity_sse(rows: list[dict[str, Any]], start: int, end: int) -> float:
-    values = [
-        _number(row.get("credits_per_visible_percent")) for row in rows[start:end]
-    ]
+    values = [_number(row.get("credits_per_visible_percent")) for row in rows[start:end]]
     if not values:
         return 0.0
     mean_value = sum(values) / len(values)
@@ -225,9 +216,7 @@ def _allowance_split_record(
         "left_end_event_timestamp": left[-1]["end_event_timestamp"] if left else None,
         "right_start_event_timestamp": right[0]["start_event_timestamp"] if right else None,
         "right_end_event_timestamp": right[-1]["end_event_timestamp"] if right else None,
-        "left_mean_credits_per_percent": _rounded(
-            _mean_field(left, "credits_per_visible_percent")
-        ),
+        "left_mean_credits_per_percent": _rounded(_mean_field(left, "credits_per_visible_percent")),
         "right_mean_credits_per_percent": _rounded(
             _mean_field(right, "credits_per_visible_percent")
         ),
@@ -250,17 +239,11 @@ def _allowance_segment_record(
         "end_index": end - 1,
         "span_start_index": int(segment_rows[0]["span_index"]) if segment_rows else None,
         "span_end_index": int(segment_rows[-1]["span_index"]) if segment_rows else None,
-        "start_event_timestamp": segment_rows[0]["start_event_timestamp"]
-        if segment_rows
-        else None,
-        "end_event_timestamp": segment_rows[-1]["end_event_timestamp"]
-        if segment_rows
-        else None,
+        "start_event_timestamp": segment_rows[0]["start_event_timestamp"] if segment_rows else None,
+        "end_event_timestamp": segment_rows[-1]["end_event_timestamp"] if segment_rows else None,
         "n": len(segment_rows),
         "credits_per_visible_percent": _allowance_capacity_distribution(segment_rows),
-        "mean_delta_usage_percent": _rounded(
-            _mean_field(segment_rows, "delta_usage_percent")
-        ),
+        "mean_delta_usage_percent": _rounded(_mean_field(segment_rows, "delta_usage_percent")),
         "mean_standard_usage_credits": _rounded(
             _mean_field(segment_rows, "standard_usage_credits")
         ),

--- a/src/codex_usage_tracker/usage_drain/allowance_online.py
+++ b/src/codex_usage_tracker/usage_drain/allowance_online.py
@@ -222,12 +222,8 @@ def _allowance_online_capacity_error_diagnostics(
         predicted,
         segment_start_indexes=segment_start_indexes,
     )
-    breakpoint_errors = _allowance_online_abs_errors(
-        errors, is_known_breakpoint=True
-    )
-    non_breakpoint_errors = _allowance_online_abs_errors(
-        errors, is_known_breakpoint=False
-    )
+    breakpoint_errors = _allowance_online_abs_errors(errors, is_known_breakpoint=True)
+    non_breakpoint_errors = _allowance_online_abs_errors(errors, is_known_breakpoint=False)
     return {
         "known_breakpoint_row_count": len(breakpoint_errors),
         "non_breakpoint_row_count": len(non_breakpoint_errors),
@@ -267,11 +263,7 @@ def _allowance_online_error_rows(
 def _allowance_online_abs_errors(
     errors: list[dict[str, Any]], *, is_known_breakpoint: bool
 ) -> list[float]:
-    return [
-        row["abs_error"]
-        for row in errors
-        if row["is_known_breakpoint"] is is_known_breakpoint
-    ]
+    return [row["abs_error"] for row in errors if row["is_known_breakpoint"] is is_known_breakpoint]
 
 
 def _known_breakpoint_abs_error_share(
@@ -306,12 +298,8 @@ def _allowance_online_error_record(
         "actual_delta_percent": _rounded(_number(item["actual"])),
         "predicted_delta_percent": _rounded(_number(item["predicted"])),
         "abs_error": _rounded(_number(item["abs_error"])),
-        "credits_per_visible_percent": _rounded(
-            _number(row.get("credits_per_visible_percent"))
-        ),
-        "standard_usage_credits": _rounded(
-            _number(row.get("standard_usage_credits"))
-        ),
+        "credits_per_visible_percent": _rounded(_number(row.get("credits_per_visible_percent"))),
+        "standard_usage_credits": _rounded(_number(row.get("standard_usage_credits"))),
         "start_event_timestamp": row.get("start_event_timestamp"),
         "end_event_timestamp": row.get("end_event_timestamp"),
     }

--- a/src/codex_usage_tracker/usage_drain/boundary_delta_core.py
+++ b/src/codex_usage_tracker/usage_drain/boundary_delta_core.py
@@ -14,9 +14,7 @@ from codex_usage_tracker.usage_drain.utils import number as _number
 from codex_usage_tracker.usage_drain.utils import rounded as _rounded
 
 BOUNDARY_RISK_MODEL_SIGNATURES: dict[str, tuple[tuple[str, ...], ...]] = {
-    "previous_label_risk": (
-        ("previous_label",),
-    ),
+    "previous_label_risk": (("previous_label",),),
     "segment_age_risk": (
         ("previous_segment_position_bucket",),
         ("previous_segment_wall_time_bucket",),

--- a/src/codex_usage_tracker/usage_drain/boundary_delta_rows.py
+++ b/src/codex_usage_tracker/usage_drain/boundary_delta_rows.py
@@ -55,18 +55,22 @@ def _initial_boundary_delta_predictions(
         previous_state_rows,
         previous_delta,
     )
-    return previous_delta, {
-        "previous_delta": previous_delta,
-        "prior_mode_delta": prior_mode,
-    }, {
-        "previous_delta": {
-            "source": "previous_delta",
-            "signature": [],
-            "support": 1,
-            "matched_mode": _rounded(previous_delta),
+    return (
+        previous_delta,
+        {
+            "previous_delta": previous_delta,
+            "prior_mode_delta": prior_mode,
         },
-        "prior_mode_delta": prior_mode_detail,
-    }
+        {
+            "previous_delta": {
+                "source": "previous_delta",
+                "signature": [],
+                "support": 1,
+                "matched_mode": _rounded(previous_delta),
+            },
+            "prior_mode_delta": prior_mode_detail,
+        },
+    )
 
 
 def _add_state_delta_predictions(
@@ -213,13 +217,11 @@ def _add_risk_adjusted_delta_predictions(
             training_count=threshold_training_count,
         )
     )
-    predictions["risk_gated_label_segment_age_mode"] = (
-        risk_gated_boundary_delta_prediction(
-            previous_delta=previous_delta,
-            alternate_prediction=label_prediction,
-            risk=risk,
-            threshold=BOUNDARY_DELTA_RISK_GATE_THRESHOLD,
-        )
+    predictions["risk_gated_label_segment_age_mode"] = risk_gated_boundary_delta_prediction(
+        previous_delta=previous_delta,
+        alternate_prediction=label_prediction,
+        risk=risk,
+        threshold=BOUNDARY_DELTA_RISK_GATE_THRESHOLD,
     )
     predictions["risk_weighted_label_segment_age_mode"] = _risk_weighted_prediction(
         previous_delta=previous_delta,
@@ -231,21 +233,17 @@ def _add_risk_adjusted_delta_predictions(
         alternate_prediction=boundary_conditioned_prediction,
         risk=risk,
     )
-    predictions["adaptive_mae_gate_label_segment_age_mode"] = (
-        risk_gated_boundary_delta_prediction(
-            previous_delta=previous_delta,
-            alternate_prediction=label_prediction,
-            risk=risk,
-            threshold=mae_threshold,
-        )
+    predictions["adaptive_mae_gate_label_segment_age_mode"] = risk_gated_boundary_delta_prediction(
+        previous_delta=previous_delta,
+        alternate_prediction=label_prediction,
+        risk=risk,
+        threshold=mae_threshold,
     )
-    predictions["adaptive_rmse_gate_label_segment_age_mode"] = (
-        risk_gated_boundary_delta_prediction(
-            previous_delta=previous_delta,
-            alternate_prediction=label_prediction,
-            risk=risk,
-            threshold=rmse_threshold,
-        )
+    predictions["adaptive_rmse_gate_label_segment_age_mode"] = risk_gated_boundary_delta_prediction(
+        previous_delta=previous_delta,
+        alternate_prediction=label_prediction,
+        risk=risk,
+        threshold=rmse_threshold,
     )
     details["risk_gated_label_segment_age_mode"] = _risk_gate_detail(
         source="risk_gate_override"

--- a/src/codex_usage_tracker/usage_drain/boundary_delta_summary.py
+++ b/src/codex_usage_tracker/usage_drain/boundary_delta_summary.py
@@ -50,8 +50,6 @@ BOUNDARY_DELTA_ERROR_CONTEXT_FIELDS = (
 )
 
 
-
-
 def boundary_walk_forward_delta_prediction_summary(
     rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -61,9 +59,7 @@ def boundary_walk_forward_delta_prediction_summary(
         "prediction_models": {
             "previous_delta": "Predicts the previous visible usage delta.",
             "prior_mode_delta": "Predicts the modal prior next-span delta.",
-            "segment_age_mode": (
-                "Uses the modal prior next-span delta from matching segment age."
-            ),
+            "segment_age_mode": ("Uses the modal prior next-span delta from matching segment age."),
             "label_segment_age_mode": (
                 "Uses the modal prior next-span delta from matching previous label "
                 "plus segment-position age."
@@ -93,8 +89,7 @@ def boundary_walk_forward_delta_prediction_summary(
                 "between previous delta and matched label/segment-age mode."
             ),
             "boundary_conditioned_label_segment_age_mode": (
-                "Uses the modal prior next-span delta from matching prior boundary "
-                "rows only."
+                "Uses the modal prior next-span delta from matching prior boundary rows only."
             ),
             "risk_weighted_boundary_conditioned_mode": (
                 "Blends previous delta with the boundary-conditioned mode according "
@@ -109,7 +104,6 @@ def boundary_walk_forward_delta_prediction_summary(
             for scope_name, start in BOUNDARY_RISK_SCOPE_STARTS.items()
         },
     }
-
 
 
 def _boundary_delta_prediction_scope(
@@ -216,9 +210,6 @@ def _boundary_delta_model_names(rows: list[dict[str, Any]]) -> list[str]:
     return names
 
 
-
-
-
 def _boundary_delta_risk_gate_diagnostics(
     rows: list[dict[str, Any]], model_name: str
 ) -> dict[str, Any]:
@@ -228,17 +219,11 @@ def _boundary_delta_risk_gate_diagnostics(
     source_counts = _boundary_delta_risk_gate_source_counts(details)
     return {
         "n": len(details),
-        "override_share": _boundary_delta_risk_gate_override_share(
-            source_counts, len(details)
-        ),
+        "override_share": _boundary_delta_risk_gate_override_share(source_counts, len(details)),
         "mean_risk": _boundary_delta_risk_gate_mean_number(details, "risk"),
         "mean_support": _boundary_delta_risk_gate_mean_support(details),
-        "mean_threshold": _boundary_delta_risk_gate_mean_number(
-            details, "risk_threshold"
-        ),
-        "source_counts": _boundary_delta_risk_gate_source_count_rows(
-            source_counts, len(details)
-        ),
+        "mean_threshold": _boundary_delta_risk_gate_mean_number(details, "risk_threshold"),
+        "source_counts": _boundary_delta_risk_gate_source_count_rows(source_counts, len(details)),
     }
 
 
@@ -246,8 +231,7 @@ def _boundary_delta_risk_gate_details(
     rows: list[dict[str, Any]], model_name: str
 ) -> list[dict[str, Any]]:
     return [
-        (row.get("boundary_delta_prediction_details") or {}).get(model_name) or {}
-        for row in rows
+        (row.get("boundary_delta_prediction_details") or {}).get(model_name) or {} for row in rows
     ]
 
 
@@ -308,9 +292,7 @@ def _boundary_delta_risk_gate_source_count_rows(
             "count": count,
             "share": _rounded(count / total_count),
         }
-        for source, count in sorted(
-            source_counts.items(), key=lambda item: (-item[1], item[0])
-        )
+        for source, count in sorted(source_counts.items(), key=lambda item: (-item[1], item[0]))
     ]
 
 
@@ -335,9 +317,7 @@ def _boundary_delta_residual_error_rows(
     return [_boundary_delta_residual_error_row(row, model_name) for row in rows]
 
 
-def _boundary_delta_residual_error_row(
-    row: dict[str, Any], model_name: str
-) -> dict[str, Any]:
+def _boundary_delta_residual_error_row(row: dict[str, Any], model_name: str) -> dict[str, Any]:
     predicted = _number((row.get("boundary_delta_predictions") or {}).get(model_name))
     actual = _number(row.get("delta_percent"))
     error = predicted - actual
@@ -450,9 +430,7 @@ def _boundary_delta_error_group_row(
         field_name: key,
         "count": len(items),
         "count_share": _rounded(len(items) / total_count),
-        "share_abs_error": _rounded(
-            abs_error_sum / total_abs_error if total_abs_error else None
-        ),
+        "share_abs_error": _rounded(abs_error_sum / total_abs_error if total_abs_error else None),
         "mean_abs_error": _rounded(abs_error_sum / len(items)),
         "rmse": _rounded(_boundary_delta_rmse(items)),
         "max_abs_error": _rounded(max(item["abs_error"] for item in items)),
@@ -492,9 +470,7 @@ def _largest_boundary_delta_errors(errors: list[dict[str, Any]]) -> list[dict[st
             "previous_segment_position_bucket": item["metadata"].get(
                 "previous_segment_position_bucket"
             ),
-            "boundary_state": "boundary"
-            if item["metadata"].get("is_boundary")
-            else "same_label",
+            "boundary_state": "boundary" if item["metadata"].get("is_boundary") else "same_label",
             "previous_delta_percent": _rounded(item["previous_delta_percent"]),
             "actual_delta_percent": _rounded(item["actual"]),
             "predicted_delta_percent": _rounded(item["predicted"]),

--- a/src/codex_usage_tracker/usage_drain/boundary_scopes.py
+++ b/src/codex_usage_tracker/usage_drain/boundary_scopes.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any
 
-BOUNDARY_RISK_SCOPE_STARTS = MappingProxyType({
-    "all_after_first": 1,
-    "all_after_10": 10,
-    "time_ordered_holdout_20": 0.8,
-    "latest_500": -500,
-    "latest_100": -100,
-})
+BOUNDARY_RISK_SCOPE_STARTS = MappingProxyType(
+    {
+        "all_after_first": 1,
+        "all_after_10": 10,
+        "time_ordered_holdout_20": 0.8,
+        "latest_500": -500,
+        "latest_100": -100,
+    }
+)
 
 
 def boundary_scope_start_index(rows: list[dict[str, Any]], start: int | float) -> int:

--- a/src/codex_usage_tracker/usage_drain/boundary_summary.py
+++ b/src/codex_usage_tracker/usage_drain/boundary_summary.py
@@ -49,6 +49,7 @@ BOUNDARY_CONTEXT_FIELDS = (
     "rate_limit_limit_id",
 )
 
+
 def piecewise_boundary_diagnostics(
     spans: list[UsageDeltaSpan],
     prediction_rows: dict[int, dict[str, Any]],
@@ -58,8 +59,7 @@ def piecewise_boundary_diagnostics(
         row
         for row in rows
         if row["previous_label"] == "stable_one_percent"
-        and int(row.get("one_percent_streak_count") or 0)
-        >= REGIME_GRACE_STREAK_THRESHOLD
+        and int(row.get("one_percent_streak_count") or 0) >= REGIME_GRACE_STREAK_THRESHOLD
     ]
     return {
         "target": "next_span_regime_label_changes",
@@ -114,21 +114,15 @@ def _piecewise_boundary_rows(
             "previous_segment_position_bucket": regime_labels.segment_position_bucket(
                 previous_segment_position
             ),
-            "previous_segment_wall_time_seconds": _rounded(
-                previous_segment_wall_time_seconds
-            ),
-            "previous_segment_wall_time_bucket": _second_bucket(
-                previous_segment_wall_time_seconds
-            ),
+            "previous_segment_wall_time_seconds": _rounded(previous_segment_wall_time_seconds),
+            "previous_segment_wall_time_bucket": _second_bucket(previous_segment_wall_time_seconds),
             "timestamp": span.start_event_timestamp,
         }
         for field_name in BOUNDARY_CONTEXT_FIELDS:
             if field_name in row:
                 continue
             row[field_name] = metadata.get(field_name, "missing")
-        row["one_percent_streak_count"] = int(
-            metadata.get("one_percent_streak_count") or 0
-        )
+        row["one_percent_streak_count"] = int(metadata.get("one_percent_streak_count") or 0)
         rows.append(row)
         if current_label != previous_label:
             segment_start_index = index
@@ -159,9 +153,7 @@ def _piecewise_boundary_transition_counts(rows: list[dict[str, Any]]) -> list[di
             "count": count,
             "share": _rounded(count / total if total else None),
         }
-        for transition, count in sorted(
-            counts.items(), key=lambda item: (-item[1], item[0])
-        )[:10]
+        for transition, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:10]
     ]
 
 
@@ -202,9 +194,7 @@ def _latest_piecewise_boundaries(rows: list[dict[str, Any]]) -> list[dict[str, A
             "window_elapsed_bucket": row.get("window_elapsed_bucket"),
             "previous_delta_percent": row.get("previous_delta_percent"),
             "previous_segment_position": row.get("previous_segment_position"),
-            "previous_segment_position_bucket": row.get(
-                "previous_segment_position_bucket"
-            ),
+            "previous_segment_position_bucket": row.get("previous_segment_position_bucket"),
             "delta_percent": row.get("delta_percent"),
             "one_percent_streak_count": row.get("one_percent_streak_count"),
         }
@@ -240,8 +230,6 @@ def _boundary_walk_forward_risk_summary(rows: list[dict[str, Any]]) -> dict[str,
     }
 
 
-
-
 def _boundary_walk_forward_risk_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     output: list[dict[str, Any]] = []
     previous_rows: list[dict[str, Any]] = []
@@ -275,12 +263,7 @@ def _boundary_walk_forward_risk_rows(rows: list[dict[str, Any]]) -> list[dict[st
     return output
 
 
-
-
-
-def _boundary_risk_scope(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> dict[str, Any]:
+def _boundary_risk_scope(rows: list[dict[str, Any]], *, start_index: int) -> dict[str, Any]:
     scope_rows = _boundary_scope_rows(rows, start_index=start_index)
     actual = _boundary_actuals(scope_rows)
     model_names = _boundary_risk_model_names(scope_rows)
@@ -290,15 +273,11 @@ def _boundary_risk_scope(
         "boundary_count": sum(actual),
         "boundary_rate": _boundary_rate(actual),
         "models": _boundary_risk_model_metrics(scope_rows, actual, model_names),
-        "risk_detail_diagnostics": _boundary_risk_scope_detail_diagnostics(
-            scope_rows, model_names
-        ),
+        "risk_detail_diagnostics": _boundary_risk_scope_detail_diagnostics(scope_rows, model_names),
     }
 
 
-def _boundary_scope_rows(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> list[dict[str, Any]]:
+def _boundary_scope_rows(rows: list[dict[str, Any]], *, start_index: int) -> list[dict[str, Any]]:
     return [row for row in rows if int(row["index"]) >= start_index]
 
 
@@ -326,13 +305,8 @@ def _boundary_risk_model_metrics(
     }
 
 
-def _boundary_risk_scores(
-    rows: list[dict[str, Any]], model_name: str
-) -> list[float]:
-    return [
-        _number((row.get("boundary_risks") or {}).get(model_name))
-        for row in rows
-    ]
+def _boundary_risk_scores(rows: list[dict[str, Any]], model_name: str) -> list[float]:
+    return [_number((row.get("boundary_risks") or {}).get(model_name)) for row in rows]
 
 
 def _boundary_risk_scope_detail_diagnostics(
@@ -378,20 +352,13 @@ def _boundary_risk_detail_diagnostics(
 def _boundary_risk_details_for_model(
     rows: list[dict[str, Any]], model_name: str
 ) -> list[dict[str, Any]]:
-    return [
-        (row.get("boundary_risk_details") or {}).get(model_name) or {}
-        for row in rows
-    ]
+    return [(row.get("boundary_risk_details") or {}).get(model_name) or {} for row in rows]
 
 
 def _matched_boundary_risk_details(
     details: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    return [
-        detail
-        for detail in details
-        if detail.get("source") == "matched_boundary_state"
-    ]
+    return [detail for detail in details if detail.get("source") == "matched_boundary_state"]
 
 
 def _mean_boundary_risk_support(details: list[dict[str, Any]]) -> float | None:

--- a/src/codex_usage_tracker/usage_drain/error_diagnostics.py
+++ b/src/codex_usage_tracker/usage_drain/error_diagnostics.py
@@ -39,6 +39,7 @@ def span_error_metadata(span: UsageDeltaSpan) -> dict[str, Any]:
         "usage_window_source": span.usage_window_source or "missing",
     }
 
+
 def _span_reset_remaining_minutes(span: UsageDeltaSpan, start_dt: Any) -> float:
     remaining_minutes = reset_remaining_minutes(start_dt, span_reset_timestamp(span))
     return remaining_minutes or 0.0
@@ -50,18 +51,14 @@ def _span_window_elapsed_fraction(span: UsageDeltaSpan, reset_minutes: float) ->
     return window_elapsed_fraction(elapsed_minutes, window_minutes)
 
 
-def prediction_error_diagnostics(
-    rows: list[dict[str, Any]], model_name: str
-) -> dict[str, Any]:
+def prediction_error_diagnostics(rows: list[dict[str, Any]], model_name: str) -> dict[str, Any]:
     errors = prediction_error_rows(rows, model_name)
     if not errors:
         return empty_prediction_error_diagnostics()
     return prediction_error_summary(errors)
 
 
-def prediction_error_rows(
-    rows: list[dict[str, Any]], model_name: str
-) -> list[dict[str, Any]]:
+def prediction_error_rows(rows: list[dict[str, Any]], model_name: str) -> list[dict[str, Any]]:
     return [_prediction_error_row(row, model_name) for row in rows]
 
 
@@ -112,14 +109,11 @@ def prediction_error_summary(errors: list[dict[str, Any]]) -> dict[str, Any]:
         "error_by_day_of_week": top_error_groups(errors, "day_of_week"),
         "error_by_hour": top_error_groups(errors, "hour_bucket"),
         "error_by_reset_phase": top_error_groups(errors, "reset_phase"),
-        "error_by_one_percent_streak": top_error_groups(
-            errors, "one_percent_streak_bucket"
-        ),
-        "error_by_same_delta_streak": top_error_groups(
-            errors, "same_delta_streak_bucket"
-        ),
+        "error_by_one_percent_streak": top_error_groups(errors, "one_percent_streak_bucket"),
+        "error_by_same_delta_streak": top_error_groups(errors, "same_delta_streak_bucket"),
         "largest_errors": largest_prediction_errors(errors),
     }
+
 
 def prediction_error_share(
     errors: list[dict[str, Any]],
@@ -151,9 +145,7 @@ def top_transition_errors(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "previous_delta_percent": previous,
             "actual_delta_percent": actual,
             "count": len(items),
-            "mean_abs_error": rounded(
-                sum(item["abs_error"] for item in items) / len(items)
-            ),
+            "mean_abs_error": rounded(sum(item["abs_error"] for item in items) / len(items)),
             "max_abs_error": rounded(max(item["abs_error"] for item in items)),
         }
         for (previous, actual), items in grouped.items()
@@ -166,6 +158,7 @@ def top_transition_errors(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
     )
     return rows[:10]
 
+
 def top_error_groups(errors: list[dict[str, Any]], field_name: str) -> list[dict[str, Any]]:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for item in errors:
@@ -176,9 +169,7 @@ def top_error_groups(errors: list[dict[str, Any]], field_name: str) -> list[dict
         {
             field_name: key,
             "count": len(items),
-            "mean_abs_error": rounded(
-                sum(item["abs_error"] for item in items) / len(items)
-            ),
+            "mean_abs_error": rounded(sum(item["abs_error"] for item in items) / len(items)),
             "max_abs_error": rounded(max(item["abs_error"] for item in items)),
         }
         for key, items in grouped.items()
@@ -190,6 +181,7 @@ def top_error_groups(errors: list[dict[str, Any]], field_name: str) -> list[dict
         )
     )
     return rows[:10]
+
 
 def largest_prediction_errors(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
     rows = sorted(errors, key=lambda item: item["abs_error"], reverse=True)[:10]
@@ -207,6 +199,7 @@ def largest_prediction_errors(errors: list[dict[str, Any]]) -> list[dict[str, An
         }
         for item in rows
     ]
+
 
 def value_distribution(values: list[float]) -> dict[str, Any]:
     if not values:

--- a/src/codex_usage_tracker/usage_drain/feature_history.py
+++ b/src/codex_usage_tracker/usage_drain/feature_history.py
@@ -158,9 +158,7 @@ def _capacity_estimates(state: _CausalHistoryState) -> dict[str, float]:
         "previous": previous_capacity_per_visible_percent(previous_rows),
         "rolling3": rolling_capacity_per_visible_percent(previous_rows, 3),
         "rolling10": rolling_capacity_per_visible_percent(previous_rows, 10),
-        "rolling10_median": rolling_capacity_median_per_visible_percent(
-            previous_rows, 10
-        ),
+        "rolling10_median": rolling_capacity_median_per_visible_percent(previous_rows, 10),
         "ewma": state.ewma_capacity or 0.0,
     }
 
@@ -173,9 +171,7 @@ def _attach_capacity_features(
     row["previous_capacity_credits_per_percent"] = capacity_estimates["previous"]
     row["rolling3_capacity_credits_per_percent"] = capacity_estimates["rolling3"]
     row["rolling10_capacity_credits_per_percent"] = capacity_estimates["rolling10"]
-    row["rolling10_median_capacity_credits_per_percent"] = capacity_estimates[
-        "rolling10_median"
-    ]
+    row["rolling10_median_capacity_credits_per_percent"] = capacity_estimates["rolling10_median"]
     row["ewma_capacity_credits_per_percent"] = capacity_estimates["ewma"]
     for capacity_name, capacity in capacity_estimates.items():
         row[f"{capacity_name}_capacity_delta_prediction"] = (
@@ -280,9 +276,7 @@ def attach_remainder_features(
     row[f"{prefix}_remainder_floor_delta_prediction"] = (
         float(math.floor(accumulated + 1e-9)) if accumulated > 0 else 0.0
     )
-    row[f"{prefix}_remainder_ceiling_delta_prediction"] = ceil_to_visible_tick(
-        accumulated
-    )
+    row[f"{prefix}_remainder_ceiling_delta_prediction"] = ceil_to_visible_tick(accumulated)
 
 
 def updated_remainder_credits(
@@ -310,18 +304,14 @@ def previous_capacity_per_visible_percent(rows: list[dict[str, Any]]) -> float:
     return capacity_per_visible_percent(rows[-1])
 
 
-def rolling_capacity_per_visible_percent(
-    rows: list[dict[str, Any]], window: int
-) -> float:
+def rolling_capacity_per_visible_percent(rows: list[dict[str, Any]], window: int) -> float:
     selected = rows[-window:]
     if not selected:
         return 0.0
     return sum(capacity_per_visible_percent(row) for row in selected) / len(selected)
 
 
-def rolling_capacity_median_per_visible_percent(
-    rows: list[dict[str, Any]], window: int
-) -> float:
+def rolling_capacity_median_per_visible_percent(rows: list[dict[str, Any]], window: int) -> float:
     selected = rows[-window:]
     if not selected:
         return 0.0
@@ -383,9 +373,7 @@ def rolling_low_delta_share(rows: list[dict[str, Any]], window: int) -> float:
     return low_count / len(selected)
 
 
-def row_tail_streak(
-    rows: list[dict[str, Any]], *, predicate: Any
-) -> int:
+def row_tail_streak(rows: list[dict[str, Any]], *, predicate: Any) -> int:
     count = 0
     for row in reversed(rows):
         if not predicate(row):

--- a/src/codex_usage_tracker/usage_drain/features.py
+++ b/src/codex_usage_tracker/usage_drain/features.py
@@ -127,9 +127,7 @@ def _span_credit_features(span: UsageDeltaSpan, *, proxy: str) -> dict[str, Any]
     }
 
 
-def _span_turn_features(
-    span: UsageDeltaSpan, credit_features: dict[str, Any]
-) -> dict[str, Any]:
+def _span_turn_features(span: UsageDeltaSpan, credit_features: dict[str, Any]) -> dict[str, Any]:
     standard = float(credit_features["standard_usage_credits"])
     total_tokens = float(credit_features["total_tokens"])
     input_tokens = float(credit_features["input_tokens"])
@@ -171,9 +169,7 @@ def _span_effort_features(span: UsageDeltaSpan) -> dict[str, Any]:
     dominant_effort_count = span.effort_counts.get(dominant_effort, 0)
     effort_purity = dominant_effort_count / effort_total if effort_total else 0.0
     effort_shares = {
-        effort: span.effort_counts.get(effort, 0) / effort_total
-        if effort_total
-        else 0.0
+        effort: span.effort_counts.get(effort, 0) / effort_total if effort_total else 0.0
         for effort in EFFORT_LEVELS
     }
     return {
@@ -245,14 +241,10 @@ def _span_timing_features(
     return {
         "call_duration_seconds": duration,
         "mean_call_duration_seconds": _safe_div(duration, span.row_count),
-        "previous_call_delta_seconds": span.timing_totals.get(
-            "previous_call_delta_seconds", 0.0
-        ),
+        "previous_call_delta_seconds": span.timing_totals.get("previous_call_delta_seconds", 0.0),
         "span_wall_time_seconds": wall_time_seconds,
         "span_wall_time_minutes": wall_time_seconds / 60.0,
-        "mean_span_wall_time_seconds_per_call": _safe_div(
-            wall_time_seconds, span.row_count
-        ),
+        "mean_span_wall_time_seconds_per_call": _safe_div(wall_time_seconds, span.row_count),
         "row_count_bucket": row_count_bucket,
         "call_duration_bucket": call_duration_bucket,
         "span_wall_time_bucket": span_wall_time_bucket,
@@ -266,8 +258,6 @@ def _span_timing_features(
     }
 
 
-
-
 def add_days_since_first_span(rows: list[dict[str, Any]]) -> None:
     first_date: datetime | None = None
     for row in rows:
@@ -279,6 +269,4 @@ def add_days_since_first_span(rows: list[dict[str, Any]]) -> None:
         if parsed is None or first_date is None:
             row["days_since_first_span"] = 0.0
         else:
-            row["days_since_first_span"] = max(
-                (parsed.date() - first_date.date()).days, 0
-            )
+            row["days_since_first_span"] = max((parsed.date() - first_date.date()).days, 0)

--- a/src/codex_usage_tracker/usage_drain/grace.py
+++ b/src/codex_usage_tracker/usage_drain/grace.py
@@ -22,6 +22,7 @@ REGIME_GRACE_THRESHOLD_GRID = (3, 5, 10, 25, 50, 100, 200)
 
 REGIME_GRACE_SPAN_GRID = (1, 2, 3)
 
+
 def one_percent_grace_calibration(
     spans: list[UsageDeltaSpan], scopes: dict[str, int]
 ) -> dict[str, Any]:
@@ -82,6 +83,7 @@ def one_percent_grace_calibration(
         "scopes": scope_results,
     }
 
+
 def one_percent_grace_calibration_row(
     values: list[float],
     *,
@@ -112,9 +114,7 @@ def one_percent_grace_calibration_row(
         "exact_match_share": rounded(
             sum(
                 1
-                for actual_value, predicted_value in zip(
-                    actual, predictions, strict=True
-                )
+                for actual_value, predicted_value in zip(actual, predictions, strict=True)
                 if round(actual_value, 6) == round(predicted_value, 6)
             )
             / len(actual)
@@ -123,14 +123,14 @@ def one_percent_grace_calibration_row(
         ),
     }
 
-def one_percent_grace_config(
-    streak_threshold: int, grace_spans: int
-) -> dict[str, Any]:
+
+def one_percent_grace_config(streak_threshold: int, grace_spans: int) -> dict[str, Any]:
     return {
         "streak_threshold": streak_threshold,
         "grace_spans": grace_spans,
         "max_break_delta_percent": REGIME_GRACE_MAX_BREAK_DELTA,
     }
+
 
 def one_percent_regime_grace_prediction(
     previous_deltas: list[float],
@@ -141,9 +141,7 @@ def one_percent_regime_grace_prediction(
 ) -> float:
     if not previous_deltas:
         return 0.0
-    one_percent_streak = tail_streak(
-        previous_deltas, predicate=is_one_percent_delta
-    )
+    one_percent_streak = tail_streak(previous_deltas, predicate=is_one_percent_delta)
     if one_percent_streak >= streak_threshold:
         return 1.0
     break_age = small_break_age_after_one_percent_run(
@@ -155,6 +153,7 @@ def one_percent_regime_grace_prediction(
         return 1.0
     return previous_deltas[-1]
 
+
 def small_break_age_after_one_percent_run(
     values: list[float], *, streak_threshold: int, max_break_delta: float
 ) -> int | None:
@@ -163,9 +162,7 @@ def small_break_age_after_one_percent_run(
     index = len(values) - 1
     break_age = 0
     while (
-        index >= 0
-        and not is_one_percent_delta(values[index])
-        and values[index] <= max_break_delta
+        index >= 0 and not is_one_percent_delta(values[index]) and values[index] <= max_break_delta
     ):
         break_age += 1
         index -= 1

--- a/src/codex_usage_tracker/usage_drain/history_state.py
+++ b/src/codex_usage_tracker/usage_drain/history_state.py
@@ -24,12 +24,8 @@ def history_state_for_span(
     previous_deltas: list[float],
 ) -> dict[str, Any]:
     if previous_deltas:
-        one_percent_streak = tail_streak(
-            previous_deltas, predicate=is_one_percent_delta
-        )
-        low_delta_streak = tail_streak(
-            previous_deltas, predicate=lambda value: value <= 1.0
-        )
+        one_percent_streak = tail_streak(previous_deltas, predicate=is_one_percent_delta)
+        low_delta_streak = tail_streak(previous_deltas, predicate=lambda value: value <= 1.0)
         same_delta_streak = same_value_tail_streak(previous_deltas)
         previous_delta_value = previous_deltas[-1]
         previous_delta_bucket = delta_bucket(previous_deltas[-1])
@@ -49,9 +45,7 @@ def history_state_for_span(
         "low_delta_streak_bucket": streak_bucket(low_delta_streak),
         "same_delta_streak_count": same_delta_streak,
         "same_delta_streak_bucket": streak_bucket(same_delta_streak),
-        "previous_span_wall_time_bucket": previous_span_wall_time_bucket(
-            spans, index
-        ),
+        "previous_span_wall_time_bucket": previous_span_wall_time_bucket(spans, index),
         "previous_call_duration_bucket": previous_call_duration_bucket(spans, index),
     }
 
@@ -65,9 +59,7 @@ def previous_span_wall_time_bucket(spans: list[UsageDeltaSpan], index: int) -> s
 def previous_call_duration_bucket(spans: list[UsageDeltaSpan], index: int) -> str:
     if index <= 0:
         return "missing"
-    return second_bucket(
-        spans[index - 1].timing_totals.get("call_duration_seconds", 0.0)
-    )
+    return second_bucket(spans[index - 1].timing_totals.get("call_duration_seconds", 0.0))
 
 
 def delta_bucket(value: float) -> str:

--- a/src/codex_usage_tracker/usage_drain/model.py
+++ b/src/codex_usage_tracker/usage_drain/model.py
@@ -108,6 +108,8 @@ ALLOWANCE_BREAKPOINT_MAX_SEGMENTS = 6
 ALLOWANCE_BREAKPOINT_MIN_REDUCTION_SHARE = 0.12
 
 USAGE_DRAIN_MODEL_SCHEMA = "codex-usage-tracker-usage-drain-model-v1"
+
+
 def summarize_usage_drain_model(
     rows: list[dict[str, Any]],
     *,
@@ -128,9 +130,11 @@ def summarize_usage_drain_model(
     )
     best_predictive_mae_model = min(
         predictive_models,
-        key=lambda result: _number(result.get("holdout", {}).get("mae"))
-        if result.get("holdout", {}).get("mae") is not None
-        else math.inf,
+        key=lambda result: (
+            _number(result.get("holdout", {}).get("mae"))
+            if result.get("holdout", {}).get("mae") is not None
+            else math.inf
+        ),
         default=None,
     )
     return {
@@ -224,9 +228,7 @@ def summarize_usage_drain_model(
 
 def _span_correlation_summary(spans: list[UsageDeltaSpan]) -> dict[str, Any]:
     rows = [_span_correlation_row(span) for span in spans]
-    one_percent_rows = [
-        row for row in rows if _is_one_percent_delta(row["delta_usage_percent"])
-    ]
+    one_percent_rows = [row for row in rows if _is_one_percent_delta(row["delta_usage_percent"])]
     latest_rows = rows[-500:]
     return {
         "delta_usage_percent": _correlation_report(
@@ -264,9 +266,7 @@ def _span_correlation_summary(spans: list[UsageDeltaSpan]) -> dict[str, Any]:
 
 
 def _one_percent_capacity_modeling(spans: list[UsageDeltaSpan]) -> dict[str, Any]:
-    one_percent_spans = [
-        span for span in spans if _is_one_percent_delta(span.delta_usage_percent)
-    ]
+    one_percent_spans = [span for span in spans if _is_one_percent_delta(span.delta_usage_percent)]
     rows = [_one_percent_capacity_row(span) for span in one_percent_spans]
     if len(rows) < 10:
         return _empty_one_percent_capacity_modeling(one_percent_spans, rows)
@@ -302,14 +302,10 @@ def _prepare_one_percent_capacity_rows(rows: list[dict[str, Any]]) -> None:
 
 def _fit_one_percent_capacity_models(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     models: list[dict[str, Any]] = []
-    for split_name, train_rows, holdout_rows in _split_feature_rows(
-        rows, train_fraction=0.8
-    ):
+    for split_name, train_rows, holdout_rows in _split_feature_rows(rows, train_fraction=0.8):
         models.extend(_fit_capacity_baseline_models(train_rows, holdout_rows, split_name))
         models.extend(
-            _fit_one_percent_capacity_predictive_models(
-                train_rows, holdout_rows, split_name
-            )
+            _fit_one_percent_capacity_predictive_models(train_rows, holdout_rows, split_name)
         )
     return models
 
@@ -354,9 +350,7 @@ def _one_percent_capacity_modeling_report(
             "Aggregate standard usage credits inside exact 1% visible-counter spans."
         ),
         "span_count": len(rows),
-        "target_distribution": _value_distribution(
-            [_number(row.get("target")) for row in rows]
-        ),
+        "target_distribution": _value_distribution([_number(row.get("target")) for row in rows]),
         "splits": ["time_ordered_80_20", "interleaved_every_5th"],
         "best_by_holdout_mae": best_model["name"] if best_model else None,
         "best_causal_by_holdout_mae": best_causal["name"] if best_causal else None,
@@ -407,9 +401,7 @@ def _add_capacity_history_features(rows: list[dict[str, Any]]) -> None:
         row["rolling10_capacity_credits"] = _rolling_mean(previous_rows, "target", 10)
         row["rolling10_capacity_median"] = _rolling_median(previous_rows, "target", 10)
         row["rolling10_capacity_stddev"] = _rolling_stddev(previous_rows, "target", 10)
-        row["same_hour_rolling10_capacity_credits"] = _rolling_mean(
-            recent_hour_rows, "target", 10
-        )
+        row["same_hour_rolling10_capacity_credits"] = _rolling_mean(recent_hour_rows, "target", 10)
         row["same_hour_seen_count"] = float(len(recent_hour_rows))
         row["same_day_of_week_rolling10_capacity_credits"] = _rolling_mean(
             recent_day_of_week_rows, "target", 10
@@ -479,8 +471,6 @@ def _fit_capacity_baseline_models(
             }
         )
     return results
-
-
 
 
 def write_usage_drain_spans_csv(spans: list[UsageDeltaSpan], path: Path) -> Path:

--- a/src/codex_usage_tracker/usage_drain/predictive.py
+++ b/src/codex_usage_tracker/usage_drain/predictive.py
@@ -75,9 +75,7 @@ def empty_capacity_residual_diagnostics() -> dict[str, Any]:
 def capacity_residual_summary(errors: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "n": len(errors),
-        "mean_error": rounded(
-            sum(item["error"] for item in errors) / len(errors)
-        ),
+        "mean_error": rounded(sum(item["error"] for item in errors) / len(errors)),
         "within_5_credits_share": capacity_error_share(errors, max_error=5.0),
         "within_10_credits_share": capacity_error_share(errors, max_error=10.0),
         "large_error_share": capacity_error_share(errors, min_error=25.0),
@@ -105,7 +103,7 @@ def capacity_error_share(
 
 
 def capacity_residual_top_error_groups(
-    errors: list[dict[str, Any]]
+    errors: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
     return {
         field_name: capacity_top_error_groups(errors, field_name)
@@ -115,8 +113,7 @@ def capacity_residual_top_error_groups(
 
 def capacity_residual_metadata(row: dict[str, Any]) -> dict[str, Any]:
     return {
-        field_name: row.get(field_name, "missing")
-        for field_name in CAPACITY_RESIDUAL_GROUP_FIELDS
+        field_name: row.get(field_name, "missing") for field_name in CAPACITY_RESIDUAL_GROUP_FIELDS
     }
 
 
@@ -132,15 +129,11 @@ def capacity_top_error_groups(
         {
             field_name: key,
             "count": len(items),
-            "mean_abs_error": rounded(
-                sum(item["abs_error"] for item in items) / len(items)
-            ),
+            "mean_abs_error": rounded(sum(item["abs_error"] for item in items) / len(items)),
             "mean_error": rounded(sum(item["error"] for item in items) / len(items)),
             "max_abs_error": rounded(max(item["abs_error"] for item in items)),
             "mean_actual": rounded(sum(item["actual"] for item in items) / len(items)),
-            "meanpredicted": rounded(
-                sum(item["predicted"] for item in items) / len(items)
-            ),
+            "meanpredicted": rounded(sum(item["predicted"] for item in items) / len(items)),
         }
         for key, items in grouped.items()
     ]
@@ -153,9 +146,7 @@ def capacity_top_error_groups(
     return rows[:10]
 
 
-def largest_capacity_residual_errors(
-    errors: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def largest_capacity_residual_errors(errors: list[dict[str, Any]]) -> list[dict[str, Any]]:
     rows = sorted(errors, key=lambda item: item["abs_error"], reverse=True)[:10]
     return [
         {
@@ -258,9 +249,7 @@ def fit_causal_baseline_models(
     for name, feature_field, constant in baselines:
         train_y = [number(row.get("target")) for row in train_rows]
         holdout_y = [number(row.get("target")) for row in holdout_rows]
-        train_predictions = baseline_predictions(
-            train_rows, field=feature_field, constant=constant
-        )
+        train_predictions = baseline_predictions(train_rows, field=feature_field, constant=constant)
         holdout_predictions = baseline_predictions(
             holdout_rows, field=feature_field, constant=constant
         )

--- a/src/codex_usage_tracker/usage_drain/proxy_fit.py
+++ b/src/codex_usage_tracker/usage_drain/proxy_fit.py
@@ -91,9 +91,7 @@ def _two_feature_fit(
         return beta_non, beta_candidate, implied_multiplier, None
     y_hat = [
         (beta_non * non_candidate) + (beta_candidate * candidate)
-        for non_candidate, candidate in zip(
-            non_candidate_values, candidate_values, strict=True
-        )
+        for non_candidate, candidate in zip(non_candidate_values, candidate_values, strict=True)
     ]
     return beta_non, beta_candidate, implied_multiplier, y_hat
 
@@ -113,9 +111,7 @@ def _proxy_grid_fit(
         key=lambda item: _number(item.get("r2_slope")),
         default=None,
     )
-    return grid, (
-        _number(best_grid.get("multiplier")) if best_grid is not None else None
-    )
+    return grid, (_number(best_grid.get("multiplier")) if best_grid is not None else None)
 
 
 def _candidate_drain_comparison(

--- a/src/codex_usage_tracker/usage_drain/regime_segments.py
+++ b/src/codex_usage_tracker/usage_drain/regime_segments.py
@@ -38,6 +38,7 @@ SEGMENT_POSITION_BUCKETS = (
     "sixth_plus_span",
 )
 
+
 def delta_regime_summary(spans: list[UsageDeltaSpan]) -> dict[str, Any]:
     train_size = max(1, min(len(spans) - 1, int(len(spans) * 0.8))) if spans else 0
     return {
@@ -93,9 +94,7 @@ def _current_one_percent_run(
     return current_run
 
 
-def _top_one_percent_runs(
-    one_percent_runs: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def _top_one_percent_runs(one_percent_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(one_percent_runs, key=lambda run: -run["span_count"])[:10]
 
 
@@ -127,8 +126,7 @@ def piecewise_regime_segment_summary(spans: list[UsageDeltaSpan]) -> dict[str, A
     }
     segments = _piecewise_regime_segments(spans)
     segment_records = [
-        _piecewise_segment_record(spans, prediction_rows, segment)
-        for segment in segments
+        _piecewise_segment_record(spans, prediction_rows, segment) for segment in segments
     ]
     label_rows: dict[str, list[dict[str, Any]]] = {}
     for row in prediction_rows.values():
@@ -138,25 +136,18 @@ def piecewise_regime_segment_summary(spans: list[UsageDeltaSpan]) -> dict[str, A
         "segment_count": len(segment_records),
         "segment_label_counts": _count_segment_labels(segment_records),
         "latest_segment": segment_records[-1] if segment_records else None,
-        "longest_segments": sorted(
-            segment_records, key=lambda row: -int(row["span_count"])
-        )[:10],
+        "longest_segments": sorted(segment_records, key=lambda row: -int(row["span_count"]))[:10],
         "largest_mean_delta_segments": sorted(
             segment_records,
-            key=lambda row: _number(
-                (row.get("distribution") or {}).get("mean_delta_percent")
-            ),
+            key=lambda row: _number((row.get("distribution") or {}).get("mean_delta_percent")),
             reverse=True,
         )[:10],
-        "adaptation_by_position": _piecewise_adaptation_by_position(
-            prediction_rows, segments
-        ),
+        "adaptation_by_position": _piecewise_adaptation_by_position(prediction_rows, segments),
         "boundary_diagnostics": boundary_summary.piecewise_boundary_diagnostics(
             spans, prediction_rows
         ),
         "by_label": {
-            label: _piecewise_label_record(rows)
-            for label, rows in sorted(label_rows.items())
+            label: _piecewise_label_record(rows) for label, rows in sorted(label_rows.items())
         },
     }
 
@@ -243,9 +234,7 @@ def _piecewise_adaptation_by_position(
             all_rows_by_position=all_rows_by_position,
             label_rows_by_position=label_rows_by_position,
         )
-    return _piecewise_adaptation_position_report(
-        all_rows_by_position, label_rows_by_position
-    )
+    return _piecewise_adaptation_position_report(all_rows_by_position, label_rows_by_position)
 
 
 def _empty_segment_position_rows() -> dict[str, list[dict[str, Any]]]:
@@ -262,9 +251,7 @@ def _collect_piecewise_position_rows(
     label = str(segment.get("label") or "missing")
     start_index = int(segment["start_index"])
     end_index = int(segment["end_index"])
-    label_rows = label_rows_by_position.setdefault(
-        label, _empty_segment_position_rows()
-    )
+    label_rows = label_rows_by_position.setdefault(label, _empty_segment_position_rows())
     for index in range(start_index, end_index + 1):
         row = prediction_rows.get(index)
         if row is not None:
@@ -322,17 +309,12 @@ def _piecewise_position_record(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-
-
 def _segment_prediction_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
     actual = [_number(row.get("actual")) for row in rows]
     return {
         model_name: _regression_metrics(
             actual,
-            [
-                _number((row.get("predictions") or {}).get(model_name))
-                for row in rows
-            ],
+            [_number((row.get("predictions") or {}).get(model_name)) for row in rows],
         )
         for model_name in SEGMENT_PREDICTION_MODELS
     }
@@ -361,8 +343,6 @@ def _count_segment_labels(segment_records: list[dict[str, Any]]) -> dict[str, in
     return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
 
 
-
-
 def _one_percent_runs(spans: list[UsageDeltaSpan]) -> list[dict[str, Any]]:
     runs: list[dict[str, Any]] = []
     run_start: int | None = None
@@ -379,9 +359,7 @@ def _one_percent_runs(spans: list[UsageDeltaSpan]) -> list[dict[str, Any]]:
     return runs
 
 
-def _run_record(
-    spans: list[UsageDeltaSpan], start_index: int, end_index: int
-) -> dict[str, Any]:
+def _run_record(spans: list[UsageDeltaSpan], start_index: int, end_index: int) -> dict[str, Any]:
     start_span = spans[start_index]
     end_span = spans[end_index]
     return {
@@ -395,9 +373,7 @@ def _run_record(
     }
 
 
-def _run_break_record(
-    spans: list[UsageDeltaSpan], run: dict[str, Any]
-) -> dict[str, Any]:
+def _run_break_record(spans: list[UsageDeltaSpan], run: dict[str, Any]) -> dict[str, Any]:
     break_index = int(run["end_index"]) + 1
     break_span = spans[break_index]
     return {

--- a/src/codex_usage_tracker/usage_drain/regression.py
+++ b/src/codex_usage_tracker/usage_drain/regression.py
@@ -15,9 +15,7 @@ def prepare_design(
 ) -> tuple[list[str], dict[str, float], dict[str, float], dict[str, list[str]]] | None:
     if not rows:
         return None
-    numeric_features, means, stddevs = _numeric_design_features(
-        rows, spec.numeric_features
-    )
+    numeric_features, means, stddevs = _numeric_design_features(rows, spec.numeric_features)
     categorical_features, category_levels = _categorical_design_features(
         rows, spec.categorical_features
     )
@@ -35,9 +33,7 @@ def _numeric_design_features(
     return list(features), means, stddevs
 
 
-def _numeric_feature_stats(
-    rows: list[dict[str, Any]], feature: str
-) -> tuple[float, float]:
+def _numeric_feature_stats(rows: list[dict[str, Any]], feature: str) -> tuple[float, float]:
     values = [number(row.get(feature)) for row in rows]
     mean = sum(values) / len(values)
     variance = sum((value - mean) ** 2 for value in values) / len(values)
@@ -126,9 +122,7 @@ def solve_linear_system(lhs: list[list[float]], rhs: list[float]) -> list[float]
                 continue
             matrix[row_index] = [
                 value - factor * pivot_component
-                for value, pivot_component in zip(
-                    matrix[row_index], matrix[column], strict=True
-                )
+                for value, pivot_component in zip(matrix[row_index], matrix[column], strict=True)
             ]
     return [matrix[row][size] for row in range(size)]
 
@@ -139,7 +133,6 @@ def predict(x_rows: list[list[float]], coefficients: list[float]) -> list[float]
         + sum(value * coefficient for value, coefficient in zip(row, coefficients[1:], strict=True))
         for row in x_rows
     ]
-
 
 
 def fit_linear_coefficients(
@@ -286,9 +279,7 @@ def fit_one_feature_no_intercept(x_values: list[float], y_values: list[float]) -
     return sum(x * y for x, y in zip(x_values, y_values, strict=True)) / denominator
 
 
-def documented_weighted_multiplier(
-    spans: list[UsageDeltaSpan], proxy: str
-) -> float | None:
+def documented_weighted_multiplier(spans: list[UsageDeltaSpan], proxy: str) -> float | None:
     candidate = sum(span.candidate_standard_credits.get(proxy, 0.0) for span in spans)
     if candidate <= 0:
         return None
@@ -324,9 +315,7 @@ def drain_stats(spans: list[UsageDeltaSpan]) -> dict[str, float | int | None]:
         "spans": len(spans),
         "median_delta_percent": rounded(median(deltas) if deltas else None),
         "median_drain_per_standard_credit": rounded(median(drains) if drains else None),
-        "mean_drain_per_standard_credit": rounded(
-            sum(drains) / len(drains) if drains else None
-        ),
+        "mean_drain_per_standard_credit": rounded(sum(drains) / len(drains) if drains else None),
     }
 
 
@@ -337,10 +326,7 @@ def r2(y_values: list[float], y_hat: list[float] | None) -> float | None:
     sst = sum((value - mean_y) ** 2 for value in y_values)
     if sst <= 0:
         return None
-    sse = sum(
-        (actual - predicted) ** 2
-        for actual, predicted in zip(y_values, y_hat, strict=True)
-    )
+    sse = sum((actual - predicted) ** 2 for actual, predicted in zip(y_values, y_hat, strict=True))
     return 1.0 - (sse / sst)
 
 
@@ -349,10 +335,7 @@ def pearson(x_values: list[float], y_values: list[float]) -> float | None:
         return None
     mean_x = sum(x_values) / len(x_values)
     mean_y = sum(y_values) / len(y_values)
-    covariance = sum(
-        (x - mean_x) * (y - mean_y)
-        for x, y in zip(x_values, y_values, strict=True)
-    )
+    covariance = sum((x - mean_x) * (y - mean_y) for x, y in zip(x_values, y_values, strict=True))
     x_var = sum((x - mean_x) ** 2 for x in x_values)
     y_var = sum((y - mean_y) ** 2 for y in y_values)
     denominator = math.sqrt(x_var * y_var)
@@ -373,10 +356,7 @@ def rank_values(values: list[float]) -> list[float]:
     index = 0
     while index < len(ordered):
         end_index = index
-        while (
-            end_index + 1 < len(ordered)
-            and ordered[end_index + 1][0] == ordered[index][0]
-        ):
+        while end_index + 1 < len(ordered) and ordered[end_index + 1][0] == ordered[index][0]:
             end_index += 1
         rank = ((index + 1) + (end_index + 1)) / 2.0
         for rank_index in range(index, end_index + 1):

--- a/src/codex_usage_tracker/usage_drain/reports.py
+++ b/src/codex_usage_tracker/usage_drain/reports.py
@@ -132,19 +132,13 @@ def _report_summary(
         "censored_or_reset_pending_segments": _int_from_mapping(
             span_stats, "censored_or_reset_pending_segments"
         ),
-        "rows_without_usage_snapshot": _int_from_mapping(
-            span_stats, "rows_without_usage_snapshot"
-        ),
+        "rows_without_usage_snapshot": _int_from_mapping(span_stats, "rows_without_usage_snapshot"),
         "estimated_cost_usd": round(estimated_cost, 6),
         "usage_credits": round(usage_credits, 6),
         "top_thread_cost_share": curves.get("top_thread_share"),
         "best_predictive_model": best.get("name") if isinstance(best, dict) else None,
         "raw_context_included": False,
     }
-
-
-
-
 
 
 def _model_highlights(rows: list[dict[str, Any]], spans: list[UsageDeltaSpan]) -> dict[str, Any]:
@@ -227,10 +221,7 @@ def _prediction_model_record(
 
 
 def _absolute_errors(actual: list[float], predicted: list[float]) -> list[float]:
-    return [
-        abs(left - right)
-        for left, right in zip(actual, predicted, strict=False)
-    ]
+    return [abs(left - right) for left, right in zip(actual, predicted, strict=False)]
 
 
 def _mean_absolute_error(errors: list[float]) -> float | None:
@@ -242,9 +233,7 @@ def _mean_absolute_error(errors: list[float]) -> float | None:
 def _root_mean_square_error(actual: list[float], predicted: list[float]) -> float | None:
     if not actual:
         return None
-    squared_error = sum(
-        (left - right) ** 2 for left, right in zip(actual, predicted, strict=False)
-    )
+    squared_error = sum((left - right) ** 2 for left, right in zip(actual, predicted, strict=False))
     return (squared_error / len(actual)) ** 0.5
 
 
@@ -272,9 +261,7 @@ def _token_accounting_highlights(
 
 def _token_accounting_totals(rows: list[dict[str, Any]]) -> dict[str, float | None]:
     return {
-        field_name: _rounded(
-            sum(_number(row.get(field_name)) for row in rows)
-        )
+        field_name: _rounded(sum(_number(row.get(field_name)) for row in rows))
         for field_name in TOKEN_ACCOUNTING_TOTAL_FIELDS
     }
 
@@ -347,7 +334,10 @@ def _allowance_breakpoint_highlights(spans: list[UsageDeltaSpan]) -> dict[str, A
             _r2([_number(row["delta_usage_percent"]) for row in rows], piecewise_predictions)
         ),
         "best_single_break": best_break,
-        "segments": [_allowance_segment_record(rows, start, end, index) for index, (start, end) in enumerate(segments, start=1)],
+        "segments": [
+            _allowance_segment_record(rows, start, end, index)
+            for index, (start, end) in enumerate(segments, start=1)
+        ],
         "notes": [
             "Compact dashboard breakpoints use one efficient single-break scan.",
             "Segments are chronological diagnostics over closed positive usage-delta spans, not proof of an official allowance change.",
@@ -425,9 +415,7 @@ def _piecewise_mean_capacity_predictions(
     predictions = [0.0 for _row in rows]
     for start, end in segments:
         segment = rows[start:end]
-        mean_capacity = _mean(
-            [_number(row["credits_per_visible_percent"]) for row in segment]
-        )
+        mean_capacity = _mean([_number(row["credits_per_visible_percent"]) for row in segment])
         if mean_capacity <= 0:
             continue
         for index in range(start, end):
@@ -467,14 +455,6 @@ def _range_sse(
     total = prefix_sum[end] - prefix_sum[start]
     square_total = prefix_square[end] - prefix_square[start]
     return square_total - (total * total / n)
-
-
-
-
-
-
-
-
 
 
 def _count_values(rows: list[dict[str, Any]], field: str) -> dict[str, int]:
@@ -544,9 +524,7 @@ def _r2(actual: list[float], predicted: list[float]) -> float | None:
     total = sum((value - mean_actual) ** 2 for value in actual)
     if total <= 0:
         return None
-    residual = sum(
-        (left - right) ** 2 for left, right in zip(actual, predicted, strict=False)
-    )
+    residual = sum((left - right) ** 2 for left, right in zip(actual, predicted, strict=False))
     return 1.0 - (residual / total)
 
 

--- a/src/codex_usage_tracker/usage_drain/spans.py
+++ b/src/codex_usage_tracker/usage_drain/spans.py
@@ -52,10 +52,8 @@ def load_fast_proxy_annotations(path: Path | None) -> dict[str, FastProxyAnnotat
                 continue
             annotations[record_id] = FastProxyAnnotation(
                 label=str(row.get("fast_proxy_label") or "not_fast_proxy").strip(),
-                timing_confidence=str(row.get("timing_confidence") or "unknown")
-                .strip()
-                .lower(),
-            score=_span_optional_number(row.get("fast_proxy_score")),
+                timing_confidence=str(row.get("timing_confidence") or "unknown").strip().lower(),
+                score=_span_optional_number(row.get("fast_proxy_score")),
             )
     return annotations
 
@@ -254,10 +252,7 @@ def _span_proxy_count_totals() -> dict[str, int]:
 
 
 def _span_weighted_token_totals() -> dict[str, dict[str, float]]:
-    return {
-        proxy: dict.fromkeys(TOKEN_COMPONENT_FIELDS, 0.0)
-        for proxy in DEFAULT_PROXY_NAMES
-    }
+    return {proxy: dict.fromkeys(TOKEN_COMPONENT_FIELDS, 0.0) for proxy in DEFAULT_PROXY_NAMES}
 
 
 def _add_span_row_dimensions(
@@ -313,9 +308,7 @@ def _add_span_proxy_totals(
     for proxy_name, is_candidate in _span_proxy_flags(annotation).items():
         token_multiplier = multiplier if is_candidate else 1.0
         for field_name, value in token_components.items():
-            documented_weighted_token_totals[proxy_name][
-                field_name
-            ] += value * token_multiplier
+            documented_weighted_token_totals[proxy_name][field_name] += value * token_multiplier
         if is_candidate:
             candidate[proxy_name] += credits
             documented_weighted[proxy_name] += credits * multiplier
@@ -429,19 +422,13 @@ def _preferred_span_usage_observation(row: dict[str, Any]) -> dict[str, Any]:
         {
             "source": "primary",
             "used_percent": _span_optional_number(row.get("rate_limit_primary_used_percent")),
-            "window_minutes": _span_optional_number(
-                row.get("rate_limit_primary_window_minutes")
-            ),
+            "window_minutes": _span_optional_number(row.get("rate_limit_primary_window_minutes")),
             "resets_at": _span_optional_number(row.get("rate_limit_primary_resets_at")),
         },
         {
             "source": "secondary",
-            "used_percent": _span_optional_number(
-                row.get("rate_limit_secondary_used_percent")
-            ),
-            "window_minutes": _span_optional_number(
-                row.get("rate_limit_secondary_window_minutes")
-            ),
+            "used_percent": _span_optional_number(row.get("rate_limit_secondary_used_percent")),
+            "window_minutes": _span_optional_number(row.get("rate_limit_secondary_window_minutes")),
             "resets_at": _span_optional_number(row.get("rate_limit_secondary_resets_at")),
         },
     ]

--- a/src/codex_usage_tracker/usage_drain/state_buckets.py
+++ b/src/codex_usage_tracker/usage_drain/state_buckets.py
@@ -61,17 +61,12 @@ STATE_BUCKET_MODEL_SIGNATURES: dict[str, tuple[tuple[str, ...], ...]] = {
 STATE_BUCKET_MIN_SUPPORT = 2
 
 TRANSITION_RISK_MODEL_SIGNATURES: dict[str, tuple[tuple[str, ...], ...]] = {
-    "history_state_risk": STATE_BUCKET_MODEL_SIGNATURES[
-        "empirical_history_state_mode"
-    ],
-    "calendar_state_risk": STATE_BUCKET_MODEL_SIGNATURES[
-        "empirical_calendar_state_mode"
-    ],
+    "history_state_risk": STATE_BUCKET_MODEL_SIGNATURES["empirical_history_state_mode"],
+    "calendar_state_risk": STATE_BUCKET_MODEL_SIGNATURES["empirical_calendar_state_mode"],
     "reset_state_risk": STATE_BUCKET_MODEL_SIGNATURES["empirical_reset_state_mode"],
-    "previous_work_state_risk": STATE_BUCKET_MODEL_SIGNATURES[
-        "empirical_previous_work_state_mode"
-    ],
+    "previous_work_state_risk": STATE_BUCKET_MODEL_SIGNATURES["empirical_previous_work_state_mode"],
 }
+
 
 def state_bucket_predictions(
     previous_state_rows: list[dict[str, Any]],
@@ -92,6 +87,7 @@ def state_bucket_predictions(
         details[model_name] = detail
     return predictions, details
 
+
 def state_bucket_transition_risk(
     previous_state_rows: list[dict[str, Any]],
     state: dict[str, Any],
@@ -103,8 +99,7 @@ def state_bucket_transition_risk(
         matches = [
             row
             for row in previous_state_rows
-            if state_signature(row.get("state", {}), signature)
-            == state_signature(state, signature)
+            if state_signature(row.get("state", {}), signature) == state_signature(state, signature)
         ]
         if len(matches) < STATE_BUCKET_MIN_SUPPORT:
             continue
@@ -122,10 +117,12 @@ def state_bucket_transition_risk(
         "risk": rounded(fallback_rate),
     }
 
+
 def transition_rate(rows: list[dict[str, Any]]) -> float:
     if not rows:
         return 0.0
     return sum(1 for row in rows if not is_one_percent_delta(number(row.get("actual")))) / len(rows)
+
 
 def state_bucket_prediction(
     previous_state_rows: list[dict[str, Any]],
@@ -138,8 +135,7 @@ def state_bucket_prediction(
         matches = [
             row
             for row in previous_state_rows
-            if state_signature(row.get("state", {}), signature)
-            == state_signature(state, signature)
+            if state_signature(row.get("state", {}), signature) == state_signature(state, signature)
         ]
         if len(matches) < STATE_BUCKET_MIN_SUPPORT:
             continue
@@ -158,9 +154,8 @@ def state_bucket_prediction(
         "matched_mode": None,
     }
 
-def state_bucket_model_diagnostics(
-    rows: list[dict[str, Any]], model_name: str
-) -> dict[str, Any]:
+
+def state_bucket_model_diagnostics(rows: list[dict[str, Any]], model_name: str) -> dict[str, Any]:
     details = _details_for_model(rows, model_name, field_name="prediction_details")
     if not details:
         return {
@@ -200,10 +195,7 @@ def transition_risk_detail_diagnostics(
 def _details_for_model(
     rows: list[dict[str, Any]], model_name: str, *, field_name: str
 ) -> list[dict[str, Any]]:
-    return [
-        (row.get(field_name) or {}).get(model_name) or {}
-        for row in rows
-    ]
+    return [(row.get(field_name) or {}).get(model_name) or {} for row in rows]
 
 
 def _matched_state_detail_summary(details: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/codex_usage_tracker/usage_drain/state_diagnostics.py
+++ b/src/codex_usage_tracker/usage_drain/state_diagnostics.py
@@ -51,9 +51,8 @@ STATE_AMBIGUITY_SIGNATURES: dict[str, tuple[str, ...]] = {
     ),
 }
 
-def state_ambiguity_summary(
-    rows: list[dict[str, Any]], scopes: dict[str, int]
-) -> dict[str, Any]:
+
+def state_ambiguity_summary(rows: list[dict[str, Any]], scopes: dict[str, int]) -> dict[str, Any]:
     return {
         "target": "next_visible_usage_delta_percent",
         "definition": (
@@ -67,8 +66,7 @@ def state_ambiguity_summary(
             "Unique states can look perfect by construction, so repeated-state metrics are the stricter signal.",
         ],
         "signatures": {
-            name: list(signature)
-            for name, signature in STATE_AMBIGUITY_SIGNATURES.items()
+            name: list(signature) for name, signature in STATE_AMBIGUITY_SIGNATURES.items()
         },
         "scopes": {
             scope_name: state_ambiguity_scope(rows, start_index=start_index)
@@ -76,9 +74,8 @@ def state_ambiguity_summary(
         },
     }
 
-def state_ambiguity_scope(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> dict[str, Any]:
+
+def state_ambiguity_scope(rows: list[dict[str, Any]], *, start_index: int) -> dict[str, Any]:
     scope_rows = [row for row in rows if int(row["index"]) >= start_index]
     return {
         "start_index": start_index,
@@ -88,6 +85,7 @@ def state_ambiguity_scope(
             for name, signature in STATE_AMBIGUITY_SIGNATURES.items()
         },
     }
+
 
 def state_signature_ambiguity(
     rows: list[dict[str, Any]],
@@ -188,9 +186,7 @@ def _state_signature_ambiguity_result(
     }
 
 
-def _state_analysis_values(
-    analyses: list[dict[str, Any]], field: str
-) -> list[float]:
+def _state_analysis_values(analyses: list[dict[str, Any]], field: str) -> list[float]:
     values: list[float] = []
     for analysis in analyses:
         values.extend(analysis[field])
@@ -201,9 +197,7 @@ def _state_analysis_row_count(analyses: list[dict[str, Any]]) -> int:
     return sum(len(analysis["values"]) for analysis in analyses)
 
 
-def _state_ambiguous_records(
-    analyses: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def _state_ambiguous_records(analyses: list[dict[str, Any]]) -> list[dict[str, Any]]:
     records = [
         analysis["ambiguous_record"]
         for analysis in analyses
@@ -218,6 +212,7 @@ def _state_ambiguous_record_sort_key(row: dict[str, Any]) -> tuple[float, int, s
         -int(row.get("n") or 0),
         str(row.get("state") or ""),
     )
+
 
 def state_ambiguous_group_record(
     key: tuple[str, ...],
@@ -260,9 +255,7 @@ def _mode_errors(values: list[float], mode_value: float) -> list[float]:
 
 
 def _row_dates(rows: list[dict[str, Any]]) -> list[str]:
-    return [
-        str((row.get("metadata") or {}).get("date") or "missing") for row in rows
-    ]
+    return [str((row.get("metadata") or {}).get("date") or "missing") for row in rows]
 
 
 def _signature_state(key: tuple[str, ...], signature: tuple[str, ...]) -> dict[str, str]:
@@ -272,18 +265,14 @@ def _signature_state(key: tuple[str, ...], signature: tuple[str, ...]) -> dict[s
     }
 
 
-def _actual_value_rows(
-    value_counts: dict[float, int], *, row_count: int
-) -> list[dict[str, Any]]:
+def _actual_value_rows(value_counts: dict[float, int], *, row_count: int) -> list[dict[str, Any]]:
     return [
         {
             "delta_percent": value,
             "count": count,
             "share": rounded(count / row_count),
         }
-        for value, count in sorted(
-            value_counts.items(), key=lambda item: (-item[1], item[0])
-        )
+        for value, count in sorted(value_counts.items(), key=lambda item: (-item[1], item[0]))
     ]
 
 
@@ -297,6 +286,7 @@ def _mean_error(errors: list[float]) -> float | None:
     if not errors:
         return None
     return rounded(sum(errors) / len(errors))
+
 
 def state_signature(state: dict[str, Any], signature: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(str(state.get(field) or "missing") for field in signature)

--- a/src/codex_usage_tracker/usage_drain/summary_metrics.py
+++ b/src/codex_usage_tracker/usage_drain/summary_metrics.py
@@ -175,9 +175,7 @@ def _model_family_rows_for_validation(
             continue
         mae = holdout_metric(matched_model, "mae")
         r2 = holdout_metric(matched_model, "r2")
-        rows.append(
-            _model_family_row(family, matched_model, mae, r2, previous_mae, previous_r2)
-        )
+        rows.append(_model_family_row(family, matched_model, mae, r2, previous_mae, previous_r2))
         previous_mae = mae
         previous_r2 = r2
     return rows
@@ -207,9 +205,7 @@ def _model_metric_delta(previous: float | None, current: float | None) -> float 
     return rounded(current - previous)
 
 
-def _model_metric_improvement(
-    previous: float | None, current: float | None
-) -> float | None:
+def _model_metric_improvement(previous: float | None, current: float | None) -> float | None:
     if previous is None or current is None:
         return None
     return rounded(previous - current)
@@ -236,9 +232,11 @@ def holdout_metric(model: dict[str, Any], metric: str) -> float | None:
 def best_holdout_model(models: list[dict[str, Any]]) -> dict[str, Any] | None:
     return min(
         models,
-        key=lambda result: number(result.get("holdout", {}).get("mae"))
-        if result.get("holdout", {}).get("mae") is not None
-        else math.inf,
+        key=lambda result: (
+            number(result.get("holdout", {}).get("mae"))
+            if result.get("holdout", {}).get("mae") is not None
+            else math.inf
+        ),
         default=None,
     )
 
@@ -249,9 +247,7 @@ def span_correlation_row(span: UsageDeltaSpan) -> dict[str, float]:
         "row_count": float(span.row_count),
         "standard_usage_credits": span.standard_usage_credits,
         "call_duration_seconds": span.timing_totals.get("call_duration_seconds", 0.0),
-        "previous_call_delta_seconds": span.timing_totals.get(
-            "previous_call_delta_seconds", 0.0
-        ),
+        "previous_call_delta_seconds": span.timing_totals.get("previous_call_delta_seconds", 0.0),
         "span_wall_time_seconds": span_wall_time_seconds(span),
         "baseline_used_percent": span.baseline_used_percent,
     }
@@ -276,12 +272,8 @@ def correlation_report(
     correlations = [
         {
             "feature": feature_name,
-            "pearson": rounded(
-                pearson([row[feature_name] for row in rows], target_values)
-            ),
-            "spearman": rounded(
-                spearman([row[feature_name] for row in rows], target_values)
-            ),
+            "pearson": rounded(pearson([row[feature_name] for row in rows], target_values)),
+            "spearman": rounded(spearman([row[feature_name] for row in rows], target_values)),
         }
         for feature_name in feature_names
         if feature_name != target
@@ -328,9 +320,7 @@ def delta_distribution(spans: list[UsageDeltaSpan]) -> dict[str, Any]:
             "count": count,
             "share": rounded(count / len(values)),
         }
-        for value, count in sorted(
-            counts.items(), key=lambda item: (-item[1], item[0])
-        )[:8]
+        for value, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:8]
     ]
     return {
         "spans": len(values),

--- a/src/codex_usage_tracker/usage_drain/thread_curves.py
+++ b/src/codex_usage_tracker/usage_drain/thread_curves.py
@@ -79,6 +79,7 @@ def _thread_curve_summary(
         "threads": thread_rows[:max_threads],
     }
 
+
 def _thread_curve_record(
     bucket: dict[str, Any],
     *,
@@ -125,6 +126,7 @@ def _thread_curve_record(
         "points": _sample_curve_points(points, max_points=max_curve_points),
     }
 
+
 def _representative_call(calls: list[dict[str, Any]]) -> dict[str, Any]:
     if not calls:
         return {}
@@ -156,10 +158,9 @@ def _sample_curve_points(
     if max_points == 1:
         return [points[0]]
     last_index = len(points) - 1
-    selected_indexes = {
-        round(index * last_index / (max_points - 1)) for index in range(max_points)
-    }
+    selected_indexes = {round(index * last_index / (max_points - 1)) for index in range(max_points)}
     return [points[index] for index in sorted(selected_indexes)]
+
 
 def _curve_shape(first_half_share: float, largest_call_share: float) -> str:
     if largest_call_share >= 0.2:
@@ -169,6 +170,7 @@ def _curve_shape(first_half_share: float, largest_call_share: float) -> str:
     if first_half_share > 0.6:
         return "front-loaded"
     return "near-linear"
+
 
 def _thread_label(row: dict[str, Any]) -> str:
     return str(
@@ -180,12 +182,14 @@ def _thread_label(row: dict[str, Any]) -> str:
         or "Unknown thread"
     )
 
+
 def _thread_curve_chronological_key(row: dict[str, Any]) -> tuple[str, int, str]:
     return (
         str(row.get("event_timestamp") or ""),
         int(number(row.get("cumulative_total_tokens"))),
         str(row.get("record_id") or ""),
     )
+
 
 def number(value: object) -> float:
     if isinstance(value, bool):

--- a/src/codex_usage_tracker/usage_drain/time_series.py
+++ b/src/codex_usage_tracker/usage_drain/time_series.py
@@ -257,7 +257,9 @@ def _weekly_projection_trend(points: list[dict[str, Any]]) -> dict[str, Any]:
         "latest_projected_weekly_credits": _rounded(values[-1]),
         "change_from_first_credits": _rounded(change),
         "change_from_first_pct": _rounded(change / values[0] if values[0] else None),
-        "rate_limit_plan_type": trend_points[-1].get("rate_limit_plan_type") if trend_points else None,
+        "rate_limit_plan_type": trend_points[-1].get("rate_limit_plan_type")
+        if trend_points
+        else None,
     }
 
 
@@ -283,7 +285,9 @@ def _insufficient_weekly_projection_trend(
         "latest_projected_weekly_credits": _rounded(values[-1]) if values else None,
         "change_from_first_credits": None,
         "change_from_first_pct": None,
-        "rate_limit_plan_type": trend_points[0].get("rate_limit_plan_type") if trend_points else None,
+        "rate_limit_plan_type": trend_points[0].get("rate_limit_plan_type")
+        if trend_points
+        else None,
     }
 
 
@@ -307,12 +311,20 @@ def _weekly_projection_direction(slope: float) -> str:
 
 def _trend_points_for_latest_plan(points: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str]:
     latest_plan = next(
-        (point.get("rate_limit_plan_type") for point in reversed(points) if point.get("rate_limit_plan_type")),
+        (
+            point.get("rate_limit_plan_type")
+            for point in reversed(points)
+            if point.get("rate_limit_plan_type")
+        ),
         None,
     )
     if latest_plan is not None:
-        plan_points = [point for point in points if point.get("rate_limit_plan_type") == latest_plan]
-        confident = [point for point in plan_points if point.get("confidence") in {"medium", "high"}]
+        plan_points = [
+            point for point in points if point.get("rate_limit_plan_type") == latest_plan
+        ]
+        confident = [
+            point for point in plan_points if point.get("confidence") in {"medium", "high"}
+        ]
         if len(confident) >= 3:
             return confident, "latest_plan_medium_high_confidence"
         if len(plan_points) >= 3:
@@ -340,9 +352,7 @@ def _sample_curve_points(
     if max_points <= 0 or len(points) <= max_points:
         return points
     last_index = len(points) - 1
-    selected_indexes = {
-        round(index * last_index / (max_points - 1)) for index in range(max_points)
-    }
+    selected_indexes = {round(index * last_index / (max_points - 1)) for index in range(max_points)}
     return [points[index] for index in sorted(selected_indexes)]
 
 

--- a/src/codex_usage_tracker/usage_drain/token_components.py
+++ b/src/codex_usage_tracker/usage_drain/token_components.py
@@ -49,12 +49,8 @@ def _token_component_regression_variant(
 ) -> dict[str, Any]:
     x_rows = _token_component_x_rows(spans, weighted_proxy=weighted_proxy)
     visible_target = [span.delta_usage_percent for span in spans]
-    credit_target = _token_component_credit_target(
-        spans, weighted_proxy=weighted_proxy
-    )
-    candidate_counts = _weighted_proxy_candidate_counts(
-        spans, weighted_proxy=weighted_proxy
-    )
+    credit_target = _token_component_credit_target(spans, weighted_proxy=weighted_proxy)
+    candidate_counts = _weighted_proxy_candidate_counts(spans, weighted_proxy=weighted_proxy)
     return {
         "weighted_proxy": weighted_proxy,
         **candidate_counts,
@@ -73,9 +69,7 @@ def _token_component_x_rows(
     return [
         [
             value / 1_000_000.0
-            for value in _span_token_components(
-                span, weighted_proxy=weighted_proxy
-            ).values()
+            for value in _span_token_components(span, weighted_proxy=weighted_proxy).values()
         ]
         for span in spans
     ]
@@ -86,10 +80,7 @@ def _token_component_credit_target(
 ) -> list[float]:
     if weighted_proxy is None:
         return [span.standard_usage_credits for span in spans]
-    return [
-        span.documented_fast_weighted_credits.get(weighted_proxy, 0.0)
-        for span in spans
-    ]
+    return [span.documented_fast_weighted_credits.get(weighted_proxy, 0.0) for span in spans]
 
 
 def _weighted_proxy_candidate_counts(
@@ -98,50 +89,39 @@ def _weighted_proxy_candidate_counts(
     if weighted_proxy is None:
         return {"candidate_rows": 0, "candidate_spans": 0}
     return {
-        "candidate_rows": sum(
-            span.candidate_row_counts.get(weighted_proxy, 0) for span in spans
-        ),
+        "candidate_rows": sum(span.candidate_row_counts.get(weighted_proxy, 0) for span in spans),
         "candidate_spans": sum(
-            1
-            for span in spans
-            if span.candidate_row_counts.get(weighted_proxy, 0) > 0
+            1 for span in spans if span.candidate_row_counts.get(weighted_proxy, 0) > 0
         ),
     }
 
 
-def _span_token_components(
-    span: UsageDeltaSpan, *, weighted_proxy: str | None
-) -> dict[str, float]:
+def _span_token_components(span: UsageDeltaSpan, *, weighted_proxy: str | None) -> dict[str, float]:
     if weighted_proxy:
         weighted = span.documented_fast_weighted_token_totals.get(weighted_proxy)
         if weighted:
             return {
-                field_name: weighted.get(field_name, 0.0)
-                for field_name in TOKEN_COMPONENT_FIELDS
+                field_name: weighted.get(field_name, 0.0) for field_name in TOKEN_COMPONENT_FIELDS
             }
     return {
         "uncached_input_tokens": span.token_totals.get("uncached_input_tokens", 0.0),
         "cached_input_tokens": span.token_totals.get("cached_input_tokens", 0.0),
-        "reasoning_output_tokens": span.token_totals.get(
-            "reasoning_output_tokens", 0.0
-        ),
+        "reasoning_output_tokens": span.token_totals.get("reasoning_output_tokens", 0.0),
         "nonreasoning_output_tokens": max(
             span.token_totals.get("output_tokens", 0.0)
             - span.token_totals.get("reasoning_output_tokens", 0.0),
             0.0,
         ),
     }
+
+
 def _token_component_target_regression(
     x_rows: list[list[float]], y_values: list[float], *, target: str
 ) -> dict[str, Any]:
     return {
         "target": target,
-        "with_intercept": _token_component_fit_summary(
-            x_rows, y_values, intercept=True
-        ),
-        "no_intercept": _token_component_fit_summary(
-            x_rows, y_values, intercept=False
-        ),
+        "with_intercept": _token_component_fit_summary(x_rows, y_values, intercept=True),
+        "no_intercept": _token_component_fit_summary(x_rows, y_values, intercept=False),
     }
 
 
@@ -154,15 +134,11 @@ def _token_component_fit_summary(
             "time_ordered_holdout_20": _regression_metrics([], []),
         }
     train_size = max(1, min(len(x_rows) - 1, int(len(x_rows) * 0.8)))
-    all_coefficients = _fit_linear_regression_coefficients(
-        x_rows, y_values, intercept=intercept
-    )
+    all_coefficients = _fit_linear_regression_coefficients(x_rows, y_values, intercept=intercept)
     train_coefficients = _fit_linear_regression_coefficients(
         x_rows[:train_size], y_values[:train_size], intercept=intercept
     )
-    all_predictions = _linear_regression_predictions(
-        x_rows, all_coefficients, intercept=intercept
-    )
+    all_predictions = _linear_regression_predictions(x_rows, all_coefficients, intercept=intercept)
     holdout_x = x_rows[train_size:]
     holdout_y = y_values[train_size:]
     holdout_predictions = _linear_regression_predictions(
@@ -171,9 +147,7 @@ def _token_component_fit_summary(
     return {
         "all": {
             **_regression_metrics(y_values, all_predictions),
-            "coefficients": _component_coefficient_rows(
-                all_coefficients, intercept=intercept
-            ),
+            "coefficients": _component_coefficient_rows(all_coefficients, intercept=intercept),
         },
         "time_ordered_holdout_20": {
             **_regression_metrics(holdout_y, holdout_predictions),
@@ -184,8 +158,6 @@ def _token_component_fit_summary(
     }
 
 
-
-
 def _component_coefficient_rows(
     coefficients: list[float], *, intercept: bool
 ) -> list[dict[str, Any]]:
@@ -194,6 +166,7 @@ def _component_coefficient_rows(
         {"feature": name, "coefficient": _rounded(coefficient)}
         for name, coefficient in zip(names, coefficients, strict=True)
     ]
+
 
 def one_percent_capacity_component_regression(
     spans: list[UsageDeltaSpan],
@@ -230,9 +203,7 @@ def _one_percent_capacity_component_variant(
     x_rows = [
         [
             value / 1_000_000.0
-            for value in _span_token_components(
-                span, weighted_proxy=weighted_proxy
-            ).values()
+            for value in _span_token_components(span, weighted_proxy=weighted_proxy).values()
         ]
         for span in spans
     ]

--- a/src/codex_usage_tracker/usage_drain/transition_gates.py
+++ b/src/codex_usage_tracker/usage_drain/transition_gates.py
@@ -35,6 +35,7 @@ TRANSITION_DELTA_RISK_GATE_THRESHOLD = 0.5
 
 TRANSITION_DELTA_RISK_GATE_THRESHOLDS = RISK_GATE_THRESHOLDS
 
+
 def risk_gated_transition_delta_prediction(
     *,
     continuation_prediction: float,
@@ -45,6 +46,7 @@ def risk_gated_transition_delta_prediction(
     if risk >= threshold:
         return alternate_prediction
     return continuation_prediction
+
 
 def best_transition_delta_gate_threshold_from_sums(
     error_sums: dict[float, float],
@@ -59,8 +61,7 @@ def best_transition_delta_gate_threshold_from_sums(
             "error": None,
         }
     candidates = [
-        (threshold, error_sum / training_count)
-        for threshold, error_sum in error_sums.items()
+        (threshold, error_sum / training_count) for threshold, error_sum in error_sums.items()
     ]
     threshold, error_value = min(
         candidates,
@@ -76,6 +77,7 @@ def best_transition_delta_gate_threshold_from_sums(
         "support": training_count,
         "error": rounded(error_value),
     }
+
 
 def update_transition_delta_gate_threshold_sums(
     absolute_error_sums: dict[float, float],
@@ -97,6 +99,7 @@ def update_transition_delta_gate_threshold_sums(
             threshold=threshold,
         )
         absolute_error_sums[threshold] += abs(prediction - actual)
+
 
 def transition_delta_gate_diagnostics(
     rows: list[dict[str, Any]], model_name: str
@@ -120,9 +123,7 @@ def transition_delta_gate_diagnostics(
 def _transition_delta_gate_details(
     rows: list[dict[str, Any]], model_name: str
 ) -> list[dict[str, Any]]:
-    return [
-        (row.get("prediction_details") or {}).get(model_name) or {} for row in rows
-    ]
+    return [(row.get("prediction_details") or {}).get(model_name) or {} for row in rows]
 
 
 def _empty_transition_delta_gate_diagnostics() -> dict[str, Any]:
@@ -156,9 +157,7 @@ def _transition_delta_gate_detail_summary(
 
 def _override_share(source_counts: dict[str, int], detail_count: int) -> float | None:
     override_count = sum(
-        count
-        for source, count in source_counts.items()
-        if source.endswith("_history_state_mode")
+        count for source, count in source_counts.items() if source.endswith("_history_state_mode")
     )
     return rounded(override_count / detail_count)
 
@@ -178,7 +177,5 @@ def _transition_delta_gate_source_rows(
             "count": count,
             "share": rounded(count / detail_count),
         }
-        for source, count in sorted(
-            source_counts.items(), key=lambda item: (-item[1], item[0])
-        )
+        for source, count in sorted(source_counts.items(), key=lambda item: (-item[1], item[0]))
     ]

--- a/src/codex_usage_tracker/usage_drain/transition_metrics.py
+++ b/src/codex_usage_tracker/usage_drain/transition_metrics.py
@@ -17,10 +17,7 @@ from codex_usage_tracker.usage_drain.utils import number, rounded
 
 
 def transition_target_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    actual = [
-        0 if is_one_percent_delta(number(row.get("actual"))) else 1
-        for row in rows
-    ]
+    actual = [0 if is_one_percent_delta(number(row.get("actual"))) else 1 for row in rows]
     risk_models = transition_risk_model_names(rows)
     return {
         "n": len(rows),
@@ -29,10 +26,7 @@ def transition_target_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "models": {
             model_name: binary_risk_metrics(
                 actual,
-                [
-                    number((row.get("transition_risks") or {}).get(model_name))
-                    for row in rows
-                ],
+                [number((row.get("transition_risks") or {}).get(model_name)) for row in rows],
             )
             for model_name in risk_models
         },
@@ -43,15 +37,17 @@ def transition_target_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
         },
     }
 
+
 def transition_risk_model_names(rows: list[dict[str, Any]]) -> list[str]:
     if not rows:
         return []
     names: list[str] = []
     for row in rows:
-        for name in (row.get("transition_risks") or {}):
+        for name in row.get("transition_risks") or {}:
             if name not in names:
                 names.append(str(name))
     return names
+
 
 def binary_risk_metrics(actual: list[int], scores: list[float]) -> dict[str, Any]:
     if not actual or len(actual) != len(scores):
@@ -95,9 +91,7 @@ def _clipped_scores(scores: list[float]) -> list[float]:
     return [min(max(score, 0.0), 1.0) for score in scores]
 
 
-def _score_groups(
-    actual: list[int], scores: list[float]
-) -> tuple[list[float], list[float]]:
+def _score_groups(actual: list[int], scores: list[float]) -> tuple[list[float], list[float]]:
     positives: list[float] = []
     negatives: list[float] = []
     for value, score in zip(actual, scores, strict=True):
@@ -110,9 +104,7 @@ def _score_groups(
 
 def _top_risk_rows(actual: list[int], scores: list[float]) -> list[tuple[int, float]]:
     top_count = max(1, math.ceil(len(actual) * 0.1))
-    ranked = sorted(
-        zip(actual, scores, strict=True), key=lambda item: item[1], reverse=True
-    )
+    ranked = sorted(zip(actual, scores, strict=True), key=lambda item: item[1], reverse=True)
     return ranked[:top_count]
 
 
@@ -121,15 +113,16 @@ def _top_positive_count(top_rows: list[tuple[int, float]]) -> int:
 
 
 def _brier_score(actual: list[int], scores: list[float]) -> float:
-    return sum(
-        (score - value) ** 2 for value, score in zip(actual, scores, strict=True)
-    ) / len(actual)
+    return sum((score - value) ** 2 for value, score in zip(actual, scores, strict=True)) / len(
+        actual
+    )
 
 
 def _mean_score(scores: list[float]) -> float | None:
     if not scores:
         return None
     return rounded(sum(scores) / len(scores))
+
 
 def binary_auc(actual: list[int], scores: list[float]) -> float | None:
     positive_count = sum(actual)
@@ -151,13 +144,12 @@ def binary_auc(actual: list[int], scores: list[float]) -> float | None:
         positive_count * negative_count
     )
 
+
 def average_precision(actual: list[int], scores: list[float]) -> float | None:
     positive_count = sum(actual)
     if positive_count == 0:
         return None
-    ranked = sorted(
-        zip(actual, scores, strict=True), key=lambda item: item[1], reverse=True
-    )
+    ranked = sorted(zip(actual, scores, strict=True), key=lambda item: item[1], reverse=True)
     seen_positive = 0
     precision_sum = 0.0
     for rank, (value, _score) in enumerate(ranked, start=1):
@@ -177,8 +169,7 @@ def transition_risk_predictions(
         "overall_prior_rate": prior_rate,
         "stable_one_percent_rule": (
             0.0
-            if int(state.get("one_percent_streak_count") or 0)
-            >= REGIME_GRACE_STREAK_THRESHOLD
+            if int(state.get("one_percent_streak_count") or 0) >= REGIME_GRACE_STREAK_THRESHOLD
             else prior_rate
         ),
     }
@@ -189,8 +180,7 @@ def transition_risk_predictions(
         },
         "stable_one_percent_rule": {
             "source": "long_one_percent_streak"
-            if int(state.get("one_percent_streak_count") or 0)
-            >= REGIME_GRACE_STREAK_THRESHOLD
+            if int(state.get("one_percent_streak_count") or 0) >= REGIME_GRACE_STREAK_THRESHOLD
             else "fallback_prior_rate",
             "support": len(previous_state_rows),
         },
@@ -207,9 +197,7 @@ def transition_risk_predictions(
     return risks, details
 
 
-def transition_risk_summary(
-    rows: list[dict[str, Any]], scopes: dict[str, int]
-) -> dict[str, Any]:
+def transition_risk_summary(rows: list[dict[str, Any]], scopes: dict[str, int]) -> dict[str, Any]:
     target_definitions = {
         "non_one_percent_delta": (
             "Next visible positive delta is not exactly 1%, across all scoped spans."
@@ -241,9 +229,7 @@ def transition_risk_summary(
     }
 
 
-def transition_risk_scope(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> dict[str, Any]:
+def transition_risk_scope(rows: list[dict[str, Any]], *, start_index: int) -> dict[str, Any]:
     scope_rows = [row for row in rows if int(row["index"]) >= start_index]
     long_run_rows = [
         row
@@ -253,7 +239,5 @@ def transition_risk_scope(
     ]
     return {
         "non_one_percent_delta": transition_target_metrics(scope_rows),
-        "break_after_long_one_percent_run": transition_target_metrics(
-            long_run_rows
-        ),
+        "break_after_long_one_percent_run": transition_target_metrics(long_run_rows),
     }

--- a/src/codex_usage_tracker/usage_drain/types.py
+++ b/src/codex_usage_tracker/usage_drain/types.py
@@ -40,6 +40,7 @@ TIMING_TOTAL_FIELDS = (
 
 EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "missing", "other")
 
+
 def _span_optional_round(value: float | int | None, digits: int = 6) -> float | None:
     if value is None:
         return None
@@ -86,9 +87,7 @@ class UsageDeltaSpan:
     candidate_standard_credits: dict[str, float]
     documented_fast_weighted_credits: dict[str, float]
     candidate_row_counts: dict[str, int]
-    documented_fast_weighted_token_totals: dict[str, dict[str, float]] = field(
-        default_factory=dict
-    )
+    documented_fast_weighted_token_totals: dict[str, dict[str, float]] = field(default_factory=dict)
     models: dict[str, int] = field(default_factory=dict)
     effort_counts: dict[str, int] = field(default_factory=dict)
     turn_count: int = 0

--- a/src/codex_usage_tracker/usage_drain/utils.py
+++ b/src/codex_usage_tracker/usage_drain/utils.py
@@ -41,19 +41,14 @@ def reset_phase_bucket(elapsed_fraction: float) -> str:
     return "fourth_quarter"
 
 
-def numeric_bucket(
-    value: float, *, width: float, max_value: float, suffix: str
-) -> str:
+def numeric_bucket(value: float, *, width: float, max_value: float, suffix: str) -> str:
     if value <= 0 or width <= 0:
         return f"0_{suffix}"
     if value >= max_value:
         return f"{format_bucket_number(max_value)}_plus_{suffix}"
     lower = math.floor(value / width) * width
     upper = lower + width
-    return (
-        f"{format_bucket_number(lower)}_"
-        f"{format_bucket_number(upper)}_{suffix}"
-    )
+    return f"{format_bucket_number(lower)}_{format_bucket_number(upper)}_{suffix}"
 
 
 def minute_bucket(minutes: float) -> str:

--- a/src/codex_usage_tracker/usage_drain/walk_forward.py
+++ b/src/codex_usage_tracker/usage_drain/walk_forward.py
@@ -118,12 +118,6 @@ def walk_forward_prediction_rows(spans: list[UsageDeltaSpan]) -> list[dict[str, 
     return _walk_forward_prediction_rows(spans)
 
 
-
-
-
-
-
-
 ERROR_DIAGNOSTIC_MODELS = (
     "constant_one_percent",
     "previous_delta",
@@ -147,9 +141,8 @@ TRANSITION_GATE_DIAGNOSTIC_MODELS = (
     "adaptive_mae_transition_gate_history_state_mode",
 )
 
-def _walk_forward_scope_metrics(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> dict[str, Any]:
+
+def _walk_forward_scope_metrics(rows: list[dict[str, Any]], *, start_index: int) -> dict[str, Any]:
     scope_rows = _scope_rows(rows, start_index=start_index)
     actual = _scope_actual_values(scope_rows)
     model_names = _scope_model_names(scope_rows)
@@ -158,18 +151,12 @@ def _walk_forward_scope_metrics(
         "actual": _value_distribution(actual),
         "models": _scope_model_metrics(scope_rows, actual, model_names),
         "error_diagnostics": _scope_error_diagnostics(scope_rows, model_names),
-        "transition_gate_diagnostics": _scope_transition_gate_diagnostics(
-            scope_rows, model_names
-        ),
-        "state_bucket_diagnostics": _scope_state_bucket_diagnostics(
-            scope_rows, model_names
-        ),
+        "transition_gate_diagnostics": _scope_transition_gate_diagnostics(scope_rows, model_names),
+        "state_bucket_diagnostics": _scope_state_bucket_diagnostics(scope_rows, model_names),
     }
 
 
-def _scope_rows(
-    rows: list[dict[str, Any]], *, start_index: int
-) -> list[dict[str, Any]]:
+def _scope_rows(rows: list[dict[str, Any]], *, start_index: int) -> list[dict[str, Any]]:
     return [row for row in rows if int(row["index"]) >= start_index]
 
 
@@ -187,19 +174,13 @@ def _scope_model_metrics(
     scope_rows: list[dict[str, Any]], actual: list[float], model_names: list[str]
 ) -> dict[str, Any]:
     return {
-        model_name: _regression_metrics(
-            actual, _scope_model_predictions(scope_rows, model_name)
-        )
+        model_name: _regression_metrics(actual, _scope_model_predictions(scope_rows, model_name))
         for model_name in model_names
     }
 
 
-def _scope_model_predictions(
-    scope_rows: list[dict[str, Any]], model_name: str
-) -> list[float]:
-    return [
-        _number(row.get("predictions", {}).get(model_name)) for row in scope_rows
-    ]
+def _scope_model_predictions(scope_rows: list[dict[str, Any]], model_name: str) -> list[float]:
+    return [_number(row.get("predictions", {}).get(model_name)) for row in scope_rows]
 
 
 def _scope_error_diagnostics(
@@ -229,8 +210,6 @@ def _scope_state_bucket_diagnostics(
     }
 
 
-def _included_models(
-    candidates: tuple[str, ...], model_names: list[str]
-) -> tuple[str, ...]:
+def _included_models(candidates: tuple[str, ...], model_names: list[str]) -> tuple[str, ...]:
     model_name_set = set(model_names)
     return tuple(model_name for model_name in candidates if model_name in model_name_set)

--- a/src/codex_usage_tracker/usage_drain/walk_forward_rows.py
+++ b/src/codex_usage_tracker/usage_drain/walk_forward_rows.py
@@ -94,9 +94,7 @@ def walk_forward_prediction_rows(spans: list[UsageDeltaSpan]) -> list[dict[str, 
         previous_state_rows.append(
             {
                 "actual": actual,
-                "state": _history_state_for_span(
-                    spans, index, metadata, previous_deltas
-                ),
+                "state": _history_state_for_span(spans, index, metadata, previous_deltas),
             }
         )
         previous_deltas.append(actual)
@@ -161,9 +159,7 @@ def _walk_forward_history_metrics(previous_deltas: list[float]) -> dict[str, Any
     recent3 = previous_deltas[-3:]
     recent10 = previous_deltas[-10:]
     rolling10_mode = _value_mode(recent10)
-    one_percent_streak = _tail_streak(
-        previous_deltas, predicate=_is_one_percent_delta
-    )
+    one_percent_streak = _tail_streak(previous_deltas, predicate=_is_one_percent_delta)
     same_delta_streak = _same_value_tail_streak(previous_deltas)
     return {
         "recent3": recent3,
@@ -172,9 +168,7 @@ def _walk_forward_history_metrics(previous_deltas: list[float]) -> dict[str, Any
         "rolling10_stddev": _value_stddev(recent10),
         "rolling10_low_share": _low_delta_share(recent10),
         "one_percent_streak": one_percent_streak,
-        "low_delta_streak": _tail_streak(
-            previous_deltas, predicate=lambda value: value <= 1.0
-        ),
+        "low_delta_streak": _tail_streak(previous_deltas, predicate=lambda value: value <= 1.0),
         "same_delta_streak": same_delta_streak,
         "hybrid_streak": _hybrid_streak_prediction(
             previous_deltas=previous_deltas,
@@ -230,12 +224,8 @@ def _walk_forward_state(
         "low_delta_streak_bucket": _streak_bucket(low_delta_streak),
         "same_delta_streak_count": same_delta_streak,
         "same_delta_streak_bucket": _streak_bucket(same_delta_streak),
-        "previous_span_wall_time_bucket": _previous_span_wall_time_bucket(
-            spans, index
-        ),
-        "previous_call_duration_bucket": _previous_call_duration_bucket(
-            spans, index
-        ),
+        "previous_span_wall_time_bucket": _previous_span_wall_time_bucket(spans, index),
+        "previous_call_duration_bucket": _previous_call_duration_bucket(spans, index),
     }
 
 
@@ -300,11 +290,9 @@ def _walk_forward_transition_predictions(
     history_state_prediction = _number(predictions.get("empirical_history_state_mode"))
     continuation_prediction = _number(predictions.get("one_percent_regime_grace"))
     history_state_risk = _number(transition_risks.get("history_state_risk"))
-    adaptive_threshold, adaptive_threshold_detail = (
-        _best_transition_delta_gate_threshold_from_sums(
-            transition_gate_absolute_error_sums,
-            training_count=training_count,
-        )
+    adaptive_threshold, adaptive_threshold_detail = _best_transition_delta_gate_threshold_from_sums(
+        transition_gate_absolute_error_sums,
+        training_count=training_count,
     )
     transition_predictions = _transition_delta_predictions(
         continuation_prediction=continuation_prediction,

--- a/tests/cli/test_allowance_intelligence_cli_mcp.py
+++ b/tests/cli/test_allowance_intelligence_cli_mcp.py
@@ -13,9 +13,7 @@ def test_allowance_intelligence_cli_commands_parse() -> None:
     diagnostics = parser.parse_args(
         ["allowance-diagnostics", "--window-kind", "weekly", "--limit", "0", "--json"]
     )
-    export = parser.parse_args(
-        ["allowance-export", "--output", "/tmp/allowance-evidence.json"]
-    )
+    export = parser.parse_args(["allowance-export", "--output", "/tmp/allowance-evidence.json"])
 
     assert diagnostics.command == "allowance-diagnostics"
     assert diagnostics.window_kind == "weekly"
@@ -25,9 +23,7 @@ def test_allowance_intelligence_cli_commands_parse() -> None:
     assert export.output == Path("/tmp/allowance-evidence.json")
 
 
-def test_usage_allowance_mcp_tools_return_contracts(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_usage_allowance_mcp_tools_return_contracts(tmp_path: Path, monkeypatch) -> None:
     from codex_usage_tracker.cli import mcp_server
 
     db_path = tmp_path / "usage.sqlite3"

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -584,15 +584,9 @@ def test_diagnostics_cli_returns_aggregate_json(tmp_path: Path) -> None:
     assert overview_refresh_payload["status"] == "ready"
     assert overview_refresh_payload["overview"]["usage_rows"] == 2
     assert overview_refresh_payload["refreshed"] is True
-    assert (
-        tool_output_refresh_payload["schema"]
-        == "codex-usage-tracker-diagnostic-tool-output-v1"
-    )
+    assert tool_output_refresh_payload["schema"] == "codex-usage-tracker-diagnostic-tool-output-v1"
     assert tool_output_refresh_payload["summary"]["original_token_sum"] == 9
-    assert (
-        commands_refresh_payload["schema"]
-        == "codex-usage-tracker-diagnostic-commands-v1"
-    )
+    assert commands_refresh_payload["schema"] == "codex-usage-tracker-diagnostic-commands-v1"
     assert commands_refresh_payload["commands"][0]["root"] == "git"
     assert commands_refresh_payload["commands"][0]["children"][0] == {
         "child": "status",
@@ -604,10 +598,7 @@ def test_diagnostics_cli_returns_aggregate_json(tmp_path: Path) -> None:
     )
     assert git_interactions_refresh_payload["summary"]["git_shell_calls"] == 1
     assert git_interactions_refresh_payload["interactions"][0]["operation"] == "status"
-    assert (
-        file_reads_refresh_payload["schema"]
-        == "codex-usage-tracker-diagnostic-file-reads-v1"
-    )
+    assert file_reads_refresh_payload["schema"] == "codex-usage-tracker-diagnostic-file-reads-v1"
     assert file_reads_refresh_payload["summary"]["read_events"] == 0
     assert (
         file_modifications_refresh_payload["schema"]
@@ -620,8 +611,7 @@ def test_diagnostics_cli_returns_aggregate_json(tmp_path: Path) -> None:
     )
     assert read_productivity_refresh_payload["summary"]["read_events_modified_later"] == 0
     assert (
-        concentration_refresh_payload["schema"]
-        == "codex-usage-tracker-diagnostic-concentration-v1"
+        concentration_refresh_payload["schema"] == "codex-usage-tracker-diagnostic-concentration-v1"
     )
     assert concentration_refresh_payload["summary"]["usage_rows"] == 2
     assert concentration_refresh_payload["metrics"]
@@ -631,18 +621,12 @@ def test_diagnostics_cli_returns_aggregate_json(tmp_path: Path) -> None:
     )
     assert guided_summary_refresh_payload["summary"]["usage_rows"] == 2
     assert guided_summary_refresh_payload["drivers"]
-    assert (
-        usage_drain_refresh_payload["schema"]
-        == "codex-usage-tracker-diagnostic-usage-drain-v1"
-    )
+    assert usage_drain_refresh_payload["schema"] == "codex-usage-tracker-diagnostic-usage-drain-v1"
     assert usage_drain_refresh_payload["summary"]["usage_rows"] == 2
     assert "thread_cost_curves" in usage_drain_refresh_payload
     usage_drain_thread = usage_drain_refresh_payload["thread_cost_curves"]["threads"][0]
     assert usage_drain_thread["largest_record_id"]
-    assert (
-        usage_drain_thread["representative_record_id"]
-        == usage_drain_thread["largest_record_id"]
-    )
+    assert usage_drain_thread["representative_record_id"] == usage_drain_thread["largest_record_id"]
     assert fact_calls_payload["view"] == "fact-calls"
     assert fact_calls_payload["filters"]["privacy_mode"] == "strict"
     assert fact_calls_payload["rows"][0]["cwd"].startswith("[redacted cwd:")
@@ -829,9 +813,7 @@ def _make_diagnostics_codex_home(tmp_path: Path) -> Path:
                         {
                             "type": "message",
                             "role": "assistant",
-                            "content": [
-                                {"type": "output_text", "text": "SECRET COMPACTION TEXT"}
-                            ],
+                            "content": [{"type": "output_text", "text": "SECRET COMPACTION TEXT"}],
                         }
                     ],
                 },
@@ -889,8 +871,6 @@ def _subprocess_env() -> dict[str, str]:
     repo_root = Path(__file__).resolve().parents[2]
     src_path = str(repo_root / "src")
     env["PYTHONPATH"] = (
-        f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
-        if env.get("PYTHONPATH")
-        else src_path
+        f"{src_path}{os.pathsep}{env['PYTHONPATH']}" if env.get("PYTHONPATH") else src_path
     )
     return env

--- a/tests/cli/test_cli_module_entrypoints.py
+++ b/tests/cli/test_cli_module_entrypoints.py
@@ -31,5 +31,7 @@ def _subprocess_env() -> dict[str, str]:
     repo_root = Path(__file__).resolve().parents[2]
     env = os.environ.copy()
     src = str(repo_root / "src")
-    env["PYTHONPATH"] = src if not env.get("PYTHONPATH") else f"{src}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = (
+        src if not env.get("PYTHONPATH") else f"{src}{os.pathsep}{env['PYTHONPATH']}"
+    )
     return env

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -81,7 +81,7 @@ MCP_TOOL_NAMES = {
     "usage_file_churn_scan",
     "usage_repeated_file_rediscovery",
     "usage_shell_churn",
-        "usage_large_low_output_calls",
+    "usage_large_low_output_calls",
     "usage_suggest_investigations",
     "usage_investigate",
     "usage_action_brief",
@@ -89,7 +89,7 @@ MCP_TOOL_NAMES = {
     "usage_dogfood_status",
     "usage_dogfood_result",
     "usage_test_hypotheses",
-        "usage_context_bloat_scan",
+    "usage_context_bloat_scan",
     "usage_investigation_walk",
     "usage_local_evidence_export",
     "generate_usage_dashboard",
@@ -361,6 +361,7 @@ def test_dashboard_history_scope_labels_remain_user_facing() -> None:
     assert "history.all_includes" in live_runtime
 
     from codex_usage_tracker.core.i18n import translations_for
+
     en_trans = translations_for("en")
     assert en_trans["history.active_only"] == "Active sessions only"
     assert "All history" in en_trans["history.all_includes"]
@@ -539,9 +540,7 @@ def _subprocess_env() -> dict[str, str]:
     repo_root = Path(__file__).resolve().parents[2]
     src_path = str(repo_root / "src")
     env["PYTHONPATH"] = (
-        f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
-        if env.get("PYTHONPATH")
-        else src_path
+        f"{src_path}{os.pathsep}{env['PYTHONPATH']}" if env.get("PYTHONPATH") else src_path
     )
     return env
 

--- a/tests/cli/test_mcp_integration.py
+++ b/tests/cli/test_mcp_integration.py
@@ -577,9 +577,7 @@ def test_pricing_annotation_and_doctor_pass(tmp_path: Path) -> None:
                     "codex-usage-tracker": {
                         "command": sys.executable,
                         "args": ["-m", "codex_usage_tracker.mcp_server"],
-                        "env": {
-                            "PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src")
-                        },
+                        "env": {"PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src")},
                     }
                 }
             }

--- a/tests/cli/test_plugin_installer.py
+++ b/tests/cli/test_plugin_installer.py
@@ -135,7 +135,9 @@ def test_install_plugin_force_replaces_existing_symlink(tmp_path: Path) -> None:
     assert (plugin_dir / ".codex-plugin" / "plugin.json").exists()
 
 
-def test_uninstall_plugin_removes_only_tracker_wrapper_and_marketplace_entry(tmp_path: Path) -> None:
+def test_uninstall_plugin_removes_only_tracker_wrapper_and_marketplace_entry(
+    tmp_path: Path,
+) -> None:
     plugin_dir = tmp_path / "plugins" / "codex-usage-tracker"
     marketplace_path = tmp_path / "marketplace.json"
     install_plugin(
@@ -215,7 +217,10 @@ def test_doctor_detects_mcp_python_that_cannot_import_server(tmp_path: Path) -> 
     assert report["status"] == "fail"
     assert checks["MCP runtime"]["status"] == "fail"
     assert "cannot import the server" in checks["MCP runtime"]["detail"]
-    assert any("install-plugin --python .venv/bin/python --force" in suggestion for suggestion in report["repair_suggestions"])
+    assert any(
+        "install-plugin --python .venv/bin/python --force" in suggestion
+        for suggestion in report["repair_suggestions"]
+    )
 
 
 def _fake_python(tmp_path: Path, *, exit_code: int = 0) -> Path:

--- a/tests/context/test_context_evidence.py
+++ b/tests/context/test_context_evidence.py
@@ -86,7 +86,9 @@ def test_context_loads_raw_log_only_on_demand(tmp_path: Path) -> None:
     assert any(entry["label"] == "message / user" for entry in context["entries"])
     token_entry = next(entry for entry in context["entries"] if entry["label"] == "Token count")
     assert token_entry["token_usage"]["last_token_usage"]["uncached_input_tokens"] >= 0
-    compaction_entries = [entry for entry in context["entries"] if entry["label"] == "Compaction detected"]
+    compaction_entries = [
+        entry for entry in context["entries"] if entry["label"] == "Compaction detected"
+    ]
     assert len(compaction_entries) == 2
     compaction_entry = next(
         entry for entry in compaction_entries if entry["compaction"]["replacement_entry_count"] == 2
@@ -339,7 +341,9 @@ def test_context_carries_incoming_compaction_history_into_selected_turn(tmp_path
         db_path=db_path,
         include_compaction_history=True,
     )
-    compaction_entries = [entry for entry in context["entries"] if entry["label"] == "Compaction detected"]
+    compaction_entries = [
+        entry for entry in context["entries"] if entry["label"] == "Compaction detected"
+    ]
 
     assert [entry["line_number"] for entry in compaction_entries] == [4, 6]
     assert compaction_entries[0]["compaction"]["replacement_entry_count"] == 1

--- a/tests/context/test_context_scan.py
+++ b/tests/context/test_context_scan.py
@@ -21,13 +21,21 @@ def test_context_scan_counts_parse_errors_without_losing_selected_turn(tmp_path:
     )
     _write_jsonl(
         codex_home / "session_index.jsonl",
-        [{"id": session_id, "thread_name": "Parse error context", "updated_at": "2026-06-11T22:55:00Z"}],
+        [
+            {
+                "id": session_id,
+                "thread_name": "Parse error context",
+                "updated_at": "2026-06-11T22:55:00Z",
+            }
+        ],
     )
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("w", encoding="utf-8") as handle:
         handle.write(json.dumps(_entry("session_meta", {"id": session_id})) + "\n")
         handle.write("{not valid json\n")
-        handle.write(json.dumps(_entry("turn_context", {"turn_id": "parse-turn", "model": "gpt-5.5"})) + "\n")
+        handle.write(
+            json.dumps(_entry("turn_context", {"turn_id": "parse-turn", "model": "gpt-5.5"})) + "\n"
+        )
         handle.write(
             json.dumps(
                 _entry(

--- a/tests/context/test_context_values.py
+++ b/tests/context/test_context_values.py
@@ -18,13 +18,16 @@ def test_redact_json_value_recurses_through_lists_and_dicts() -> None:
 
 
 def test_content_text_extracts_nested_text_pieces() -> None:
-    assert context_values.content_text(
-        [
-            {"type": "input_text", "text": "first"},
-            {"type": "output_text", "content": "second"},
-            "third",
-        ]
-    ) == "first\nsecond\nthird"
+    assert (
+        context_values.content_text(
+            [
+                {"type": "input_text", "text": "first"},
+                {"type": "output_text", "content": "second"},
+                "third",
+            ]
+        )
+        == "first\nsecond\nthird"
+    )
 
 
 def test_numeric_helpers_reject_invalid_values() -> None:

--- a/tests/core/test_call_origin.py
+++ b/tests/core/test_call_origin.py
@@ -28,32 +28,44 @@ def test_call_origin_classifies_metadata_segments_without_raw_text() -> None:
 
 
 def test_call_origin_reads_only_event_shape_metadata() -> None:
-    assert event_flags_from_envelope(
-        _entry(
-            "response_item",
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "SECRET RAW PROMPT"}],
-            },
-        )
-    ).user_message is True
-    assert event_flags_from_envelope(
-        _entry("response_item", {"type": "function_call_output", "output": "SECRET"})
-    ).tool_result is True
-    assert event_flags_from_envelope(
-        _entry("event_msg", {"type": "context_compacted", "replacement_history": ["SECRET"]})
-    ).compaction is True
-    assert event_flags_from_envelope(
-        _entry(
-            "response_item",
-            {
-                "type": "message",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": "SECRET RAW ANSWER"}],
-            },
-        )
-    ).codex_activity is True
+    assert (
+        event_flags_from_envelope(
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "SECRET RAW PROMPT"}],
+                },
+            )
+        ).user_message
+        is True
+    )
+    assert (
+        event_flags_from_envelope(
+            _entry("response_item", {"type": "function_call_output", "output": "SECRET"})
+        ).tool_result
+        is True
+    )
+    assert (
+        event_flags_from_envelope(
+            _entry("event_msg", {"type": "context_compacted", "replacement_history": ["SECRET"]})
+        ).compaction
+        is True
+    )
+    assert (
+        event_flags_from_envelope(
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "SECRET RAW ANSWER"}],
+                },
+            )
+        ).codex_activity
+        is True
+    )
 
 
 def test_call_origin_falls_back_to_subagent_metadata_for_migrated_rows() -> None:
@@ -75,9 +87,7 @@ def test_call_origin_falls_back_to_subagent_metadata_for_migrated_rows() -> None
 
 
 def test_event_flags_from_envelope_detects_event_message_user_shape() -> None:
-    flags = event_flags_from_envelope(
-        {"type": "event_msg", "payload": {"type": "user_message"}}
-    )
+    flags = event_flags_from_envelope({"type": "event_msg", "payload": {"type": "user_message"}})
 
     assert flags.user_message
 
@@ -91,9 +101,7 @@ def test_event_flags_from_envelope_detects_mcp_tool_result_shape() -> None:
 
 
 def test_event_flags_from_envelope_detects_agent_event_activity_shape() -> None:
-    flags = event_flags_from_envelope(
-        {"type": "event_msg", "payload": {"type": "agent_message"}}
-    )
+    flags = event_flags_from_envelope({"type": "event_msg", "payload": {"type": "agent_message"}})
 
     assert flags.codex_activity
 

--- a/tests/core/test_i18n.py
+++ b/tests/core/test_i18n.py
@@ -86,12 +86,7 @@ def dashboard_template_text() -> str:
 def dashboard_js_text() -> str:
     repo_root = Path(__file__).resolve().parents[2]
     return (
-        repo_root
-        / "src"
-        / "codex_usage_tracker"
-        / "plugin_data"
-        / "dashboard"
-        / "dashboard.js"
+        repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard.js"
     ).read_text(encoding="utf-8")
 
 
@@ -233,7 +228,9 @@ def test_non_english_catalogs_translate_call_investigator_readout(language: str)
     ]
 
     untranslated = [key for key in readout_labels if current[key] == english[key]]
-    assert not untranslated, f"{language} leaves call investigator readout untranslated: {untranslated}"
+    assert not untranslated, (
+        f"{language} leaves call investigator readout untranslated: {untranslated}"
+    )
 
 
 def test_catalog_keys_use_expected_namespaces() -> None:
@@ -312,7 +309,9 @@ def test_unknown_language_falls_back_to_english() -> None:
         (None, "en"),
     ],
 )
-def test_normalize_language_aliases(raw: str | None, expected: str, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_normalize_language_aliases(
+    raw: str | None, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.delenv(LANGUAGE_ENV_VAR, raising=False)
 
     assert normalize_language(raw) == expected
@@ -359,7 +358,9 @@ def test_dashboard_i18n_payload_shape_for_each_supported_language() -> None:
         payload = dashboard_i18n_payload(language)
         assert payload["language"] == normalize_language(language)
         assert payload["language_direction"] == language_direction(language)
-        assert {entry["code"] for entry in payload["available_languages"]} == set(SUPPORTED_LANGUAGES)  # type: ignore[index]
+        assert {entry["code"] for entry in payload["available_languages"]} == set(
+            SUPPORTED_LANGUAGES
+        )  # type: ignore[index]
         assert set(payload["translation_catalog"]) == set(SUPPORTED_LANGUAGES)  # type: ignore[arg-type]
         assert payload["translations"]["dashboard.title"]  # type: ignore[index]
 
@@ -436,7 +437,10 @@ def test_dashboard_js_generates_language_options_and_preserves_runtime_state() -
     assert "availableLanguages.map" in populate_options
     assert "language.native_name" in populate_options
     assert "document.documentElement.lang = i18n.currentLanguage" in apply_translations
-    assert "document.documentElement.dir = languageDirection(i18n.currentLanguage)" in apply_translations
+    assert (
+        "document.documentElement.dir = languageDirection(i18n.currentLanguage)"
+        in apply_translations
+    )
     assert "if (element === detailEl) return" in apply_translations
     assert "renderLiveStatus()" in apply_translations
     assert "i18n.setLanguage(language)" in set_language
@@ -483,7 +487,9 @@ def test_dashboard_js_runtime_i18n_uses_stable_keys() -> None:
     assert "'metric.usage_observed': 'Usage observed'" in i18n_js
     assert "'allowance.live_check_short': 'Verify live'" in i18n_js
     assert "'button.run': 'Run'" not in i18n_js
-    assert "translatedField(recommendation.title_key, recommendation.title)" in recommendation_summary
+    assert (
+        "translatedField(recommendation.title_key, recommendation.title)" in recommendation_summary
+    )
     assert "translatedField(recommendation.why_key, recommendation.why)" in recommendation_summary
     assert "translatedField(row.recommended_action_key, row.recommended_action)" in next_action
     assert "translatedField(explanationKeys[index], explanation)" in show_detail

--- a/tests/core/test_json_contracts.py
+++ b/tests/core/test_json_contracts.py
@@ -73,7 +73,6 @@ def test_json_contract_validation_reports_schema_and_type_errors() -> None:
     assert "codex-usage-tracker-query-v1.row_count must be int, got bool" in errors
     assert "codex-usage-tracker-query-v1.filters.since is required" in errors
 
-
     nested_type_payload = {
         **payload,
         "row_count": 0,

--- a/tests/dashboard/test_dashboard_data.py
+++ b/tests/dashboard/test_dashboard_data.py
@@ -13,7 +13,14 @@ def _run_dashboard_data_script(script: str) -> dict[str, object]:
     if node is None:
         pytest.skip("node is required for dashboard data helper tests")
     repo_root = Path(__file__).resolve().parents[2]
-    script_path = repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard_data.js"
+    script_path = (
+        repo_root
+        / "src"
+        / "codex_usage_tracker"
+        / "plugin_data"
+        / "dashboard"
+        / "dashboard_data.js"
+    )
     wrapped = f"""
 const fs = require('fs');
 const vm = require('vm');
@@ -38,7 +45,14 @@ def _run_dashboard_format_script(script: str) -> dict[str, object]:
     if node is None:
         pytest.skip("node is required for dashboard format helper tests")
     repo_root = Path(__file__).resolve().parents[2]
-    script_path = repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard_format.js"
+    script_path = (
+        repo_root
+        / "src"
+        / "codex_usage_tracker"
+        / "plugin_data"
+        / "dashboard"
+        / "dashboard_format.js"
+    )
     wrapped = f"""
 const fs = require('fs');
 const vm = require('vm');

--- a/tests/dashboard/test_dashboard_live.py
+++ b/tests/dashboard/test_dashboard_live.py
@@ -466,12 +466,7 @@ def test_dashboard_live_hydrates_empty_shell_after_refresh() -> None:
 def test_dashboard_bootstraps_direct_diagnostics_view() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     dashboard_js = (
-        repo_root
-        / "src"
-        / "codex_usage_tracker"
-        / "plugin_data"
-        / "dashboard"
-        / "dashboard.js"
+        repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard.js"
     ).read_text(encoding="utf-8")
 
     assert "allowDiagnosticsBootstrap: true" in dashboard_js

--- a/tests/dashboard/test_dashboard_payload.py
+++ b/tests/dashboard/test_dashboard_payload.py
@@ -52,21 +52,17 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     dashboard_actions_js = (asset_dir / "dashboard_actions.js").read_text(encoding="utf-8")
     dashboard_live_js = (asset_dir / "dashboard_live.js").read_text(encoding="utf-8")
     dashboard_events_js = (asset_dir / "dashboard_events.js").read_text(encoding="utf-8")
-    dashboard_diagnostics_js = (asset_dir / "dashboard_diagnostics.js").read_text(
+    dashboard_diagnostics_js = (asset_dir / "dashboard_diagnostics.js").read_text(encoding="utf-8")
+    dashboard_diagnostics_facts_js = (asset_dir / "dashboard_diagnostics_facts.js").read_text(
         encoding="utf-8"
     )
-    dashboard_diagnostics_facts_js = (
-        asset_dir / "dashboard_diagnostics_facts.js"
-    ).read_text(encoding="utf-8")
     dashboard_diagnostics_snapshots_js = (
         asset_dir / "dashboard_diagnostics_snapshots.js"
     ).read_text(encoding="utf-8")
-    dashboard_call_diagnostics_js = (
-        asset_dir / "dashboard_call_diagnostics.js"
-    ).read_text(encoding="utf-8")
-    dashboard_call_js = (asset_dir / "dashboard_call_investigator.js").read_text(
+    dashboard_call_diagnostics_js = (asset_dir / "dashboard_call_diagnostics.js").read_text(
         encoding="utf-8"
     )
+    dashboard_call_js = (asset_dir / "dashboard_call_investigator.js").read_text(encoding="utf-8")
     dashboard_state_js = (asset_dir / "dashboard_state.js").read_text(encoding="utf-8")
     dashboard_stylesheets = [
         "dashboard.css",
@@ -78,36 +74,37 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
         "dashboard_responsive.css",
     ]
     dashboard_css = "\n".join(
-        (asset_dir / stylesheet).read_text(encoding="utf-8")
-        for stylesheet in dashboard_stylesheets
+        (asset_dir / stylesheet).read_text(encoding="utf-8") for stylesheet in dashboard_stylesheets
     )
     render_calls_js = _extract_js_function(dashboard_tables_js, "renderCalls")
-    dashboard_surface = "\n".join([
-        dashboard,
-        dashboard_format_js,
-        dashboard_data_js,
-        dashboard_analysis_js,
-        dashboard_cells_js,
-        dashboard_details_js,
-        dashboard_insights_js,
-        dashboard_tables_js,
-        dashboard_filters_js,
-        dashboard_payload_cache_js,
-        dashboard_i18n_js,
-        dashboard_tooltips_js,
-        dashboard_status_js,
-        dashboard_actions_js,
-        dashboard_live_js,
-        dashboard_events_js,
-        dashboard_diagnostics_js,
-        dashboard_diagnostics_facts_js,
-        dashboard_diagnostics_snapshots_js,
-        dashboard_call_diagnostics_js,
-        dashboard_call_js,
-        dashboard_js,
-        dashboard_state_js,
-        dashboard_css,
-    ])
+    dashboard_surface = "\n".join(
+        [
+            dashboard,
+            dashboard_format_js,
+            dashboard_data_js,
+            dashboard_analysis_js,
+            dashboard_cells_js,
+            dashboard_details_js,
+            dashboard_insights_js,
+            dashboard_tables_js,
+            dashboard_filters_js,
+            dashboard_payload_cache_js,
+            dashboard_i18n_js,
+            dashboard_tooltips_js,
+            dashboard_status_js,
+            dashboard_actions_js,
+            dashboard_live_js,
+            dashboard_events_js,
+            dashboard_diagnostics_js,
+            dashboard_diagnostics_facts_js,
+            dashboard_diagnostics_snapshots_js,
+            dashboard_call_diagnostics_js,
+            dashboard_call_js,
+            dashboard_js,
+            dashboard_state_js,
+            dashboard_css,
+        ]
+    )
     csv_text = csv_path.read_text(encoding="utf-8")
     assert exported == 4
     assert exported_with_zero_limit == 4
@@ -229,6 +226,7 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert "metric.session_cumulative" in dashboard_surface.lower()
 
     from codex_usage_tracker.core.i18n import translations_for
+
     en_trans = translations_for("en")
     assert "session cumulative" in en_trans["metric.session_cumulative"].lower()
     assert "Estimated Cost" in dashboard
@@ -397,8 +395,8 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert "Click a call row for deep diagnostics." in dashboard_surface
     assert "data-open-investigator-record" not in render_calls_js
     assert "rowInvestigatorLink(row" in render_calls_js
-    assert "target=\"_blank\"" in dashboard_actions_js
-    assert "rel=\"noopener\"" in dashboard_actions_js
+    assert 'target="_blank"' in dashboard_actions_js
+    assert 'rel="noopener"' in dashboard_actions_js
     assert "a.row-investigator-link" in dashboard_events_js
     assert "/api/open-investigator" in dashboard_actions_js
     assert "openInvestigatorUrl(rowLink.href)" in dashboard_events_js
@@ -496,6 +494,7 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert "thread.spawned_threads" in dashboard_tables_js
 
     from codex_usage_tracker.core.i18n import translations_for
+
     en_trans = translations_for("en")
     assert en_trans["detail.why_flagged"] == "Why flagged"
     assert en_trans["detail.thread_lifecycle"] == "Thread lifecycle"
@@ -535,7 +534,10 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert "Aggregate only" not in dashboard
     assert "Call Details" in dashboard
     assert "Dashboard guide" in dashboard
-    assert "github.com/douglasmonsky/codex-usage-tracker/blob/main/docs/dashboard-guide.md" not in dashboard
+    assert (
+        "github.com/douglasmonsky/codex-usage-tracker/blob/main/docs/dashboard-guide.md"
+        not in dashboard
+    )
     assert "codex-usage-tracker-guide/dashboard-guide.html" in dashboard
     assert (tmp_path / "codex-usage-tracker-guide" / "dashboard-guide.html").exists()
     dashboard_guide = (tmp_path / "codex-usage-tracker-guide" / "dashboard-guide.html").read_text(
@@ -569,14 +571,17 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
         assert (asset_dir / stylesheet).exists()
     assert "detail-section" in dashboard
     assert "detailToggle" in dashboard
-    assert "body[data-detail-panel=\"expanded\"] .grid" in dashboard_css
+    assert 'body[data-detail-panel="expanded"] .grid' in dashboard_css
     assert "applyDetailPanelState()" in dashboard_js
     assert "time-cell" in dashboard_surface
     assert "formatTimestamp" in dashboard_js
     assert "formatDuration" in dashboard_js
     assert 'data-sort-key="duration"' in dashboard
     assert 'data-sort-key="gap"' in dashboard
-    assert '<option value="duration" data-i18n="option.longest_duration">Longest duration</option>' in dashboard
+    assert (
+        '<option value="duration" data-i18n="option.longest_duration">Longest duration</option>'
+        in dashboard
+    )
     assert '<option value="gap" data-i18n="option.longest_gap">Longest gap</option>' in dashboard
     assert "scrollbar-gutter: stable" in dashboard_css
     assert "overflow-y: scroll" in dashboard_css
@@ -616,9 +621,15 @@ def test_dashboard_and_csv_are_aggregate_only(tmp_path: Path) -> None:
     assert 'data-sort-key="reasoning"' in dashboard
     assert 'data-sort-header="signals"' not in dashboard
     assert '<option value="signals"' not in dashboard
-    assert '<option value="time" selected data-i18n="option.newest_calls">Newest calls</option>' in dashboard
+    assert (
+        '<option value="time" selected data-i18n="option.newest_calls">Newest calls</option>'
+        in dashboard
+    )
     assert '<option value="initiator" data-i18n="table.initiated">Initiated</option>' in dashboard
-    assert '<option value="usage" data-i18n="option.highest_codex_credits">Highest Codex credits</option>' in dashboard
+    assert (
+        '<option value="usage" data-i18n="option.highest_codex_credits">Highest Codex credits</option>'
+        in dashboard
+    )
     assert 'id="insightsView" type="button" aria-pressed="false"' in dashboard
     assert 'id="callsView" type="button" aria-pressed="true"' in dashboard
     assert 'id="diagnosticsView" type="button" aria-pressed="false"' in dashboard

--- a/tests/dashboard/test_dashboard_pricing_snapshot.py
+++ b/tests/dashboard/test_dashboard_pricing_snapshot.py
@@ -28,6 +28,5 @@ def test_pricing_snapshot_warning_prefers_timestamp_labels() -> None:
     )
 
     assert warning == (
-        "Pricing snapshot changed since the previous dashboard render: "
-        "2026-06-01 -> 2026-06-02."
+        "Pricing snapshot changed since the previous dashboard render: 2026-06-01 -> 2026-06-02."
     )

--- a/tests/dashboard/test_dashboard_state.py
+++ b/tests/dashboard/test_dashboard_state.py
@@ -13,7 +13,14 @@ def test_dashboard_url_state_round_trips() -> None:
     if node is None:
         pytest.skip("node is required for dashboard_state.js round-trip test")
     repo_root = Path(__file__).resolve().parents[2]
-    script_path = repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / "dashboard_state.js"
+    script_path = (
+        repo_root
+        / "src"
+        / "codex_usage_tracker"
+        / "plugin_data"
+        / "dashboard"
+        / "dashboard_state.js"
+    )
     script = f"""
 const fs = require('fs');
 const vm = require('vm');

--- a/tests/diagnostics/test_diagnostic_snapshot_events.py
+++ b/tests/diagnostics/test_diagnostic_snapshot_events.py
@@ -25,10 +25,7 @@ def test_shell_command_from_payload_reads_supported_argument_shapes() -> None:
         )
         == "pytest -q"
     )
-    assert (
-        shell_command_from_payload({"cmd": "rg TODO"}, function_name="shell")
-        == "rg TODO"
-    )
+    assert shell_command_from_payload({"cmd": "rg TODO"}, function_name="shell") == "rg TODO"
     assert (
         shell_command_from_payload(
             {"arguments": "{not json", "command": "fallback"},
@@ -36,10 +33,7 @@ def test_shell_command_from_payload_reads_supported_argument_shapes() -> None:
         )
         == "fallback"
     )
-    assert (
-        shell_command_from_payload({"cmd": "git status"}, function_name="read_file")
-        is None
-    )
+    assert shell_command_from_payload({"cmd": "git status"}, function_name="read_file") is None
 
 
 @pytest.mark.parametrize(
@@ -57,6 +51,8 @@ def test_shell_command_from_payload_reads_supported_argument_shapes() -> None:
         ("$PWCLI status", "pwcli"),
     ],
 )
-def test_command_root_and_child_normalizes_common_wrappers(command: str, expected_root: str) -> None:
+def test_command_root_and_child_normalizes_common_wrappers(
+    command: str, expected_root: str
+) -> None:
     root, _child = command_root_and_child(command)
     assert root == expected_root

--- a/tests/diagnostics/test_diagnostic_snapshot_report.py
+++ b/tests/diagnostics/test_diagnostic_snapshot_report.py
@@ -68,6 +68,5 @@ def test_diagnostic_snapshot_report_renders_unavailable_snapshot() -> None:
     ).render()
 
     assert rendered == (
-        "No diagnostic tool-output snapshot. "
-        "Run diagnostics tool-output --refresh first."
+        "No diagnostic tool-output snapshot. Run diagnostics tool-output --refresh first."
     )

--- a/tests/diagnostics/test_diagnostic_snapshots.py
+++ b/tests/diagnostics/test_diagnostic_snapshots.py
@@ -418,10 +418,7 @@ def test_git_interaction_snapshot_uses_safe_aggregate_operations(tmp_path: Path)
     assert git_interactions["summary"]["interactions_missing_original_token_count"] == 1
     assert git_interactions["summary"]["original_token_sum"] == 118
 
-    rows = {
-        (row["root"], row["operation"]): row
-        for row in git_interactions["interactions"]
-    }
+    rows = {(row["root"], row["operation"]): row for row in git_interactions["interactions"]}
     assert rows[("git", "status")]["category"] == "read_only"
     assert rows[("git", "status")]["mutability"] == "read_only"
     assert rows[("git", "status")]["representative_record_id"] == record_id

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -328,9 +328,7 @@ def test_parser_collects_diagnostic_facts_between_token_counts(tmp_path: Path) -
                         {
                             "type": "message",
                             "role": "assistant",
-                            "content": [
-                                {"type": "output_text", "text": "SECRET COMPACTION TEXT"}
-                            ],
+                            "content": [{"type": "output_text", "text": "SECRET COMPACTION TEXT"}],
                         }
                     ],
                 },
@@ -596,8 +594,6 @@ def _subprocess_env() -> dict[str, str]:
     repo_root = Path(__file__).resolve().parents[2]
     src_path = str(repo_root / "src")
     env["PYTHONPATH"] = (
-        f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
-        if env.get("PYTHONPATH")
-        else src_path
+        f"{src_path}{os.pathsep}{env['PYTHONPATH']}" if env.get("PYTHONPATH") else src_path
     )
     return env

--- a/tests/pricing/test_allowance.py
+++ b/tests/pricing/test_allowance.py
@@ -29,7 +29,10 @@ def test_allowance_estimates_exact_codex_credit_usage() -> None:
 
     assert rows[0]["usage_credit_model"] == "gpt-5.5"
     assert rows[0]["usage_credit_confidence"] == "exact"
-    assert rows[0]["usage_credit_source_url"] == "https://help.openai.com/en/articles/20001106-codex-rate-card"
+    assert (
+        rows[0]["usage_credit_source_url"]
+        == "https://help.openai.com/en/articles/20001106-codex-rate-card"
+    )
     assert rows[0]["usage_credit_fetched_at"] == "2026-06-03"
     assert rows[0]["usage_credit_tier"] == "standard"
     assert rows[0]["usage_credits"] == 0.1775
@@ -51,7 +54,10 @@ def test_allowance_marks_inferred_auto_review_mapping() -> None:
 
     assert rows[0]["usage_credit_model"] == "gpt-5.3-codex"
     assert rows[0]["usage_credit_confidence"] == "estimated"
-    assert rows[0]["usage_credit_source_url"] == "https://help.openai.com/en/articles/20001106-codex-rate-card"
+    assert (
+        rows[0]["usage_credit_source_url"]
+        == "https://help.openai.com/en/articles/20001106-codex-rate-card"
+    )
     assert rows[0]["usage_credits"] == 0.0590625
 
 
@@ -157,7 +163,17 @@ def test_parse_allowance_text_reads_status_percentages() -> None:
 def test_write_allowance_from_text_preserves_local_overrides(tmp_path: Path) -> None:
     path = tmp_path / "allowance.json"
     path.write_text(
-        json.dumps({"credit_rates": {"local-codex": {"input_per_million": 1, "cached_input_per_million": 1, "output_per_million": 1}}}),
+        json.dumps(
+            {
+                "credit_rates": {
+                    "local-codex": {
+                        "input_per_million": 1,
+                        "cached_input_per_million": 1,
+                        "output_per_million": 1,
+                    }
+                }
+            }
+        ),
         encoding="utf-8",
     )
 

--- a/tests/server/test_server_api.py
+++ b/tests/server/test_server_api.py
@@ -47,4 +47,7 @@ def test_serve_dashboard_opens_react_dashboard_and_prints_legacy_fallback(
     output = capsys.readouterr().out
     assert opened == ["http://127.0.0.1:8765/react-dashboard.html"]
     assert "Serving Codex usage dashboard at http://127.0.0.1:8765/react-dashboard.html" in output
-    assert "Legacy dashboard fallback remains available at http://127.0.0.1:8765/dashboard.html" in output
+    assert (
+        "Legacy dashboard fallback remains available at http://127.0.0.1:8765/dashboard.html"
+        in output
+    )

--- a/tests/server/test_server_open_investigator.py
+++ b/tests/server/test_server_open_investigator.py
@@ -47,8 +47,12 @@ def test_open_investigator_payload_preserves_fragment() -> None:
     )
 
     assert payload["opened"] is False
-    assert payload["url"] == "http://localhost:8898/react-dashboard.html?view=call&record=abc#section"
-    assert opened_urls == ["http://localhost:8898/react-dashboard.html?view=call&record=abc#section"]
+    assert (
+        payload["url"] == "http://localhost:8898/react-dashboard.html?view=call&record=abc#section"
+    )
+    assert opened_urls == [
+        "http://localhost:8898/react-dashboard.html?view=call&record=abc#section"
+    ]
 
 
 def test_open_investigator_payload_accepts_preferred_react_dashboard_url() -> None:
@@ -75,7 +79,10 @@ def test_open_investigator_payload_accepts_preferred_react_dashboard_url() -> No
     ("query", "message"),
     [
         ("", "url is required"),
-        ("url=ftp://127.0.0.1/dashboard.html?view=call&record=abc", "Only dashboard URLs can be opened"),
+        (
+            "url=ftp://127.0.0.1/dashboard.html?view=call&record=abc",
+            "Only dashboard URLs can be opened",
+        ),
         (
             "url=http://example.com/dashboard.html?view=call&record=abc",
             "Only loopback dashboard URLs can be opened",

--- a/tests/server/test_server_routes.py
+++ b/tests/server/test_server_routes.py
@@ -10,13 +10,9 @@ from codex_usage_tracker.server.routes import (
 
 def test_server_route_tables_cover_dashboard_api_paths() -> None:
     assert GET_ROUTE_METHODS["/api/context"] == "_handle_context"
-    assert GET_ROUTE_METHODS["/api/diagnostics/usage-drain"] == (
-        "_handle_diagnostics_usage_drain"
-    )
+    assert GET_ROUTE_METHODS["/api/diagnostics/usage-drain"] == ("_handle_diagnostics_usage_drain")
     assert GET_ROUTE_METHODS["/api/allowance/history"] == "_handle_allowance_history"
-    assert GET_ROUTE_METHODS["/api/allowance/diagnostics"] == (
-        "_handle_allowance_diagnostics"
-    )
+    assert GET_ROUTE_METHODS["/api/allowance/diagnostics"] == ("_handle_allowance_diagnostics")
     assert GET_ROUTE_METHODS["/api/allowance/export"] == "_handle_allowance_export"
     assert GET_ROUTE_METHODS["/api/usage"] == "_handle_usage"
     assert GET_DIAGNOSTIC_FACT_ROUTES == {

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -51,9 +51,7 @@ def test_refresh_populates_normalized_content_index_by_default(tmp_path: Path) -
     assert all("SECRET RAW PROMPT" not in row["safe_label"] for row in fragment_rows)
 
 
-def test_refresh_incrementally_indexes_appended_content(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_refresh_incrementally_indexes_appended_content(tmp_path: Path, monkeypatch) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
 
@@ -101,9 +99,7 @@ def test_refresh_incrementally_indexes_appended_content(
     assert report["total_matched_rows"] == 1
 
 
-def test_refresh_batches_full_content_fts_rebuild(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_refresh_batches_full_content_fts_rebuild(tmp_path: Path, monkeypatch) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     refresh_usage_index(codex_home=codex_home, db_path=db_path, aggregate_only=True)
@@ -131,16 +127,11 @@ def test_refresh_batches_full_content_fts_rebuild(
     assert rebuild_calls == 1
 
 
-def test_refresh_batches_content_index_row_writes(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_refresh_batches_content_index_row_writes(tmp_path: Path, monkeypatch) -> None:
     codex_home = tmp_path / ".codex"
     log_dir = codex_home / "sessions" / "2026" / "05" / "17"
     log_dir.mkdir(parents=True)
-    log_path = log_dir / (
-        "rollout-2026-05-17T14-58-23-"
-        "019e374d-c19f-7da3-a44f-8de043a7a64e.jsonl"
-    )
+    log_path = log_dir / ("rollout-2026-05-17T14-58-23-019e374d-c19f-7da3-a44f-8de043a7a64e.jsonl")
     rows: list[dict[str, object]] = []
     for index in range(3):
         rows.extend(
@@ -179,9 +170,7 @@ def test_refresh_batches_content_index_row_writes(
     assert fragment_write_sizes == [2, 1]
 
 
-def test_refresh_indexes_content_sources_in_parallel(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_refresh_indexes_content_sources_in_parallel(tmp_path: Path, monkeypatch) -> None:
     codex_home = tmp_path / ".codex"
     log_dir = codex_home / "sessions" / "2026" / "05" / "17"
     log_dir.mkdir(parents=True)
@@ -242,7 +231,12 @@ def test_refresh_populates_normalized_local_event_tables(tmp_path: Path) -> None
     db_path = tmp_path / "usage.sqlite3"
     session_id = "019e37f1-15d4-76a5-bf68-9d7616f9b8db"
     log_path = (
-        codex_home / "sessions" / "2026" / "05" / "18" / f"rollout-2026-05-18T09-00-00-{session_id}.jsonl"
+        codex_home
+        / "sessions"
+        / "2026"
+        / "05"
+        / "18"
+        / f"rollout-2026-05-18T09-00-00-{session_id}.jsonl"
     )
     _write_jsonl(
         log_path,
@@ -660,7 +654,9 @@ def test_shell_churn_display_labels_repair_legacy_unknown_command_rows() -> None
     fallback_root = _display_command_root("unknown_command", "$PWCLI", distinct_label_count=2)
     assert fallback_root == "unclassified_shell_script"
 
-    fallback_root = _display_command_root("unknown_command", "unknown_command", distinct_label_count=1)
+    fallback_root = _display_command_root(
+        "unknown_command", "unknown_command", distinct_label_count=1
+    )
     assert fallback_root == "unclassified_shell_script"
     assert _display_command_label(fallback_root, "unknown_command") == "unclassified_shell_script"
     assert _command_family(fallback_root) == "unclassified_shell"
@@ -790,7 +786,9 @@ def test_large_low_output_calls_flags_cold_resume_candidates(tmp_path: Path) -> 
     ).payload
     assert validate_json_payload_contract(walk) == []
     assert any(branch["scan_type"] == "large_low_output" for branch in walk["branches"])
-    assert any(tool["tool"] == "usage_large_low_output_calls" for tool in walk["recommended_next_tools"])
+    assert any(
+        tool["tool"] == "usage_large_low_output_calls" for tool in walk["recommended_next_tools"]
+    )
 
 
 def _custom_token_event(

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -50,9 +50,7 @@ class BrokenProcessPoolExecutor:
         return future
 
 
-def test_refresh_parses_multiple_sources_with_worker_pool(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_refresh_parses_multiple_sources_with_worker_pool(tmp_path: Path, monkeypatch) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     RecordingProcessPoolExecutor.instances.clear()
@@ -119,9 +117,7 @@ def test_refresh_reports_phase_progress(tmp_path: Path, monkeypatch) -> None:
     assert phases[-1] == "finalizing"
     assert events[-1]["status"] == "completed"
     assert events[-1]["result"]["parsed_events"] == result.parsed_events
-    content_events = [
-        event for event in events if event["phase"] == "indexing_content"
-    ]
+    content_events = [event for event in events if event["phase"] == "indexing_content"]
     assert content_events
     assert content_events[-1]["status"] == "completed"
     assert content_events[-1]["percent"] == 100.0

--- a/tests/store/test_source_records.py
+++ b/tests/store/test_source_records.py
@@ -117,9 +117,7 @@ def test_source_file_metadata_refreshes_source_record_parser_details(
     assert rows[0]["parser_version"] == "codex-jsonl-v2"
 
 
-def test_source_file_metadata_uses_parser_final_line_number(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_source_file_metadata_uses_parser_final_line_number(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "usage.sqlite3"
     source_path = tmp_path / "sessions" / "fast-metadata.jsonl"
     source_path.parent.mkdir(parents=True)

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -129,7 +129,9 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
 def test_refresh_reports_skipped_corrupt_token_events(tmp_path: Path) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
-    log_path = next(path for path in (codex_home / "sessions").glob("**/*.jsonl") if SESSION_ID in path.name)
+    log_path = next(
+        path for path in (codex_home / "sessions").glob("**/*.jsonl") if SESSION_ID in path.name
+    )
     corrupt = _token_event(600, 300)
     corrupt["payload"]["info"]["last_token_usage"]["total_tokens"] = "bad-total"  # type: ignore[index]
     valid = _token_event(650, 50)
@@ -512,9 +514,7 @@ def test_refresh_persists_diagnostic_facts_without_raw_content(tmp_path: Path) -
                         {
                             "type": "message",
                             "role": "assistant",
-                            "content": [
-                                {"type": "output_text", "text": "SECRET COMPACTION TEXT"}
-                            ],
+                            "content": [{"type": "output_text", "text": "SECRET COMPACTION TEXT"}],
                         }
                     ],
                 },
@@ -613,9 +613,7 @@ def test_refresh_persists_richer_diagnostic_detectors_without_command_text(
     assert tools_payload["filters"]["fact_group"] == "tools"
     assert by_key[("command_family", "pytest")]["associated_total_tokens"] == 120
     assert by_key[("function", "functions.exec_command")]["associated_total_tokens"] == 120
-    assert by_key[("mcp_tool", "mcp__calendar__search_events")][
-        "associated_total_tokens"
-    ] == 120
+    assert by_key[("mcp_tool", "mcp__calendar__search_events")]["associated_total_tokens"] == 120
     assert by_key[("mcp_server", "google-calendar")]["associated_total_tokens"] == 120
     assert by_key[("skill", "brooks-test")]["associated_total_tokens"] == 120
     serialized = json.dumps(facts, sort_keys=True)
@@ -741,12 +739,10 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     with connect(db_path) as conn:
         init_db(conn)
         columns = {
-            row["name"]
-            for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
+            row["name"] for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
         }
         indexes = {
-            row["name"]
-            for row in conn.execute("PRAGMA index_list(usage_events)").fetchall()
+            row["name"] for row in conn.execute("PRAGMA index_list(usage_events)").fetchall()
         }
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
         migrations = [
@@ -757,15 +753,11 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
         ]
         allowance_columns = {
             row["name"]
-            for row in conn.execute(
-                "PRAGMA table_info(allowance_observations)"
-            ).fetchall()
+            for row in conn.execute("PRAGMA table_info(allowance_observations)").fetchall()
         }
         allowance_indexes = {
             row["name"]
-            for row in conn.execute(
-                "PRAGMA index_list(allowance_observations)"
-            ).fetchall()
+            for row in conn.execute("PRAGMA index_list(allowance_observations)").fetchall()
         }
 
     assert {
@@ -1251,6 +1243,7 @@ def test_thread_summaries_keep_active_and_all_history_scopes_separate(
     assert sum(row["call_count"] for row in all_summaries) == 5
     assert sum(row["archived_call_count"] for row in active_summaries) == 0
     assert sum(row["archived_call_count"] for row in all_summaries) == 1
+
 
 def test_dashboard_query_limit_zero_loads_all_rows(tmp_path: Path) -> None:
     codex_home = _make_codex_home(tmp_path)

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -161,8 +161,7 @@ def test_init_db_does_not_rerun_applied_migrations(
         schema_module,
         "_schema_migrations",
         lambda: tuple(
-            (version, fail_if_rerun)
-            for version in range(1, schema_module.SCHEMA_VERSION + 1)
+            (version, fail_if_rerun) for version in range(1, schema_module.SCHEMA_VERSION + 1)
         ),
     )
 
@@ -206,9 +205,10 @@ def test_malformed_legacy_schema_reports_actionable_error_without_data_loss(
     db_path = tmp_path / "usage.sqlite3"
     _write_legacy_usage_database(db_path, omit_source_file=True)
 
-    with pytest.raises(SchemaMigrationError, match="missing required columns: source_file"), connect(
-        db_path
-    ) as conn:
+    with (
+        pytest.raises(SchemaMigrationError, match="missing required columns: source_file"),
+        connect(db_path) as conn,
+    ):
         init_db(conn)
 
     raw = sqlite3.connect(db_path)

--- a/tests/store/test_store_sources.py
+++ b/tests/store/test_store_sources.py
@@ -132,8 +132,7 @@ def test_upsert_source_file_metadata_uses_parser_state_when_no_events(
     upsert_source_file_metadata(conn, parsed_files=[(source_path, [], {}, state)])
 
     row = conn.execute(
-        "SELECT latest_record_id, latest_event_timestamp FROM source_files "
-        "WHERE source_file = ?",
+        "SELECT latest_record_id, latest_event_timestamp FROM source_files WHERE source_file = ?",
         (str(source_path),),
     ).fetchone()
     assert dict(row) == {

--- a/tests/usage_drain/test_usage_drain_allowance_fits.py
+++ b/tests/usage_drain/test_usage_drain_allowance_fits.py
@@ -180,9 +180,7 @@ def test_allowance_online_capacity_error_diagnostics_reports_largest_errors() ->
     }
 
 
-def _allowance_row(
-    span_index: int, *, credits_per_visible_percent: float
-) -> dict[str, object]:
+def _allowance_row(span_index: int, *, credits_per_visible_percent: float) -> dict[str, object]:
     return {
         "span_index": span_index,
         "credits_per_visible_percent": credits_per_visible_percent,

--- a/tests/usage_drain/test_usage_drain_boundary_delta_summary.py
+++ b/tests/usage_drain/test_usage_drain_boundary_delta_summary.py
@@ -265,12 +265,8 @@ def test_boundary_delta_prediction_scope_summarizes_models_and_filters_rows() ->
         "risk_gated_label_segment_age_mode",
     ]
     assert result["models"]["previous_delta"]["mae"] == 1.0
-    assert sorted(result["risk_gate_diagnostics"]) == [
-        "risk_gated_label_segment_age_mode"
-    ]
-    assert result["risk_gate_diagnostics"]["risk_gated_label_segment_age_mode"][
-        "mean_risk"
-    ] == 0.45
+    assert sorted(result["risk_gate_diagnostics"]) == ["risk_gated_label_segment_age_mode"]
+    assert result["risk_gate_diagnostics"]["risk_gated_label_segment_age_mode"]["mean_risk"] == 0.45
     assert sorted(result["residual_diagnostics"]) == ["previous_delta"]
 
     filtered = _boundary_delta_prediction_scope(rows, start_index=1)

--- a/tests/usage_drain/test_usage_drain_feature_history.py
+++ b/tests/usage_drain/test_usage_drain_feature_history.py
@@ -29,7 +29,14 @@ def test_add_causal_history_features_only_uses_prior_rows() -> None:
     rows = [
         _feature_row(target=1.0, credits=100.0),
         _feature_row(target=2.0, credits=200.0),
-        _feature_row(target=1.0, credits=150.0, limit_id="limit-b", date="2026-06-02", hour="10", day="Tuesday"),
+        _feature_row(
+            target=1.0,
+            credits=150.0,
+            limit_id="limit-b",
+            date="2026-06-02",
+            hour="10",
+            day="Tuesday",
+        ),
         _feature_row(target=1.0, credits=100.0),
     ]
 

--- a/tests/usage_drain/test_usage_drain_model.py
+++ b/tests/usage_drain/test_usage_drain_model.py
@@ -205,15 +205,13 @@ def test_regime_streaks_expose_one_percent_runs_and_breaks() -> None:
     }
     walk_forward = summary["walk_forward_prediction"]["scopes"]["all_after_first"]
     assert walk_forward["models"]["hybrid_streak_regime"]["mae"] < 0.5
-    assert "error_by_one_percent_streak" in walk_forward["error_diagnostics"][
-        "hybrid_streak_regime"
-    ]
+    assert (
+        "error_by_one_percent_streak" in walk_forward["error_diagnostics"]["hybrid_streak_regime"]
+    )
     assert "one_percent_regime_grace" in walk_forward["models"]
     assert summary["span_correlations"]["delta_usage_percent"]["n"] == 6
     assert (
-        summary["span_correlations"]["one_percent_span_capacity"][
-            "standard_usage_credits"
-        ]["n"]
+        summary["span_correlations"]["one_percent_span_capacity"]["standard_usage_credits"]["n"]
         == 5
     )
     calibration = summary["walk_forward_prediction"]["one_percent_grace_calibration"]
@@ -238,9 +236,7 @@ def test_regime_streaks_expose_one_percent_runs_and_breaks() -> None:
         "sixth_plus_span",
     ]
     assert adaptation["all_segments"]["first_span"]["prediction_rows"] == 2
-    assert adaptation["by_label"]["stable_one_percent"]["first_span"][
-        "prediction_rows"
-    ] == 1
+    assert adaptation["by_label"]["stable_one_percent"]["first_span"]["prediction_rows"] == 1
     boundaries = segments["boundary_diagnostics"]
     assert boundaries["n"] == 5
     assert boundaries["boundary_count"] == 2
@@ -333,9 +329,7 @@ def test_boundary_walk_forward_risk_learns_segment_age_pattern() -> None:
 
     summary = summarize_usage_drain_model(rows)
 
-    risk = summary["piecewise_regime_segments"]["boundary_diagnostics"][
-        "walk_forward_risk"
-    ]
+    risk = summary["piecewise_regime_segments"]["boundary_diagnostics"]["walk_forward_risk"]
     scope = risk["scopes"]["all_after_10"]
     assert scope["boundary_count"] > 0
     prior = scope["models"]["overall_prior_rate"]
@@ -356,18 +350,10 @@ def test_boundary_walk_forward_risk_learns_segment_age_pattern() -> None:
     delta_scope = delta_prediction["scopes"]["all_after_10"]
     previous_delta = delta_scope["models"]["previous_delta"]
     label_segment_age_mode = delta_scope["models"]["label_segment_age_mode"]
-    boundary_conditioned = delta_scope["models"][
-        "boundary_conditioned_label_segment_age_mode"
-    ]
-    adaptive_mae_gate = delta_scope["models"][
-        "adaptive_mae_gate_label_segment_age_mode"
-    ]
-    adaptive_rmse_gate = delta_scope["models"][
-        "adaptive_rmse_gate_label_segment_age_mode"
-    ]
-    boundary_conditioned_weighted = delta_scope["models"][
-        "risk_weighted_boundary_conditioned_mode"
-    ]
+    boundary_conditioned = delta_scope["models"]["boundary_conditioned_label_segment_age_mode"]
+    adaptive_mae_gate = delta_scope["models"]["adaptive_mae_gate_label_segment_age_mode"]
+    adaptive_rmse_gate = delta_scope["models"]["adaptive_rmse_gate_label_segment_age_mode"]
+    boundary_conditioned_weighted = delta_scope["models"]["risk_weighted_boundary_conditioned_mode"]
     assert label_segment_age_mode["mae"] == 0.0
     assert label_segment_age_mode["rmse"] == 0.0
     assert label_segment_age_mode["mae"] < previous_delta["mae"]
@@ -376,9 +362,7 @@ def test_boundary_walk_forward_risk_learns_segment_age_pattern() -> None:
     assert boundary_conditioned["mae"] >= boundary_conditioned_weighted["mae"]
     assert adaptive_mae_gate["mae"] == 0.0
     assert adaptive_rmse_gate["rmse"] == 0.0
-    delta_diagnostics = delta_scope["prediction_detail_diagnostics"][
-        "label_segment_age_mode"
-    ]
+    delta_diagnostics = delta_scope["prediction_detail_diagnostics"]["label_segment_age_mode"]
     assert delta_diagnostics["matched_state_share"] == 1.0
     assert delta_diagnostics["top_signatures"][0]["signature"] == (
         "previous_label,previous_segment_position_bucket"
@@ -387,9 +371,9 @@ def test_boundary_walk_forward_risk_learns_segment_age_pattern() -> None:
         "boundary_conditioned_label_segment_age_mode"
     ]
     assert boundary_conditioned_diagnostics["matched_state_share"] > 0.0
-    ambiguity = summary["walk_forward_prediction"]["state_ambiguity"]["scopes"][
-        "all_after_10"
-    ]["signatures"]
+    ambiguity = summary["walk_forward_prediction"]["state_ambiguity"]["scopes"]["all_after_10"][
+        "signatures"
+    ]
     assert ambiguity["previous_delta"]["ambiguous_group_count"] == 1
     assert ambiguity["previous_delta"]["ambiguous_row_share"] > 0.0
     assert ambiguity["history_state"]["ambiguous_group_count"] == 0
@@ -430,26 +414,19 @@ def test_boundary_delta_risk_gate_keeps_previous_delta_for_stable_regime() -> No
     label_segment_age_mode = delta_scope["models"]["label_segment_age_mode"]
     gated = delta_scope["models"]["risk_gated_label_segment_age_mode"]
     weighted = delta_scope["models"]["risk_weighted_label_segment_age_mode"]
-    adaptive_mae_gate = delta_scope["models"][
-        "adaptive_mae_gate_label_segment_age_mode"
-    ]
+    adaptive_mae_gate = delta_scope["models"]["adaptive_mae_gate_label_segment_age_mode"]
     assert gated["mae"] == previous_delta["mae"]
     assert gated["mae"] < label_segment_age_mode["mae"]
     assert weighted["mae"] <= label_segment_age_mode["mae"]
     assert adaptive_mae_gate["mae"] == previous_delta["mae"]
-    gate_diagnostics = delta_scope["risk_gate_diagnostics"][
-        "risk_gated_label_segment_age_mode"
-    ]
+    gate_diagnostics = delta_scope["risk_gate_diagnostics"]["risk_gated_label_segment_age_mode"]
     assert gate_diagnostics["override_share"] == 0.0
     assert gate_diagnostics["source_counts"][0]["source"] == "risk_gate_previous_delta"
     adaptive_diagnostics = delta_scope["risk_gate_diagnostics"][
         "adaptive_mae_gate_label_segment_age_mode"
     ]
     assert adaptive_diagnostics["override_share"] == 0.0
-    assert (
-        adaptive_diagnostics["source_counts"][0]["source"]
-        == "adaptive_risk_gate_previous_delta"
-    )
+    assert adaptive_diagnostics["source_counts"][0]["source"] == "adaptive_risk_gate_previous_delta"
     previous_delta_residuals = delta_scope["residual_diagnostics"]["previous_delta"]
     boundary_errors = previous_delta_residuals["top_error_groups"]["boundary_state"]
     assert boundary_errors[0]["boundary_state"] == "same_label"
@@ -477,9 +454,7 @@ def test_empirical_state_bucket_predictor_learns_prior_transitions() -> None:
     walk_forward = summary["walk_forward_prediction"]["scopes"]["all_after_10"]
     previous = walk_forward["models"]["previous_delta"]
     empirical = walk_forward["models"]["empirical_history_state_mode"]
-    adaptive_gate = walk_forward["models"][
-        "adaptive_mae_transition_gate_history_state_mode"
-    ]
+    adaptive_gate = walk_forward["models"]["adaptive_mae_transition_gate_history_state_mode"]
     assert empirical["mae"] < previous["mae"]
     assert adaptive_gate["mae"] == empirical["mae"]
     assert adaptive_gate["r2"] == empirical["r2"]
@@ -490,9 +465,9 @@ def test_empirical_state_bucket_predictor_learns_prior_transitions() -> None:
         > 0.0
     )
     assert "empirical_calendar_state_mode" in walk_forward["models"]
-    transition = summary["walk_forward_prediction"]["transition_risk"]["scopes"][
-        "all_after_10"
-    ]["non_one_percent_delta"]
+    transition = summary["walk_forward_prediction"]["transition_risk"]["scopes"]["all_after_10"][
+        "non_one_percent_delta"
+    ]
     assert transition["positive_rate"] > 0.0
     assert (
         transition["models"]["history_state_risk"]["brier"]
@@ -549,23 +524,11 @@ def test_allowance_breakpoint_analysis_detects_capacity_denominator_change() -> 
         piecewise["global_no_intercept_credit_slope"]["metrics"]["r2"]
         == analysis["global_credit_to_delta_fit"]["metrics"]["r2"]
     )
-    assert (
-        piecewise["piecewise_mean_capacity_denominator"]["metrics"]["r2"]
-        == 1.0
-    )
-    assert (
-        piecewise["piecewise_ceiling_mean_capacity_denominator"]["metrics"]["r2"]
-        == 1.0
-    )
-    assert (
-        piecewise["piecewise_leave_one_out_capacity_denominator"]["metrics"]["r2"]
-        == 1.0
-    )
+    assert piecewise["piecewise_mean_capacity_denominator"]["metrics"]["r2"] == 1.0
+    assert piecewise["piecewise_ceiling_mean_capacity_denominator"]["metrics"]["r2"] == 1.0
+    assert piecewise["piecewise_leave_one_out_capacity_denominator"]["metrics"]["r2"] == 1.0
     assert piecewise["piecewise_no_intercept_credit_slope"]["metrics"]["r2"] == 1.0
-    assert (
-        piecewise["piecewise_ceiling_no_intercept_credit_slope"]["metrics"]["r2"]
-        == 1.0
-    )
+    assert piecewise["piecewise_ceiling_no_intercept_credit_slope"]["metrics"]["r2"] == 1.0
     online = analysis["online_capacity_credit_to_delta_fit"]
     assert online["prediction_rows"] == 59
     previous = online["models"]["previous_capacity_denominator"]
@@ -625,9 +588,7 @@ def test_token_component_regression_recovers_rate_card_and_fast_weighting() -> N
     summary = summarize_usage_drain_model(rows, fast_proxy_annotations=proxies)
 
     regression = summary["token_component_regression"]
-    unweighted = regression["variants"]["unweighted"]["credit_accounting"][
-        "no_intercept"
-    ]["all"]
+    unweighted = regression["variants"]["unweighted"]["credit_accounting"]["no_intercept"]["all"]
     weighted = regression["variants"]["high_medium_fast_weighted"]["credit_accounting"][
         "no_intercept"
     ]["all"]
@@ -651,9 +612,7 @@ def _component_credits(
     nonreasoning: int,
 ) -> float:
     return (
-        (uncached * 125.0)
-        + (cached * 12.5)
-        + ((reasoning + nonreasoning) * 750.0)
+        (uncached * 125.0) + (cached * 12.5) + ((reasoning + nonreasoning) * 750.0)
     ) / 1_000_000.0
 
 
@@ -771,16 +730,13 @@ def test_predictive_models_compare_control_families_on_holdout() -> None:
     assert by_name["time_controls__interleaved_every_5th"]["holdout"]["mae"] < 0.2
 
     summary = summarize_usage_drain_model(raw_rows)
-    attribution = summary["predictive_modeling"]["feature_family_attribution"][
-        "sequences"
-    ]
+    attribution = summary["predictive_modeling"]["feature_family_attribution"]["sequences"]
     rows = attribution["cost_and_time_controls"]["interleaved_every_5th"]
     by_family = {row["family"]: row for row in rows}
     assert "cyclic time" in by_family
     assert by_family["cyclic time"]["mae_improvement_vs_previous"] > 0.0
     assert "history/regime" in {
-        row["family"]
-        for row in attribution["history_regime_controls"]["interleaved_every_5th"]
+        row["family"] for row in attribution["history_regime_controls"]["interleaved_every_5th"]
     }
 
 
@@ -812,9 +768,7 @@ def test_causal_baselines_capture_low_delta_regime_shift() -> None:
     persistence = by_name["persistence_previous_delta__time_ordered_80_20"]["holdout"]
     rolling_mode = by_name["rolling10_mode_delta__time_ordered_80_20"]["holdout"]
     hybrid = by_name["hybrid_streak_regime__time_ordered_80_20"]["holdout"]
-    same_bucket_mode = by_name[
-        "same_bucket_rolling10_mode_delta__time_ordered_80_20"
-    ]["holdout"]
+    same_bucket_mode = by_name["same_bucket_rolling10_mode_delta__time_ordered_80_20"]["holdout"]
     train_mean = by_name["baseline_train_mean__time_ordered_80_20"]["holdout"]
     assert persistence["mae"] == 0.0
     assert rolling_mode["mae"] == 0.0

--- a/tests/usage_drain/test_usage_drain_one_percent_capacity.py
+++ b/tests/usage_drain/test_usage_drain_one_percent_capacity.py
@@ -80,10 +80,7 @@ def test_one_percent_capacity_modeling_reports_tick_capacity_models() -> None:
     assert "capacity_history_state_interactions_ridge100__time_ordered_80_20" in model_names
     assert "capacity_same_span_shape_buckets__time_ordered_80_20" in model_names
     assert "capacity_same_span_shape_interactions__time_ordered_80_20" in model_names
-    assert (
-        "capacity_same_span_shape_interactions_ridge30__time_ordered_80_20"
-        in model_names
-    )
+    assert "capacity_same_span_shape_interactions_ridge30__time_ordered_80_20" in model_names
     shape_bucket_model = next(
         model
         for model in capacity["models"]
@@ -91,14 +88,11 @@ def test_one_percent_capacity_modeling_reports_tick_capacity_models() -> None:
     )
     assert "row_count_bucket" in shape_bucket_model["categorical_features"]
     assert "span_wall_time_bucket" in shape_bucket_model["categorical_features"]
-    assert "row_count_x_call_duration_bucket" in shape_bucket_model[
-        "categorical_features"
-    ]
+    assert "row_count_x_call_duration_bucket" in shape_bucket_model["categorical_features"]
     ridge_model = next(
         model
         for model in capacity["models"]
-        if model["name"]
-        == "capacity_same_span_shape_interactions_ridge30__time_ordered_80_20"
+        if model["name"] == "capacity_same_span_shape_interactions_ridge30__time_ordered_80_20"
     )
     assert ridge_model["ridge_alpha"] == 30.0
     diagnostics = ridge_model["holdout_error_diagnostics"]

--- a/tests/usage_drain/test_usage_drain_reports.py
+++ b/tests/usage_drain/test_usage_drain_reports.py
@@ -63,11 +63,21 @@ def test_weekly_projection_uses_high_water_usage_deltas(tmp_path: Path) -> None:
     db_path = tmp_path / "usage.sqlite3"
     pricing_path = _write_pricing(tmp_path / "pricing.json")
     events = [
-        _event("base", "thread:Alpha", "2026-06-01T00:00:00Z", 100, 0.0, secondary_used_percent=0.0),
-        _event("up-1", "thread:Alpha", "2026-06-01T00:01:00Z", 220, 1.0, secondary_used_percent=1.0),
-        _event("down", "thread:Alpha", "2026-06-01T00:02:00Z", 340, 0.0, secondary_used_percent=0.0),
-        _event("repeat", "thread:Alpha", "2026-06-01T00:03:00Z", 460, 1.0, secondary_used_percent=1.0),
-        _event("up-2", "thread:Alpha", "2026-06-01T00:04:00Z", 580, 2.0, secondary_used_percent=2.0),
+        _event(
+            "base", "thread:Alpha", "2026-06-01T00:00:00Z", 100, 0.0, secondary_used_percent=0.0
+        ),
+        _event(
+            "up-1", "thread:Alpha", "2026-06-01T00:01:00Z", 220, 1.0, secondary_used_percent=1.0
+        ),
+        _event(
+            "down", "thread:Alpha", "2026-06-01T00:02:00Z", 340, 0.0, secondary_used_percent=0.0
+        ),
+        _event(
+            "repeat", "thread:Alpha", "2026-06-01T00:03:00Z", 460, 1.0, secondary_used_percent=1.0
+        ),
+        _event(
+            "up-2", "thread:Alpha", "2026-06-01T00:04:00Z", 580, 2.0, secondary_used_percent=2.0
+        ),
     ]
     upsert_usage_events(events, db_path=db_path)
 
@@ -96,7 +106,9 @@ def test_weekly_time_series_ignores_stale_reset_window_snapshots(tmp_path: Path)
             50.0,
             secondary_used_percent=90.0,
         ),
-        _event("base", "thread:Alpha", "2026-06-01T00:00:00Z", 220, 0.0, secondary_used_percent=0.0),
+        _event(
+            "base", "thread:Alpha", "2026-06-01T00:00:00Z", 220, 0.0, secondary_used_percent=0.0
+        ),
         _event("up", "thread:Alpha", "2026-06-01T00:01:00Z", 340, 1.0, secondary_used_percent=1.0),
     ]
     upsert_usage_events(events, db_path=db_path)

--- a/tests/usage_drain/test_usage_drain_token_components.py
+++ b/tests/usage_drain/test_usage_drain_token_components.py
@@ -39,7 +39,4 @@ def test_token_component_summary_reports_weighted_proxy_metadata() -> None:
     assert weighted["weighted_proxy"] == "high_medium_candidates"
     assert weighted["candidate_rows"] == 2
     assert weighted["candidate_spans"] == 1
-    assert (
-        weighted["credit_accounting"]["target"]
-        == "high_medium_fast_weighted_credits"
-    )
+    assert weighted["credit_accounting"]["target"] == "high_medium_fast_weighted_credits"

--- a/tests/usage_drain/test_usage_drain_walk_forward.py
+++ b/tests/usage_drain/test_usage_drain_walk_forward.py
@@ -55,7 +55,5 @@ def test_walk_forward_summary_preserves_scope_metric_contract() -> None:
     assert all_scope["actual"]["n"] == 3
     assert "previous_delta" in all_scope["models"]
     assert "previous_delta" in all_scope["error_diagnostics"]
-    assert "transition_gated_history_state_mode" in all_scope[
-        "transition_gate_diagnostics"
-    ]
+    assert "transition_gated_history_state_mode" in all_scope["transition_gate_diagnostics"]
     assert "empirical_history_state_mode" in all_scope["state_bucket_diagnostics"]


### PR DESCRIPTION
## Summary
- run `ruff format .` as a mechanical-only formatting pass
- clear the current `ruff-format` verifier blocker without behavior changes

## Validation
- `python -m ruff format --check .`
- `python -m ruff check .`
- `pytest -q --tb=short --disable-warnings -p no:tach --cov=src --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=json:/tmp/ruff-format-coverage.json --junitxml=/tmp/ruff-format-pytest-junit.xml --cov-fail-under=80 tests`
- `python3 scripts/check_release.py`
- `git diff --check`
- `python -m agent_maintainer guidance --check`
- `actionlint .github/workflows/*.yml`
- `gitleaks dir --no-banner --redact=100 --report-format json --report-path /tmp/gitleaks-format.json .`
- `npx markdownlint-cli2`
- `yamllint .github .yamllint` (existing warning-level issue-template line lengths only)
- `taplo fmt --check pyproject.toml tach.toml`
- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/ci.yml .github/workflows/pricing-compat.yml .github/workflows/publish.yml`

## Notes
This is intentionally large because it is the one mechanical Ruff-format pass called out in the hardening roadmap. No non-Python files were modified.