### PR TITLE
chore: upgrade Agent Maintainer frontend governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
           cargo install taplo-cli --version 0.9.0 --locked
       - name: Agent Maintainer guidance drift
         run: python -m agent_maintainer guidance --check
+      - name: Dashboard lint
+        run: npm run dashboard:lint
+      - name: Dashboard type check
+        run: npm run dashboard:typecheck
+      - name: Dashboard tests
+        run: npm run dashboard:test
+      - name: Dashboard build
+        run: npm run dashboard:build
       - name: Whole-source Pyright
         run: python -m pyright --pythonpath "$(command -v python)" src
       - name: Dependency hygiene

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 *.db
 *.csv
 *.html
+!frontend/dashboard/index.html
 !src/codex_usage_tracker/plugin_data/docs/dashboard-guide.html
 !src/codex_usage_tracker/plugin_data/dashboard/dashboard_template.html
 

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Codex Usage Tracker React Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/douglasmonsky/codex-usage-tracker/blob/main/CHAN
 
 [project.optional-dependencies]
 dev = [
-  "agent-maintainer[core]>=0.1.0b1; python_version >= '3.11'",
+  "agent-maintainer[core]>=0.1.0b5; python_version >= '3.11'",
   "build>=1.2",
   "check-jsonschema>=0.37.4; python_version >= '3.11'",
   "git-agent-ratchet>=1.3.0; python_version >= '3.11'",
@@ -154,6 +154,27 @@ enable_yamllint = true
 enable_taplo = true
 enable_markdownlint = true
 enable_check_jsonschema = true
+enable_typescript = true
+typescript_lint_command = [
+  "npm",
+  "--workspace",
+  "frontend/dashboard",
+  "run",
+  "lint",
+  "--",
+  "--format",
+  "json",
+]
+typescript_typecheck_command = ["npm", "run", "dashboard:typecheck"]
+typescript_test_command = [
+  "npm",
+  "--workspace",
+  "frontend/dashboard",
+  "run",
+  "test",
+  "--",
+  "--reporter=json",
+]
 check_jsonschema_args = [
   "--builtin-schema",
   "vendor.github-workflows",
@@ -163,6 +184,46 @@ check_jsonschema_args = [
 ]
 enable_wemake = false
 enable_interrogate = false
+
+[tool.agent_maintainer.file_baselines]
+enabled = true
+mode = "advisory"
+
+[tool.agent_maintainer.file_baselines.groups.dashboard-source]
+include = ["frontend/dashboard/src/**/*.ts", "frontend/dashboard/src/**/*.tsx"]
+exclude = [
+  "frontend/dashboard/src/**/*.test.ts",
+  "frontend/dashboard/src/**/*.test.tsx",
+  "frontend/dashboard/src/vite-env.d.ts",
+]
+role = "source"
+max_physical_lines = 500
+max_nonblank_lines = 400
+changed_file_warn = 10
+changed_line_warn = 800
+
+[tool.agent_maintainer.file_baselines.groups.dashboard-tests]
+include = [
+  "frontend/dashboard/src/**/*.test.ts",
+  "frontend/dashboard/src/**/*.test.tsx",
+  "tests/playwright/**/*.mjs",
+]
+role = "test"
+max_physical_lines = 600
+max_nonblank_lines = 500
+changed_file_warn = 12
+changed_line_warn = 1000
+
+[tool.agent_maintainer.file_baselines.groups.dashboard-styles]
+include = [
+  "frontend/dashboard/src/**/*.css",
+  "frontend/dashboard/src/**/*.scss",
+]
+role = "source"
+max_physical_lines = 600
+max_nonblank_lines = 500
+changed_file_warn = 8
+changed_line_warn = 700
 
 [tool.deptry]
 known_first_party = ["codex_usage_tracker"]


### PR DESCRIPTION
## Summary
- raise the Agent Maintainer development floor to 0.1.0b5 while retaining the exact latest-main CI pin at 90a860e
- enable explicit TypeScript/React lint, typecheck, and Vitest commands plus advisory dashboard file baselines
- add React lint, typecheck, tests, and production build to CI
- track the missing Vite source index so production builds are reproducible

## Evidence
- Agent Maintainer doctor recognizes all configuration and the TypeScript provider
- dashboard lint and typecheck pass
- 41 Vitest files / 242 tests pass
- production Vite build passes
- actionlint and GitHub workflow schema validation pass
- release readiness and whitespace checks pass

## Notes
- advisory file baselines identify 24 existing dashboard source/test overages; these are inputs to the experimental redesign roadmap, not newly blocking debt
- the current bundle warning (598 kB minified) will be addressed in the redesign architecture rather than hidden