### PR TITLE
test: harden dashboard release candidate

### DIFF
--- a/docs/dashboard-final-redesign-release-candidate.md
+++ b/docs/dashboard-final-redesign-release-candidate.md
@@ -1,0 +1,241 @@
+# Dashboard Final Redesign Release-Candidate Guide
+
+This guide defines the migration, default-launch, rollback, and maintainer
+signoff contract for R11 of the dashboard redesign. It tracks issue #201 from
+base commit `88ebcd80d08c1eb2229d9c7e929849e328af4097`.
+
+## Status And Decision Boundary
+
+The statements below use these labels:
+
+- **Verified at the R11 base** means the behavior is present in current code,
+  documentation, or focused compatibility tests.
+- **Pending R11 evidence** means the behavior must not be treated as release
+  proof until the named release-candidate check is run and recorded.
+- **Open decision** means maintainer approval is required; this guide does not
+  guess or silently change the behavior.
+
+No accessibility, performance, package-install, or broad release check is
+claimed by this document.
+
+## Launch Paths
+
+### Installed package
+
+Install or upgrade the published distribution, refresh package-owned plugin
+files, and start the live dashboard:
+
+```bash
+pipx install codex-usage-tracking
+codex-usage-tracker setup
+codex-usage-tracker serve-dashboard --open
+```
+
+For an existing pipx installation, replace the first command with:
+
+```bash
+pipx upgrade codex-usage-tracking
+```
+
+**Verified at the R11 base:** `serve-dashboard --open` opens
+`http://127.0.0.1:8765/react-dashboard.html` by default. The command refreshes
+active-session usage before startup unless `--no-refresh` is supplied. Its JSON
+output reports both `dashboard_url` and `legacy_dashboard_url`.
+
+**Pending R11 evidence:** repeat these steps against the built wheel in a clean
+environment and record the wheel version, Python version, operating system,
+asset responses, and smoke-check result in the evidence table below.
+
+### Source checkout
+
+From the repository root:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install ".[dev]"
+codex-usage-tracker install-plugin --python .venv/bin/python
+codex-usage-tracker serve-dashboard --open
+```
+
+This path is for branch development and release-candidate testing. The plugin
+installer points the generated MCP configuration at the selected Python and
+supports the checkout's `src` directory.
+
+**Pending R11 evidence:** record a clean source-checkout launch separately from
+the installed-wheel launch. A passing source launch is not package evidence.
+
+### Static snapshot
+
+```bash
+codex-usage-tracker open-dashboard
+```
+
+**Verified at the R11 base:** `open-dashboard` generates and opens the static
+legacy dashboard file. It is not an alias for the live React route. Use
+`serve-dashboard` for the redesign's live query, refresh, and lazy-context
+workflow.
+
+## Default And Compatibility Policy
+
+The release-candidate policy is to retain the current transition behavior:
+
+| Entry point | Behavior at the R11 base | Release-candidate disposition |
+| --- | --- | --- |
+| `serve-dashboard --open` | Opens `/react-dashboard.html` | Keep as the preferred live launch |
+| `/react-dashboard.html` | Serves the React redesign | Candidate default live UI |
+| `/dashboard.html` | Serves the legacy dashboard shell | Keep as the rollback route |
+| `/` | Serves the legacy dashboard shell | Keep unchanged unless the open decision below is approved |
+| `open-dashboard` | Opens a generated static legacy file | Keep unchanged for static snapshots |
+
+Do not delete the legacy assets, redirect `/dashboard.html`, or redefine the
+static command during R11. Those changes would remove the same-server rollback
+surface and require a separate reviewed decision.
+
+**Open decision:** should `/` remain a legacy entry point for the transition
+release, or redirect to `/react-dashboard.html`? Current code serves the legacy
+shell at `/`. R11 can ship without changing it because the CLI already opens
+the React route explicitly. Record the maintainer decision before R12; do not
+describe a root-route switch as complete unless code, tests, and this guide are
+updated together.
+
+## Migration Expectations
+
+- Existing `serve-dashboard` users move to the redesign automatically only
+  when the CLI opens the browser. Manually saved `/dashboard.html` and `/`
+  bookmarks continue to open the legacy shell.
+- Existing `?view=` links remain valid on the React route. Maintained values are
+  `overview`, `investigator`, `calls`, `call`, `threads`, `usage-drain`,
+  `cache-context`, `diagnostics`, `reports`, and `settings`.
+- The historical `view=insights` alias resolves to Overview, and unknown view
+  values fall back to Overview. Relevant record, return-route, filter, search,
+  paging, thread, and context-option parameters remain compatibility inputs.
+- `usage-drain` remains the stable route identifier even though the visible
+  destination is named Limits.
+- Existing local database, pricing, allowance, thresholds, projects, privacy,
+  and plugin paths remain authoritative. The redesign does not introduce a
+  second settings store or authorize a storage/schema migration.
+- Existing aggregate JSON, CSV, API, and MCP contracts remain the analytical
+  source of truth. Explicit raw-context access remains localhost-only, gated,
+  redacted, and absent from static HTML payloads.
+- Users who require a static file continue to use `open-dashboard`; users who
+  require the redesign use the localhost server.
+
+## Exact Rollback
+
+### Roll back the dashboard view without changing the installation
+
+1. Leave the current `codex-usage-tracker serve-dashboard` process running.
+2. Open `http://127.0.0.1:8765/dashboard.html` in the same browser.
+3. When rolling back a bookmarked workflow, copy the query string from the
+   React URL to the legacy URL. For example:
+
+   ```text
+   http://127.0.0.1:8765/dashboard.html?view=calls
+   ```
+
+4. Confirm the required workspace and aggregate data load before continuing.
+5. Preserve the failed React URL and non-sensitive console/error details for
+   the R11 evidence record. Do not include prompts, messages, tool output, raw
+   logs, or other private content.
+
+If a non-default `--host`, `--port`, or dashboard output name was used, take the
+exact `legacy_dashboard_url` from `serve-dashboard --json` instead of assuming
+the example URL.
+
+### Roll back an installed release candidate
+
+1. Stop the dashboard server.
+2. Reinstall the maintainer-designated last-known-good version:
+
+   ```bash
+   pipx install --force "codex-usage-tracking==<last-known-good-version>"
+   codex-usage-tracker setup
+   codex-usage-tracker doctor
+   codex-usage-tracker serve-dashboard --open
+   ```
+
+3. Open the printed `legacy_dashboard_url` if the last-known-good package still
+   prefers the React route.
+4. Record the exact package version and result without publishing local paths
+   or private usage data.
+
+**Open decision:** replace `<last-known-good-version>` with an approved released
+version before publishing release notes. The R11 base does not identify that
+release, so this guide does not invent one.
+
+### Roll back a source-checkout candidate
+
+Use a separate clean checkout or worktree at the R11 base, then reinstall its
+plugin wrapper:
+
+```bash
+git switch --detach 88ebcd80d08c1eb2229d9c7e929849e328af4097
+. .venv/bin/activate
+python -m pip install -e ".[dev]"
+codex-usage-tracker install-plugin --python .venv/bin/python --force
+codex-usage-tracker serve-dashboard --open
+```
+
+Do not use this procedure in a worktree with uncommitted changes. The detached
+checkout is a local verification surface, not a release or publishing action.
+
+## Known Limits At Release-Candidate Draft
+
+- Full route/viewport automation, axe, keyboard, focus, 200% zoom, reduced
+  motion, contrast, containment, and chart/table-equivalence evidence is
+  pending R11.
+- Startup, 5k-row, no-cap, 100k-synthetic-row, reload, cache-hit, and
+  single-appended-record performance evidence is pending R11.
+- Query-cache reuse exists, but benchmark and invalidation evidence is pending
+  R11.
+- Built-wheel assets and clean installed-package launch behavior remain pending
+  R11 package verification.
+- Static packaged workspaces retain fixture fallback; static mode does not
+  provide the live refresh and lazy-context workflow.
+- Settings reports authoritative local state but does not add writable pricing,
+  allowance, privacy, or parser configuration controls.
+- SVG and PNG output from MCP visualization tools remains deliberately deferred;
+  semantic visualization specifications remain the supported contract.
+- The final merge, root-route decision, release version, and package rollback
+  version require maintainer review. This draft does not authorize publishing.
+
+## R11 Evidence Record
+
+Fill this table with links or artifact identifiers from synthetic-data checks.
+Do not paste raw logs or real user data into this document.
+
+| Evidence gate | Status | Artifact or result | Reviewer |
+| --- | --- | --- | --- |
+| Route and viewport matrix | Pending R11 evidence | `<artifact>` | `<name>` |
+| Accessibility and keyboard matrix | Pending R11 evidence | `<artifact>` | `<name>` |
+| Performance and cache benchmarks | Pending R11 evidence | `<artifact>` | `<name>` |
+| Production bundle and package assets | Pending R11 evidence | `<artifact>` | `<name>` |
+| Clean installed-wheel smoke | Pending R11 evidence | `<artifact>` | `<name>` |
+| Source-checkout launch smoke | Pending R11 evidence | `<artifact>` | `<name>` |
+| Synthetic documentation screenshots | Pending R11 evidence | `<artifact>` | `<name>` |
+| Dependency and security audit | Pending R11 evidence | `<artifact>` | `<name>` |
+| Release-readiness and broad checks | Pending R11 evidence | `<artifact>` | `<name>` |
+| Same-server legacy rollback rehearsal | Pending R11 evidence | `<artifact>` | `<name>` |
+| Installed-version rollback rehearsal | Pending R11 evidence | `<artifact>` | `<name>` |
+
+## Maintainer Signoff Checklist
+
+- [ ] All R11 evidence rows are complete and link to synthetic, share-safe
+  artifacts.
+- [ ] The parity ledger has no unexplained omission or unreviewed R11 gate.
+- [ ] Both source-checkout and installed-wheel launch paths were exercised.
+- [ ] `/react-dashboard.html`, `/dashboard.html`, and compatibility query links
+  were exercised from the packaged candidate.
+- [ ] Same-server rollback was rehearsed without changing or losing local data.
+- [ ] The last-known-good package version was selected and package rollback was
+  rehearsed in a clean environment.
+- [ ] The `/` route decision is recorded and matches code, tests, and docs.
+- [ ] Known limits are acceptable for the transition release and appear in the
+  final release notes.
+- [ ] Accessibility, performance, security, and package results contain no
+  invented or unrun outcomes.
+- [ ] Privacy review confirms that evidence and screenshots use synthetic data
+  and expose no raw session content.
+- [ ] R12 maintainer approval is recorded before merge or release work begins.

--- a/docs/dashboard-final-redesign-release-candidate.md
+++ b/docs/dashboard-final-redesign-release-candidate.md
@@ -86,19 +86,17 @@ The release-candidate policy is to retain the current transition behavior:
 | `serve-dashboard --open` | Opens `/react-dashboard.html` | Keep as the preferred live launch |
 | `/react-dashboard.html` | Serves the React redesign | Candidate default live UI |
 | `/dashboard.html` | Serves the legacy dashboard shell | Keep as the rollback route |
-| `/` | Serves the legacy dashboard shell | Keep unchanged unless the open decision below is approved |
+| `/` | Serves the legacy dashboard shell | Keep unchanged as the transition rollback entry |
 | `open-dashboard` | Opens a generated static legacy file | Keep unchanged for static snapshots |
 
 Do not delete the legacy assets, redirect `/dashboard.html`, or redefine the
 static command during R11. Those changes would remove the same-server rollback
 surface and require a separate reviewed decision.
 
-**Open decision:** should `/` remain a legacy entry point for the transition
-release, or redirect to `/react-dashboard.html`? Current code serves the legacy
-shell at `/`. R11 can ship without changing it because the CLI already opens
-the React route explicitly. Record the maintainer decision before R12; do not
-describe a root-route switch as complete unless code, tests, and this guide are
-updated together.
+**Maintainer decision:** `/` remains the legacy entry point for the transition
+release. The CLI continues to open the React route explicitly, while `/` and
+`/dashboard.html` preserve a same-server recovery path. A later root-route
+switch requires a separate reviewed change to code, tests, and this guide.
 
 ## Migration Expectations
 
@@ -150,7 +148,7 @@ the example URL.
 2. Reinstall the maintainer-designated last-known-good version:
 
    ```bash
-   pipx install --force "codex-usage-tracking==<last-known-good-version>"
+   pipx install --force "codex-usage-tracking==0.17.1"
    codex-usage-tracker setup
    codex-usage-tracker doctor
    codex-usage-tracker serve-dashboard --open
@@ -161,9 +159,9 @@ the example URL.
 4. Record the exact package version and result without publishing local paths
    or private usage data.
 
-**Open decision:** replace `<last-known-good-version>` with an approved released
-version before publishing release notes. The R11 base does not identify that
-release, so this guide does not invent one.
+`0.17.1` is the last tagged release before this redesign candidate and is the
+designated installed-package rollback version. Rehearse the command in a clean
+environment before publishing release notes.
 
 ### Roll back a source-checkout candidate
 
@@ -229,9 +227,9 @@ Do not paste raw logs or real user data into this document.
 - [ ] `/react-dashboard.html`, `/dashboard.html`, and compatibility query links
   were exercised from the packaged candidate.
 - [ ] Same-server rollback was rehearsed without changing or losing local data.
-- [ ] The last-known-good package version was selected and package rollback was
-  rehearsed in a clean environment.
-- [ ] The `/` route decision is recorded and matches code, tests, and docs.
+- [x] The last-known-good package version was selected as `0.17.1`.
+- [ ] Package rollback was rehearsed in a clean environment.
+- [x] The `/` route decision is recorded and matches code, tests, and docs.
 - [ ] Known limits are acceptable for the transition release and appear in the
   final release notes.
 - [ ] Accessibility, performance, security, and package results contain no

--- a/frontend/dashboard/src/features/explore/FileEvidenceExplorer.tsx
+++ b/frontend/dashboard/src/features/explore/FileEvidenceExplorer.tsx
@@ -123,7 +123,7 @@ export function FileEvidenceExplorer({
         <StatusBadge label={fileStatus(canLoad, fetching, loaded, error)} tone={loaded ? 'green' : 'blue'} />
       </div>
       <div className={styles.splitWorkspace}>
-        <main className={styles.evidenceSurface}>
+        <section className={styles.evidenceSurface} aria-label="File evidence results">
           <EvidenceGrid
             ariaLabel="File evidence"
             columns={columns}
@@ -151,7 +151,7 @@ export function FileEvidenceExplorer({
             emptyLabel={canLoad ? 'No file evidence is available in the stored diagnostic snapshots.' : 'File evidence requires the localhost dashboard server.'}
           />
           <div className={styles.gridFooter}><span>{filteredRows.length.toLocaleString()} ranked files</span></div>
-        </main>
+        </section>
         <FileInspector row={selected} onCopyCallLink={onCopyCallLink} onOpenInvestigator={onOpenInvestigator} />
       </div>
     </div>

--- a/frontend/dashboard/src/features/explore/ToolEvidenceExplorer.tsx
+++ b/frontend/dashboard/src/features/explore/ToolEvidenceExplorer.tsx
@@ -161,7 +161,7 @@ export function ToolEvidenceExplorer({
         <StatusBadge label={toolStatus(canLoad, query.isFetching, Boolean(query.data), query.error)} tone={query.data ? 'green' : 'blue'} />
       </div>
       <div className={styles.splitWorkspace}>
-        <main className={styles.evidenceSurface}>
+        <section className={styles.evidenceSurface} aria-label="Tool evidence results">
           <EvidenceGrid
             ariaLabel="Tool evidence"
             columns={columns}
@@ -197,7 +197,7 @@ export function ToolEvidenceExplorer({
               </button>
             ) : null}
           </div>
-        </main>
+        </section>
         <ToolInspector
           row={selected}
           calls={callsQuery.data?.calls ?? []}

--- a/frontend/dashboard/src/features/reports/ReportsPage.tsx
+++ b/frontend/dashboard/src/features/reports/ReportsPage.tsx
@@ -160,7 +160,7 @@ export function ReportsPage({
       </div>
 
       <div className={styles.workspace}>
-        <main className={styles.main}>
+        <section className={styles.main} aria-label="Report evidence">
           <Visualization spec={visualizationSpec} height={320} />
           <Panel
             title="Report Evidence Calls"
@@ -173,7 +173,7 @@ export function ReportsPage({
               onCopyCallLink={onCopyCallLink}
             />
           </Panel>
-        </main>
+        </section>
 
         <aside className={styles.research}>
           <Panel title="Research Notes" subtitle="Interpretation boundary">

--- a/frontend/dashboard/src/features/threads/ThreadsExplorerView.tsx
+++ b/frontend/dashboard/src/features/threads/ThreadsExplorerView.tsx
@@ -183,7 +183,7 @@ export function ThreadsExplorerView({
         </div>
       </div>
       <div className={styles.splitWorkspace}>
-        <main className={styles.evidenceSurface}>
+        <section className={styles.evidenceSurface} aria-label="Thread evidence">
           {viewMode === 'table' ? (
             <>
               <EvidenceGrid
@@ -238,7 +238,7 @@ export function ThreadsExplorerView({
           {viewMode === 'lifecycle' ? (
             <Visualization spec={lifecycleSpec} height={520} onSelectionChange={onOpenInvestigator} />
           ) : null}
-        </main>
+        </section>
         <ThreadInspector
           {...inspector}
           onCallSortChange={onCallSortChange}

--- a/tests/playwright/dashboard-performance.spec.mjs
+++ b/tests/playwright/dashboard-performance.spec.mjs
@@ -1,0 +1,279 @@
+import { expect, test } from '@playwright/test';
+import { performance } from 'node:perf_hooks';
+
+const budgetsMs = {
+  startup5k: 15_000,
+  uncapped5k: 15_000,
+  startup100k: 60_000,
+  cachedReload5k: 15_000,
+  appendedRefresh5k: 15_000,
+};
+
+test.describe('dashboard release-candidate performance evidence', () => {
+  test.describe.configure({ mode: 'serial', timeout: 90_000 });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'chromium-desktop', 'Performance evidence uses one stable desktop browser profile.');
+    page.on('pageerror', error => {
+      throw error;
+    });
+  });
+
+  test('starts deterministically with 5k synthetic rows inside the startup budget', async ({ page }, testInfo) => {
+    await installSyntheticBoot(page, { rowCount: 5_000, limit: 5_000 });
+
+    const elapsedMs = await openCallsAndMeasure(page);
+
+    await expect(page.getByText('5,000 ranked evidence rows', { exact: true })).toBeVisible();
+    await expectVirtualizedRowWindow(page, 5_000);
+    expect(
+      elapsedMs,
+      `5k synthetic startup took ${formatMs(elapsedMs)}, exceeding the ${formatMs(budgetsMs.startup5k)} RC budget; inspect boot-to-model conversion and first Calls render.`,
+    ).toBeLessThanOrEqual(budgetsMs.startup5k);
+    await attachEvidence(testInfo, 'startup-5k', { elapsedMs, budgetMs: budgetsMs.startup5k, rows: 5_000 });
+  });
+
+  test('loads the 5k synthetic history in No cap mode inside the paging budget', async ({ page }, testInfo) => {
+    const allRows = syntheticRows(5_000);
+    await installSyntheticBoot(page, { rowCount: 500, limit: 500, totalRows: 5_000, apiToken: 'performance-token' });
+    let usageRequests = 0;
+    await page.route('**/api/usage?**', async route => {
+      usageRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(syntheticPayload(allRows, { limit: 10_000, totalRows: 5_000, apiToken: 'performance-token' })),
+      });
+    });
+    await page.goto('/?view=calls&sort=cost&qa=r11-performance-no-cap');
+    await expect(page.getByRole('heading', { name: 'Calls', exact: true })).toBeVisible();
+
+    const startedAt = performance.now();
+    await page.getByRole('button', { name: 'Load all rows', exact: true }).click();
+    await expect(page.getByText('5,000 ranked evidence rows', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Row limit control')).toContainText('All rows mode');
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(usageRequests, 'No cap should fetch the bounded 5k synthetic history in one 10k page.').toBe(1);
+    expect(
+      elapsedMs,
+      `No cap loading took ${formatMs(elapsedMs)}, exceeding the ${formatMs(budgetsMs.uncapped5k)} RC budget; inspect /api/usage paging and model replacement.`,
+    ).toBeLessThanOrEqual(budgetsMs.uncapped5k);
+    await attachEvidence(testInfo, 'no-cap-5k', { elapsedMs, budgetMs: budgetsMs.uncapped5k, rows: 5_000, usageRequests });
+  });
+
+  test('keeps a 100k synthetic history virtualized inside the focused-load budget', async ({ page }, testInfo) => {
+    const focusedRows = syntheticRows(100_000);
+    await installSyntheticBoot(page, { rowCount: 500, limit: 500, totalRows: 100_000, apiToken: 'performance-token' });
+    await page.route('**/api/calls?**', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema: 'codex-usage-tracker-calls-v1',
+          rows: focusedRows,
+          row_count: focusedRows.length,
+          total_matched_rows: focusedRows.length,
+          limit: null,
+          offset: 0,
+          has_more: false,
+          next_offset: null,
+        }),
+      });
+    });
+
+    const startedAt = performance.now();
+    await page.goto('/?view=calls&qa=r11-performance-virtualized');
+    await expect(page.getByRole('heading', { name: 'Calls', exact: true })).toBeVisible({ timeout: budgetsMs.startup100k });
+    await expect(page.getByText('100,000 ranked evidence rows', { exact: true })).toBeVisible({ timeout: budgetsMs.startup100k });
+    const elapsedMs = performance.now() - startedAt;
+    const renderedRows = await expectVirtualizedRowWindow(page, 100_000);
+
+    expect(
+      elapsedMs,
+      `100k virtualized focused load took ${formatMs(elapsedMs)}, exceeding the ${formatMs(budgetsMs.startup100k)} RC budget; inspect calls response decoding and EvidenceGrid row-model work.`,
+    ).toBeLessThanOrEqual(budgetsMs.startup100k);
+    await attachEvidence(testInfo, 'virtualized-100k', {
+      elapsedMs,
+      budgetMs: budgetsMs.startup100k,
+      rows: 100_000,
+      renderedRows,
+    });
+  });
+
+  test('reuses the loaded 5k snapshot across reload without a usage request', async ({ page }, testInfo) => {
+    await installSyntheticBoot(page, { rowCount: 5_000, limit: 5_000, apiToken: 'performance-token' });
+    let usageRequests = 0;
+    await page.route('**/api/usage?**', async route => {
+      usageRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(syntheticPayload(syntheticRows(5_000), { limit: 5_000, apiToken: 'performance-token' })),
+      });
+    });
+    await page.goto('/?view=calls&sort=cost&qa=r11-performance-cache');
+    await expect(page.getByText('5,000 ranked evidence rows', { exact: true })).toBeVisible();
+
+    const startedAt = performance.now();
+    await page.reload();
+    await expect(page.getByText('5,000 ranked evidence rows', { exact: true })).toBeVisible();
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(usageRequests, 'A complete loaded snapshot should be reused on reload instead of issuing /api/usage.').toBe(0);
+    expect(
+      elapsedMs,
+      `Cached 5k reload took ${formatMs(elapsedMs)}, exceeding the ${formatMs(budgetsMs.cachedReload5k)} RC budget; inspect snapshot hydration and duplicate startup work.`,
+    ).toBeLessThanOrEqual(budgetsMs.cachedReload5k);
+    await attachEvidence(testInfo, 'cached-reload-5k', { elapsedMs, budgetMs: budgetsMs.cachedReload5k, rows: 5_000, usageRequests });
+  });
+
+  test('refreshes exactly one appended synthetic record inside the refresh budget', async ({ page }, testInfo) => {
+    const refreshedRows = syntheticRows(5_001);
+    refreshedRows.at(-1).thread_name = 'synthetic-appended-thread';
+    refreshedRows.at(-1).thread_key = 'synthetic-appended-thread';
+    await installSyntheticBoot(page, { rowCount: 5_000, limit: 5_000, totalRows: 5_000, apiToken: 'performance-token' });
+    let usageRequests = 0;
+    await page.route('**/api/usage?**', async route => {
+      usageRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(syntheticPayload(refreshedRows, { limit: 5_000, totalRows: 5_001, apiToken: 'performance-token' })),
+      });
+    });
+    await page.goto('/?view=calls&sort=cost&qa=r11-performance-append');
+    await expect(page.getByText('5,000 ranked evidence rows', { exact: true })).toBeVisible();
+
+    const startedAt = performance.now();
+    await page.getByRole('button', { name: 'Refresh all dashboard data' }).click();
+    await expect(page.getByText('5,001 ranked evidence rows', { exact: true })).toBeVisible();
+    await page.getByPlaceholder('Search calls, cwd, projects, models...').fill('synthetic-appended-thread');
+    await expect(page.getByText('synthetic-appended-thread', { exact: true }).first()).toBeVisible();
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(usageRequests, 'One appended-record refresh should issue exactly one bounded /api/usage request.').toBe(1);
+    expect(
+      elapsedMs,
+      `One-record append refresh took ${formatMs(elapsedMs)}, exceeding the ${formatMs(budgetsMs.appendedRefresh5k)} RC budget; inspect query invalidation and model replacement.`,
+    ).toBeLessThanOrEqual(budgetsMs.appendedRefresh5k);
+    await attachEvidence(testInfo, 'appended-refresh-5k', {
+      elapsedMs,
+      budgetMs: budgetsMs.appendedRefresh5k,
+      rowsBefore: 5_000,
+      rowsAfter: 5_001,
+      usageRequests,
+    });
+  });
+});
+
+async function installSyntheticBoot(page, { rowCount, limit, totalRows = rowCount, apiToken = '' }) {
+  await page.addInitScript(
+    ({ syntheticRowCount, syntheticLimit, syntheticTotalRows, syntheticApiToken }) => {
+      const rows = Array.from({ length: syntheticRowCount }, (_, index) => ({
+        record_id: `synthetic-call-${index}`,
+        session_id: `synthetic-session-${index % 500}`,
+        call_started_at: new Date(Date.UTC(2026, 6, 10, 12, 0, 0) - index * 1_000).toISOString(),
+        thread_name: `synthetic-thread-${index % 500}`,
+        thread_key: `synthetic-thread-${index % 500}`,
+        model: index % 2 ? 'codex-1' : 'o4-mini',
+        effort: index % 3 ? 'medium' : 'high',
+        input_tokens: 1_000 + (index % 100),
+        cached_input_tokens: 600 + (index % 50),
+        output_tokens: 100 + (index % 20),
+        reasoning_output_tokens: index % 10,
+        total_tokens: 1_100 + (index % 120),
+        estimated_cost_usd: (index % 25) / 1_000,
+      }));
+      window.__CODEX_USAGE_BOOT__ = {
+        api_token: syntheticApiToken || undefined,
+        context_api_enabled: false,
+        refresh_jobs_available: false,
+        history_scope: 'active',
+        include_archived: false,
+        limit: syntheticLimit,
+        limit_label: syntheticLimit === 0 ? 'All' : String(syntheticLimit),
+        has_more: syntheticRowCount < syntheticTotalRows,
+        latest_refresh_at: 'synthetic-r11-initial',
+        loaded_row_count: syntheticRowCount,
+        total_available_rows: syntheticTotalRows,
+        active_available_rows: syntheticTotalRows,
+        rows,
+      };
+    },
+    {
+      syntheticRowCount: rowCount,
+      syntheticLimit: limit,
+      syntheticTotalRows: totalRows,
+      syntheticApiToken: apiToken,
+    },
+  );
+}
+
+function syntheticRows(rowCount) {
+  return Array.from({ length: rowCount }, (_, index) => ({
+    record_id: `synthetic-call-${index}`,
+    session_id: `synthetic-session-${index % 500}`,
+    call_started_at: new Date(Date.UTC(2026, 6, 10, 12, 0, 0) - index * 1_000).toISOString(),
+    thread_name: `synthetic-thread-${index % 500}`,
+    thread_key: `synthetic-thread-${index % 500}`,
+    model: index % 2 ? 'codex-1' : 'o4-mini',
+    effort: index % 3 ? 'medium' : 'high',
+    input_tokens: 1_000 + (index % 100),
+    cached_input_tokens: 600 + (index % 50),
+    output_tokens: 100 + (index % 20),
+    reasoning_output_tokens: index % 10,
+    total_tokens: 1_100 + (index % 120),
+    estimated_cost_usd: (index % 25) / 1_000,
+  }));
+}
+
+function syntheticPayload(rows, { limit, totalRows = rows.length, apiToken }) {
+  return {
+    api_token: apiToken,
+    context_api_enabled: false,
+    refresh_jobs_available: false,
+    history_scope: 'active',
+    include_archived: false,
+    limit,
+    limit_label: String(limit),
+    has_more: rows.length < totalRows,
+    latest_refresh_at: `synthetic-r11-${rows.length}`,
+    loaded_row_count: rows.length,
+    total_available_rows: totalRows,
+    active_available_rows: totalRows,
+    rows,
+  };
+}
+
+async function openCallsAndMeasure(page) {
+  const startedAt = performance.now();
+  await page.goto('/?view=calls&sort=cost&qa=r11-performance');
+  await expect(page.getByRole('heading', { name: 'Calls', exact: true })).toBeVisible({ timeout: budgetsMs.startup100k });
+  await expect(page.getByRole('table', { name: 'Model calls' })).toBeVisible({ timeout: budgetsMs.startup100k });
+  return performance.now() - startedAt;
+}
+
+async function expectVirtualizedRowWindow(page, totalRows) {
+  const table = page.getByRole('table', { name: 'Model calls' });
+  await expect(table).toHaveAttribute('aria-rowcount', String(totalRows + 1));
+  const scroller = page.locator('[data-virtualized="true"]').filter({ has: table });
+  await expect(scroller).toHaveAttribute('data-virtualized', 'true');
+  const renderedRows = await table.locator('tbody tr').count();
+  expect(
+    renderedRows,
+    `${totalRows.toLocaleString()} logical rows rendered ${renderedRows.toLocaleString()} DOM rows; EvidenceGrid should keep the browser window below 100 rows.`,
+  ).toBeLessThan(100);
+  return renderedRows;
+}
+
+async function attachEvidence(testInfo, name, evidence) {
+  await testInfo.attach(`${name}.json`, {
+    body: Buffer.from(`${JSON.stringify({ scenario: name, ...evidence }, null, 2)}\n`),
+    contentType: 'application/json',
+  });
+}
+
+function formatMs(value) {
+  return `${Math.round(value).toLocaleString()}ms`;
+}

--- a/tests/playwright/dashboard-release-candidate.spec.mjs
+++ b/tests/playwright/dashboard-release-candidate.spec.mjs
@@ -1,0 +1,225 @@
+import { expect, test } from '@playwright/test';
+
+const workspaces = [
+  ['Overview', '/?view=overview&qa=r11-accessibility'],
+  ['Investigate', '/?view=investigator&qa=r11-accessibility'],
+  ['Calls', '/?view=calls&qa=r11-accessibility'],
+  ['Call Investigator', '/?view=call&record=fixture-call-2&qa=r11-accessibility'],
+  ['Threads', '/?view=threads&thread=thread-9f3a1c&qa=r11-accessibility'],
+  ['Limits', '/?view=usage-drain&qa=r11-accessibility'],
+  ['Cache And Context Lab', '/?view=cache-context&qa=r11-accessibility'],
+  ['Diagnostics Notebook', '/?view=diagnostics&qa=r11-accessibility'],
+  ['Reports', '/?view=reports&qa=r11-accessibility'],
+  ['Settings', '/?view=settings&qa=r11-accessibility'],
+];
+
+const viewports = [
+  ['desktop', { width: 1600, height: 900 }],
+  ['tablet', { width: 1024, height: 768 }],
+  ['mobile', { width: 390, height: 844 }],
+];
+
+test.describe('R11 dashboard release candidate', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'chromium-desktop', 'This spec owns its viewport and media matrix.');
+    test.setTimeout(180_000);
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+  });
+
+  test('passes the workspace accessibility and viewport matrix', async ({ page }) => {
+    const browserIssues = collectBrowserIssues(page);
+
+    for (const [viewportName, viewport] of viewports) {
+      await page.setViewportSize(viewport);
+
+      for (const [workspaceName, path] of workspaces) {
+        browserIssues.length = 0;
+        await openWorkspace(page, workspaceName, path);
+        const audit = await accessibilityAudit(page);
+
+        expect(audit, `${viewportName} ${workspaceName} accessibility audit`).toEqual({
+          documentOverflow: expect.any(Number),
+          duplicateIds: [],
+          emptyHeadings: [],
+          landmarkCount: 1,
+          unnamedControls: [],
+        });
+        expect(audit.documentOverflow, `${viewportName} ${workspaceName} document overflow`).toBeLessThanOrEqual(2);
+        expect(browserIssues, `${viewportName} ${workspaceName} console/page errors`).toEqual([]);
+      }
+    }
+  });
+
+  test('reflows every workspace at a 200 percent desktop zoom equivalent', async ({ page }) => {
+    const browserIssues = collectBrowserIssues(page);
+
+    // A 1600 x 900 desktop viewport exposes 800 x 450 CSS pixels at 200% browser zoom.
+    await page.setViewportSize({ width: 800, height: 450 });
+    for (const [workspaceName, path] of workspaces) {
+      browserIssues.length = 0;
+      await openWorkspace(page, workspaceName, path);
+      await expectDocumentContainment(page, `200% zoom ${workspaceName}`);
+      expect(browserIssues, `200% zoom ${workspaceName} console/page errors`).toEqual([]);
+    }
+  });
+
+  test('honors reduced motion and exposes visible keyboard focus in every workspace', async ({ page }) => {
+    const browserIssues = collectBrowserIssues(page);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+
+    for (const [workspaceName, path] of workspaces) {
+      browserIssues.length = 0;
+      await openWorkspace(page, workspaceName, path);
+      await expect.poll(() => page.evaluate(() => globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true);
+
+      const motion = await page.evaluate(() => Array.from(globalThis.document.querySelectorAll('*'))
+        .filter(element => {
+          const style = globalThis.getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+        })
+        .map(element => {
+          const style = globalThis.getComputedStyle(element);
+          return {
+            animation: style.animationName,
+            animationDuration: style.animationDuration,
+            transitionDuration: style.transitionDuration,
+          };
+        })
+        .filter(value => value.animation !== 'none' && durationMilliseconds(value.animationDuration) > 10));
+      expect(motion, `${workspaceName} reduced-motion animations`).toEqual([]);
+
+      await page.locator('body').press('Tab');
+      const focus = await page.evaluate(() => {
+        const element = globalThis.document.activeElement;
+        if (!(element instanceof globalThis.HTMLElement) || element === globalThis.document.body) return null;
+        const rect = element.getBoundingClientRect();
+        const style = globalThis.getComputedStyle(element);
+        return {
+          label: element.getAttribute('aria-label') || element.textContent?.trim().slice(0, 80) || element.tagName,
+          visible: rect.width > 0 && rect.height > 0 && rect.bottom > 0 && rect.top < globalThis.innerHeight,
+          hasIndicator: style.outlineStyle !== 'none' || style.boxShadow !== 'none',
+        };
+      });
+      expect(focus, `${workspaceName} first keyboard focus target`).not.toBeNull();
+      expect(focus?.visible, `${workspaceName} focused control visibility`).toBe(true);
+      expect(focus?.hasIndicator, `${workspaceName} focused control indicator`).toBe(true);
+      expect(browserIssues, `${workspaceName} reduced-motion console/page errors`).toEqual([]);
+    }
+  });
+
+  test('keeps chart and table evidence equivalent in every visualized workspace', async ({ page }) => {
+    const browserIssues = collectBrowserIssues(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    for (const [workspaceName, path] of workspaces) {
+      browserIssues.length = 0;
+      await openWorkspace(page, workspaceName, path);
+      const visualizations = page.locator('[data-visualization-id]');
+
+      for (let index = 0; index < await visualizations.count(); index += 1) {
+        const visualization = visualizations.nth(index);
+        const id = await visualization.getAttribute('data-visualization-id');
+        const title = (await visualization.getByRole('heading').first().textContent())?.trim();
+        const summary = (await visualization.locator('footer').textContent())?.trim();
+        const chartButton = visualization.getByRole('button', { name: 'Chart view' });
+        const tableButton = visualization.getByRole('button', { name: 'Table view' });
+
+        await expect(chartButton, `${workspaceName} ${id} chart control`).toHaveAttribute('aria-pressed', 'true');
+        await expect(visualization.getByRole('region', { name: `${title} chart` })).toBeVisible();
+        await tableButton.click();
+        await expect(tableButton).toHaveAttribute('aria-pressed', 'true');
+
+        const tableRegion = visualization.getByRole('region', { name: `${title} table` });
+        await expect(tableRegion).toBeVisible();
+        expect(await tableRegion.getByRole('row').count(), `${workspaceName} ${id} table evidence rows`).toBeGreaterThan(1);
+        expect((await visualization.locator('footer').textContent())?.trim(), `${workspaceName} ${id} summary`).toBe(summary);
+
+        await chartButton.click();
+        await expect(chartButton).toHaveAttribute('aria-pressed', 'true');
+      }
+
+      expect(browserIssues, `${workspaceName} chart/table console/page errors`).toEqual([]);
+    }
+  });
+});
+
+async function openWorkspace(page, workspaceName, path) {
+  await page.goto(path);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('heading', { name: workspaceName, exact: true }).first()).toBeVisible();
+  await expect(page.locator('vite-error-overlay')).toHaveCount(0);
+}
+
+function collectBrowserIssues(page) {
+  const issues = [];
+  page.on('console', message => {
+    if (message.type() === 'error') issues.push(`console: ${message.text()}`);
+  });
+  page.on('pageerror', error => issues.push(`pageerror: ${error.message}`));
+  return issues;
+}
+
+async function expectDocumentContainment(page, label) {
+  const overflow = await page.evaluate(() => (
+    Math.max(globalThis.document.documentElement.scrollWidth, globalThis.document.body.scrollWidth)
+      - globalThis.document.documentElement.clientWidth
+  ));
+  expect(overflow, label).toBeLessThanOrEqual(2);
+}
+
+async function accessibilityAudit(page) {
+  return page.evaluate(() => {
+    const visible = element => {
+      const style = globalThis.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+    };
+    const label = element => {
+      const labelledBy = element.getAttribute('aria-labelledby');
+      const labelledText = labelledBy
+        ? labelledBy.split(/\s+/).map(id => globalThis.document.getElementById(id)?.textContent || '').join(' ')
+        : '';
+      const nativeLabel = 'labels' in element
+        ? Array.from(element.labels || []).map(item => item.textContent || '').join(' ')
+        : '';
+      return (
+        element.getAttribute('aria-label')
+        || labelledText
+        || nativeLabel
+        || element.getAttribute('alt')
+        || element.getAttribute('title')
+        || element.textContent
+        || ''
+      ).replace(/\s+/g, ' ').trim();
+    };
+    const ids = Array.from(globalThis.document.querySelectorAll('[id]')).map(element => element.id);
+    const duplicateIds = [...new Set(ids.filter((id, index) => id && ids.indexOf(id) !== index))];
+    const unnamedControls = Array.from(globalThis.document.querySelectorAll('button, a[href], input, select, textarea'))
+      .filter(visible)
+      .filter(element => !label(element))
+      .map(element => element.outerHTML.slice(0, 120));
+    const emptyHeadings = Array.from(globalThis.document.querySelectorAll('h1, h2, h3, h4, h5, h6'))
+      .filter(visible)
+      .filter(element => !label(element))
+      .map(element => element.outerHTML.slice(0, 120));
+
+    return {
+      documentOverflow: Math.max(globalThis.document.documentElement.scrollWidth, globalThis.document.body.scrollWidth)
+        - globalThis.document.documentElement.clientWidth,
+      duplicateIds,
+      emptyHeadings,
+      landmarkCount: globalThis.document.querySelectorAll('main').length,
+      unnamedControls,
+    };
+  });
+}
+
+function durationMilliseconds(value) {
+  return value.split(',').reduce((maximum, item) => {
+    const duration = Number.parseFloat(item);
+    const milliseconds = item.trim().endsWith('ms') ? duration : duration * 1000;
+    return Math.max(maximum, milliseconds);
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- add a 10-workspace accessibility matrix at desktop, tablet, mobile, and 200% zoom
- add deterministic startup, no-cap, 100k virtualization, cache reuse, and incremental-refresh performance gates
- replace nested page-level `main` landmarks with named evidence sections
- document migration, rollback, root-route, and last-known-good release policy

## Validation
- full dashboard verify: passed
- accessibility matrix: 4 passed
- performance matrix: 5 passed
- no console/page errors or document overflow in the covered matrix
- markdown lint and release check: passed

Targets the redesign experiment branch; packaged asset regeneration is intentionally isolated into a follow-up artifact PR.