### PR TITLE
ci: maintain a clean Pyright surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   hardening:
     name: Hardening gates
     runs-on: ubuntu-latest
+    env:
+      AGENT_MAINTAINER_REV: 3267894ce8cb5259b16ebfb06f6a6edc0f3ea9c1
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,6 +25,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
+          python -m pip install --force-reinstall --no-deps \
+            "agent-maintainer @ git+https://github.com/douglasmonsky/agent-maintainer.git@${AGENT_MAINTAINER_REV}"
           npm ci
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           go install github.com/zricethezav/gitleaks/v8@v8.30.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           python -m pyright \
             src/codex_usage_tracker/cli/main.py \
+            src/codex_usage_tracker/cli/inspect_log_output.py \
             src/codex_usage_tracker/context/reader.py
       - name: GitHub Actions lint
         run: actionlint .github/workflows/*.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           go install github.com/zricethezav/gitleaks/v8@v8.30.1
           cargo install taplo-cli --version 0.9.0 --locked
+      - name: Agent Maintainer guidance drift
+        run: python -m agent_maintainer guidance --check
+      - name: Maintained Pyright surface
+        run: |
+          python -m pyright \
+            src/codex_usage_tracker/cli/main.py \
+            src/codex_usage_tracker/context/reader.py
       - name: GitHub Actions lint
         run: actionlint .github/workflows/*.yml
       - name: Secret scan

--- a/docs/agent-maintainer-hardening-branch-roadmap.md
+++ b/docs/agent-maintainer-hardening-branch-roadmap.md
@@ -1,6 +1,6 @@
 # Agent Maintainer Hardening Branch Roadmap
 
-Branch: `refactor/secret-scan-hardening`
+Current chunk: `fix/pyright-maintained-surface`
 
 ## Goal
 

--- a/docs/agent-maintainer-hardening-branch-roadmap.md
+++ b/docs/agent-maintainer-hardening-branch-roadmap.md
@@ -4,49 +4,50 @@ Branch: `refactor/secret-scan-hardening`
 
 ## Goal
 
-Adopt the latest Agent Maintainer ratchet and a small set of low-noise hardening
-checks without mixing in broad Python refactors or large documentation cleanup.
+Adopt latest Agent Maintainer ratchets as low-noise maintained gates, without
+mixing in broad Python refactors or unrelated documentation cleanup.
 
 ## Completed Chunks
 
-- Upgrade generated Agent Maintainer guidance and add local `just` wrappers.
-- Add a latest-main ratchet baseline for existing file-length and structure debt.
+- Upgrade generated Agent Maintainer guidance and local `just` wrappers.
+- Add latest-main ratchet baseline for existing file-length structure debt.
 - Enable configured `gitleaks` secret scanning with allowlists for ignored local
   artifacts and intentional fake-secret fixtures.
 - Fix the publish workflow glob flagged by `actionlint`.
 - Format TOML configuration with Taplo.
 - Enable repo-configured `yamllint`.
-- Add a repo-specific Markdown lint config and enable the gate with historical
+- Add repo-specific Markdown lint config and enable the gate with historical
   prose/layout rules disabled.
 - Add CI hardening job for `actionlint`, `gitleaks`, `markdownlint`,
   `yamllint`, Taplo, and GitHub workflow schema validation.
 - Fix pytest verifier imports by including the repository root in pytest's
   Python path.
-- Run one mechanical `ruff format` PR to clear format gate without behavior
+- Run one mechanical `ruff format` PR to clear the format gate without behavior
   changes.
-- Enable Taplo as Agent Maintainer gate after formatting TOML configuration.
-- Enable GitHub workflow schema validation with explicit `check-jsonschema`
+- Enable Taplo Agent Maintainer gate for TOML configuration formatting.
+- Enable GitHub workflow schema validation through explicit `check-jsonschema`
   arguments.
-- Re-run focused validation for the enabled optional gates.
-- Add explicit root Tach module inventory and ADR so architecture checks report
-  real dependency violations instead missing configuration.
+- Re-run focused validation for enabled optional gates.
+- Add explicit root Tach module inventory ADR so architecture checks report real
+  dependency violations instead of missing configuration.
+- Add CI-maintained Agent Maintainer guidance drift and narrow Pyright gates for
+  the source surface already cleaned on this branch.
 
 ## Branch Exit
 
-This branch is ready for PR once the latest commit is pushed and CI confirms the
+The branch is ready for PR once the latest commit is pushed and CI confirms the
 same hardening gates remotely.
 
 ## Follow-Up PRs
 
-### 1. Stabilize The Existing Full Profile
+### 1. Stabilize Existing Full Profile
 
-First fix failures that prevent the full profile from being a useful signal.
-These are not product refactors; verifier hygiene should be kept in small
-mechanical PRs.
-
-- Fix narrow Pyright errors already surfaced in `cli/main.py` and
-  `context/reader.py`. These look like concrete typing issues, not broad strict
-  mode migration.
+The pytest collection/import blocker, mechanical formatting blocker, and first
+narrow source Pyright errors are cleared. The cleaned Pyright surface is now
+protected in CI. Remaining type backlog is broader and should be handled in
+focused typing PRs, not as a blanket strictness migration. Once the profile is
+fast and consistently green, replace the narrow CI Pyright command with the
+maintained Agent Maintainer profile.
 
 ### 2. Make Architecture And Dependency Checks Actionable
 
@@ -55,14 +56,14 @@ useful review feedback.
 
 - Fix actual `tach` boundary violations only after config is explicit.
 - Triage `deptry` into three buckets: real unused dependencies, intentionally
-  optional/runtime dependencies, packaging/test-only dependencies. Commit
+  optional/runtime dependencies, and packaging/test-only dependencies. Commit
   configuration only with a short explanation.
 - Triage `vulture` similarly: delete true dead code, preserve public/CLI/MCP
-  entry points with explicit allowlists, avoid broad suppressions.
+  entry points with explicit allowlists, and avoid broad suppressions.
 
 ### 3. Security Hardening Pass
 
-Once the codebase imports and architecture checks are stable, move to security
+Once codebase imports and architecture checks are stable, move to security
 findings.
 
 - Triage `bandit` findings. Start with medium SQL-construction warnings and URL
@@ -70,11 +71,11 @@ findings.
 - Keep `gitleaks` enabled as the current-tree secret gate. Consider a separate
   history-scan PR only after confirming no real credentials are present and
   deciding how to handle historical false positives.
-- Keep `pip-audit` disabled until the project has a pinned dependency input.
+- Keep `pip-audit` disabled until the project has pinned dependency input.
   Decide between a constraints file, lock export, or dedicated audit
   requirements file before enabling it.
-- Triage `zizmor` with a repo-specific config/invocation. Do not enable as
-  blocking until it audits local workflows without remote-fetch failures.
+- Triage `zizmor` repo-specific config/invocation. Do not enable it as blocking
+  until it audits local workflows without remote-fetch failures.
 
 ### 4. Ratchet Large Python Files Down
 
@@ -96,21 +97,23 @@ module boundary and keep behavior covered by focused tests.
 
 ### 5. Optional Strictness Later
 
-These are useful but should wait until the above gates stop producing basic
-noise.
+These checks are useful, but should wait until the gates above stop producing
+basic noise.
 
 - Tighten Markdown linting by re-enabling historical spacing/inline-HTML rules
   only in dedicated docs cleanup PRs.
-- Consider `wemake` only after file-length and complexity ratchets have reduced
-  the largest modules.
-- Consider `interrogate` only if public API/docstring policy becomes a real
-  product requirement.
-- Consider mutation testing as a manual/release gate after core tests and
-  complexity failures are under control.
+- Consider `wemake` only after file-length and complexity debt drops enough to
+  make failures actionable.
+- Consider `interrogate` only after deciding the project's public-docstring
+  policy.
+- Consider mutation testing only for narrow stable modules, not the full repo.
 
-## Validation
+## Validation Pattern
 
-- `python3 scripts/check_release.py`
-- `git diff --check`
-- `python -m agent_maintainer guidance --check`
-- Focused direct checks for each enabled optional gate.
+For each PR:
+
+1. Run the focused tool or test that proves the chunk.
+2. Run the relevant Agent Maintainer profile when it is stable for that chunk.
+3. Run `python scripts/check_release.py`.
+4. Run `git diff --check`.
+5. Push only the focused branch and let CI confirm the remote gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
   "pillow>=10",
   "pytest>=8.0",
   "pytest-cov>=5.0",
+  "pyright>=1.1.405",
   "ruff>=0.8",
   "tach>=0.35.0; python_version >= '3.11'",
   "tomli>=2.0; python_version < '3.11'",

--- a/src/codex_usage_tracker/cli/inspect_log_output.py
+++ b/src/codex_usage_tracker/cli/inspect_log_output.py
@@ -1,0 +1,28 @@
+"""Text rendering for the inspect-log command."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def print_inspect_log_summary(payload: Mapping[str, Any]) -> None:
+    """Print a human-readable summary while tolerating parser shape drift."""
+    print(f"Log: {payload['path']}")
+    print(f"Adapter: {payload['adapter']}")
+    print(f"File session id: {payload['file_session_id'] or 'unknown'}")
+    print(f"Parsed events: {payload['event_count']}")
+    _print_values("Sessions", payload.get("session_ids"))
+    _print_values("Models", payload.get("models"))
+
+    diagnostics = payload.get("diagnostics")
+    if isinstance(diagnostics, Mapping) and diagnostics:
+        values = ", ".join(f"{key}={value}" for key, value in diagnostics.items())
+        print(f"Diagnostics: {values}")
+    else:
+        print("Diagnostics: none")
+
+
+def _print_values(label: str, value: Any) -> None:
+    if isinstance(value, (list, tuple)) and value:
+        print(f"{label}: " + ", ".join(str(item) for item in value))

--- a/src/codex_usage_tracker/cli/main.py
+++ b/src/codex_usage_tracker/cli/main.py
@@ -283,19 +283,30 @@ def _run_inspect_log(args: argparse.Namespace) -> int:
     print(f"Adapter: {payload['adapter']}")
     print(f"File session id: {payload['file_session_id'] or 'unknown'}")
     print(f"Parsed events: {payload['event_count']}")
-    if payload["session_ids"]:
-        print("Sessions: " + ", ".join(str(value) for value in payload["session_ids"]))
-    if payload["models"]:
-        print("Models: " + ", ".join(str(value) for value in payload["models"]))
-    diagnostics = payload["diagnostics"]
+    session_ids = _string_values(payload.get("session_ids"))
+    if session_ids:
+        print("Sessions: " + ", ".join(session_ids))
+    models = _string_values(payload.get("models"))
+    if models:
+        print("Models: " + ", ".join(models))
+    diagnostics = _mapping_items(payload.get("diagnostics"))
     if diagnostics:
-        print(
-            "Diagnostics: "
-            + ", ".join(f"{key}={value}" for key, value in dict(diagnostics).items())
-        )
+        print("Diagnostics: " + ", ".join(f"{key}={value}" for key, value in diagnostics))
     else:
         print("Diagnostics: none")
     return 0
+
+
+def _string_values(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value]
+
+
+def _mapping_items(value: Any) -> list[tuple[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    return [(str(key), item) for key, item in value.items()]
 
 
 def _run_rebuild_index(args: argparse.Namespace) -> int:

--- a/src/codex_usage_tracker/cli/main.py
+++ b/src/codex_usage_tracker/cli/main.py
@@ -28,6 +28,7 @@ from codex_usage_tracker.cli.dashboard import (
     run_serve_dashboard,
 )
 from codex_usage_tracker.cli.diagnostics import run_diagnostics
+from codex_usage_tracker.cli.inspect_log_output import print_inspect_log_summary
 from codex_usage_tracker.cli.output import print_json
 from codex_usage_tracker.cli.parser import build_parser
 from codex_usage_tracker.cli.plugin_installer import install_plugin, uninstall_plugin
@@ -279,34 +280,8 @@ def _run_inspect_log(args: argparse.Namespace) -> int:
     if args.as_json:
         print(json.dumps(payload, indent=2))
         return 0
-    print(f"Log: {payload['path']}")
-    print(f"Adapter: {payload['adapter']}")
-    print(f"File session id: {payload['file_session_id'] or 'unknown'}")
-    print(f"Parsed events: {payload['event_count']}")
-    session_ids = _string_values(payload.get("session_ids"))
-    if session_ids:
-        print("Sessions: " + ", ".join(session_ids))
-    models = _string_values(payload.get("models"))
-    if models:
-        print("Models: " + ", ".join(models))
-    diagnostics = _mapping_items(payload.get("diagnostics"))
-    if diagnostics:
-        print("Diagnostics: " + ", ".join(f"{key}={value}" for key, value in diagnostics))
-    else:
-        print("Diagnostics: none")
+    print_inspect_log_summary(payload)
     return 0
-
-
-def _string_values(value: Any) -> list[str]:
-    if not isinstance(value, (list, tuple)):
-        return []
-    return [str(item) for item in value]
-
-
-def _mapping_items(value: Any) -> list[tuple[str, Any]]:
-    if not isinstance(value, dict):
-        return []
-    return [(str(key), item) for key, item in value.items()]
 
 
 def _run_rebuild_index(args: argparse.Namespace) -> int:

--- a/src/codex_usage_tracker/context/reader.py
+++ b/src/codex_usage_tracker/context/reader.py
@@ -214,7 +214,8 @@ def _scan_context_line(
 
 
 def _context_envelope_parts(envelope: dict[str, Any]) -> tuple[str, dict[str, Any], str | None]:
-    payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else {}
+    raw_payload = envelope.get("payload")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
     return (
         optional_str(envelope.get("type")) or "unknown",
         payload,

--- a/tests/cli/test_cli_inspect_log_output.py
+++ b/tests/cli/test_cli_inspect_log_output.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+
+cli_main = importlib.import_module("codex_usage_tracker.cli.main")
+
+
+def test_inspect_log_text_output_handles_shape_drift(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli_main, "load_session_index", lambda _codex_home: {})
+    monkeypatch.setattr(
+        cli_main,
+        "inspect_log",
+        lambda _path, *, session_index: {
+            "path": "/tmp/example.jsonl",
+            "adapter": "codex-jsonl-v2",
+            "file_session_id": None,
+            "event_count": 0,
+            "session_ids": "unexpected-scalar",
+            "models": None,
+            "diagnostics": ["unexpected-list"],
+        },
+    )
+
+    result = cli_main._run_inspect_log(
+        argparse.Namespace(path="/tmp/example.jsonl", codex_home=None, as_json=False)
+    )
+
+    assert result == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "Log: /tmp/example.jsonl",
+        "Adapter: codex-jsonl-v2",
+        "File session id: unknown",
+        "Parsed events: 0",
+        "Diagnostics: none",
+    ]
+
+
+def test_inspect_log_text_output_normalizes_collection_values(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli_main, "load_session_index", lambda _codex_home: {})
+    monkeypatch.setattr(
+        cli_main,
+        "inspect_log",
+        lambda _path, *, session_index: {
+            "path": "/tmp/example.jsonl",
+            "adapter": "codex-jsonl-v2",
+            "file_session_id": "session-a",
+            "event_count": 2,
+            "session_ids": ("session-a", 7),
+            "models": ["gpt-5.6", 5],
+            "diagnostics": {"partial_field_count": 1},
+        },
+    )
+
+    result = cli_main._run_inspect_log(
+        argparse.Namespace(path="/tmp/example.jsonl", codex_home=None, as_json=False)
+    )
+
+    assert result == 0
+    assert "Sessions: session-a, 7" in capsys.readouterr().out


### PR DESCRIPTION
## What changed

- add Agent Maintainer guidance-drift validation to CI
- add a maintained Pyright gate for the CLI inspect-log and context-reader surface
- isolate inspect-log text rendering from the oversized CLI module
- tolerate collection shape drift in human-readable inspect-log output
- add focused regression coverage and update the hardening roadmap checkpoint

## Why

The full-project Pyright profile still contains a broad historical backlog, so it is not yet a useful blocking signal. This PR establishes a small clean surface that CI can maintain immediately and reduces `cli/main.py` from 699 lines on `main` to 685 lines.

## Validation

- `python -m pyright src/codex_usage_tracker/cli/main.py src/codex_usage_tracker/cli/inspect_log_output.py src/codex_usage_tracker/context/reader.py`
- `python -m pytest tests/cli/test_cli_inspect_log_output.py tests/parser/test_parser.py tests/context/test_context_scan.py -q` (15 passed)
- `python -m ruff check ...`
- `python -m ruff format --check ...`
- `python -m agent_maintainer guidance --check`
- `python scripts/check_release.py`
- `git diff --check`

The broad Agent Maintainer precommit profile still reports the roadmap's existing stale file-length baseline, whole-repo Pyright backlog, and complexity backlog. This PR does not suppress those findings; it introduces a maintained green subset and improves the changed oversized module.
