### PR TITLE
chore: enforce whole-source Pyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,8 @@ jobs:
           cargo install taplo-cli --version 0.9.0 --locked
       - name: Agent Maintainer guidance drift
         run: python -m agent_maintainer guidance --check
-      - name: Maintained Pyright surface
-        run: |
-          python -m pyright \
-            src/codex_usage_tracker/cli/main.py \
-            src/codex_usage_tracker/cli/inspect_log_output.py \
-            src/codex_usage_tracker/context/reader.py
+      - name: Whole-source Pyright
+        run: python -m pyright --pythonpath "$(command -v python)" src
       - name: Dependency hygiene
         run: deptry .
       - name: Dead code

--- a/docs/agent-maintainer-hardening-branch-roadmap.md
+++ b/docs/agent-maintainer-hardening-branch-roadmap.md
@@ -1,6 +1,6 @@
 # Agent Maintainer Hardening Branch Roadmap
 
-Current chunk: `chore/bandit-findings`
+Current chunk: `chore/whole-repo-pyright`
 
 ## Goal
 
@@ -47,6 +47,8 @@ mixing in broad Python refactors or unrelated documentation cleanup.
 - Fix actionable Bandit URL, assertion, fallback, and subprocess findings; keep
   reviewed B105/B608 heuristics in a compact baseline so new findings still
   fail in hardening CI.
+- Clear the remaining whole-source Pyright backlog and replace the narrow CI
+  type-check surface with all of `src`.
 
 ## Branch Exit
 
@@ -57,12 +59,10 @@ same hardening gates remotely.
 
 ### 1. Stabilize Existing Full Profile
 
-The pytest collection/import blocker, mechanical formatting blocker, and first
-narrow source Pyright errors are cleared. The cleaned Pyright surface is now
-protected in CI. Remaining type backlog is broader and should be handled in
-focused typing PRs, not as a blanket strictness migration. Once the profile is
-fast and consistently green, replace the narrow CI Pyright command with the
-maintained Agent Maintainer profile.
+The pytest collection/import blocker, mechanical formatting blocker, and
+whole-source Pyright backlog are cleared. All of `src` is now protected by the
+CI Pyright command. Complexity and broad style debt remain separate refactor
+work so the type gate stays fast and actionable.
 
 ### 2. Make Architecture And Dependency Checks Actionable
 

--- a/src/codex_usage_tracker/context/summaries.py
+++ b/src/codex_usage_tracker/context/summaries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from codex_usage_tracker.context.values import (
     content_text,
@@ -306,7 +306,8 @@ def _summarize_token_count(
 ) -> dict[str, Any] | None:
     if event_type != "token_count":
         return None
-    info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
+    raw_info = payload.get("info")
+    info = cast(dict[str, Any], raw_info) if isinstance(raw_info, dict) else {}
     token_usage = _token_count_summary(info)
     return {
         "label": "Token count",

--- a/src/codex_usage_tracker/dashboard/api.py
+++ b/src/codex_usage_tracker/dashboard/api.py
@@ -7,7 +7,7 @@ import json
 import re
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from codex_usage_tracker.core.call_origin import ensure_call_origin
 from codex_usage_tracker.core.i18n import dashboard_i18n_payload, language_direction
@@ -105,7 +105,7 @@ def dashboard_payload(
         allowance=allowance,
     )
     allowance_summary = summarize_allowance_usage(
-        token_summary["priced_model_rows"],
+        cast(list[dict[str, Any]], token_summary["priced_model_rows"]),
         allowance,
     )
     observed_usage = query_latest_observed_usage(
@@ -310,7 +310,7 @@ def generate_dashboard(
             output_path=output_path,
             guide_href=guide_href,
             stylesheet_hrefs=stylesheet_hrefs,
-            **script_srcs,
+            **cast(Any, script_srcs),
         ),
         encoding="utf-8",
     )

--- a/src/codex_usage_tracker/diagnostics/api.py
+++ b/src/codex_usage_tracker/diagnostics/api.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import sys
+from collections.abc import Mapping
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -369,14 +370,14 @@ def _check_parser_diagnostics(db_path: Path) -> DoctorCheck:
     return _parser_diagnostic_pass(metadata)
 
 
-def _parser_diagnostic_drift_parts(metadata: dict[str, object]) -> list[str]:
+def _parser_diagnostic_drift_parts(metadata: Mapping[str, object]) -> list[str]:
     diagnostics = _parser_diagnostic_counts(metadata)
     parts = _skipped_event_parts(metadata)
     parts.extend(f"{key}={diagnostics[key]}" for key in _parser_diagnostic_drift_keys(diagnostics))
     return parts
 
 
-def _parser_diagnostic_counts(metadata: dict[str, object]) -> dict[str, int]:
+def _parser_diagnostic_counts(metadata: Mapping[str, object]) -> dict[str, int]:
     return {
         key.removeprefix("parser_"): _safe_int(value)
         for key, value in metadata.items()
@@ -384,7 +385,7 @@ def _parser_diagnostic_counts(metadata: dict[str, object]) -> dict[str, int]:
     }
 
 
-def _skipped_event_parts(metadata: dict[str, object]) -> list[str]:
+def _skipped_event_parts(metadata: Mapping[str, object]) -> list[str]:
     skipped = _safe_int(metadata.get("skipped_events"))
     return [f"skipped_events={skipped}"] if skipped else []
 
@@ -413,7 +414,7 @@ def _parser_diagnostic_warning(parts: list[str]) -> DoctorCheck:
     )
 
 
-def _parser_diagnostic_pass(metadata: dict[str, object]) -> DoctorCheck:
+def _parser_diagnostic_pass(metadata: Mapping[str, object]) -> DoctorCheck:
     parsed = metadata.get("parsed_events", "0")
     scanned = metadata.get("scanned_files", "0")
     return DoctorCheck(

--- a/src/codex_usage_tracker/diagnostics/api.py
+++ b/src/codex_usage_tracker/diagnostics/api.py
@@ -7,7 +7,6 @@ import json
 import os
 import platform
 import sys
-from collections.abc import Mapping
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -370,14 +369,14 @@ def _check_parser_diagnostics(db_path: Path) -> DoctorCheck:
     return _parser_diagnostic_pass(metadata)
 
 
-def _parser_diagnostic_drift_parts(metadata: Mapping[str, object]) -> list[str]:
+def _parser_diagnostic_drift_parts(metadata: dict[str, object] | dict[str, str]) -> list[str]:
     diagnostics = _parser_diagnostic_counts(metadata)
     parts = _skipped_event_parts(metadata)
     parts.extend(f"{key}={diagnostics[key]}" for key in _parser_diagnostic_drift_keys(diagnostics))
     return parts
 
 
-def _parser_diagnostic_counts(metadata: Mapping[str, object]) -> dict[str, int]:
+def _parser_diagnostic_counts(metadata: dict[str, object] | dict[str, str]) -> dict[str, int]:
     return {
         key.removeprefix("parser_"): _safe_int(value)
         for key, value in metadata.items()
@@ -385,7 +384,7 @@ def _parser_diagnostic_counts(metadata: Mapping[str, object]) -> dict[str, int]:
     }
 
 
-def _skipped_event_parts(metadata: Mapping[str, object]) -> list[str]:
+def _skipped_event_parts(metadata: dict[str, object] | dict[str, str]) -> list[str]:
     skipped = _safe_int(metadata.get("skipped_events"))
     return [f"skipped_events={skipped}"] if skipped else []
 
@@ -414,7 +413,7 @@ def _parser_diagnostic_warning(parts: list[str]) -> DoctorCheck:
     )
 
 
-def _parser_diagnostic_pass(metadata: Mapping[str, object]) -> DoctorCheck:
+def _parser_diagnostic_pass(metadata: dict[str, object] | dict[str, str]) -> DoctorCheck:
     parsed = metadata.get("parsed_events", "0")
     scanned = metadata.get("scanned_files", "0")
     return DoctorCheck(

--- a/src/codex_usage_tracker/diagnostics/guided_summary.py
+++ b/src/codex_usage_tracker/diagnostics/guided_summary.py
@@ -519,18 +519,14 @@ def _label(value: object, fallback: str) -> str:
     return text or fallback
 
 
-def _int(value: object) -> int:
-    if not isinstance(value, str | bytes | bytearray | int | float):
-        return 0
+def _int(value: Any) -> int:
     try:
         return int(value or 0)
     except (TypeError, ValueError):
         return 0
 
 
-def _float(value: object) -> float:
-    if not isinstance(value, str | bytes | bytearray | int | float):
-        return 0.0
+def _float(value: Any) -> float:
     try:
         return float(value or 0)
     except (TypeError, ValueError):

--- a/src/codex_usage_tracker/diagnostics/guided_summary.py
+++ b/src/codex_usage_tracker/diagnostics/guided_summary.py
@@ -131,7 +131,7 @@ def build_guided_summary(
 
 
 def _aggregate_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    totals = {
+    totals: dict[str, int | float] = {
         "usage_rows": len(rows),
         "total_tokens": 0,
         "input_tokens": 0,
@@ -520,6 +520,8 @@ def _label(value: object, fallback: str) -> str:
 
 
 def _int(value: object) -> int:
+    if not isinstance(value, str | bytes | bytearray | int | float):
+        return 0
     try:
         return int(value or 0)
     except (TypeError, ValueError):
@@ -527,6 +529,8 @@ def _int(value: object) -> int:
 
 
 def _float(value: object) -> float:
+    if not isinstance(value, str | bytes | bytearray | int | float):
+        return 0.0
     try:
         return float(value or 0)
     except (TypeError, ValueError):

--- a/src/codex_usage_tracker/server/diagnostic_routes.py
+++ b/src/codex_usage_tracker/server/diagnostic_routes.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import threading
 from http import HTTPStatus
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from codex_usage_tracker.diagnostics.snapshots import (
@@ -57,6 +59,33 @@ _DIAGNOSTIC_SNAPSHOT_REPORTS: dict[str, tuple[Any, str]] = {
 
 class DiagnosticRouteMixin:
     """Diagnostic route adapters for ``_UsageDashboardHandler``."""
+
+    if TYPE_CHECKING:
+        path: str
+        _db_path: Path
+        _pricing_path: Path
+        _allowance_path: Path
+        _rate_card_path: Path
+        _include_archived: bool
+        _privacy_mode: str
+        _refresh_lock: threading.Lock
+
+        def _has_valid_api_token(self, params: dict[str, list[str]]) -> bool: ...
+
+        def _send_error(
+            self,
+            status: HTTPStatus,
+            message: str,
+            **extra: object,
+        ) -> None: ...
+
+        def _send_exception(self, prefix: str, exc: BaseException) -> None: ...
+
+        def _send_json(
+            self,
+            status: HTTPStatus,
+            payload: dict[str, object],
+        ) -> None: ...
 
     def _handle_diagnostics_summary(self, query: str) -> None:
         handle_diagnostics_summary_request(

--- a/src/codex_usage_tracker/server/handler.py
+++ b/src/codex_usage_tracker/server/handler.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 import webbrowser
 from http import HTTPStatus
-from http.server import SimpleHTTPRequestHandler
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 from codex_usage_tracker.core.i18n import normalize_language
@@ -49,6 +50,7 @@ from codex_usage_tracker.server.open_investigator import (
 from codex_usage_tracker.server.recommendations import handle_recommendations_request
 from codex_usage_tracker.server.reports import handle_reports_pack_request
 from codex_usage_tracker.server.request_guards import (
+    HeaderLookup,
     has_valid_api_token,
     request_origin_allowed,
 )
@@ -97,7 +99,7 @@ _REACT_DASHBOARD_INDEX_PATH = "/codex-usage-tracker-assets/react/index.html"
 class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
     def __init__(
         self,
-        *args: object,
+        *args: Any,
         db_path: Path,
         pricing_path: Path,
         allowance_path: Path,
@@ -199,7 +201,7 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
         )
         super().end_headers()
 
-    def guess_type(self, path: str) -> str:
+    def guess_type(self, path: str | os.PathLike[str]) -> str:
         forced_type = _DASHBOARD_ASSET_MIME_TYPES.get(Path(path).suffix.lower())
         if forced_type is not None:
             return forced_type
@@ -360,7 +362,7 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
             payload = open_investigator_payload(
                 query,
                 request_host=self.headers.get("Host"),
-                server_port=self.server.server_port,
+                server_port=cast(HTTPServer, self.server).server_port,
                 dashboard_name=self._dashboard_name,
                 open_new_tab=webbrowser.open_new_tab,
             )
@@ -581,10 +583,11 @@ class _UsageDashboardHandler(DiagnosticRouteMixin, SimpleHTTPRequestHandler):
         )
 
     def _request_origin_allowed(self) -> bool:
-        return request_origin_allowed(self.headers, self.server.server_port)
+        server = cast(HTTPServer, self.server)
+        return request_origin_allowed(cast(HeaderLookup, self.headers), server.server_port)
 
     def _has_valid_api_token(self, params: dict[str, list[str]]) -> bool:
-        return has_valid_api_token(self.headers, params, self._api_token)
+        return has_valid_api_token(cast(HeaderLookup, self.headers), params, self._api_token)
 
     def _send_error(
         self,

--- a/src/codex_usage_tracker/server/request_guards.py
+++ b/src/codex_usage_tracker/server/request_guards.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hmac
-from typing import Protocol
+from typing import Protocol, TypeVar, overload
 from urllib.parse import urlparse
 
 from codex_usage_tracker.server.utils import (
@@ -12,12 +12,17 @@ from codex_usage_tracker.server.utils import (
     host_header_name,
 )
 
+_T = TypeVar("_T")
+
 
 class HeaderLookup(Protocol):
     """Minimal header lookup protocol used by SimpleHTTPRequestHandler."""
 
-    def get(self, name: str, default: str | None = None) -> str | None:
-        """Return a header value when present."""
+    @overload
+    def get(self, name: str) -> str | None: ...
+
+    @overload
+    def get(self, name: str, default: _T) -> str | _T: ...
 
 
 def request_origin_allowed(headers: HeaderLookup, server_port: int) -> bool:

--- a/src/codex_usage_tracker/server/usage_refresh.py
+++ b/src/codex_usage_tracker/server/usage_refresh.py
@@ -365,9 +365,10 @@ def usage_payload(
     payload["refresh_result"] = refresh_result
 
     if diagnostics_enabled:
+        payload_rows = payload.get("rows")
         diagnostic_payload: dict[str, object] = {
             "dashboard_payload_ms": dashboard_payload_ms,
-            "rows_returned": len(payload.get("rows") or []),
+            "rows_returned": len(payload_rows) if isinstance(payload_rows, list) else 0,
             "include_archived": include_archived,
             "limit": limit,
             "offset": offset,

--- a/src/codex_usage_tracker/server/utils.py
+++ b/src/codex_usage_tracker/server/utils.py
@@ -152,6 +152,8 @@ def elapsed_ms(started_at: float) -> float:
 
 
 def safe_int(value: object) -> int:
+    if not isinstance(value, str | bytes | bytearray | int | float):
+        return 0
     try:
         return int(value)
     except (TypeError, ValueError):

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -8,7 +8,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from codex_usage_tracker import store as store_facade
 from codex_usage_tracker.core.models import DiagnosticFact, RefreshResult, UsageEvent
@@ -43,7 +43,7 @@ _PARALLEL_PARSE_WORKERS_ENV = "CODEX_USAGE_TRACKER_REFRESH_WORKERS"
 _PARALLEL_PARSE_MIN_FILES = 4
 _PARALLEL_PARSE_MAX_WORKERS = 8
 
-vars(store_facade)["parse_usage_events_from_file_with_state"] = (
+cast(Any, store_facade).parse_usage_events_from_file_with_state = (
     _parse_usage_events_from_file_with_state
 )
 

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -43,9 +43,9 @@ _PARALLEL_PARSE_WORKERS_ENV = "CODEX_USAGE_TRACKER_REFRESH_WORKERS"
 _PARALLEL_PARSE_MIN_FILES = 4
 _PARALLEL_PARSE_MAX_WORKERS = 8
 
-cast(Any, store_facade).parse_usage_events_from_file_with_state = (
-    _parse_usage_events_from_file_with_state
-)
+cast(
+    Any, store_facade
+).parse_usage_events_from_file_with_state = _parse_usage_events_from_file_with_state
 
 
 def _parse_usage_events_from_file(*args: Any, **kwargs: Any) -> Any:

--- a/src/codex_usage_tracker/usage_drain/spans.py
+++ b/src/codex_usage_tracker/usage_drain/spans.py
@@ -334,8 +334,8 @@ def _span_from_rows(
     model_counts: dict[str, int] = {}
     effort_counts: dict[str, int] = {}
     turn_counts: dict[tuple[str, str], int] = {}
-    token_totals = dict.fromkeys(TOKEN_TOTAL_FIELDS, 0.0)
-    timing_totals = dict.fromkeys(TIMING_TOTAL_FIELDS, 0.0)
+    token_totals: dict[str, float] = dict.fromkeys(TOKEN_TOTAL_FIELDS, 0.0)
+    timing_totals: dict[str, float] = dict.fromkeys(TIMING_TOTAL_FIELDS, 0.0)
     for row in rows:
         credits = max(_span_number(row.get("usage_credits")), 0.0)
         standard += credits

--- a/tests/server/test_server_request_guards.py
+++ b/tests/server/test_server_request_guards.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from email.message import Message
+
 from codex_usage_tracker.server.request_guards import (
     has_valid_api_token,
     request_origin_allowed,
@@ -8,6 +10,13 @@ from codex_usage_tracker.server.request_guards import (
 
 def test_request_origin_allowed_accepts_loopback_host_without_origin() -> None:
     headers = {"Host": "127.0.0.1:8898"}
+
+    assert request_origin_allowed(headers, server_port=8898) is True
+
+
+def test_request_origin_allowed_accepts_stdlib_message_headers() -> None:
+    headers = Message()
+    headers["Host"] = "127.0.0.1:8898"
 
     assert request_origin_allowed(headers, server_port=8898) is True
 


### PR DESCRIPTION
## Summary
- clear the remaining Pyright errors across the Python source tree
- make handler and diagnostics mixin contracts explicit without runtime behavior changes
- replace the narrow CI type-check surface with all of src

## Validation
- .venv/bin/pyright --pythonpath .venv/bin/python src
- .venv/bin/ruff check src tests/server/test_server_request_guards.py
- .venv/bin/pytest -q (627 passed)
- .venv/bin/python scripts/check_release.py
- git diff --check