### PR TITLE
Fix GPT-5.6 pricing and credit compatibility

### DIFF
--- a/.github/workflows/pricing-compat.yml
+++ b/.github/workflows/pricing-compat.yml
@@ -25,19 +25,30 @@ jobs:
           from urllib.request import Request, urlopen
 
           from codex_usage_tracker.pricing import (
+              OPENAI_LATEST_MODEL_MD_URL,
               OPENAI_PRICING_MD_URL,
               VALID_PRICING_TIERS,
+              parse_openai_latest_model_id,
               parse_openai_pricing_markdown,
           )
 
-          request = Request(
-              OPENAI_PRICING_MD_URL,
-              headers={"User-Agent": "codex-usage-tracker-pricing-compat"},
-          )
-          with urlopen(request, timeout=20) as response:
-              markdown = response.read().decode("utf-8")
+          def fetch(url: str) -> str:
+              request = Request(
+                  url,
+                  headers={"User-Agent": "codex-usage-tracker-pricing-compat"},
+              )
+              with urlopen(request, timeout=20) as response:
+                  return response.read().decode("utf-8")
+
+          markdown = fetch(OPENAI_PRICING_MD_URL)
+          latest_model = parse_openai_latest_model_id(fetch(OPENAI_LATEST_MODEL_MD_URL))
 
           for tier in VALID_PRICING_TIERS:
               models = parse_openai_pricing_markdown(markdown, tier=tier)
               print(f"{tier}: parsed {len(models)} models")
+              if tier == "standard" and latest_model not in models:
+                  raise RuntimeError(
+                      f"latest model {latest_model!r} missing from parsed standard pricing"
+                  )
+          print(f"latest model: {latest_model}")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add GPT-5.6 Sol, Terra, and Luna API pricing and Codex credit-rate support, including the official `gpt-5.6` alias and compatibility with OpenAI's new cache-write pricing column.
+
 ## 0.17.1 - 2026-07-09
 
 - Stabilize async dogfood cache fingerprints so repeated unchanged MCP dogfood runs can reuse cached reports even when SQLite file metadata changes during read/report activity.

--- a/docs/pricing-and-credits.md
+++ b/docs/pricing-and-credits.md
@@ -16,6 +16,8 @@ codex-usage-tracker update-pricing
 
 This fetches OpenAI text-token pricing from `https://developers.openai.com/api/docs/pricing.md`, parses the selected tier, and writes a source-stamped local cache to `~/.codex-usage-tracker/pricing.json`. The default tier is `standard`; other supported tiers are `batch`, `flex`, and `priority`.
 
+The updater supports both the older four-value pricing rows and the newer five-value rows used by GPT-5.6 for input, cached input, cache writes, and output. GPT-5.6 Sol, Terra, and Luna are loaded from the published table, and the documented `gpt-5.6` alias resolves to `gpt-5.6-sol`. Current Codex logs do not expose a separate cache-write token counter, so cost estimates use the logged uncached input, cached input, and output counters without adding an explicit cache-write charge.
+
 If a pricing file already exists, the updater leaves a timestamped `.bak` copy next to it before replacing the active cache.
 
 The updater also includes marked best-guess estimates for Codex labels that are not finalized in the public pricing table. `codex-auto-review` uses OpenAI's published `codex-mini-latest` Codex pricing from `https://openai.com/index/introducing-codex/`: `$1.50` per 1M input tokens, a 75% prompt-cache discount (`$0.375` per 1M cached input tokens), and `$6.00` per 1M output tokens. `gpt-5.3-codex-spark` is listed by OpenAI as a research preview with non-final Codex rates, so the tracker estimates it as `gpt-5.3-codex` at `$1.75` per 1M input tokens, `$0.175` per 1M cached input tokens, and `$14.00` per 1M output tokens.
@@ -40,6 +42,8 @@ Edit `~/.codex-usage-tracker/pricing.json` with USD-per-million-token rates for 
 ## Codex Credits
 
 `Codex Credits` is a calculated usage number, not a dashboard-only unit. The tracker uses Codex's logged aggregate token counters and the bundled OpenAI Codex rate-card snapshot to estimate credits consumed by local Codex calls.
+
+The bundled rate card includes the published GPT-5.6 Sol, Terra, and Luna credit rates from the current Codex pricing documentation.
 
 The estimate uses:
 

--- a/docs/usage-drain-modeling.md
+++ b/docs/usage-drain-modeling.md
@@ -23,7 +23,7 @@ Sources:
 
 - [Codex Speed](https://developers.openai.com/codex/speed)
 - [Codex Pricing](https://developers.openai.com/codex/pricing)
-- [Codex rate card](https://help.openai.com/en/articles/20001106-codex-rate-card)
+- [Codex pricing and rate card](https://developers.openai.com/codex/pricing)
 - [Codex app-server](https://developers.openai.com/codex/app-server)
 - [Codex configuration reference](https://developers.openai.com/codex/config-reference)
 

--- a/src/codex_usage_tracker/plugin_data/rate_cards/codex-credit-rates.json
+++ b/src/codex_usage_tracker/plugin_data/rate_cards/codex-credit-rates.json
@@ -1,22 +1,49 @@
 {
   "schema": "codex-usage-tracker-codex-rate-card-v1",
-  "version": "2026-06-03",
+  "version": "2026-07-09",
   "source": {
-    "name": "OpenAI Codex rate card",
-    "url": "https://help.openai.com/en/articles/20001106-codex-rate-card",
+    "name": "OpenAI Codex pricing docs",
+    "url": "https://developers.openai.com/codex/pricing",
     "pricing_url": "https://developers.openai.com/codex/pricing",
-    "fetched_at": "2026-06-03",
+    "fetched_at": "2026-07-09",
     "basis": "credits per 1M input, cached input, and output tokens",
     "tier": "standard"
   },
   "credit_rates": {
+    "gpt-5.6-sol": {
+      "input_per_million": 250.0,
+      "cached_input_per_million": 25.0,
+      "output_per_million": 1500.0,
+      "confidence": "exact",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
+      "tier": "standard"
+    },
+    "gpt-5.6-terra": {
+      "input_per_million": 125.0,
+      "cached_input_per_million": 12.5,
+      "output_per_million": 125.0,
+      "confidence": "exact",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
+      "tier": "standard"
+    },
+    "gpt-5.6-luna": {
+      "input_per_million": 50.0,
+      "cached_input_per_million": 5.0,
+      "output_per_million": 300.0,
+      "confidence": "exact",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
+      "tier": "standard"
+    },
     "gpt-5.5": {
       "input_per_million": 125.0,
       "cached_input_per_million": 12.5,
       "output_per_million": 750.0,
       "confidence": "exact",
-      "source_url": "https://help.openai.com/en/articles/20001106-codex-rate-card",
-      "fetched_at": "2026-06-03",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
       "tier": "standard"
     },
     "gpt-5.4": {
@@ -24,8 +51,8 @@
       "cached_input_per_million": 6.25,
       "output_per_million": 375.0,
       "confidence": "exact",
-      "source_url": "https://help.openai.com/en/articles/20001106-codex-rate-card",
-      "fetched_at": "2026-06-03",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
       "tier": "standard"
     },
     "gpt-5.4-mini": {
@@ -33,8 +60,8 @@
       "cached_input_per_million": 1.875,
       "output_per_million": 113.0,
       "confidence": "exact",
-      "source_url": "https://help.openai.com/en/articles/20001106-codex-rate-card",
-      "fetched_at": "2026-06-03",
+      "source_url": "https://developers.openai.com/codex/pricing",
+      "fetched_at": "2026-07-09",
       "tier": "standard"
     },
     "gpt-5.3-codex": {
@@ -57,6 +84,14 @@
     }
   },
   "aliases": {
+    "gpt-5.6": {
+      "model": "gpt-5.6-sol",
+      "confidence": "exact",
+      "note": "OpenAI documents gpt-5.6 as an alias for gpt-5.6-sol.",
+      "source_url": "https://developers.openai.com/api/docs/guides/latest-model",
+      "fetched_at": "2026-07-09",
+      "alias_reason": "The official latest-model guide states that gpt-5.6 routes to gpt-5.6-sol."
+    },
     "codex-auto-review": {
       "model": "gpt-5.3-codex",
       "confidence": "estimated",

--- a/src/codex_usage_tracker/plugin_data/rate_cards/codex-credit-rates.json
+++ b/src/codex_usage_tracker/plugin_data/rate_cards/codex-credit-rates.json
@@ -2,7 +2,7 @@
   "schema": "codex-usage-tracker-codex-rate-card-v1",
   "version": "2026-07-09",
   "source": {
-    "name": "OpenAI Codex pricing docs",
+    "name": "OpenAI Codex rate card",
     "url": "https://developers.openai.com/codex/pricing",
     "pricing_url": "https://developers.openai.com/codex/pricing",
     "fetched_at": "2026-07-09",

--- a/src/codex_usage_tracker/pricing/allowance_rate_card.py
+++ b/src/codex_usage_tracker/pricing/allowance_rate_card.py
@@ -14,15 +14,14 @@ from codex_usage_tracker.core.paths import DEFAULT_RATE_CARD_PATH
 
 RATE_CARD_SCHEMA = "codex-usage-tracker-codex-rate-card-v1"
 
-CODEX_RATE_CARD_URL = "https://help.openai.com/en/articles/20001106-codex-rate-card"
-
 CODEX_PRICING_URL = "https://developers.openai.com/codex/pricing"
+CODEX_RATE_CARD_URL = CODEX_PRICING_URL
 
 DEFAULT_SOURCE = {
     "name": "OpenAI Codex rate card",
     "url": CODEX_RATE_CARD_URL,
     "pricing_url": CODEX_PRICING_URL,
-    "fetched_at": "2026-06-03",
+    "fetched_at": "2026-07-09",
     "basis": "credits per 1M input, cached input, and output tokens",
     "tier": "standard",
 }

--- a/src/codex_usage_tracker/pricing/api.py
+++ b/src/codex_usage_tracker/pricing/api.py
@@ -24,10 +24,12 @@ from codex_usage_tracker.pricing.estimates import (
     OPENAI_GPT_53_CODEX_MODEL_URL,
 )
 from codex_usage_tracker.pricing.openai import (
+    OPENAI_LATEST_MODEL_MD_URL,
     OPENAI_PRICING_MD_URL,
     VALID_PRICING_TIERS,
     PricingParseError,
     PricingUpdateResult,
+    parse_openai_latest_model_id,
     parse_openai_pricing_markdown,
     update_pricing_from_openai_docs,
 )
@@ -37,6 +39,7 @@ __all__ = [
     "OPENAI_CODEX_LAUNCH_URL",
     "OPENAI_CODEX_RATE_CARD_URL",
     "OPENAI_GPT_53_CODEX_MODEL_URL",
+    "OPENAI_LATEST_MODEL_MD_URL",
     "OPENAI_PRICING_MD_URL",
     "PRICING_SCHEMA",
     "PRICING_TEMPLATE",
@@ -49,6 +52,7 @@ __all__ = [
     "estimate_cache_savings_usd",
     "estimate_cost_usd",
     "load_pricing_config",
+    "parse_openai_latest_model_id",
     "parse_openai_pricing_markdown",
     "pin_pricing_snapshot",
     "summarize_pricing_coverage",

--- a/src/codex_usage_tracker/pricing/openai.py
+++ b/src/codex_usage_tracker/pricing/openai.py
@@ -19,7 +19,12 @@ from codex_usage_tracker.pricing.config import PRICING_SCHEMA, load_existing_ali
 from codex_usage_tracker.pricing.estimates import ESTIMATED_MODEL_PRICES, estimated_model_prices
 
 OPENAI_PRICING_MD_URL = "https://developers.openai.com/api/docs/pricing.md"
+OPENAI_LATEST_MODEL_MD_URL = "https://developers.openai.com/api/docs/guides/latest-model.md"
 VALID_PRICING_TIERS = ("standard", "batch", "flex", "priority")
+
+_OFFICIAL_PRICING_ALIASES = {
+    "gpt-5.6": "gpt-5.6-sol",
+}
 
 
 class PricingParseError(ValueError):
@@ -64,7 +69,12 @@ def update_pricing_from_openai_docs(
     models: dict[str, dict[str, Any]] = {
         model: dict(rates) for model, rates in parsed_models.items()
     }
-    aliases = load_existing_aliases(path)
+    aliases = {
+        **{
+            alias: target for alias, target in _OFFICIAL_PRICING_ALIASES.items() if target in models
+        },
+        **load_existing_aliases(path),
+    }
     estimated_model_count = 0
     if include_estimates:
         models.update(estimated_model_prices())
@@ -135,14 +145,31 @@ def parse_openai_pricing_markdown(
     return models
 
 
+def parse_openai_latest_model_id(markdown: str) -> str:
+    """Return the canonical latest model ID from OpenAI's model guide front matter."""
+
+    match = _OPENAI_LATEST_MODEL_RE.search(markdown)
+    if match is None:
+        raise PricingParseError(
+            "latest-model source schema changed: could not find latestModelInfo.model"
+        )
+    return match.group("model")
+
+
 _OPENAI_PRICE_ROW_RE = re.compile(
     r"""\[
         \s*"(?P<model>[^"]+)"\s*,
         \s*(?P<input>[^,\]\n]+)\s*,
         \s*(?P<cached>[^,\]\n]+)\s*,
+        (?:\s*(?P<cache_write>[^,\]\n]+)\s*,)?
         \s*(?P<output>[^,\]\n]+)\s*
     \]""",
     re.VERBOSE,
+)
+
+_OPENAI_LATEST_MODEL_RE = re.compile(
+    r"^latestModelInfo:\s*$.*?^[ \t]+model:\s*(?P<model>[A-Za-z0-9._-]+)\s*$",
+    re.MULTILINE | re.DOTALL,
 )
 
 

--- a/tests/dashboard/test_dashboard_server.py
+++ b/tests/dashboard/test_dashboard_server.py
@@ -501,7 +501,7 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
     )
     assert limited_payload["pricing_configured"] is True
     assert limited_payload["allowance_configured"] is False
-    assert limited_payload["allowance_source"]["name"] == "OpenAI Codex pricing docs"
+    assert limited_payload["allowance_source"]["name"] == "OpenAI Codex rate card"
     assert limited_payload["rows"][0]["usage_credits"] is not None
     assert "refreshed_at" in limited_payload
     assert limited_payload["parser_diagnostics"] == {}

--- a/tests/dashboard/test_dashboard_server.py
+++ b/tests/dashboard/test_dashboard_server.py
@@ -501,7 +501,7 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
     )
     assert limited_payload["pricing_configured"] is True
     assert limited_payload["allowance_configured"] is False
-    assert limited_payload["allowance_source"]["name"] == "OpenAI Codex rate card"
+    assert limited_payload["allowance_source"]["name"] == "OpenAI Codex pricing docs"
     assert limited_payload["rows"][0]["usage_credits"] is not None
     assert "refreshed_at" in limited_payload
     assert limited_payload["parser_diagnostics"] == {}

--- a/tests/pricing/test_allowance.py
+++ b/tests/pricing/test_allowance.py
@@ -29,13 +29,33 @@ def test_allowance_estimates_exact_codex_credit_usage() -> None:
 
     assert rows[0]["usage_credit_model"] == "gpt-5.5"
     assert rows[0]["usage_credit_confidence"] == "exact"
-    assert (
-        rows[0]["usage_credit_source_url"]
-        == "https://help.openai.com/en/articles/20001106-codex-rate-card"
-    )
-    assert rows[0]["usage_credit_fetched_at"] == "2026-06-03"
+    assert rows[0]["usage_credit_source_url"] == "https://developers.openai.com/codex/pricing"
+    assert rows[0]["usage_credit_fetched_at"] == "2026-07-09"
     assert rows[0]["usage_credit_tier"] == "standard"
     assert rows[0]["usage_credits"] == 0.1775
+
+
+def test_allowance_estimates_gpt_5_6_direct_and_alias_credit_usage() -> None:
+    rows = annotate_rows_with_allowance(
+        [
+            {
+                "model": model,
+                "input_tokens": 1000,
+                "cached_input_tokens": 200,
+                "uncached_input_tokens": 800,
+                "output_tokens": 100,
+                "total_tokens": 1100,
+            }
+            for model in ("gpt-5.6-sol", "gpt-5.6")
+        ]
+    )
+
+    assert [row["usage_credit_model"] for row in rows] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-sol",
+    ]
+    assert [row["usage_credit_confidence"] for row in rows] == ["exact", "exact"]
+    assert [row["usage_credits"] for row in rows] == [0.355, 0.355]
 
 
 def test_allowance_marks_inferred_auto_review_mapping() -> None:
@@ -196,11 +216,14 @@ def test_update_rate_card_writes_bundled_snapshot(tmp_path: Path) -> None:
     raw = json.loads(path.read_text(encoding="utf-8"))
     config = load_allowance_config(tmp_path / "missing-allowance.json", rate_card_path=path)
 
-    assert result.model_count == 5
-    assert result.alias_count == 1
+    assert result.model_count == 8
+    assert result.alias_count == 2
     assert raw["schema"] == "codex-usage-tracker-codex-rate-card-v1"
     assert config.rate_card_loaded is True
-    assert config.source["fetched_at"] == "2026-06-03"
+    assert config.source["fetched_at"] == "2026-07-09"
+    assert config.credit_rates["gpt-5.6-sol"]["output_per_million"] == 1500.0
+    assert config.credit_rates["gpt-5.6-terra"]["output_per_million"] == 125.0
+    assert config.credit_rates["gpt-5.6-luna"]["output_per_million"] == 300.0
 
 
 def test_write_allowance_template_refuses_to_overwrite(tmp_path: Path) -> None:

--- a/tests/pricing/test_pricing.py
+++ b/tests/pricing/test_pricing.py
@@ -5,12 +5,14 @@ from pathlib import Path
 
 from codex_usage_tracker.pricing.api import (
     ESTIMATED_MODEL_PRICES,
+    OPENAI_LATEST_MODEL_MD_URL,
     OPENAI_PRICING_MD_URL,
     PRICING_SCHEMA,
     PricingParseError,
     annotate_rows_with_efficiency,
     efficiency_flags,
     load_pricing_config,
+    parse_openai_latest_model_id,
     parse_openai_pricing_markdown,
     summarize_pricing_coverage,
     update_pricing_from_openai_docs,
@@ -21,6 +23,9 @@ OPENAI_PRICING_FIXTURE = """
   client:load
   tier="standard"
   rows={[
+    ["gpt-5.6-sol", 5, 0.5, 6.25, 30],
+    ["gpt-5.6-terra", 2.5, 0.25, 3.125, 15],
+    ["gpt-5.6-luna", 1, 0.1, 1.25, 6],
     ["gpt-5.5 (<272K context length)", 5, 0.5, 30],
     ["gpt-5.4-mini", 0.75, 0.075, 4.5],
     ["gpt-5-pro", 15, null, 120],
@@ -35,10 +40,24 @@ OPENAI_PRICING_FIXTURE = """
 />
 """
 
+OPENAI_LATEST_MODEL_FIXTURE = """---
+latestModelInfo:
+  model: gpt-5.6-sol
+  migrationGuide: /api/docs/guides/upgrading-to-gpt-5p6-sol.md
+---
+"""
+
 
 def test_parse_openai_pricing_markdown_for_selected_tier() -> None:
     models = parse_openai_pricing_markdown(OPENAI_PRICING_FIXTURE, tier="standard")
 
+    assert models["gpt-5.6-sol"] == {
+        "input_per_million": 5.0,
+        "cached_input_per_million": 0.5,
+        "output_per_million": 30.0,
+    }
+    assert models["gpt-5.6-terra"]["output_per_million"] == 15
+    assert models["gpt-5.6-luna"]["output_per_million"] == 6
     assert models["gpt-5.5"]["input_per_million"] == 5
     assert models["gpt-5.5"]["cached_input_per_million"] == 0.5
     assert models["gpt-5.5"]["output_per_million"] == 30
@@ -56,6 +75,20 @@ def test_parse_openai_pricing_markdown_uses_requested_tier() -> None:
             "output_per_million": 15.0,
         }
     }
+
+
+def test_parse_openai_latest_model_id_reads_front_matter() -> None:
+    assert parse_openai_latest_model_id(OPENAI_LATEST_MODEL_FIXTURE) == "gpt-5.6-sol"
+    assert OPENAI_LATEST_MODEL_MD_URL.endswith("/latest-model.md")
+
+
+def test_parse_openai_latest_model_id_reports_schema_changes() -> None:
+    try:
+        parse_openai_latest_model_id("# Latest model\n")
+    except PricingParseError as exc:
+        assert "latestModelInfo.model" in str(exc)
+    else:
+        raise AssertionError("expected PricingParseError")
 
 
 def test_parse_openai_pricing_markdown_reports_schema_changes() -> None:
@@ -93,18 +126,21 @@ def test_update_pricing_from_openai_docs_writes_source_metadata(tmp_path: Path) 
     raw = json.loads(pricing_path.read_text(encoding="utf-8"))
     config = load_pricing_config(pricing_path)
 
-    assert result.model_count == 5
+    assert result.model_count == 8
     assert result.estimated_model_count == 2
     assert result.source_url == OPENAI_PRICING_MD_URL
     assert raw["_schema"] == PRICING_SCHEMA
     assert raw["_source"]["url"] == OPENAI_PRICING_MD_URL
     assert raw["_source"]["tier"] == "standard"
     assert raw["_source"]["estimated_model_count"] == 2
+    assert raw["aliases"]["gpt-5.6"] == "gpt-5.6-sol"
     assert raw["models"]["codex-auto-review"] == ESTIMATED_MODEL_PRICES["codex-auto-review"]
     assert raw["models"]["gpt-5.3-codex-spark"] == ESTIMATED_MODEL_PRICES["gpt-5.3-codex-spark"]
     assert config.loaded
     assert config.source and config.source["name"] == "OpenAI Developers pricing docs"
     assert config.models["gpt-5.5"]["output_per_million"] == 30
+    assert config.rates_for("gpt-5.6") == config.models["gpt-5.6-sol"]
+    assert config.priced_as("gpt-5.6") == "gpt-5.6-sol"
     assert config.models["codex-auto-review"]["input_per_million"] == 1.5
     assert config.is_estimated_model("codex-auto-review")
     assert config.models["gpt-5.3-codex-spark"]["input_per_million"] == 1.75
@@ -121,7 +157,7 @@ def test_update_pricing_from_openai_docs_can_skip_estimates(tmp_path: Path) -> N
     )
     raw = json.loads(pricing_path.read_text(encoding="utf-8"))
 
-    assert result.model_count == 3
+    assert result.model_count == 6
     assert result.estimated_model_count == 0
     assert "codex-auto-review" not in raw["models"]
     assert "gpt-5.3-codex-spark" not in raw["models"]


### PR DESCRIPTION
## What changed

- Parse OpenAI pricing rows with the new cache-write column while retaining compatibility with legacy rows.
- Add API pricing and Codex credit rates for GPT-5.6 Sol, Terra, and Luna, plus the official `gpt-5.6` alias.
- Make scheduled pricing compatibility checks verify that OpenAI's current latest model is actually parsed.
- Refresh pricing docs, source metadata, changelog, and regression coverage.

## Root cause

OpenAI's GPT-5.6 pricing rows contain five values instead of the four-value shape the parser expected. The old parser continued parsing older rows, so the scheduled check stayed green while silently skipping every GPT-5.6 entry.

## Validation

- `616 passed` in the full Python test suite
- Live official pricing probe parsed Sol, Terra, and Luna in standard, batch, flex, and priority tiers
- CLI `update-pricing` and `update-rate-card` smoke checks
- Ruff, Pyright, markdownlint, yamllint, actionlint, workflow schema validation
- Package build, Twine check, and `scripts/check_release.py --dist`
