### PR TITLE
refactor: simplify agentic evidence

### DIFF
--- a/docs/complexity-hardening-roadmap.md
+++ b/docs/complexity-hardening-roadmap.md
@@ -1,0 +1,89 @@
+# Complexity Hardening Roadmap
+
+Status: in progress
+
+## Goal
+
+Clear the current Xenon C/E function backlog without lowering the configured
+B/A/A thresholds, then enable Xenon as a maintained CI gate. Triage Pylint into
+low-noise correctness/maintainability checks instead of attempting a cosmetic
+full-tree cleanup.
+
+## Baseline
+
+- Xenon: 21 C/E-ranked functions, including one E-ranked function in
+  `reports/agentic_evidence.py`.
+- Pylint: 9.12/10 across `src`, with broad historical convention and design
+  findings.
+- Existing required gates remain unchanged: Ruff, Mypy, whole-source Pyright,
+  Tach, Deptry, Vulture, Bandit, pip-audit, workflow/security checks, package
+  build, and the full test suite.
+
+## PR Sequence
+
+### 1. Agentic Evidence
+
+- [ ] Lock compact evidence row and summary behavior with direct tests.
+- [ ] Split `_compact_agentic_evidence_row` into field-family helpers.
+- [ ] Replace `_agentic_evidence_summary` branch accumulation with declarative
+  metric specifications and bounded reducers.
+- Exit: both functions rank B or better and report/MCP contracts are unchanged.
+
+### 2. Agentic Report Assembly
+
+- [ ] Reduce `build_agentic_investigation_report` and
+  `build_action_brief_report` through focused finding/section builders.
+- [ ] Reduce investigation export, shell-churn hypothesis, and dogfood payload
+  compaction through typed/declarative helpers.
+- Exit: all report-family functions rank B or better with report and MCP tests
+  green.
+
+### 3. Content Indexing
+
+- [ ] Reduce content snippets and source-file extraction with explicit parsing
+  and clipping helpers.
+- [ ] Split serial source indexing into read, accumulate, flush, and FTS phases.
+- [ ] Simplify shell/path token classification without changing privacy-safe
+  path identities.
+- Exit: content query/extract/index/event functions rank B or better with
+  incremental, parallel, FTS, and MCP content tests green.
+
+### 4. Waste Candidate Diagnostics
+
+- [ ] Reduce repeated-file, shell-churn, and large-low-output candidate builders
+  through shared metric and explanation helpers.
+- Exit: all candidate functions rank B or better and diagnostic payload schemas
+  remain unchanged.
+
+### 5. Allowance And Isolated Utilities
+
+- [ ] Reduce allowance analysis/readiness and nonparametric statistical branch
+  complexity while preserving evidence grades and exact test results.
+- [ ] Reduce doctor formatting and command-wrapper classification.
+- Exit: every remaining C/E function ranks B or better.
+
+### 6. Maintained Gates
+
+- [ ] Add Xenon B/A/A to hardening CI only after the full source tree passes.
+- [ ] Audit Pylint messages into correctness, maintainability, and convention
+  groups.
+- [ ] Enable a reviewed low-noise Pylint selection or changed-code ratchet; do
+  not add broad suppressions to manufacture a green full-tree score.
+- [ ] Run the full CI, security, package, and release validation matrix.
+
+## Validation Pattern
+
+Each refactor PR must:
+
+1. Add or identify direct behavior-lock tests before changing a hotspot.
+2. Run Xenon against the touched module and the complete source tree.
+3. Run focused tests plus whole-source Pyright, Ruff, file-length, release, and
+   whitespace checks.
+4. Merge only after the remote CI matrix is green.
+
+## Non-Goals
+
+- Lowering Xenon thresholds or baseline-suppressing current C/E functions.
+- Mass docstring, naming, or formatting churn for Pylint score improvement.
+- Combining feature work with complexity refactors.
+- Changing MCP, API, CLI, dashboard, or persisted payload contracts.

--- a/docs/complexity-hardening-roadmap.md
+++ b/docs/complexity-hardening-roadmap.md
@@ -23,9 +23,9 @@ full-tree cleanup.
 
 ### 1. Agentic Evidence
 
-- [ ] Lock compact evidence row and summary behavior with direct tests.
-- [ ] Split `_compact_agentic_evidence_row` into field-family helpers.
-- [ ] Replace `_agentic_evidence_summary` branch accumulation with declarative
+- [x] Lock compact evidence row and summary behavior with direct tests.
+- [x] Split `_compact_agentic_evidence_row` into field-family helpers.
+- [x] Replace `_agentic_evidence_summary` branch accumulation with declarative
   metric specifications and bounded reducers.
 - Exit: both functions rank B or better and report/MCP contracts are unchanged.
 

--- a/src/codex_usage_tracker/reports/agentic_evidence.py
+++ b/src/codex_usage_tracker/reports/agentic_evidence.py
@@ -5,144 +5,157 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+_COMPACT_EVIDENCE_FIELDS = (
+    "record_id",
+    "session_id",
+    "thread_key",
+    "thread_name",
+    "event_timestamp",
+    "model",
+    "effort",
+    "total_tokens",
+    "input_tokens",
+    "cached_input_tokens",
+    "uncached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "cache_ratio",
+    "context_window_percent",
+    "candidate_explanation",
+    "explanation_reasons",
+    "command_root",
+    "command_label",
+    "command_family",
+    "churn_kind",
+    "occurrences",
+    "call_count",
+    "thread_count",
+    "session_count",
+    "failure_count",
+    "path_hash",
+    "path_identity",
+    "path_basename",
+    "path_extension",
+    "candidate_kind",
+    "operation_mix",
+    "recommendation",
+    "primary_signal",
+    "secondary_signals",
+    "recommended_action",
+    "usage_credits",
+    "estimated_cost_usd",
+    "next_tool",
+)
+_PRIMARY_RECOMMENDATION_FIELDS = ("key", "severity", "title", "action")
+_NEARBY_ACTIVITY_FIELDS = (
+    "tool_call_count",
+    "command_run_count",
+    "failed_command_count",
+    "file_event_count",
+)
+_TRACE_HANDLE_FIELDS = (
+    "thread_key",
+    "thread",
+    "session_id",
+    "call_count",
+    "total_tokens",
+    "next_tool",
+)
+_SUMMARY_TOTAL_FIELDS = (
+    ("occurrences", "total_occurrences"),
+    ("call_count", "total_call_count"),
+    ("failure_count", "total_failure_count"),
+)
+
 
 def _compact_agentic_evidence_row(row: dict[str, Any]) -> dict[str, Any]:
-    keep_fields = (
-        "record_id",
-        "session_id",
-        "thread_key",
-        "thread_name",
-        "event_timestamp",
-        "model",
-        "effort",
-        "total_tokens",
-        "input_tokens",
-        "cached_input_tokens",
-        "uncached_input_tokens",
-        "output_tokens",
-        "reasoning_output_tokens",
-        "cache_ratio",
-        "context_window_percent",
-        "candidate_explanation",
-        "explanation_reasons",
-        "command_root",
-        "command_label",
-        "command_family",
-        "churn_kind",
-        "occurrences",
-        "call_count",
-        "thread_count",
-        "session_count",
-        "failure_count",
-        "path_hash",
-        "path_identity",
-        "path_basename",
-        "path_extension",
-        "candidate_kind",
-        "operation_mix",
-        "recommendation",
-        "primary_signal",
-        "secondary_signals",
-        "recommended_action",
-        "usage_credits",
-        "estimated_cost_usd",
-        "next_tool",
+    compact = _non_null_fields(row, _COMPACT_EVIDENCE_FIELDS)
+    _set_optional(
+        compact,
+        "primary_recommendation",
+        _compact_mapping(row.get("primary_recommendation"), _PRIMARY_RECOMMENDATION_FIELDS),
     )
-    compact = {key: row[key] for key in keep_fields if key in row and row[key] is not None}
-    if "primary_recommendation" in row and isinstance(row["primary_recommendation"], dict):
-        primary = row["primary_recommendation"]
-        compact["primary_recommendation"] = {
-            key: primary[key]
-            for key in ("key", "severity", "title", "action")
-            if key in primary and primary[key] is not None
-        }
-    if "nearby_activity" in row and isinstance(row["nearby_activity"], dict):
-        compact["nearby_activity"] = {
-            key: row["nearby_activity"].get(key)
-            for key in (
-                "tool_call_count",
-                "command_run_count",
-                "failed_command_count",
-                "file_event_count",
-            )
-            if row["nearby_activity"].get(key) is not None
-        }
-    if "trace_handles" in row and isinstance(row["trace_handles"], list):
-        compact["trace_handles"] = [
-            {
-                key: handle.get(key)
-                for key in (
-                    "thread_key",
-                    "thread",
-                    "session_id",
-                    "call_count",
-                    "total_tokens",
-                    "next_tool",
-                )
-                if isinstance(handle, dict) and handle.get(key) is not None
-            }
-            for handle in row["trace_handles"][:3]
-            if isinstance(handle, dict)
-        ]
+    _set_optional(
+        compact,
+        "nearby_activity",
+        _compact_mapping(row.get("nearby_activity"), _NEARBY_ACTIVITY_FIELDS),
+    )
+    _set_optional(compact, "trace_handles", _compact_trace_handles(row.get("trace_handles")))
     return compact
 
 
 def _agentic_evidence_summary(evidence: list[dict[str, Any]]) -> dict[str, Any]:
-    token_values = [
-        int(row["total_tokens"])
-        for row in evidence
-        if isinstance(row.get("total_tokens"), int | float)
-    ]
-    timestamps = [str(row["event_timestamp"]) for row in evidence if row.get("event_timestamp")]
-    threads = _ordered_unique(
-        str(row.get("thread_name") or row.get("thread") or row.get("thread_key"))
-        for row in evidence
-    )
-    models = _ordered_unique(str(row.get("model")) for row in evidence if row.get("model"))
-    efforts = _ordered_unique(str(row.get("effort")) for row in evidence if row.get("effort"))
-    explanations = _ordered_unique(
-        str(row.get("candidate_explanation"))
-        for row in evidence
-        if row.get("candidate_explanation")
-    )
-    recommendations = _ordered_unique(
-        str(row.get("recommendation") or row.get("recommended_action"))
-        for row in evidence
-        if row.get("recommendation") or row.get("recommended_action")
-    )
+    token_values = _numeric_values(evidence, "total_tokens")
     summary: dict[str, Any] = {
         "row_count": len(evidence),
         "total_tokens": sum(token_values),
         "max_total_tokens": max(token_values) if token_values else None,
-        "threads": threads[:5],
-        "models": models[:5],
-        "efforts": efforts[:5],
-        "candidate_explanations": explanations[:5],
-        "recommendations": recommendations[:5],
+        "threads": _ordered_text_values(evidence, "thread_name", "thread", "thread_key")[:5],
+        "models": _ordered_text_values(evidence, "model")[:5],
+        "efforts": _ordered_text_values(evidence, "effort")[:5],
+        "candidate_explanations": _ordered_text_values(evidence, "candidate_explanation")[:5],
+        "recommendations": _ordered_text_values(evidence, "recommendation", "recommended_action")[
+            :5
+        ],
     }
-    if timestamps:
-        summary["first_event_timestamp"] = min(timestamps)
-        summary["last_event_timestamp"] = max(timestamps)
-    occurrence_values = [
-        int(row["occurrences"])
-        for row in evidence
-        if isinstance(row.get("occurrences"), int | float)
-    ]
-    call_count_values = [
-        int(row["call_count"]) for row in evidence if isinstance(row.get("call_count"), int | float)
-    ]
-    failure_values = [
-        int(row["failure_count"])
-        for row in evidence
-        if isinstance(row.get("failure_count"), int | float)
-    ]
-    if occurrence_values:
-        summary["total_occurrences"] = sum(occurrence_values)
-    if call_count_values:
-        summary["total_call_count"] = sum(call_count_values)
-    if failure_values:
-        summary["total_failure_count"] = sum(failure_values)
+    summary.update(_timestamp_bounds(evidence))
+    summary.update(_optional_numeric_totals(evidence))
     return {key: value for key, value in summary.items() if value not in (None, [], {})}
+
+
+def _non_null_fields(source: dict[str, Any], fields: Iterable[str]) -> dict[str, Any]:
+    return {key: source[key] for key in fields if key in source and source[key] is not None}
+
+
+def _compact_mapping(value: object, fields: Iterable[str]) -> dict[str, Any] | None:
+    return _non_null_fields(value, fields) if isinstance(value, dict) else None
+
+
+def _compact_trace_handles(value: object) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list):
+        return None
+    return [
+        _non_null_fields(handle, _TRACE_HANDLE_FIELDS)
+        for handle in value[:3]
+        if isinstance(handle, dict)
+    ]
+
+
+def _set_optional(target: dict[str, Any], key: str, value: object | None) -> None:
+    if value is not None:
+        target[key] = value
+
+
+def _numeric_values(rows: list[dict[str, Any]], field: str) -> list[int]:
+    return [int(row[field]) for row in rows if isinstance(row.get(field), int | float)]
+
+
+def _first_text(row: dict[str, Any], fields: tuple[str, ...]) -> str:
+    value = next((row.get(field) for field in fields if row.get(field)), "")
+    return str(value)
+
+
+def _ordered_text_values(rows: list[dict[str, Any]], *fields: str) -> list[str]:
+    return _ordered_unique(_first_text(row, fields) for row in rows)
+
+
+def _timestamp_bounds(rows: list[dict[str, Any]]) -> dict[str, str]:
+    timestamps = _ordered_text_values(rows, "event_timestamp")
+    if not timestamps:
+        return {}
+    return {
+        "first_event_timestamp": min(timestamps),
+        "last_event_timestamp": max(timestamps),
+    }
+
+
+def _optional_numeric_totals(rows: list[dict[str, Any]]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for source_field, result_field in _SUMMARY_TOTAL_FIELDS:
+        values = _numeric_values(rows, source_field)
+        if values:
+            totals[result_field] = sum(values)
+    return totals
 
 
 def _ordered_unique(values: Iterable[str]) -> list[str]:

--- a/tests/reports/test_agentic_evidence.py
+++ b/tests/reports/test_agentic_evidence.py
@@ -1,0 +1,104 @@
+from codex_usage_tracker.reports.agentic_evidence import (
+    _agentic_evidence_summary,
+    _compact_agentic_evidence_row,
+)
+
+
+def test_compact_agentic_evidence_row_preserves_bounded_safe_fields() -> None:
+    row = {
+        "record_id": "record-1",
+        "total_tokens": 1200,
+        "ignored": "private detail",
+        "primary_recommendation": {
+            "key": "fresh-thread",
+            "severity": "medium",
+            "title": "Start a fresh thread",
+            "action": "Create a handoff.",
+            "ignored": "detail",
+        },
+        "nearby_activity": {
+            "tool_call_count": 3,
+            "command_run_count": 2,
+            "failed_command_count": 1,
+            "file_event_count": 4,
+            "ignored": 99,
+        },
+        "trace_handles": [
+            {
+                "thread_key": f"thread-{index}",
+                "call_count": index,
+                "next_tool": "usage_thread_trace",
+                "ignored": "detail",
+            }
+            for index in range(4)
+        ],
+    }
+
+    compact = _compact_agentic_evidence_row(row)
+
+    assert compact["record_id"] == "record-1"
+    assert compact["total_tokens"] == 1200
+    assert compact["primary_recommendation"] == {
+        "key": "fresh-thread",
+        "severity": "medium",
+        "title": "Start a fresh thread",
+        "action": "Create a handoff.",
+    }
+    assert compact["nearby_activity"] == {
+        "tool_call_count": 3,
+        "command_run_count": 2,
+        "failed_command_count": 1,
+        "file_event_count": 4,
+    }
+    assert [row["thread_key"] for row in compact["trace_handles"]] == [
+        "thread-0",
+        "thread-1",
+        "thread-2",
+    ]
+    assert "ignored" not in compact
+
+
+def test_agentic_evidence_summary_preserves_order_and_optional_totals() -> None:
+    summary = _agentic_evidence_summary(
+        [
+            {
+                "total_tokens": 100,
+                "event_timestamp": "2026-01-02T00:00:00Z",
+                "thread_name": "alpha",
+                "model": "gpt-a",
+                "effort": "high",
+                "candidate_explanation": "large context",
+                "recommendation": "start fresh",
+                "occurrences": 2,
+                "call_count": 3,
+                "failure_count": 1,
+            },
+            {
+                "total_tokens": 250.9,
+                "event_timestamp": "2026-01-01T00:00:00Z",
+                "thread_name": "alpha",
+                "model": "gpt-b",
+                "effort": "low",
+                "candidate_explanation": "large context",
+                "recommended_action": "narrow reads",
+                "occurrences": 4,
+                "call_count": 5,
+            },
+        ]
+    )
+
+    assert summary == {
+        "row_count": 2,
+        "total_tokens": 350,
+        "max_total_tokens": 250,
+        "threads": ["alpha"],
+        "models": ["gpt-a", "gpt-b"],
+        "efforts": ["high", "low"],
+        "candidate_explanations": ["large context"],
+        "recommendations": ["start fresh", "narrow reads"],
+        "first_event_timestamp": "2026-01-01T00:00:00Z",
+        "last_event_timestamp": "2026-01-02T00:00:00Z",
+        "total_occurrences": 6,
+        "total_call_count": 8,
+        "total_failure_count": 1,
+    }


### PR DESCRIPTION
## Summary
- add direct behavior-lock tests for compact agentic evidence and summaries
- replace nested conditional copying with field-family reducers
- replace E-ranked metric accumulation with declarative totals and bounded helpers

## Validation
- touched module passes Xenon B/A/A
- Ruff and whole-source Pyright
- report and MCP integration tests (27 passed)
- file-length, release, and whitespace checks