### PR TITLE
test: finish standard Pyright fixture coverage

### DIFF
--- a/tests/context/test_context_action_timing.py
+++ b/tests/context/test_context_action_timing.py
@@ -7,7 +7,7 @@ from codex_usage_tracker.context.action_timing import (
 
 
 def test_annotate_action_timing_adds_elapsed_and_gap_metadata() -> None:
-    entries = [
+    entries: list[dict[str, object]] = [
         {"timestamp": "2026-06-01T10:00:00Z", "text": "start"},
         {"timestamp": "2026-06-01T10:00:01Z", "text": "middle"},
         {"timestamp": "2026-06-01T10:00:01.500Z", "text": "end"},
@@ -27,9 +27,13 @@ def test_annotate_action_timing_adds_elapsed_and_gap_metadata() -> None:
         "since_turn_start_ms": 0,
         "timestamp_source": "entry.timestamp",
     }
-    assert entries[1]["action_timing"]["since_turn_start_ms"] == 1000
-    assert entries[1]["action_timing"]["since_previous_entry_ms"] == 1000
-    assert entries[2]["action_timing"]["since_previous_entry_ms"] == 500
+    middle_timing = entries[1]["action_timing"]
+    end_timing = entries[2]["action_timing"]
+    assert isinstance(middle_timing, dict)
+    assert isinstance(end_timing, dict)
+    assert middle_timing["since_turn_start_ms"] == 1000
+    assert middle_timing["since_previous_entry_ms"] == 1000
+    assert end_timing["since_previous_entry_ms"] == 500
 
 
 def test_annotate_action_timing_ignores_invalid_timestamps() -> None:

--- a/tests/core/test_i18n.py
+++ b/tests/core/test_i18n.py
@@ -358,11 +358,16 @@ def test_dashboard_i18n_payload_shape_for_each_supported_language() -> None:
         payload = dashboard_i18n_payload(language)
         assert payload["language"] == normalize_language(language)
         assert payload["language_direction"] == language_direction(language)
-        assert {entry["code"] for entry in payload["available_languages"]} == set(
-            SUPPORTED_LANGUAGES
-        )  # type: ignore[index]
-        assert set(payload["translation_catalog"]) == set(SUPPORTED_LANGUAGES)  # type: ignore[arg-type]
-        assert payload["translations"]["dashboard.title"]  # type: ignore[index]
+        languages = payload["available_languages"]
+        catalog = payload["translation_catalog"]
+        translations = payload["translations"]
+        assert isinstance(languages, list)
+        assert all(isinstance(entry, dict) for entry in languages)
+        assert isinstance(catalog, dict)
+        assert isinstance(translations, dict)
+        assert {entry["code"] for entry in languages} == set(SUPPORTED_LANGUAGES)
+        assert set(catalog) == set(SUPPORTED_LANGUAGES)
+        assert translations["dashboard.title"]
 
 
 def test_dashboard_i18n_payload_unknown_language_falls_back_to_english() -> None:

--- a/tests/core/test_privacy.py
+++ b/tests/core/test_privacy.py
@@ -89,7 +89,10 @@ def test_aggregate_outputs_exclude_raw_transcript_content(tmp_path: Path) -> Non
         for output in shareable_outputs:
             assert sentinel not in output
 
-    strict_row = strict_payload["rows"][0]
+    strict_rows = strict_payload["rows"]
+    assert isinstance(strict_rows, list)
+    strict_row = strict_rows[0]
+    assert isinstance(strict_row, dict)
     with csv_path.open(encoding="utf-8", newline="") as handle:
         csv_rows = list(csv.DictReader(handle))
     assert strict_payload["privacy_mode"] == "strict"
@@ -291,8 +294,10 @@ def test_context_server_requires_loopback_origin_token_and_enablement(tmp_path: 
         server.server_close()
         thread.join(timeout=5)
 
+    disabled_payload = disabled_error["payload"]
+    assert isinstance(disabled_payload, dict)
     assert disabled_error["status"] == 403
-    assert disabled_error["payload"]["context_api_enabled"] is False
+    assert disabled_payload["context_api_enabled"] is False
     assert foreign_origin_error["status"] == 403
     assert missing_token_error["status"] == 403
     assert settings_payload["schema"] == "codex-usage-tracker-context-settings-v1"

--- a/tests/dashboard/test_dashboard_live.py
+++ b/tests/dashboard/test_dashboard_live.py
@@ -4,11 +4,12 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 
-def _run_dashboard_live_script(script: str) -> dict[str, object]:
+def _run_dashboard_live_script(script: str) -> dict[str, Any]:
     node = shutil.which("node")
     if node is None:
         pytest.skip("node is required for dashboard live helper tests")

--- a/tests/parser/test_parser_inspect_log.py
+++ b/tests/parser/test_parser_inspect_log.py
@@ -18,7 +18,10 @@ def test_inspect_log_reports_aggregate_event_rows(tmp_path: Path) -> None:
     )
 
     payload = inspect_log(log_path)
-    event_row = payload["events"][0]
+    events = payload["events"]
+    assert isinstance(events, list)
+    event_row = events[0]
+    assert isinstance(event_row, dict)
 
     assert payload["event_count"] == 1
     assert {

--- a/tests/server/test_server_api.py
+++ b/tests/server/test_server_api.py
@@ -25,7 +25,7 @@ def test_serve_dashboard_opens_react_dashboard_and_prints_legacy_fallback(
             self.closed = True
 
     def generate_dashboard(**kwargs: object) -> Path:
-        return Path(kwargs["output_path"])
+        return Path(str(kwargs["output_path"]))
 
     monkeypatch.setattr(server_api, "generate_dashboard", generate_dashboard)
     monkeypatch.setattr(server_api, "ThreadingHTTPServer", FakeServer)

--- a/tests/server/test_server_call_detail.py
+++ b/tests/server/test_server_call_detail.py
@@ -103,7 +103,7 @@ def test_call_detail_payload_includes_annotated_adjacent_records(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    rows = {
+    rows: dict[str, dict[str, object]] = {
         "previous": {"record_id": "previous"},
         "current": {
             "record_id": "current",

--- a/tests/server/test_server_diagnostic_refresh_auth.py
+++ b/tests/server/test_server_diagnostic_refresh_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from email.message import Message
 from http import HTTPStatus
 
 import pytest
@@ -10,7 +11,7 @@ from codex_usage_tracker.server.api import _UsageDashboardHandler
 def _handler_with_token(token: str) -> _UsageDashboardHandler:
     handler = object.__new__(_UsageDashboardHandler)
     handler._api_token = token
-    handler.headers = {}
+    handler.headers = Message()
     return handler
 
 
@@ -38,7 +39,7 @@ def test_reject_missing_diagnostic_refresh_token_accepts_valid_header(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     handler = _handler_with_token("secret-token")
-    handler.headers = {"X-Codex-Usage-Token": "secret-token"}
+    handler.headers["X-Codex-Usage-Token"] = "secret-token"
     monkeypatch.setattr(
         handler,
         "_send_error",

--- a/tests/server/test_server_investigations.py
+++ b/tests/server/test_server_investigations.py
@@ -92,8 +92,11 @@ def test_investigation_payload_matches_existing_report_payload(
 
     assert payload == expected
     assert payload["includes_raw_fragments"] is False
-    assert "content" not in payload["rows"][0]
-    assert "raw_fragment" not in payload["rows"][0]
+    rows = payload["rows"]
+    assert isinstance(rows, list)
+    assert isinstance(rows[0], dict)
+    assert "content" not in rows[0]
+    assert "raw_fragment" not in rows[0]
     assert calls["since"] == "2026-07-01"
     assert calls["include_archived"] is True
     assert calls["privacy_mode"] == "strict"

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -116,9 +116,13 @@ def test_refresh_reports_phase_progress(tmp_path: Path, monkeypatch) -> None:
     assert "indexing_content" in phases
     assert phases[-1] == "finalizing"
     assert events[-1]["status"] == "completed"
-    assert events[-1]["result"]["parsed_events"] == result.parsed_events
+    final_result = events[-1]["result"]
+    assert isinstance(final_result, dict)
+    assert final_result["parsed_events"] == result.parsed_events
     content_events = [event for event in events if event["phase"] == "indexing_content"]
     assert content_events
     assert content_events[-1]["status"] == "completed"
     assert content_events[-1]["percent"] == 100.0
-    assert content_events[-1]["content_fragments"] > 0
+    content_fragments = content_events[-1]["content_fragments"]
+    assert isinstance(content_fragments, (int, float))
+    assert content_fragments > 0

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -232,10 +232,10 @@ def test_doctor_reports_malformed_legacy_schema_without_traceback(tmp_path: Path
 
     assert report["status"] == "fail"
     assert schema_check["status"] == "fail"
-    assert "source_file" in schema_check["detail"]
+    assert "source_file" in str(schema_check["detail"])
     assert "rebuild-index" in str(schema_check["remediation"])
     assert parser_check["status"] == "fail"
-    assert "database migration failed" in parser_check["detail"]
+    assert "database migration failed" in str(parser_check["detail"])
 
 
 def _write_legacy_usage_database(db_path: Path, *, omit_source_file: bool = False) -> None:

--- a/tests/usage_drain/test_usage_drain_error_diagnostics.py
+++ b/tests/usage_drain/test_usage_drain_error_diagnostics.py
@@ -16,7 +16,7 @@ def test_span_error_metadata_reports_time_reset_and_usage_buckets() -> None:
         delta_usage_percent=1.0,
         row_count=1,
         standard_usage_credits=100.0,
-        non_candidate_standard_credits=0.0,
+        non_candidate_standard_credits={},
         candidate_standard_credits={},
         documented_fast_weighted_credits={},
         candidate_row_counts={},

--- a/tests/usage_drain/test_usage_drain_model.py
+++ b/tests/usage_drain/test_usage_drain_model.py
@@ -617,7 +617,12 @@ def _component_credits(
 
 
 def _coefficients_by_feature(rows: list[dict[str, object]]) -> dict[str, float | None]:
-    return {str(row["feature"]): row["coefficient"] for row in rows}
+    coefficients: dict[str, float | None] = {}
+    for row in rows:
+        coefficient = row["coefficient"]
+        assert coefficient is None or isinstance(coefficient, (int, float))
+        coefficients[str(row["feature"])] = None if coefficient is None else float(coefficient)
+    return coefficients
 
 
 def test_fit_usage_drain_proxy_recovers_documented_multiplier() -> None:

--- a/tests/usage_drain/test_usage_drain_regime_segments.py
+++ b/tests/usage_drain/test_usage_drain_regime_segments.py
@@ -14,7 +14,7 @@ def _span(index: int, delta: float) -> UsageDeltaSpan:
         delta_usage_percent=delta,
         row_count=1,
         standard_usage_credits=100.0 * delta,
-        non_candidate_standard_credits=0.0,
+        non_candidate_standard_credits={},
         candidate_standard_credits={},
         documented_fast_weighted_credits={},
         candidate_row_counts={},

--- a/tests/usage_drain/test_usage_drain_regression.py
+++ b/tests/usage_drain/test_usage_drain_regression.py
@@ -20,7 +20,9 @@ def test_prepare_design_standardizes_numeric_and_filters_sparse_categories() -> 
         {"tokens": 6.0, "duration": 5.0, "mode": "B"},
     ]
 
-    feature_names, means, stddevs, category_levels = prepare_design(rows, spec)
+    design = prepare_design(rows, spec)
+    assert design is not None
+    feature_names, means, stddevs, category_levels = design
 
     assert feature_names == ["tokens", "duration", "mode=A"]
     assert means == {"tokens": 4.0, "duration": 3.0}

--- a/tests/usage_drain/test_usage_drain_walk_forward.py
+++ b/tests/usage_drain/test_usage_drain_walk_forward.py
@@ -16,7 +16,7 @@ def _span(index: int, delta: float) -> UsageDeltaSpan:
         delta_usage_percent=delta,
         row_count=1,
         standard_usage_credits=100.0 * delta,
-        non_candidate_standard_credits=0.0,
+        non_candidate_standard_credits={},
         candidate_standard_credits={},
         documented_fast_weighted_credits={},
         candidate_row_counts={},


### PR DESCRIPTION
## Summary
- narrow the final opaque JSON and mutable test payloads at their runtime boundaries
- update stale usage-drain fixtures to the current structured credit contract
- remove obsolete type ignores while preserving all test behavior

## Validation
- full `pyright src tests`: 0 errors
- targeted pytest: 208 passed
- Ruff formatting and `git diff --check`: passed

Completes the inherited standard-mode Pyright backlog for R11.