### PR TITLE
refactor: reduce backend complexity hotspots

### DIFF
--- a/src/codex_usage_tracker/allowance_intelligence/model.py
+++ b/src/codex_usage_tracker/allowance_intelligence/model.py
@@ -34,41 +34,19 @@ _MIN_CHANGE_SPANS = _MIN_BASELINE_CHANGE_SPANS + _MIN_RECENT_CHANGE_SPANS
 def build_allowance_analysis(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Build aggregate allowance-change evidence from normalized observations."""
 
-    observation_rows = [
-        row
-        for row in sorted(rows, key=_observation_sort_key)
-        if _number(row.get("used_percent")) is not None
-    ]
-    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
-    for row in observation_rows:
-        grouped.setdefault(_analysis_key(row), []).append(row)
-
-    window_reports = [
-        _window_report(key, group_rows) for key, group_rows in sorted(grouped.items())
-    ]
-    spans = [span for report in window_reports for span in report["spans"]]
-    candidates = [
-        candidate for report in window_reports for candidate in report.get("change_candidates", [])
-    ]
+    observation_rows = _normalized_observations(rows)
+    window_reports = _grouped_window_reports(observation_rows)
+    spans = _flatten_window_rows(window_reports, "spans")
+    candidates = _flatten_window_rows(window_reports, "change_candidates")
     primary = _primary_window_report(window_reports)
     return {
-        "summary": {
-            "observation_count": len(observation_rows),
-            "window_report_count": len(window_reports),
-            "positive_span_count": len(spans),
-            "candidate_change_count": len(candidates),
-            "primary_window_kind": primary.get("window_kind") if primary else None,
-            "primary_evidence_grade": primary.get("evidence_grade")
-            if primary
-            else "insufficient_data",
-            "weekly_observation_count": sum(
-                1 for row in observation_rows if row.get("window_kind") == "weekly"
-            ),
-            "five_hour_observation_count": sum(
-                1 for row in observation_rows if row.get("window_kind") == "five_hour"
-            ),
-            "research_readiness": _research_readiness(window_reports, candidates),
-        },
+        "summary": _allowance_analysis_summary(
+            observation_rows=observation_rows,
+            window_reports=window_reports,
+            spans=spans,
+            candidates=candidates,
+            primary=primary,
+        ),
         "windows": window_reports,
         "spans": spans,
         "change_candidates": candidates,
@@ -78,6 +56,68 @@ def build_allowance_analysis(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "Unexplained movement can mean allowance behavior changed, but it can also mean usage outside these local Codex logs.",
         ],
     }
+
+
+def _normalized_observations(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in sorted(rows, key=_observation_sort_key)
+        if _number(row.get("used_percent")) is not None
+    ]
+
+
+def _grouped_window_reports(
+    observation_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for row in observation_rows:
+        grouped.setdefault(_analysis_key(row), []).append(row)
+    return [_window_report(key, group_rows) for key, group_rows in sorted(grouped.items())]
+
+
+def _flatten_window_rows(
+    window_reports: list[dict[str, Any]],
+    field: str,
+) -> list[dict[str, Any]]:
+    return [
+        row for report in window_reports for row in report.get(field, []) if isinstance(row, dict)
+    ]
+
+
+def _allowance_analysis_summary(
+    *,
+    observation_rows: list[dict[str, Any]],
+    window_reports: list[dict[str, Any]],
+    spans: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    primary: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "observation_count": len(observation_rows),
+        "window_report_count": len(window_reports),
+        "positive_span_count": len(spans),
+        "candidate_change_count": len(candidates),
+        "primary_window_kind": primary.get("window_kind") if primary else None,
+        "primary_evidence_grade": (
+            primary.get("evidence_grade") if primary else "insufficient_data"
+        ),
+        "weekly_observation_count": _window_observation_count(
+            observation_rows,
+            "weekly",
+        ),
+        "five_hour_observation_count": _window_observation_count(
+            observation_rows,
+            "five_hour",
+        ),
+        "research_readiness": _research_readiness(window_reports, candidates),
+    }
+
+
+def _window_observation_count(
+    observation_rows: list[dict[str, Any]],
+    window_kind: str,
+) -> int:
+    return sum(1 for row in observation_rows if row.get("window_kind") == window_kind)
 
 
 def _window_report(key: tuple[str, str, str], rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -360,20 +400,28 @@ def _research_readiness_reasons(
             "Public allowance-change claims need repeated weekly spans before and after a candidate split.",
         ]
     evidence = best_candidate.get("statistical_evidence") or {}
-    reasons: list[str] = []
     before_count = int(evidence.get("sample_size_before") or 0)
     after_count = int(evidence.get("sample_size_after") or 0)
     p_value = _number(evidence.get("p_value_one_sided"))
-    if before_count < _PUBLIC_CLAIM_MIN_SPLIT_SPANS:
-        reasons.append("Too few weekly spans before the candidate split.")
-    if after_count < _PUBLIC_CLAIM_MIN_SPLIT_SPANS:
-        reasons.append("Too few weekly spans after the candidate split.")
-    if p_value is None or p_value > _PUBLIC_CLAIM_P_VALUE_THRESHOLD:
-        reasons.append("Nonparametric p-value is not yet strong enough for a public claim.")
-    if best_candidate.get("outside_usage_possible"):
-        reasons.append(
-            "Observed movement could still reflect usage outside these local logs; disclose this caveat."
-        )
+    rules = (
+        (
+            before_count < _PUBLIC_CLAIM_MIN_SPLIT_SPANS,
+            "Too few weekly spans before the candidate split.",
+        ),
+        (
+            after_count < _PUBLIC_CLAIM_MIN_SPLIT_SPANS,
+            "Too few weekly spans after the candidate split.",
+        ),
+        (
+            _p_value_not_ready(p_value),
+            "Nonparametric p-value is not yet strong enough for a public claim.",
+        ),
+        (
+            bool(best_candidate.get("outside_usage_possible")),
+            "Observed movement could still reflect usage outside these local logs; disclose this caveat.",
+        ),
+    )
+    reasons = [message for failed, message in rules if failed]
     if ready:
         reasons.insert(
             0,
@@ -382,6 +430,10 @@ def _research_readiness_reasons(
     if weekly_span_count < _PUBLIC_CLAIM_MIN_SPLIT_SPANS * 2:
         reasons.append("More weekly spans would improve stability of change-point estimates.")
     return reasons
+
+
+def _p_value_not_ready(p_value: float | None) -> bool:
+    return p_value is None or p_value > _PUBLIC_CLAIM_P_VALUE_THRESHOLD
 
 
 def _primary_window_report(windows: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/src/codex_usage_tracker/allowance_intelligence/statistics.py
+++ b/src/codex_usage_tracker/allowance_intelligence/statistics.py
@@ -28,12 +28,8 @@ def _statistical_evidence(
         "sample_size_before": len(previous_values),
         "sample_size_after": len(recent_values),
         "median_shift_credits_per_percent": _rounded(shift),
-        "median_confidence_interval_before_95": _median_confidence_interval(
-            previous_values
-        ),
-        "median_confidence_interval_after_95": _median_confidence_interval(
-            recent_values
-        ),
+        "median_confidence_interval_before_95": _median_confidence_interval(previous_values),
+        "median_confidence_interval_after_95": _median_confidence_interval(recent_values),
         "effect_size_cliffs_delta": _rounded(effect_size),
         "p_value_one_sided": _rounded(p_value),
         "combinations_evaluated": combinations_evaluated,
@@ -72,9 +68,7 @@ def _median_confidence_interval(values: list[float]) -> dict[str, Any]:
             break
         selected_rank = rank
         achieved_coverage = 1.0 - (2.0 * lower_tail_numerator / denominator)
-        binomial_coefficient = (
-            binomial_coefficient * (sample_size - rank + 1) // rank
-        )
+        binomial_coefficient = binomial_coefficient * (sample_size - rank + 1) // rank
 
     if selected_rank is None:
         return {
@@ -139,18 +133,38 @@ def _exact_permutation_p_value(
     if observed is None:
         return None, "insufficient_metric_values", None
 
-    values = previous + recent
+    extreme_count = _permutation_extreme_count(
+        previous + recent,
+        before_size=before_size,
+        observed=observed,
+    )
+    return extreme_count / combination_count, "exact_permutation_mean_shift", combination_count
+
+
+def _permutation_extreme_count(
+    values: list[float],
+    *,
+    before_size: int,
+    observed: float,
+) -> int:
     extreme_count = 0
-    for before_indices in combinations(range(total_size), before_size):
-        before_index_set = set(before_indices)
-        permuted_previous = [values[index] for index in before_indices]
-        permuted_recent = [
-            values[index] for index in range(total_size) if index not in before_index_set
-        ]
-        permuted_shift = _mean_shift(permuted_previous, permuted_recent)
+    for before_indices in combinations(range(len(values)), before_size):
+        permuted_shift = _permuted_mean_shift(values, before_indices)
         if permuted_shift is not None and permuted_shift <= observed + 1e-12:
             extreme_count += 1
-    return extreme_count / combination_count, "exact_permutation_mean_shift", combination_count
+    return extreme_count
+
+
+def _permuted_mean_shift(
+    values: list[float],
+    before_indices: tuple[int, ...],
+) -> float | None:
+    before_index_set = set(before_indices)
+    permuted_previous = [values[index] for index in before_indices]
+    permuted_recent = [
+        values[index] for index in range(len(values)) if index not in before_index_set
+    ]
+    return _mean_shift(permuted_previous, permuted_recent)
 
 
 def _cliffs_delta(previous: list[float], recent: list[float]) -> float | None:
@@ -186,19 +200,47 @@ def _statistical_signal(
 ) -> str:
     if before_count < 2 or after_count < 2 or effect_size is None:
         return "insufficient_metric_values"
-    if (
-        before_count >= _PUBLIC_CLAIM_MIN_SPLIT_SPANS
-        and after_count >= _PUBLIC_CLAIM_MIN_SPLIT_SPANS
-        and effect_size <= -0.8
-        and p_value is not None
-        and p_value <= _PUBLIC_CLAIM_P_VALUE_THRESHOLD
+    if _is_strong_nonparametric_shift(
+        effect_size=effect_size,
+        p_value=p_value,
+        before_count=before_count,
+        after_count=after_count,
     ):
         return "strong_nonparametric_shift"
-    if effect_size <= -0.8 and p_value is not None and p_value <= 0.2:
+    if _is_directionally_consistent(effect_size=effect_size, p_value=p_value):
         return "directionally_consistent_small_sample"
     if effect_size <= -0.5:
         return "directional_effect_limited"
     return "weak_or_mixed"
+
+
+def _is_strong_nonparametric_shift(
+    *,
+    effect_size: float,
+    p_value: float | None,
+    before_count: int,
+    after_count: int,
+) -> bool:
+    if p_value is None:
+        return False
+    return all(
+        (
+            before_count >= _PUBLIC_CLAIM_MIN_SPLIT_SPANS,
+            after_count >= _PUBLIC_CLAIM_MIN_SPLIT_SPANS,
+            effect_size <= -0.8,
+            p_value <= _PUBLIC_CLAIM_P_VALUE_THRESHOLD,
+        )
+    )
+
+
+def _is_directionally_consistent(
+    *,
+    effect_size: float,
+    p_value: float | None,
+) -> bool:
+    if p_value is None:
+        return False
+    return effect_size <= -0.8 and p_value <= 0.2
 
 
 def _statistical_public_claim_ready(

--- a/src/codex_usage_tracker/core/formatting.py
+++ b/src/codex_usage_tracker/core/formatting.py
@@ -180,53 +180,92 @@ def format_doctor(report: dict[str, Any]) -> str:
         f"Failures: {report.get('failures', 0)} | warnings: {report.get('warnings', 0)}",
         "",
     ]
-    environment = report.get("environment")
-    if isinstance(environment, dict):
-        lines.extend(["Environment:"])
-        package = environment.get("package")
-        if isinstance(package, dict):
-            lines.append(
-                f"Package: {package.get('name', 'unknown')} {package.get('version', 'unknown')}"
-            )
-        python = environment.get("python")
-        if isinstance(python, dict):
-            lines.append(
-                "Python: "
-                f"{python.get('version', 'unknown')} "
-                f"({python.get('implementation', 'unknown')})"
-            )
-        paths = environment.get("paths")
-        if isinstance(paths, dict):
-            lines.append(f"Codex home: {paths.get('codex_home', 'unknown')}")
-            lines.append(f"Database: {paths.get('db_path', 'unknown')}")
-            lines.append(f"Dashboard: {paths.get('dashboard_path', 'unknown')}")
-        codex_logs = environment.get("codex_logs")
-        if isinstance(codex_logs, dict):
-            sessions_status = "found" if codex_logs.get("sessions_dir_exists") else "missing"
-            lines.append(
-                "Codex logs: "
-                f"{sessions_status}, "
-                f"{_fmt_int(codex_logs.get('jsonl_files'))} JSONL files"
-            )
-        assets = environment.get("dashboard_assets")
-        if isinstance(assets, dict):
-            asset_status = "available" if assets.get("available") else "missing"
-            missing = assets.get("missing")
-            suffix = f" ({len(missing)} missing)" if isinstance(missing, list) and missing else ""
-            lines.append(f"Dashboard assets: {asset_status}{suffix}")
-        lines.append("")
-    for check in report.get("checks", []):
+    lines.extend(_doctor_environment_lines(report.get("environment")))
+    lines.extend(_doctor_check_lines(report.get("checks", [])))
+    lines.extend(_doctor_suggestion_lines(report.get("repair_suggestions")))
+    return "\n".join(lines)
+
+
+def _doctor_environment_lines(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    lines = ["Environment:"]
+    for formatter in (
+        _doctor_package_lines,
+        _doctor_python_lines,
+        _doctor_path_lines,
+        _doctor_log_lines,
+        _doctor_asset_lines,
+    ):
+        lines.extend(formatter(value))
+    lines.append("")
+    return lines
+
+
+def _doctor_package_lines(environment: dict[str, Any]) -> list[str]:
+    package = environment.get("package")
+    if not isinstance(package, dict):
+        return []
+    return [f"Package: {package.get('name', 'unknown')} {package.get('version', 'unknown')}"]
+
+
+def _doctor_python_lines(environment: dict[str, Any]) -> list[str]:
+    python = environment.get("python")
+    if not isinstance(python, dict):
+        return []
+    return [
+        f"Python: {python.get('version', 'unknown')} ({python.get('implementation', 'unknown')})"
+    ]
+
+
+def _doctor_path_lines(environment: dict[str, Any]) -> list[str]:
+    paths = environment.get("paths")
+    if not isinstance(paths, dict):
+        return []
+    return [
+        f"Codex home: {paths.get('codex_home', 'unknown')}",
+        f"Database: {paths.get('db_path', 'unknown')}",
+        f"Dashboard: {paths.get('dashboard_path', 'unknown')}",
+    ]
+
+
+def _doctor_log_lines(environment: dict[str, Any]) -> list[str]:
+    codex_logs = environment.get("codex_logs")
+    if not isinstance(codex_logs, dict):
+        return []
+    sessions_status = "found" if codex_logs.get("sessions_dir_exists") else "missing"
+    return [f"Codex logs: {sessions_status}, {_fmt_int(codex_logs.get('jsonl_files'))} JSONL files"]
+
+
+def _doctor_asset_lines(environment: dict[str, Any]) -> list[str]:
+    assets = environment.get("dashboard_assets")
+    if not isinstance(assets, dict):
+        return []
+    asset_status = "available" if assets.get("available") else "missing"
+    missing = assets.get("missing")
+    suffix = f" ({len(missing)} missing)" if isinstance(missing, list) and missing else ""
+    return [f"Dashboard assets: {asset_status}{suffix}"]
+
+
+def _doctor_check_lines(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    lines: list[str] = []
+    for check in value:
+        if not isinstance(check, dict):
+            continue
         status = str(check.get("status", "unknown")).upper()
         lines.append(f"- [{status}] {check.get('name')}: {check.get('detail')}")
         remediation = check.get("remediation")
         if remediation:
             lines.append(f"  Next: {remediation}")
-    suggestions = report.get("repair_suggestions")
-    if isinstance(suggestions, list) and suggestions:
-        lines.extend(["", "Repair suggestions:"])
-        for suggestion in suggestions:
-            lines.append(f"- {suggestion}")
-    return "\n".join(lines)
+    return lines
+
+
+def _doctor_suggestion_lines(value: Any) -> list[str]:
+    if not isinstance(value, list) or not value:
+        return []
+    return ["", "Repair suggestions:", *(f"- {suggestion}" for suggestion in value)]
 
 
 def format_pricing_coverage(report: dict[str, Any], limit: int = 20) -> str:

--- a/src/codex_usage_tracker/diagnostics/fact_classifiers.py
+++ b/src/codex_usage_tracker/diagnostics/fact_classifiers.py
@@ -333,27 +333,34 @@ def _command_tokens(command: str) -> list[str]:
 def _strip_command_wrappers(tokens: list[str]) -> list[str]:
     remaining = list(tokens)
     while remaining:
-        while remaining and _looks_like_assignment(remaining[0]):
-            remaining.pop(0)
-        if not remaining:
+        remaining = _strip_leading_assignments(remaining)
+        unwrapped = _unwrap_command_once(remaining)
+        if unwrapped is None:
             break
-        base = _command_basename(remaining[0])
-        if base in {"command", "env", "sudo"}:
-            remaining.pop(0)
-            continue
-        if base in SHELL_EXEC_WRAPPERS:
-            nested = _shell_exec_nested_tokens(remaining)
-            if nested:
-                remaining = nested
-                continue
-        if base in RUN_WRAPPERS and len(remaining) > 2 and remaining[1] == "run":
-            remaining = remaining[2:]
-            continue
-        if base == "npx" and len(remaining) > 1:
-            remaining = remaining[1:]
-            continue
-        break
+        remaining = unwrapped
     return remaining
+
+
+def _strip_leading_assignments(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens) and _looks_like_assignment(tokens[index]):
+        index += 1
+    return tokens[index:]
+
+
+def _unwrap_command_once(tokens: list[str]) -> list[str] | None:
+    if not tokens:
+        return None
+    base = _command_basename(tokens[0])
+    if base in {"command", "env", "sudo"}:
+        return tokens[1:]
+    if base in SHELL_EXEC_WRAPPERS:
+        return _shell_exec_nested_tokens(tokens) or None
+    if base in RUN_WRAPPERS and len(tokens) > 2 and tokens[1] == "run":
+        return tokens[2:]
+    if base == "npx" and len(tokens) > 1:
+        return tokens[1:]
+    return None
 
 
 def _looks_like_assignment(token: str) -> bool:

--- a/src/codex_usage_tracker/pricing/config.py
+++ b/src/codex_usage_tracker/pricing/config.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeGuard
 
 from codex_usage_tracker.core.paths import DEFAULT_PRICING_PATH
 
@@ -136,55 +136,90 @@ def pin_pricing_snapshot(
 
 
 def parse_models(raw: object) -> dict[str, dict[str, float]]:
+    model_payload = _required_model_payload(raw)
+    models: dict[str, dict[str, float]] = {}
+    for model, rates in model_payload.items():
+        if not _valid_model_name(model):
+            continue
+        parsed_rates = _parsed_model_rates(model, rates)
+        if parsed_rates is not None:
+            models[model] = parsed_rates
+    return models
+
+
+def _required_model_payload(raw: object) -> dict[object, object]:
     if not isinstance(raw, dict):
         raise ValueError("pricing config must be a JSON object")
     model_payload = raw.get("models", raw)
     if not isinstance(model_payload, dict):
         raise ValueError("pricing config 'models' must be an object")
+    return model_payload
 
-    models: dict[str, dict[str, float]] = {}
-    for model, rates in model_payload.items():
-        if not isinstance(model, str) or model.startswith("_"):
-            continue
-        if not isinstance(rates, dict):
-            continue
-        input_rate = _required_rate(rates, "input_per_million", model)
-        cached_rate = _optional_rate(rates, "cached_input_per_million")
-        output_rate = _required_rate(rates, "output_per_million", model)
-        models[model] = {
-            "input_per_million": float(input_rate),
-            "cached_input_per_million": float(
-                cached_rate if cached_rate is not None else input_rate
-            ),
-            "output_per_million": float(output_rate),
-        }
-    return models
+
+def _optional_model_payload(raw: object) -> dict[object, object]:
+    if not isinstance(raw, dict):
+        return {}
+    model_payload = raw.get("models", raw)
+    if not isinstance(model_payload, dict):
+        return {}
+    return model_payload
+
+
+def _parsed_model_rates(model: str, rates: object) -> dict[str, float] | None:
+    if not isinstance(rates, dict):
+        return None
+    input_rate = _required_rate(rates, "input_per_million", model)
+    cached_rate = _optional_rate(rates, "cached_input_per_million")
+    output_rate = _required_rate(rates, "output_per_million", model)
+    return {
+        "input_per_million": float(input_rate),
+        "cached_input_per_million": float(cached_rate if cached_rate is not None else input_rate),
+        "output_per_million": float(output_rate),
+    }
+
+
+def _valid_model_name(model: object) -> TypeGuard[str]:
+    return isinstance(model, str) and not model.startswith("_")
 
 
 def parse_aliases(raw: object) -> dict[str, str]:
-    if not isinstance(raw, dict):
-        return {}
-    aliases = raw.get("aliases")
-    if not isinstance(aliases, dict):
-        return {}
+    aliases = _optional_named_mapping(raw, "aliases")
     parsed: dict[str, str] = {}
-    for source, target in aliases.items():
-        if isinstance(source, str) and isinstance(target, str) and source and target:
+    for alias in aliases.items():
+        if _valid_alias(alias):
+            source, target = alias
             parsed[source] = target
     return parsed
 
 
-def parse_estimated_models(raw: object) -> set[str]:
+def _optional_named_mapping(raw: object, field: str) -> dict[object, object]:
     if not isinstance(raw, dict):
-        return set()
-    model_payload = raw.get("models", raw)
-    if not isinstance(model_payload, dict):
-        return set()
-    return {
-        model
-        for model, rates in model_payload.items()
-        if isinstance(model, str) and isinstance(rates, dict) and rates.get("estimated") is True
-    }
+        return {}
+    value = raw.get(field)
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _valid_alias(alias: tuple[object, object]) -> TypeGuard[tuple[str, str]]:
+    source, target = alias
+    return all(
+        (
+            isinstance(source, str),
+            isinstance(target, str),
+            bool(source),
+            bool(target),
+        )
+    )
+
+
+def parse_estimated_models(raw: object) -> set[str]:
+    model_payload = _optional_model_payload(raw)
+    return {model for model, rates in model_payload.items() if _estimated_model_entry(model, rates)}
+
+
+def _estimated_model_entry(model: object, rates: object) -> TypeGuard[str]:
+    return isinstance(model, str) and isinstance(rates, dict) and rates.get("estimated") is True
 
 
 def load_existing_aliases(path: Path) -> dict[str, str]:

--- a/src/codex_usage_tracker/reports/hypothesis_limit_evaluators.py
+++ b/src/codex_usage_tracker/reports/hypothesis_limit_evaluators.py
@@ -32,27 +32,13 @@ def _evaluate_effort_model_hypothesis(
         thread=thread,
         include_archived=include_archived,
     )
-    total_tokens = sum(_number(row.get("total_tokens")) for row in rows)
-    effort_totals = _token_totals_by(rows, "effort")
+    total_tokens, high_effort_ratio, effort_totals = _effort_token_share(rows)
     model_totals = _token_totals_by(rows, "model")
-    high_effort_tokens = sum(
-        value
-        for effort, value in effort_totals.items()
-        if effort.lower() in {"high", "xhigh", "maximum"}
+    status, confidence = _effort_hypothesis_outcome(
+        row_count=len(rows),
+        total_tokens=total_tokens,
+        high_effort_ratio=high_effort_ratio,
     )
-    high_effort_ratio = high_effort_tokens / total_tokens if total_tokens else 0.0
-    if not rows or not total_tokens:
-        status = "insufficient_evidence"
-        confidence = "insufficient_local_evidence"
-    elif high_effort_ratio >= 0.5:
-        status = "true"
-        confidence = "medium"
-    elif high_effort_ratio >= 0.2:
-        status = "partially_true"
-        confidence = "low"
-    else:
-        status = "false"
-        confidence = "low"
     return _hypothesis_result(
         status=status,
         confidence=confidence,
@@ -67,9 +53,7 @@ def _evaluate_effort_model_hypothesis(
             "top_models": _top_token_totals(model_totals),
         },
         evidence=[],
-        counter_evidence=[]
-        if high_effort_ratio
-        else ["No high-effort token share found in the selected scope."],
+        counter_evidence=_effort_counter_evidence(high_effort_ratio),
         next_action="Compare high-effort calls against task type, then use lower effort for routine edits and reserve higher effort for uncertain design work.",
         recommended_next_tools=[
             _next_tool("usage_summary", "Summarize usage by model or effort."),
@@ -79,6 +63,41 @@ def _evaluate_effort_model_hypothesis(
             ),
         ],
     )
+
+
+def _effort_token_share(
+    rows: list[dict[str, Any]],
+) -> tuple[float, float, dict[str, float]]:
+    total_tokens = sum(_number(row.get("total_tokens")) for row in rows)
+    effort_totals = _token_totals_by(rows, "effort")
+    high_effort_tokens = sum(
+        value
+        for effort, value in effort_totals.items()
+        if effort.lower() in {"high", "xhigh", "maximum"}
+    )
+    ratio = high_effort_tokens / total_tokens if total_tokens else 0.0
+    return total_tokens, ratio, effort_totals
+
+
+def _effort_hypothesis_outcome(
+    *,
+    row_count: int,
+    total_tokens: float,
+    high_effort_ratio: float,
+) -> tuple[str, str]:
+    if not row_count or not total_tokens:
+        return "insufficient_evidence", "insufficient_local_evidence"
+    if high_effort_ratio >= 0.5:
+        return "true", "medium"
+    if high_effort_ratio >= 0.2:
+        return "partially_true", "low"
+    return "false", "low"
+
+
+def _effort_counter_evidence(high_effort_ratio: float) -> list[str]:
+    if high_effort_ratio:
+        return []
+    return ["No high-effort token share found in the selected scope."]
 
 
 def _evaluate_allowance_hypothesis(

--- a/src/codex_usage_tracker/server/investigations.py
+++ b/src/codex_usage_tracker/server/investigations.py
@@ -91,77 +91,195 @@ def investigation_payload(
         first_query_value(params.get("include_archived")),
         include_archived_default,
     )
-    selected_privacy_mode = first_query_value(params.get("privacy_mode")) or privacy_mode
+    selected_privacy_mode = _selected_privacy_mode(params, privacy_mode)
 
     if kind == "agentic":
-        return dict(
-            build_agentic_investigation_report(
-                db_path=db_path,
-                pricing_path=pricing_path,
-                allowance_path=allowance_path,
-                projects_path=projects_path,
-                goal=first_query_value(params.get("goal")) or "token_waste",
-                since=since,
-                until=until,
-                thread=thread,
-                include_archived=include_archived,
-                evidence_limit=_bounded_int(params, "evidence_limit", 5),
-                detail_mode=first_query_value(params.get("detail_mode")) or "compact",
-                privacy_mode=selected_privacy_mode,
-            ).payload
+        return _agentic_investigation_payload(
+            params,
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            privacy_mode=selected_privacy_mode,
         )
     if kind == "repeated-file-rediscovery":
-        return dict(
-            build_repeated_file_rediscovery_report(
-                db_path=db_path,
-                since=since,
-                until=until,
-                thread=thread,
-                include_archived=include_archived,
-                min_occurrences=_bounded_int(params, "min_occurrences", 2),
-                limit=parse_api_limit(first_query_value(params.get("limit")), 20),
-                sample_limit=_bounded_int(params, "sample_limit", 3),
-                privacy_mode=selected_privacy_mode,
-            ).payload
+        return _repeated_file_investigation_payload(
+            params,
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            privacy_mode=selected_privacy_mode,
         )
     if kind == "shell-churn":
-        return dict(
-            build_shell_churn_report(
-                db_path=db_path,
-                since=since,
-                until=until,
-                thread=thread,
-                include_archived=include_archived,
-                min_occurrences=_bounded_int(params, "min_occurrences", 3),
-                limit=parse_api_limit(first_query_value(params.get("limit")), 20),
-                sample_limit=_bounded_int(params, "sample_limit", 3),
-                privacy_mode=selected_privacy_mode,
-            ).payload
+        return _shell_churn_investigation_payload(
+            params,
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            privacy_mode=selected_privacy_mode,
         )
     if kind == "large-low-output":
-        return dict(
-            build_large_low_output_report(
-                db_path=db_path,
-                since=since,
-                until=until,
-                thread=thread,
-                include_archived=include_archived,
-                min_total_tokens=_bounded_int(
-                    params,
-                    "min_total_tokens",
-                    20_000,
-                    maximum=1_000_000_000,
-                ),
-                max_output_tokens=_bounded_int(
-                    params,
-                    "max_output_tokens",
-                    1_000,
-                    maximum=1_000_000_000,
-                ),
-                limit=parse_api_limit(first_query_value(params.get("limit")), 20),
-                privacy_mode=selected_privacy_mode,
-            ).payload
+        return _large_low_output_investigation_payload(
+            params,
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            privacy_mode=selected_privacy_mode,
         )
+    return _walk_investigation_payload(
+        params,
+        db_path=db_path,
+        since=since,
+        until=until,
+        thread=thread,
+        include_archived=include_archived,
+        privacy_mode=selected_privacy_mode,
+    )
+
+
+def _selected_privacy_mode(
+    params: dict[str, list[str]],
+    privacy_mode: str,
+) -> str:
+    return first_query_value(params.get("privacy_mode")) or privacy_mode
+
+
+def _agentic_investigation_payload(
+    params: dict[str, list[str]],
+    *,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+    projects_path: Path,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    privacy_mode: str,
+) -> dict[str, object]:
+    return dict(
+        build_agentic_investigation_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            goal=first_query_value(params.get("goal")) or "token_waste",
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            evidence_limit=_bounded_int(params, "evidence_limit", 5),
+            detail_mode=first_query_value(params.get("detail_mode")) or "compact",
+            privacy_mode=privacy_mode,
+        ).payload
+    )
+
+
+def _repeated_file_investigation_payload(
+    params: dict[str, list[str]],
+    *,
+    db_path: Path,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    privacy_mode: str,
+) -> dict[str, object]:
+    return dict(
+        build_repeated_file_rediscovery_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            min_occurrences=_bounded_int(params, "min_occurrences", 2),
+            limit=parse_api_limit(first_query_value(params.get("limit")), 20),
+            sample_limit=_bounded_int(params, "sample_limit", 3),
+            privacy_mode=privacy_mode,
+        ).payload
+    )
+
+
+def _shell_churn_investigation_payload(
+    params: dict[str, list[str]],
+    *,
+    db_path: Path,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    privacy_mode: str,
+) -> dict[str, object]:
+    return dict(
+        build_shell_churn_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            min_occurrences=_bounded_int(params, "min_occurrences", 3),
+            limit=parse_api_limit(first_query_value(params.get("limit")), 20),
+            sample_limit=_bounded_int(params, "sample_limit", 3),
+            privacy_mode=privacy_mode,
+        ).payload
+    )
+
+
+def _large_low_output_investigation_payload(
+    params: dict[str, list[str]],
+    *,
+    db_path: Path,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    privacy_mode: str,
+) -> dict[str, object]:
+    return dict(
+        build_large_low_output_report(
+            db_path=db_path,
+            since=since,
+            until=until,
+            thread=thread,
+            include_archived=include_archived,
+            min_total_tokens=_bounded_int(
+                params,
+                "min_total_tokens",
+                20_000,
+                maximum=1_000_000_000,
+            ),
+            max_output_tokens=_bounded_int(
+                params,
+                "max_output_tokens",
+                1_000,
+                maximum=1_000_000_000,
+            ),
+            limit=parse_api_limit(first_query_value(params.get("limit")), 20),
+            privacy_mode=privacy_mode,
+        ).payload
+    )
+
+
+def _walk_investigation_payload(
+    params: dict[str, list[str]],
+    *,
+    db_path: Path,
+    since: str | None,
+    until: str | None,
+    thread: str | None,
+    include_archived: bool,
+    privacy_mode: str,
+) -> dict[str, object]:
     question = first_query_value(params.get("question"))
     if not question:
         raise ValueError("question is required")
@@ -175,7 +293,7 @@ def investigation_payload(
             include_archived=include_archived,
             min_occurrences=_bounded_int(params, "min_occurrences", 2),
             evidence_limit=_bounded_int(params, "evidence_limit", 5),
-            privacy_mode=selected_privacy_mode,
+            privacy_mode=privacy_mode,
         ).payload
     )
 

--- a/src/codex_usage_tracker/store/diagnostic_queries.py
+++ b/src/codex_usage_tracker/store/diagnostic_queries.py
@@ -313,18 +313,27 @@ def append_diagnostic_fact_filters(
     fact_category: str | None,
     table_alias: str,
 ) -> tuple[str, list[Any]]:
-    clauses = [where_clause.removeprefix("WHERE ")] if where_clause else []
+    clauses = _existing_fact_filter_clauses(where_clause)
     updated_params = list(params)
     prefix = f"{table_alias}."
-    if fact_type:
-        clauses.append(f"{prefix}fact_type = ?")
-        updated_params.append(fact_type)
-    if fact_name:
-        clauses.append(f"{prefix}fact_name = ?")
-        updated_params.append(fact_name)
-    if fact_category:
-        clauses.append(f"{prefix}fact_category = ?")
-        updated_params.append(fact_category)
+    for field, value in (
+        ("fact_type", fact_type),
+        ("fact_name", fact_name),
+        ("fact_category", fact_category),
+    ):
+        if value:
+            clauses.append(f"{prefix}{field} = ?")
+            updated_params.append(value)
+    return _diagnostic_where_clause(clauses), updated_params
+
+
+def _existing_fact_filter_clauses(where_clause: str) -> list[str]:
+    if not where_clause:
+        return []
+    return [where_clause.removeprefix("WHERE ")]
+
+
+def _diagnostic_where_clause(clauses: list[str]) -> str:
     if not clauses:
-        return "", updated_params
-    return "WHERE " + " AND ".join(f"({clause})" for clause in clauses), updated_params
+        return ""
+    return "WHERE " + " AND ".join(f"({clause})" for clause in clauses)

--- a/src/codex_usage_tracker/store/large_low_output.py
+++ b/src/codex_usage_tracker/store/large_low_output.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
+from codex_usage_tracker.store.query_values import row_float, row_int
+
 
 def query_large_low_output_calls(
     conn: sqlite3.Connection,
@@ -109,17 +111,17 @@ def query_large_low_output_calls(
 
 
 def _candidate(row: sqlite3.Row) -> dict[str, Any]:
-    input_tokens = int(row["input_tokens"] or 0)
-    cached_input_tokens = int(row["cached_input_tokens"] or 0)
-    uncached_input_tokens = int(row["uncached_input_tokens"] or 0)
-    output_tokens = int(row["output_tokens"] or 0)
-    total_tokens = int(row["total_tokens"] or 0)
-    context_window_percent = float(row["context_window_percent"] or 0.0)
-    tool_output_size_bytes = int(row["tool_output_size_bytes"] or 0)
-    command_output_size_bytes = int(row["command_output_size_bytes"] or 0)
-    tool_call_count = int(row["tool_call_count"] or 0)
-    command_run_count = int(row["command_run_count"] or 0)
-    file_event_count = int(row["file_event_count"] or 0)
+    input_tokens = row_int(row, "input_tokens")
+    cached_input_tokens = row_int(row, "cached_input_tokens")
+    uncached_input_tokens = row_int(row, "uncached_input_tokens")
+    output_tokens = row_int(row, "output_tokens")
+    total_tokens = row_int(row, "total_tokens")
+    context_window_percent = row_float(row, "context_window_percent")
+    tool_output_size_bytes = row_int(row, "tool_output_size_bytes")
+    command_output_size_bytes = row_int(row, "command_output_size_bytes")
+    tool_call_count = row_int(row, "tool_call_count")
+    command_run_count = row_int(row, "command_run_count")
+    file_event_count = row_int(row, "file_event_count")
     explanation, reasons = _candidate_explanation(
         input_tokens=input_tokens,
         cached_input_tokens=cached_input_tokens,
@@ -149,7 +151,7 @@ def _candidate(row: sqlite3.Row) -> dict[str, Any]:
         "cached_input_tokens": cached_input_tokens,
         "uncached_input_tokens": uncached_input_tokens,
         "output_tokens": output_tokens,
-        "reasoning_output_tokens": int(row["reasoning_output_tokens"] or 0),
+        "reasoning_output_tokens": row_int(row, "reasoning_output_tokens"),
         "cache_ratio": _ratio(cached_input_tokens, input_tokens),
         "uncached_input_ratio": _ratio(uncached_input_tokens, input_tokens),
         "model_context_window": row["model_context_window"],
@@ -160,10 +162,10 @@ def _candidate(row: sqlite3.Row) -> dict[str, Any]:
         "nearby_activity": {
             "tool_call_count": tool_call_count,
             "command_run_count": command_run_count,
-            "failed_command_count": int(row["failed_command_count"] or 0),
+            "failed_command_count": row_int(row, "failed_command_count"),
             "file_event_count": file_event_count,
-            "file_read_count": int(row["file_read_count"] or 0),
-            "file_write_count": int(row["file_write_count"] or 0),
+            "file_read_count": row_int(row, "file_read_count"),
+            "file_write_count": row_int(row, "file_write_count"),
             "tool_output_size_bytes": tool_output_size_bytes,
             "command_output_size_bytes": command_output_size_bytes,
         },
@@ -191,29 +193,71 @@ def _candidate_explanation(
     uncached_ratio = _ratio(uncached_input_tokens, input_tokens)
     activity_count = tool_call_count + command_run_count + file_event_count
     output_bytes = tool_output_size_bytes + command_output_size_bytes
-    reasons: list[str] = []
+    rules = (
+        (
+            _is_large_uncached_input(
+                input_tokens=input_tokens,
+                uncached_input_tokens=uncached_input_tokens,
+                uncached_ratio=uncached_ratio,
+                cache_ratio=cache_ratio,
+            ),
+            "large_uncached_input",
+        ),
+        (context_window_percent >= 0.60, "high_context_window_share"),
+        (
+            _has_activity_pressure(
+                output_bytes=output_bytes,
+                activity_count=activity_count,
+            ),
+            "tool_or_file_activity_pressure",
+        ),
+        (
+            _has_very_low_output_share(
+                total_tokens=total_tokens,
+                output_tokens=output_tokens,
+            ),
+            "very_low_output_share",
+        ),
+    )
+    reasons = [reason for applies, reason in rules if applies]
+    return _explanation_kind(reasons), reasons
 
-    if (
-        input_tokens
-        and uncached_input_tokens >= 10_000
-        and uncached_ratio >= 0.65
-        and cache_ratio <= 0.35
-    ):
-        reasons.append("large_uncached_input")
-    if context_window_percent >= 0.60:
-        reasons.append("high_context_window_share")
-    if output_bytes >= 50_000 or activity_count >= 8:
-        reasons.append("tool_or_file_activity_pressure")
-    if total_tokens and output_tokens <= max(250, int(total_tokens * 0.02)):
-        reasons.append("very_low_output_share")
 
-    if "large_uncached_input" in reasons:
-        return "cold_resume_or_cache_miss", reasons
-    if "tool_or_file_activity_pressure" in reasons:
-        return "tool_output_pressure", reasons
-    if "high_context_window_share" in reasons:
-        return "stale_thread_low_value_continuation", reasons
-    return "large_context_low_output", reasons
+def _is_large_uncached_input(
+    *,
+    input_tokens: int,
+    uncached_input_tokens: int,
+    uncached_ratio: float,
+    cache_ratio: float,
+) -> bool:
+    return all(
+        (
+            bool(input_tokens),
+            uncached_input_tokens >= 10_000,
+            uncached_ratio >= 0.65,
+            cache_ratio <= 0.35,
+        )
+    )
+
+
+def _has_activity_pressure(*, output_bytes: int, activity_count: int) -> bool:
+    return output_bytes >= 50_000 or activity_count >= 8
+
+
+def _has_very_low_output_share(*, total_tokens: int, output_tokens: int) -> bool:
+    return bool(total_tokens) and output_tokens <= max(250, int(total_tokens * 0.02))
+
+
+def _explanation_kind(reasons: list[str]) -> str:
+    priorities = (
+        ("large_uncached_input", "cold_resume_or_cache_miss"),
+        ("tool_or_file_activity_pressure", "tool_output_pressure"),
+        ("high_context_window_share", "stale_thread_low_value_continuation"),
+    )
+    for reason, explanation in priorities:
+        if reason in reasons:
+            return explanation
+    return "large_context_low_output"
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/src/codex_usage_tracker/store/query_values.py
+++ b/src/codex_usage_tracker/store/query_values.py
@@ -1,0 +1,13 @@
+"""Typed value coercion for SQLite query result rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def row_int(row: Any, field: str) -> int:
+    return int(row[field] or 0)
+
+
+def row_float(row: Any, field: str) -> float:
+    return float(row[field] or 0.0)

--- a/src/codex_usage_tracker/store/repeated_files.py
+++ b/src/codex_usage_tracker/store/repeated_files.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
+from codex_usage_tracker.store.query_values import row_int
+
 
 def query_repeated_file_rediscovery(
     conn: sqlite3.Connection,
@@ -118,18 +120,14 @@ def _file_candidate(
     *,
     trace_handles: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    read_count = int(row["read_count"] or 0)
-    write_count = int(row["write_count"] or 0)
-    other_count = int(row["other_operation_count"] or 0)
-    occurrences = int(row["occurrences"] or 0)
-    call_count = int(row["call_count"] or 0)
-    adjacent_count = int(row["adjacent_retouch_count"] or 0)
-    total_tokens = int(row["total_tokens"] or 0)
-    candidate_kind = (
-        "repeated_read_rediscovery"
-        if read_count >= max(write_count + other_count, 1)
-        else "edit_or_write_churn"
-    )
+    read_count = row_int(row, "read_count")
+    write_count = row_int(row, "write_count")
+    other_count = row_int(row, "other_operation_count")
+    occurrences = row_int(row, "occurrences")
+    call_count = row_int(row, "call_count")
+    adjacent_count = row_int(row, "adjacent_retouch_count")
+    total_tokens = row_int(row, "total_tokens")
+    candidate_kind = _file_candidate_kind(read_count, write_count, other_count)
     return {
         "path_hash": row["path_hash"],
         "path_identity": row["path_identity"],
@@ -138,10 +136,10 @@ def _file_candidate(
         "candidate_kind": candidate_kind,
         "occurrences": occurrences,
         "call_count": call_count,
-        "thread_count": int(row["thread_count"] or 0),
-        "session_count": int(row["session_count"] or 0),
+        "thread_count": row_int(row, "thread_count"),
+        "session_count": row_int(row, "session_count"),
         "total_tokens": total_tokens,
-        "avg_tokens_per_call": round(total_tokens / call_count, 2) if call_count else 0.0,
+        "avg_tokens_per_call": _average_per_call(total_tokens, call_count),
         "adjacent_retouch_count": adjacent_count,
         "operation_mix": {
             "read": read_count,
@@ -161,6 +159,18 @@ def _file_candidate(
         ),
         "trace_handles": trace_handles,
     }
+
+
+def _file_candidate_kind(read_count: int, write_count: int, other_count: int) -> str:
+    if read_count >= max(write_count + other_count, 1):
+        return "repeated_read_rediscovery"
+    return "edit_or_write_churn"
+
+
+def _average_per_call(total_tokens: int, call_count: int) -> float:
+    if not call_count:
+        return 0.0
+    return round(total_tokens / call_count, 2)
 
 
 def _trace_handles_for_path(

--- a/src/codex_usage_tracker/store/shell_churn.py
+++ b/src/codex_usage_tracker/store/shell_churn.py
@@ -6,6 +6,8 @@ import re
 import sqlite3
 from typing import Any
 
+from codex_usage_tracker.store.query_values import row_int
+
 SHELL_CHURN_ROOTS = {
     "sed",
     "rg",
@@ -159,35 +161,35 @@ def _shell_churn_candidate(
 ) -> dict[str, Any]:
     raw_command_root = str(row["command_root"] or "unknown")
     sample_command_label = str(row["sample_command_label"] or "")
-    distinct_label_count = int(row["distinct_label_count"] or 0)
+    distinct_label_count = row_int(row, "distinct_label_count")
     command_root = _display_command_root(
         raw_command_root,
         sample_command_label,
         distinct_label_count=distinct_label_count,
     )
-    occurrences = int(row["occurrences"] or 0)
-    failure_count = int(row["failure_count"] or 0)
-    adjacent_root_count = int(row["adjacent_root_repeat_count"] or 0)
-    adjacent_label_count = int(row["adjacent_label_repeat_count"] or 0)
-    total_tokens = int(row["total_tokens"] or 0)
-    output_size_bytes = int(row["output_size_bytes"] or 0)
+    occurrences = row_int(row, "occurrences")
+    failure_count = row_int(row, "failure_count")
+    adjacent_root_count = row_int(row, "adjacent_root_repeat_count")
+    adjacent_label_count = row_int(row, "adjacent_label_repeat_count")
+    total_tokens = row_int(row, "total_tokens")
+    output_size_bytes = row_int(row, "output_size_bytes")
     return {
         "command_root": command_root,
         "command_label": _display_command_label(command_root, sample_command_label),
         "command_family": _command_family(command_root),
         "churn_kind": _churn_kind(failure_count, adjacent_root_count),
         "occurrences": occurrences,
-        "call_count": int(row["call_count"] or 0),
-        "thread_count": int(row["thread_count"] or 0),
-        "session_count": int(row["session_count"] or 0),
+        "call_count": row_int(row, "call_count"),
+        "thread_count": row_int(row, "thread_count"),
+        "session_count": row_int(row, "session_count"),
         "total_tokens": total_tokens,
         "output_size_bytes": output_size_bytes,
-        "success_count": int(row["success_count"] or 0),
+        "success_count": row_int(row, "success_count"),
         "failure_count": failure_count,
         "distinct_label_count": distinct_label_count,
         "adjacent_root_repeat_count": adjacent_root_count,
         "adjacent_label_repeat_count": adjacent_label_count,
-        "retry_group_count": int(row["retry_group_count"] or 0),
+        "retry_group_count": row_int(row, "retry_group_count"),
         "first_seen_at": row["first_seen_at"],
         "last_seen_at": row["last_seen_at"],
         "top_labels": top_labels,

--- a/src/codex_usage_tracker/store/thread_summaries.py
+++ b/src/codex_usage_tracker/store/thread_summaries.py
@@ -72,32 +72,17 @@ def query_thread_summaries(
         search=search,
         include_archived=include_archived,
     )
-    sort_map = {
-        "tokens": "total_tokens",
-        "time": "latest_event_timestamp",
-        "calls": "call_count",
-        "cache": "avg_cache_ratio",
-        "thread": "thread_label",
-    }
-    if sort not in sort_map:
-        allowed = ", ".join(sorted(sort_map))
-        raise ValueError(f"sort must be one of: {allowed}")
+    sort_column = _thread_summary_sort_column(sort)
     direction_sql = normalize_sort_direction(direction)
     normalized_limit = normalize_limit(limit)
     normalized_offset = normalize_offset(offset)
+    limit_clause, query_params = _thread_summary_limit_clause(
+        normalized_limit,
+        normalized_offset,
+        params,
+    )
     usage_thread_key = thread_key_expression("u.")
-    active_usage_filter = "" if include_archived else "AND coalesce(u.is_archived, 0) = 0"
-    limit_clause = ""
-    query_params = list(params)
-    if normalized_limit is not None:
-        limit_clause = "LIMIT ?"
-        query_params.append(normalized_limit)
-        if normalized_offset:
-            limit_clause += " OFFSET ?"
-            query_params.append(normalized_offset)
-    elif normalized_offset:
-        limit_clause = "LIMIT -1 OFFSET ?"
-        query_params.append(normalized_offset)
+    active_usage_filter = _active_usage_filter(include_archived)
     with connect(db_path) as conn:
         init_db(conn)
         rows = conn.execute(
@@ -117,12 +102,50 @@ def query_thread_summaries(
                 ) AS latest_record_id
             FROM thread_summaries AS t
             {where_clause}
-            ORDER BY {sort_map[sort]} {direction_sql}, latest_event_timestamp DESC
+            ORDER BY {sort_column} {direction_sql}, latest_event_timestamp DESC
             {limit_clause}
             """,
             query_params,
         ).fetchall()
     return [row_to_dict(row) for row in rows]
+
+
+def _thread_summary_sort_column(sort: str) -> str:
+    sort_map = {
+        "tokens": "total_tokens",
+        "time": "latest_event_timestamp",
+        "calls": "call_count",
+        "cache": "avg_cache_ratio",
+        "thread": "thread_label",
+    }
+    if sort not in sort_map:
+        allowed = ", ".join(sorted(sort_map))
+        raise ValueError(f"sort must be one of: {allowed}")
+    return sort_map[sort]
+
+
+def _thread_summary_limit_clause(
+    limit: int | None,
+    offset: int,
+    params: list[Any],
+) -> tuple[str, list[Any]]:
+    query_params = list(params)
+    if limit is not None:
+        query_params.append(limit)
+        if offset:
+            query_params.append(offset)
+            return "LIMIT ? OFFSET ?", query_params
+        return "LIMIT ?", query_params
+    if offset:
+        query_params.append(offset)
+        return "LIMIT -1 OFFSET ?", query_params
+    return "", query_params
+
+
+def _active_usage_filter(include_archived: bool) -> str:
+    if include_archived:
+        return ""
+    return "AND coalesce(u.is_archived, 0) = 0"
 
 
 def query_thread_summary_count(

--- a/src/codex_usage_tracker/usage_drain/grace.py
+++ b/src/codex_usage_tracker/usage_drain/grace.py
@@ -159,6 +159,23 @@ def small_break_age_after_one_percent_run(
 ) -> int | None:
     if not values or is_one_percent_delta(values[-1]):
         return None
+    break_age, preceding_index = _trailing_small_break(
+        values,
+        max_break_delta=max_break_delta,
+    )
+    if not break_age:
+        return None
+    preceding_streak = _preceding_one_percent_streak(values, preceding_index)
+    if preceding_streak < streak_threshold:
+        return None
+    return break_age
+
+
+def _trailing_small_break(
+    values: list[float],
+    *,
+    max_break_delta: float,
+) -> tuple[int, int]:
     index = len(values) - 1
     break_age = 0
     while (
@@ -166,12 +183,12 @@ def small_break_age_after_one_percent_run(
     ):
         break_age += 1
         index -= 1
-    if break_age == 0:
-        return None
-    preceding_streak = 0
+    return break_age, index
+
+
+def _preceding_one_percent_streak(values: list[float], index: int) -> int:
+    streak = 0
     while index >= 0 and is_one_percent_delta(values[index]):
-        preceding_streak += 1
+        streak += 1
         index -= 1
-    if preceding_streak >= streak_threshold:
-        return break_age
-    return None
+    return streak

--- a/src/codex_usage_tracker/usage_drain/proxy_fit.py
+++ b/src/codex_usage_tracker/usage_drain/proxy_fit.py
@@ -119,24 +119,46 @@ def _candidate_drain_comparison(
     candidate_values: list[float],
 ) -> tuple[dict[str, float | int | None], dict[str, float | int | None], float | None]:
     with_candidates = _drain_stats(
-        [
-            span
-            for span, candidate in zip(spans, candidate_values, strict=True)
-            if candidate > 0 and span.standard_usage_credits > 0
-        ]
+        _spans_by_candidate_presence(
+            spans,
+            candidate_values,
+            require_candidate=True,
+        )
     )
     without_candidates = _drain_stats(
-        [
-            span
-            for span, candidate in zip(spans, candidate_values, strict=True)
-            if candidate <= 0 and span.standard_usage_credits > 0
-        ]
+        _spans_by_candidate_presence(
+            spans,
+            candidate_values,
+            require_candidate=False,
+        )
     )
-    median_ratio = (
-        float(with_candidates["median_drain_per_standard_credit"])
-        / float(without_candidates["median_drain_per_standard_credit"])
-        if with_candidates["median_drain_per_standard_credit"]
-        and without_candidates["median_drain_per_standard_credit"]
-        else None
+    return (
+        with_candidates,
+        without_candidates,
+        _median_drain_ratio(with_candidates, without_candidates),
     )
-    return with_candidates, without_candidates, median_ratio
+
+
+def _spans_by_candidate_presence(
+    spans: list[UsageDeltaSpan],
+    candidate_values: list[float],
+    *,
+    require_candidate: bool,
+) -> list[UsageDeltaSpan]:
+    selected: list[UsageDeltaSpan] = []
+    for span, candidate in zip(spans, candidate_values, strict=True):
+        has_candidate = candidate > 0
+        if has_candidate == require_candidate and span.standard_usage_credits > 0:
+            selected.append(span)
+    return selected
+
+
+def _median_drain_ratio(
+    with_candidates: dict[str, float | int | None],
+    without_candidates: dict[str, float | int | None],
+) -> float | None:
+    with_median = with_candidates["median_drain_per_standard_credit"]
+    without_median = without_candidates["median_drain_per_standard_credit"]
+    if not with_median or not without_median:
+        return None
+    return float(with_median) / float(without_median)

--- a/src/codex_usage_tracker/usage_drain/regression.py
+++ b/src/codex_usage_tracker/usage_drain/regression.py
@@ -90,6 +90,15 @@ def fit_ridge(
 ) -> list[float] | None:
     if not x_rows or not y_values:
         return None
+    lhs, rhs = _ridge_normal_equations(x_rows, y_values)
+    _regularize_ridge(lhs, alpha)
+    return solve_linear_system(lhs, rhs)
+
+
+def _ridge_normal_equations(
+    x_rows: list[list[float]],
+    y_values: list[float],
+) -> tuple[list[list[float]], list[float]]:
     width = len(x_rows[0]) + 1
     lhs = [[0.0 for _ in range(width)] for _ in range(width)]
     rhs = [0.0 for _ in range(width)]
@@ -99,32 +108,50 @@ def fit_ridge(
             rhs[i] += x_i * y_value
             for j, x_j in enumerate(expanded):
                 lhs[i][j] += x_i * x_j
-    for index in range(1, width):
+    return lhs, rhs
+
+
+def _regularize_ridge(lhs: list[list[float]], alpha: float) -> None:
+    for index in range(1, len(lhs)):
         lhs[index][index] += alpha
-    return solve_linear_system(lhs, rhs)
 
 
 def solve_linear_system(lhs: list[list[float]], rhs: list[float]) -> list[float] | None:
     size = len(rhs)
     matrix = [row[:] + [rhs_value] for row, rhs_value in zip(lhs, rhs, strict=True)]
     for column in range(size):
-        pivot = max(range(column, size), key=lambda row: abs(matrix[row][column]))
-        if abs(matrix[pivot][column]) < 1e-12:
+        if not _eliminate_linear_column(matrix, column=column, size=size):
             return None
-        matrix[column], matrix[pivot] = matrix[pivot], matrix[column]
-        pivot_value = matrix[column][column]
-        matrix[column] = [value / pivot_value for value in matrix[column]]
-        for row_index in range(size):
-            if row_index == column:
-                continue
-            factor = matrix[row_index][column]
-            if factor == 0:
-                continue
-            matrix[row_index] = [
-                value - factor * pivot_component
-                for value, pivot_component in zip(matrix[row_index], matrix[column], strict=True)
-            ]
     return [matrix[row][size] for row in range(size)]
+
+
+def _eliminate_linear_column(
+    matrix: list[list[float]],
+    *,
+    column: int,
+    size: int,
+) -> bool:
+    pivot = max(range(column, size), key=lambda row: abs(matrix[row][column]))
+    if abs(matrix[pivot][column]) < 1e-12:
+        return False
+    matrix[column], matrix[pivot] = matrix[pivot], matrix[column]
+    pivot_value = matrix[column][column]
+    matrix[column] = [value / pivot_value for value in matrix[column]]
+    for row_index in range(size):
+        if row_index == column:
+            continue
+        factor = matrix[row_index][column]
+        if factor == 0:
+            continue
+        matrix[row_index] = [
+            value - factor * pivot_component
+            for value, pivot_component in zip(
+                matrix[row_index],
+                matrix[column],
+                strict=True,
+            )
+        ]
+    return True
 
 
 def predict(x_rows: list[list[float]], coefficients: list[float]) -> list[float]:

--- a/tests/allowance_intelligence/test_allowance_intelligence.py
+++ b/tests/allowance_intelligence/test_allowance_intelligence.py
@@ -94,12 +94,8 @@ def test_weekly_capacity_drop_flags_strong_local_evidence_after_baseline() -> No
     assert candidate["statistical_evidence"]["method"] == "exact_permutation_mean_shift"
     assert candidate["statistical_evidence"]["effect_size_cliffs_delta"] == -1.0
     assert candidate["statistical_evidence"]["signal"] == "directionally_consistent_small_sample"
-    assert candidate["statistical_evidence"][
-        "median_confidence_interval_before_95"
-    ]["available"]
-    assert not candidate["statistical_evidence"][
-        "median_confidence_interval_after_95"
-    ]["available"]
+    assert candidate["statistical_evidence"]["median_confidence_interval_before_95"]["available"]
+    assert not candidate["statistical_evidence"]["median_confidence_interval_after_95"]["available"]
     assert not analysis["summary"]["research_readiness"]["ready_for_public_claim"]
 
 

--- a/tests/server/test_server_investigations.py
+++ b/tests/server/test_server_investigations.py
@@ -47,7 +47,11 @@ def paths(tmp_path: Path) -> dict[str, Any]:
 @pytest.mark.parametrize(
     ("kind", "builder_name", "schema"),
     [
-        ("agentic", "build_agentic_investigation_report", "codex-usage-tracker-agentic-investigation-v1"),
+        (
+            "agentic",
+            "build_agentic_investigation_report",
+            "codex-usage-tracker-agentic-investigation-v1",
+        ),
         (
             "repeated-file-rediscovery",
             "build_repeated_file_rediscovery_report",
@@ -119,7 +123,9 @@ def test_unlimited_filter_preserves_zero_as_none(
     assert calls["limit"] is None
 
 
-def test_bounded_integer_filters_are_capped(paths: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bounded_integer_filters_are_capped(
+    paths: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
     calls: dict[str, Any] = {}
 
     def build_report(**kwargs: Any) -> _Report:


### PR DESCRIPTION
## Summary
- decompose allowance, pricing, investigation, usage-drain, and formatting hotspots into focused helpers
- centralize defensive numeric row conversion for store diagnostics
- retain behavior while bringing the full source tree under the configured Xenon threshold
- tighten parser type boundaries without suppressions or weaker Pyright settings

## Validation
- 146 focused tests passed
- full source Pyright: 0 errors
- Xenon `B/A/A`: passed
- Ruff formatting and `git diff --check`: passed

Part of R11 release-candidate hardening. Targets the dashboard redesign experiment branch, not `main`.