### PR TITLE
test: type high-volume server fixtures

### DIFF
--- a/tests/cli/test_mcp_integration.py
+++ b/tests/cli/test_mcp_integration.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Any, cast
 
 from codex_usage_tracker.dashboard.api import generate_dashboard
 from codex_usage_tracker.diagnostics.api import run_doctor
@@ -34,6 +35,7 @@ def test_mcp_wrappers_smoke(tmp_path: Path, monkeypatch) -> None:
     from codex_usage_tracker import mcp_server
     from codex_usage_tracker.cli import mcp_dashboard, mcp_discovery, mcp_investigations
 
+    mcp_server = cast(Any, mcp_server)
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     dashboard_path = tmp_path / "dashboard.html"

--- a/tests/dashboard/test_dashboard_server.py
+++ b/tests/dashboard/test_dashboard_server.py
@@ -38,7 +38,7 @@ class MonkeyPatch(Protocol):
         target: object,
         name: str,
         value: object,
-        raising: bool = True,
+        _raising: bool = True,
     ) -> None: ...
 
 

--- a/tests/dashboard/test_dashboard_server.py
+++ b/tests/dashboard/test_dashboard_server.py
@@ -9,8 +9,7 @@ import urllib.request
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-
-import pytest
+from typing import Any, Protocol, cast
 
 from codex_usage_tracker.dashboard.api import dashboard_payload, generate_dashboard
 from codex_usage_tracker.store.api import (
@@ -30,10 +29,26 @@ from tests.store_dashboard_helpers import (
     _write_pricing,
 )
 
+JsonObject = dict[str, Any]
+
+
+class MonkeyPatch(Protocol):
+    def setattr(
+        self,
+        target: object,
+        name: str,
+        value: object,
+        raising: bool = True,
+    ) -> None: ...
+
+
+def _as_json_object(payload: dict[str, object]) -> JsonObject:
+    return cast(JsonObject, payload)
+
 
 def test_dashboard_server_forces_dashboard_asset_mime_types(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     from codex_usage_tracker.server.api import _UsageDashboardHandler
 
@@ -249,17 +264,21 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
             data=b"",
             method="POST",
         )
-        diagnostic_refresh_payload = _read_json(
-            f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview/refresh",
-            headers={"X-Codex-Usage-Token": "test-token"},
-            data=b"",
-            method="POST",
+        diagnostic_refresh_payload = _as_json_object(
+            _read_json(
+                f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview/refresh",
+                headers={"X-Codex-Usage-Token": "test-token"},
+                data=b"",
+                method="POST",
+            )
         )
-        diagnostic_batch_refresh_payload = _read_json(
-            f"http://127.0.0.1:{server.server_port}/api/diagnostics/refresh",
-            headers={"X-Codex-Usage-Token": "test-token"},
-            data=b"",
-            method="POST",
+        diagnostic_batch_refresh_payload = _as_json_object(
+            _read_json(
+                f"http://127.0.0.1:{server.server_port}/api/diagnostics/refresh",
+                headers={"X-Codex-Usage-Token": "test-token"},
+                data=b"",
+                method="POST",
+            )
         )
         diagnostic_tool_output_refresh_payload = diagnostic_batch_refresh_payload["sections"][
             "toolOutput"
@@ -288,8 +307,8 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
         diagnostic_usage_drain_refresh_payload = diagnostic_batch_refresh_payload["sections"][
             "usageDrain"
         ]
-        diagnostic_stored_payload = _read_json(
-            f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview"
+        diagnostic_stored_payload = _as_json_object(
+            _read_json(f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview")
         )
         diagnostic_tool_output_stored_payload = _read_json(
             f"http://127.0.0.1:{server.server_port}/api/diagnostics/tool-output"
@@ -327,8 +346,8 @@ def test_dashboard_server_usage_api_refreshes_aggregate_rows(tmp_path: Path) -> 
             timeout=5,
         ) as response:
             second_usage_refresh_payload = json.loads(response.read().decode("utf-8"))
-        diagnostic_after_second_usage_refresh = _read_json(
-            f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview"
+        diagnostic_after_second_usage_refresh = _as_json_object(
+            _read_json(f"http://127.0.0.1:{server.server_port}/api/diagnostics/overview")
         )
         with urllib.request.urlopen(  # noqa: S310 - local test server only
             f"http://127.0.0.1:{server.server_port}/api/usage?limit=all",
@@ -877,9 +896,11 @@ def test_dashboard_call_api_returns_adjacent_records_for_investigator(
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        payload = _read_json(
-            f"http://127.0.0.1:{server.server_port}/api/call?record_id=a2",
-            headers={"X-Codex-Usage-Token": "test-token"},
+        payload = _as_json_object(
+            _read_json(
+                f"http://127.0.0.1:{server.server_port}/api/call?record_id=a2",
+                headers={"X-Codex-Usage-Token": "test-token"},
+            )
         )
     finally:
         server.shutdown()
@@ -1004,10 +1025,14 @@ def test_dashboard_server_returns_json_for_sqlite_errors(tmp_path: Path, monkeyp
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        usage_error = _http_error_json(f"http://127.0.0.1:{server.server_port}/api/usage")
-        context_error = _http_error_json(
-            f"http://127.0.0.1:{server.server_port}/api/context?record_id=abc",
-            headers={"X-Codex-Usage-Token": "test-token"},
+        usage_error = _as_json_object(
+            _http_error_json(f"http://127.0.0.1:{server.server_port}/api/usage")
+        )
+        context_error = _as_json_object(
+            _http_error_json(
+                f"http://127.0.0.1:{server.server_port}/api/context?record_id=abc",
+                headers={"X-Codex-Usage-Token": "test-token"},
+            )
         )
     finally:
         server.shutdown()
@@ -1051,9 +1076,11 @@ def test_dashboard_server_can_enable_context_api_at_runtime(tmp_path: Path) -> N
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        disabled_error = _http_error_json(
-            f"http://127.0.0.1:{server.server_port}/api/context?record_id={record_id}",
-            headers={"X-Codex-Usage-Token": "test-token"},
+        disabled_error = _as_json_object(
+            _http_error_json(
+                f"http://127.0.0.1:{server.server_port}/api/context?record_id={record_id}",
+                headers={"X-Codex-Usage-Token": "test-token"},
+            )
         )
         enable_without_token = _http_error_json(
             f"http://127.0.0.1:{server.server_port}/api/context-settings?enabled=1"

--- a/tests/dashboard/test_dashboard_server_live_slices.py
+++ b/tests/dashboard/test_dashboard_server_live_slices.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from functools import partial
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from typing import Any, cast
 
 from codex_usage_tracker.store.api import refresh_usage_index
 from tests.store_dashboard_helpers import (
@@ -18,6 +19,12 @@ from tests.store_dashboard_helpers import (
     _read_json,
     _write_pricing,
 )
+
+JsonObject = dict[str, Any]
+
+
+def _as_json_object(payload: dict[str, object]) -> JsonObject:
+    return cast(JsonObject, payload)
 
 
 def test_dashboard_server_live_sql_api_slices_are_aggregate_only(tmp_path: Path) -> None:
@@ -51,39 +58,55 @@ def test_dashboard_server_live_sql_api_slices_are_aggregate_only(tmp_path: Path)
     try:
         base_url = f"http://127.0.0.1:{server.server_port}"
 
-        status_payload = _read_json(f"{base_url}/api/status")
-        calls_payload = _read_json(
-            f"{base_url}/api/calls?limit=2&sort=tokens&direction=desc&q=Codex"
+        status_payload = _as_json_object(_read_json(f"{base_url}/api/status"))
+        calls_payload = _as_json_object(
+            _read_json(f"{base_url}/api/calls?limit=2&sort=tokens&direction=desc&q=Codex")
         )
-        offset_payload = _read_json(
-            f"{base_url}/api/calls?limit=1&offset=1&sort=tokens&direction=desc&q=Codex"
+        offset_payload = _as_json_object(
+            _read_json(f"{base_url}/api/calls?limit=1&offset=1&sort=tokens&direction=desc&q=Codex")
         )
         record_id = calls_payload["rows"][0]["record_id"]
-        call_payload = _read_json(f"{base_url}/api/call?record_id={record_id}")
-        threads_payload = _read_json(f"{base_url}/api/threads?limit=2&sort=tokens")
+        call_payload = _as_json_object(_read_json(f"{base_url}/api/call?record_id={record_id}"))
+        threads_payload = _as_json_object(_read_json(f"{base_url}/api/threads?limit=2&sort=tokens"))
         thread_key = threads_payload["rows"][0]["thread_key"]
-        thread_calls_payload = _read_json(
-            f"{base_url}/api/thread-calls?thread_key={urllib.parse.quote(thread_key)}&limit=2"
+        thread_calls_payload = _as_json_object(
+            _read_json(
+                f"{base_url}/api/thread-calls?thread_key={urllib.parse.quote(thread_key)}&limit=2"
+            )
         )
-        summary_payload = _read_json(f"{base_url}/api/summary?group_by=model&limit=5")
-        recommendations_payload = _read_json(f"{base_url}/api/recommendations?limit=5")
-        reports_pack_payload = _read_json(f"{base_url}/api/reports/pack?limit=5&evidence_limit=2")
-        diagnostics_summary_payload = _read_json(f"{base_url}/api/diagnostics/summary?limit=5")
-        diagnostics_facts_payload = _read_json(f"{base_url}/api/diagnostics/facts?limit=5")
-        diagnostics_sorted_facts_payload = _read_json(
-            f"{base_url}/api/diagnostics/facts?limit=5&sort=cached&direction=desc"
+        summary_payload = _as_json_object(
+            _read_json(f"{base_url}/api/summary?group_by=model&limit=5")
         )
-        diagnostics_compactions_payload = _read_json(
-            f"{base_url}/api/diagnostics/compactions?limit=5"
+        recommendations_payload = _as_json_object(
+            _read_json(f"{base_url}/api/recommendations?limit=5")
         )
-        diagnostics_tools_payload = _read_json(f"{base_url}/api/diagnostics/tools?limit=5")
-        diagnostics_fact_calls_payload = _read_json(
-            f"{base_url}/api/diagnostics/fact-calls"
-            "?fact_type=compaction&fact_name=post_compaction&limit=5"
+        reports_pack_payload = _as_json_object(
+            _read_json(f"{base_url}/api/reports/pack?limit=5&evidence_limit=2")
+        )
+        diagnostics_summary_payload = _as_json_object(
+            _read_json(f"{base_url}/api/diagnostics/summary?limit=5")
+        )
+        diagnostics_facts_payload = _as_json_object(
+            _read_json(f"{base_url}/api/diagnostics/facts?limit=5")
+        )
+        diagnostics_sorted_facts_payload = _as_json_object(
+            _read_json(f"{base_url}/api/diagnostics/facts?limit=5&sort=cached&direction=desc")
+        )
+        diagnostics_compactions_payload = _as_json_object(
+            _read_json(f"{base_url}/api/diagnostics/compactions?limit=5")
+        )
+        diagnostics_tools_payload = _as_json_object(
+            _read_json(f"{base_url}/api/diagnostics/tools?limit=5")
+        )
+        diagnostics_fact_calls_payload = _as_json_object(
+            _read_json(
+                f"{base_url}/api/diagnostics/fact-calls"
+                "?fact_type=compaction&fact_name=post_compaction&limit=5"
+            )
         )
         invalid_diagnostics = _http_error_json(f"{base_url}/api/diagnostics/facts?sort=bad")
         missing_fact_calls = _http_error_json(f"{base_url}/api/diagnostics/fact-calls")
-        invalid_sort = _http_error_json(f"{base_url}/api/calls?sort=not-a-sort")
+        invalid_sort = _as_json_object(_http_error_json(f"{base_url}/api/calls?sort=not-a-sort"))
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/server/test_server_usage_refresh.py
+++ b/tests/server/test_server_usage_refresh.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
-
-import pytest
+from typing import Any, Protocol, TypedDict
 
 from codex_usage_tracker.server import usage_refresh as server_usage_refresh
+
+
+class _MonkeyPatch(Protocol):
+    def setattr(self, target: object, name: str, value: object) -> None: ...
 
 
 @dataclass
@@ -51,7 +53,7 @@ class _RouteSenders:
 
 def test_refresh_usage_payload_returns_aggregate_refresh_metadata(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: _MonkeyPatch,
 ) -> None:
     calls: dict[str, Any] = {}
 
@@ -92,7 +94,36 @@ def test_refresh_usage_payload_returns_aggregate_refresh_metadata(
     assert isinstance(refresh_ms, float)
 
 
-def _usage_kwargs(tmp_path: Path) -> dict[str, object]:
+class _UsageBaseKwargs(TypedDict):
+    db_path: Path
+    pricing_path: Path
+    allowance_path: Path
+    rate_card_path: Path
+    thresholds_path: Path
+    projects_path: Path
+    privacy_mode: str
+    since: str | None
+    api_token: str
+    context_api_enabled: bool
+    include_archived_default: bool
+    language_default: str
+    limit_default: int
+    codex_home: Path
+    refresh_lock: _FakeLock
+
+
+class _UsageKwargs(_UsageBaseKwargs):
+    refresh_allowed: bool
+
+
+class _HandleUsageKwargs(_UsageBaseKwargs):
+    has_valid_api_token: server_usage_refresh.TokenValidator
+    send_error: server_usage_refresh.ErrorSender
+    send_exception: server_usage_refresh.ExceptionSender
+    send_json: server_usage_refresh.JsonSender
+
+
+def _usage_base_kwargs(tmp_path: Path) -> _UsageBaseKwargs:
     return {
         "db_path": tmp_path / "usage.sqlite3",
         "pricing_path": tmp_path / "pricing.json",
@@ -109,8 +140,11 @@ def _usage_kwargs(tmp_path: Path) -> dict[str, object]:
         "limit_default": 500,
         "codex_home": tmp_path / "codex-home",
         "refresh_lock": _FakeLock(),
-        "refresh_allowed": False,
     }
+
+
+def _usage_kwargs(tmp_path: Path) -> _UsageKwargs:
+    return {**_usage_base_kwargs(tmp_path), "refresh_allowed": False}
 
 
 def _handle_usage_kwargs(
@@ -118,23 +152,19 @@ def _handle_usage_kwargs(
     senders: _RouteSenders,
     *,
     has_valid_api_token: server_usage_refresh.TokenValidator = lambda _params: True,
-) -> dict[str, object]:
-    kwargs = _usage_kwargs(tmp_path)
-    kwargs.pop("refresh_allowed")
-    kwargs.update(
-        {
-            "has_valid_api_token": has_valid_api_token,
-            "send_error": senders.send_error,
-            "send_exception": senders.send_exception,
-            "send_json": senders.send_json,
-        },
-    )
-    return kwargs
+) -> _HandleUsageKwargs:
+    return {
+        **_usage_base_kwargs(tmp_path),
+        "has_valid_api_token": has_valid_api_token,
+        "send_error": senders.send_error,
+        "send_exception": senders.send_exception,
+        "send_json": senders.send_json,
+    }
 
 
 def test_handle_usage_request_sends_payload(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: _MonkeyPatch,
 ) -> None:
     senders = _RouteSenders()
     seen: dict[str, Any] = {}
@@ -182,7 +212,7 @@ def test_handle_usage_request_sends_refresh_auth_error(tmp_path: Path) -> None:
 
 def test_handle_usage_request_sends_os_error(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: _MonkeyPatch,
 ) -> None:
     senders = _RouteSenders()
 
@@ -203,7 +233,7 @@ def test_handle_usage_request_sends_os_error(
 
 def test_usage_payload_forwards_query_options_to_dashboard_payload(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: _MonkeyPatch,
 ) -> None:
     calls: dict[str, Any] = {}
 
@@ -229,16 +259,20 @@ def test_usage_payload_forwards_query_options_to_dashboard_payload(
 
 
 def test_usage_payload_rejects_refresh_without_valid_token(tmp_path: Path) -> None:
-    with pytest.raises(server_usage_refresh.UsageRefreshAuthError, match="Valid API token"):
+    try:
         server_usage_refresh.usage_payload(
             "refresh=1",
             **_usage_kwargs(tmp_path),
         )
+    except server_usage_refresh.UsageRefreshAuthError as exc:
+        assert "Valid API token" in str(exc)
+    else:
+        raise AssertionError("Expected refresh authentication to fail")
 
 
 def test_usage_payload_adds_refresh_diagnostics(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: _MonkeyPatch,
 ) -> None:
     def dashboard_payload(**_kwargs: Any) -> dict[str, object]:
         return {"rows": [{"record_id": "r1"}, {"record_id": "r2"}]}
@@ -258,7 +292,9 @@ def test_usage_payload_adds_refresh_diagnostics(
     )
 
     assert payload["refresh_result"] == {"parsed_events": 7}
-    assert payload["diagnostics"]["rows_returned"] == 2
-    assert payload["diagnostics"]["refresh_ms"] == 12.5
-    assert payload["diagnostics"]["limit"] == 25
-    assert payload["diagnostics"]["offset"] == 3
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, dict)
+    assert diagnostics["rows_returned"] == 2
+    assert diagnostics["refresh_ms"] == 12.5
+    assert diagnostics["limit"] == 25
+    assert diagnostics["offset"] == 3


### PR DESCRIPTION
## Summary
- give usage-refresh fakes explicit protocol-compatible types
- type the MCP compatibility wrapper without changing behavior
- narrow dashboard server payloads and response doubles at test boundaries

## Validation
- targeted Pyright: 0 errors across 4 files
- targeted pytest: 23 passed
- Ruff and `git diff --check`: passed

R11 hardening follow-up; targets the redesign experiment branch.