### PR TITLE
chore: enforce dependency and dead code gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
             src/codex_usage_tracker/cli/main.py \
             src/codex_usage_tracker/cli/inspect_log_output.py \
             src/codex_usage_tracker/context/reader.py
+      - name: Dependency hygiene
+        run: deptry .
+      - name: Dead code
+        run: vulture src tests config/vulture-whitelist.py
       - name: GitHub Actions lint
         run: actionlint .github/workflows/*.yml
       - name: Secret scan

--- a/config/vulture-whitelist.py
+++ b/config/vulture-whitelist.py
@@ -1,0 +1,84 @@
+# ruff: noqa: B018, F821
+"""Reviewed Vulture references for dynamic and public compatibility surfaces."""
+
+# Package lazy exports are invoked by Python's module attribute protocol.
+__getattr__
+
+# MCP registers decorated tools dynamically.
+usage_refresh_start
+usage_refresh_status
+usage_action_brief
+
+# Public library helpers remain available to direct consumers and scripts.
+parse_usage_events
+refresh_usage_event_links
+refresh_thread_summaries
+index_content_for_source_files
+flush_pending_event_rows
+write_usage_drain_spans_csv
+
+# Dataclass fields are consumed through serialization and attribute access.
+session_updated_at
+current_date
+cumulative_input_tokens
+cumulative_cached_input_tokens
+cumulative_output_tokens
+cumulative_reasoning_output_tokens
+evidence_scope
+total_credits
+remaining_credits
+candidate_span_share
+coef_non_candidate_usage_pct_per_credit
+coef_candidate_usage_pct_per_credit
+two_feature_r2
+corr_candidate_credit_share_vs_drain_per_standard_credit
+spans_with_candidates
+spans_without_candidates
+with_vs_without_median_drain_ratio
+
+# HTTP handlers are selected by BaseHTTPRequestHandler or route dispatch maps.
+_.do_POST
+_._handle_diagnostics_summary
+_._handle_diagnostics_fact_calls
+_._handle_diagnostics_overview
+_._handle_diagnostics_refresh
+_._handle_diagnostics_overview_refresh
+_._handle_diagnostics_tool_output
+_._handle_diagnostics_tool_output_refresh
+_._handle_diagnostics_commands
+_._handle_diagnostics_commands_refresh
+_._handle_diagnostics_git_interactions
+_._handle_diagnostics_git_interactions_refresh
+_._handle_diagnostics_file_reads
+_._handle_diagnostics_file_reads_refresh
+_._handle_diagnostics_file_modifications
+_._handle_diagnostics_file_modifications_refresh
+_._handle_diagnostics_read_productivity
+_._handle_diagnostics_read_productivity_refresh
+_._handle_diagnostics_concentration
+_._handle_diagnostics_concentration_refresh
+_._handle_diagnostics_guided_summary
+_._handle_diagnostics_guided_summary_refresh
+_._handle_diagnostics_usage_drain
+_._handle_diagnostics_usage_drain_refresh
+_._handle_context
+_._handle_context_settings
+_._handle_open_investigator
+_._handle_status
+_._handle_calls
+_._handle_call
+_._handle_threads
+_._handle_thread_calls
+_._handle_summary
+_._handle_recommendations
+_._handle_allowance_history
+_._handle_allowance_diagnostics
+_._handle_allowance_export
+_._handle_reports_pack
+_._handle_refresh_start
+_._handle_refresh_status
+_._handle_usage
+
+# sqlite3 protocols and test doubles consume these assigned attributes.
+_.row_factory
+_.closed

--- a/docs/agent-maintainer-hardening-branch-roadmap.md
+++ b/docs/agent-maintainer-hardening-branch-roadmap.md
@@ -1,6 +1,6 @@
 # Agent Maintainer Hardening Branch Roadmap
 
-Current chunk: `refactor/tach-domain-boundaries`
+Current chunk: `chore/dependency-dead-code-gates`
 
 ## Goal
 
@@ -38,6 +38,9 @@ mixing in broad Python refactors or unrelated documentation cleanup.
 - Replace the placeholder leaf-level Tach inventory with enforceable package
   domain contracts, record the reviewed reports-to-allowance edge, and move
   shared command parsing into `core` to remove a store-to-diagnostics cycle.
+- Configure Deptry with the package's first-party and development dependency
+  model, remove five verified dead private helpers, and keep Vulture at 60%
+  confidence with a reviewed whitelist for dynamic and public surfaces.
 
 ## Branch Exit
 
@@ -60,12 +63,12 @@ maintained Agent Maintainer profile.
 After tests and mechanical formatting are stable, make structural gates produce
 useful review feedback.
 
-- Keep the now-green Tach domain contract in maintained validation and audit
+- [x] Keep the now-green Tach domain contract in maintained validation and audit
   circular dependencies separately before enabling cycle blocking.
-- Triage `deptry` into three buckets: real unused dependencies, intentionally
+- [x] Triage `deptry` into three buckets: real unused dependencies, intentionally
   optional/runtime dependencies, and packaging/test-only dependencies. Commit
   configuration only with a short explanation.
-- Triage `vulture` similarly: delete true dead code, preserve public/CLI/MCP
+- [x] Triage `vulture` similarly: delete true dead code, preserve public/CLI/MCP
   entry points with explicit allowlists, and avoid broad suppressions.
 
 ### 3. Security Hardening Pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ structure_ignore_paths = [
   "venv/**",
   "**/__pycache__/**",
 ]
-vulture_paths = ["src", "tests"]
+vulture_paths = ["src", "tests", "config/vulture-whitelist.py"]
 require_tests = true
 coverage_fail_under = 80
 diff_cover_fail_under = 90
@@ -161,6 +161,14 @@ check_jsonschema_args = [
 ]
 enable_wemake = false
 enable_interrogate = false
+
+[tool.deptry]
+known_first_party = ["codex_usage_tracker"]
+optional_dependencies_dev_groups = ["dev"]
+extend_exclude = ["scripts"]
+
+[tool.vulture]
+min_confidence = 60
 
 [tool.agent_maintainer.diagnostics]
 enabled = true

--- a/src/codex_usage_tracker/server/handler.py
+++ b/src/codex_usage_tracker/server/handler.py
@@ -94,11 +94,6 @@ _REACT_DASHBOARD_PATH = "/react-dashboard.html"
 _REACT_DASHBOARD_INDEX_PATH = "/codex-usage-tracker-assets/react/index.html"
 
 
-def _optional_int_query(params: dict[str, list[str]], key: str) -> int | None:
-    value = _first(params.get(key))
-    return None if value is None else _safe_int(value)
-
-
 class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
     def __init__(
         self,

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -1388,20 +1388,6 @@ def _pending_fragment(
     )
 
 
-def _flush_pending_fragments(
-    conn: sqlite3.Connection,
-    *,
-    pending: list[_PendingFragment],
-    usage_row: UsageContentRow,
-) -> None:
-    turn_rows, fragment_rows = _pending_fragment_rows(
-        pending=pending,
-        usage_row=usage_row,
-    )
-    _upsert_turn_rows(conn, turn_rows)
-    _upsert_fragment_rows(conn, fragment_rows)
-
-
 def _empty_pending_content_rows() -> _PendingContentRows:
     return _PendingContentRows(
         turn_rows=[],

--- a/src/codex_usage_tracker/store/content_index_events.py
+++ b/src/codex_usage_tracker/store/content_index_events.py
@@ -329,21 +329,6 @@ def _command_tokens(command: str) -> list[str]:
         return command.split()
 
 
-def _strip_assignment_prefixes(tokens: list[str]) -> list[str]:
-    index = 0
-    while (
-        index < len(tokens)
-        and "=" in tokens[index]
-        and not tokens[index].startswith(("-", "./", "/"))
-    ):
-        index += 1
-    return tokens[index:]
-
-
-def _is_python_root(root: str) -> bool:
-    return bool(re.fullmatch(r"python(?:\d+(?:\.\d+)?)?", root))
-
-
 def _file_events_from_command(
     command: str,
     *,

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -710,11 +710,6 @@ def _record_migration(conn: sqlite3.Connection, version: int) -> None:
     )
 
 
-def _record_migration_if_missing(conn: sqlite3.Connection, version: int) -> None:
-    if not _migration_record_exists(conn, version):
-        _record_migration(conn, version)
-
-
 def _migration_record_exists(conn: sqlite3.Connection, version: int) -> bool:
     return (
         conn.execute(

--- a/tests/quality/test_static_analysis_policy.py
+++ b/tests/quality/test_static_analysis_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_dependency_and_dead_code_scans_use_reviewed_project_policy() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    deptry = config["tool"]["deptry"]
+    assert deptry["known_first_party"] == ["codex_usage_tracker"]
+    assert deptry["optional_dependencies_dev_groups"] == ["dev"]
+    assert deptry["extend_exclude"] == ["scripts"]
+
+    maintainer = config["tool"]["agent_maintainer"]
+    assert "config/vulture-whitelist.py" in maintainer["vulture_paths"]
+    assert config["tool"]["vulture"]["min_confidence"] == 60


### PR DESCRIPTION
## Summary
- configure Deptry for the first-party package and development dependency group
- remove five verified dead private helpers
- keep Vulture at 60% confidence with a reviewed dynamic/public-surface whitelist
- run both gates in hardening CI
- add a policy regression test and update the hardening roadmap

## Validation
- `deptry .`
- `vulture src tests config/vulture-whitelist.py`
- focused Ruff and format checks
- `pytest tests/quality/test_static_analysis_policy.py tests/server/test_server_api.py tests/store/test_content_index.py tests/store/test_store_migrations.py -q` (23 passed)
- Actionlint and GitHub workflow schema validation
- `python scripts/check_release.py`
- `git diff --check`
- CI-equivalent Agent Maintainer profile confirms Deptry/Vulture pass; remaining failures are tracked Pyright/Xenon/Pylint/security roadmap items.