### PR TITLE
refactor: split oversized test responsibilities

### DIFF
--- a/tests/cli/test_mcp_integration.py
+++ b/tests/cli/test_mcp_integration.py
@@ -2,19 +2,11 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 import time
 from pathlib import Path
 from typing import Any, cast
 
-from codex_usage_tracker.dashboard.api import generate_dashboard
-from codex_usage_tracker.diagnostics.api import run_doctor
-from codex_usage_tracker.pricing.api import (
-    annotate_rows_with_efficiency,
-    load_pricing_config,
-)
 from codex_usage_tracker.store.api import (
-    query_most_expensive_calls,
     query_session_usage,
     refresh_usage_index,
 )
@@ -550,58 +542,3 @@ def test_mcp_dogfood_async_job_reports_progress(tmp_path: Path, monkeypatch) -> 
     assert disk_cached["status"] == "completed"
     assert disk_cached["result_cache"]["hit"] is True
     assert disk_cached["result_cache"]["source"] == "disk"
-
-
-def test_pricing_annotation_and_doctor_pass(tmp_path: Path) -> None:
-    codex_home = _make_codex_home(tmp_path)
-    db_path = tmp_path / "usage.sqlite3"
-    dashboard_path = tmp_path / "dashboard.html"
-    pricing_path = _write_pricing(tmp_path / "pricing.json")
-    refresh_usage_index(codex_home=codex_home, db_path=db_path)
-    generate_dashboard(db_path=db_path, output_path=dashboard_path, pricing_path=pricing_path)
-
-    rows = query_most_expensive_calls(db_path=db_path, limit=1)
-    annotated = annotate_rows_with_efficiency(
-        rows, pricing=load_pricing_config(tmp_path / "missing-pricing.json")
-    )
-    assert annotated[0]["estimated_cost_usd"] is None
-    annotated = annotate_rows_with_efficiency(rows, pricing=load_pricing_config(pricing_path))
-    assert annotated[0]["estimated_cost_usd"] > 0
-
-    repo_root = tmp_path / "repo"
-    (repo_root / ".codex-plugin").mkdir(parents=True)
-    (repo_root / ".codex-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
-    (repo_root / ".mcp.json").write_text(
-        json.dumps(
-            {
-                "mcpServers": {
-                    "codex-usage-tracker": {
-                        "command": sys.executable,
-                        "args": ["-m", "codex_usage_tracker.mcp_server"],
-                        "env": {"PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src")},
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    plugin_link = tmp_path / "plugins" / "codex-usage-tracker"
-    plugin_link.parent.mkdir()
-    plugin_link.symlink_to(repo_root, target_is_directory=True)
-    marketplace_path = tmp_path / "marketplace.json"
-    marketplace_path.write_text(
-        json.dumps({"plugins": [{"name": "codex-usage-tracker"}]}),
-        encoding="utf-8",
-    )
-
-    report = run_doctor(
-        codex_home=codex_home,
-        db_path=db_path,
-        dashboard_path=dashboard_path,
-        pricing_path=pricing_path,
-        plugin_link=plugin_link,
-        marketplace_path=marketplace_path,
-        repo_root=repo_root,
-    )
-
-    assert report["status"] == "pass"

--- a/tests/cli/test_mcp_runtime_compatibility.py
+++ b/tests/cli/test_mcp_runtime_compatibility.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from codex_usage_tracker.dashboard.api import generate_dashboard
+from codex_usage_tracker.diagnostics.api import run_doctor
+from codex_usage_tracker.pricing.api import (
+    annotate_rows_with_efficiency,
+    load_pricing_config,
+)
+from codex_usage_tracker.store.api import query_most_expensive_calls, refresh_usage_index
+from tests.store_dashboard_helpers import _make_codex_home, _write_pricing
+
+
+def test_pricing_annotation_and_doctor_pass(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    dashboard_path = tmp_path / "dashboard.html"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    generate_dashboard(db_path=db_path, output_path=dashboard_path, pricing_path=pricing_path)
+
+    rows = query_most_expensive_calls(db_path=db_path, limit=1)
+    annotated = annotate_rows_with_efficiency(
+        rows, pricing=load_pricing_config(tmp_path / "missing-pricing.json")
+    )
+    assert annotated[0]["estimated_cost_usd"] is None
+    annotated = annotate_rows_with_efficiency(rows, pricing=load_pricing_config(pricing_path))
+    assert annotated[0]["estimated_cost_usd"] > 0
+
+    repo_root = tmp_path / "repo"
+    (repo_root / ".codex-plugin").mkdir(parents=True)
+    (repo_root / ".codex-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
+    (repo_root / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "codex-usage-tracker": {
+                        "command": sys.executable,
+                        "args": ["-m", "codex_usage_tracker.mcp_server"],
+                        "env": {"PYTHONPATH": str(Path(__file__).resolve().parents[2] / "src")},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    plugin_link = tmp_path / "plugins" / "codex-usage-tracker"
+    plugin_link.parent.mkdir()
+    plugin_link.symlink_to(repo_root, target_is_directory=True)
+    marketplace_path = tmp_path / "marketplace.json"
+    marketplace_path.write_text(
+        json.dumps({"plugins": [{"name": "codex-usage-tracker"}]}),
+        encoding="utf-8",
+    )
+
+    report = run_doctor(
+        codex_home=codex_home,
+        db_path=db_path,
+        dashboard_path=dashboard_path,
+        pricing_path=pricing_path,
+        plugin_link=plugin_link,
+        marketplace_path=marketplace_path,
+        repo_root=repo_root,
+    )
+
+    assert report["status"] == "pass"

--- a/tests/context/test_context_evidence.py
+++ b/tests/context/test_context_evidence.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from codex_usage_tracker.context.api import load_call_context
 from codex_usage_tracker.store.api import (
     query_diagnostic_fact_calls,
@@ -242,47 +240,6 @@ def test_context_evidence_includes_lightweight_action_timing(tmp_path: Path) -> 
     assert entries_by_label["Token count"]["action_timing"]["since_previous_entry_ms"] == 2250
     assert ".jsonl" not in action_timing_text
     assert "Run focused evidence timing" not in action_timing_text
-
-
-def test_context_loading_uses_one_source_scan_for_evidence_and_serialized_estimate(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    codex_home = _make_codex_home(tmp_path)
-    db_path = tmp_path / "usage.sqlite3"
-    refresh_usage_index(codex_home=codex_home, db_path=db_path)
-    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
-    source_file = Path(str(row["source_file"]))
-    open_count = 0
-    real_open = Path.open
-
-    def counting_open(
-        path: Path,
-        mode: str = "r",
-        buffering: int = -1,
-        encoding: str | None = None,
-        errors: str | None = None,
-        newline: str | None = None,
-    ):
-        nonlocal open_count
-        if path == source_file:
-            open_count += 1
-        return real_open(path, mode, buffering, encoding, errors, newline)
-
-    monkeypatch.setattr(Path, "open", counting_open)
-
-    context = load_call_context(row["record_id"], db_path=db_path, diagnostics=True)
-
-    assert open_count == 1
-    assert any(entry["label"] == "message / user" for entry in context["entries"])
-    assert context["include_tool_output"] is False
-    assert context["context_mode"] == "quick"
-    assert context["serialized_evidence"]["available"] is True
-    assert context["serialized_evidence"]["deferred_buckets"] is True
-    assert "call_anchors" not in context
-    assert "thread_anchors" not in context
-    assert context["diagnostics"]["source_scan_ms"] >= 0
-    assert context["diagnostics"]["serialized_estimate_ms"] >= 0
 
 
 def test_context_carries_incoming_compaction_history_into_selected_turn(tmp_path: Path) -> None:

--- a/tests/context/test_context_source_scan.py
+++ b/tests/context/test_context_source_scan.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.context.api import load_call_context
+from codex_usage_tracker.store.api import query_session_usage, refresh_usage_index
+from tests.store_dashboard_helpers import SESSION_ID, _make_codex_home
+
+
+def test_context_loading_uses_one_source_scan_for_evidence_and_serialized_estimate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_file = Path(str(row["source_file"]))
+    open_count = 0
+    real_open = Path.open
+
+    def counting_open(
+        path: Path,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ):
+        nonlocal open_count
+        if path == source_file:
+            open_count += 1
+        return real_open(path, mode, buffering, encoding, errors, newline)
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    context = load_call_context(row["record_id"], db_path=db_path, diagnostics=True)
+
+    assert open_count == 1
+    assert any(entry["label"] == "message / user" for entry in context["entries"])
+    assert context["include_tool_output"] is False
+    assert context["context_mode"] == "quick"
+    assert context["serialized_evidence"]["available"] is True
+    assert context["serialized_evidence"]["deferred_buckets"] is True
+    assert "call_anchors" not in context
+    assert "thread_anchors" not in context
+    assert context["diagnostics"]["source_scan_ms"] >= 0
+    assert context["diagnostics"]["serialized_estimate_ms"] >= 0

--- a/tests/dashboard/dashboard_node_test_helpers.py
+++ b/tests/dashboard/dashboard_node_test_helpers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _run_node_script(
+    *, asset_name: str, script: str, context: str, setup: str = ""
+) -> dict[str, Any]:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for dashboard JavaScript tests")
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = (
+        repo_root / "src" / "codex_usage_tracker" / "plugin_data" / "dashboard" / asset_name
+    )
+    wrapped = f"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync({json.dumps(str(script_path))}, 'utf8');
+const context = {context};
+vm.createContext(context);
+vm.runInContext(code, context);
+{setup}
+{script}
+"""
+    result = subprocess.run(
+        [node, "-e", wrapped],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def run_snapshot_renderer_script(script: str) -> dict[str, Any]:
+    setup = """
+const factory = context.window.CodexUsageDashboardDiagnosticSnapshots;
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+"""
+    return _run_node_script(
+        asset_name="dashboard_diagnostics_snapshots.js",
+        script=script,
+        context="{ window: {}, console }",
+        setup=setup,
+    )
+
+
+def run_dashboard_live_script(script: str) -> dict[str, Any]:
+    return _run_node_script(
+        asset_name="dashboard_live.js",
+        script=script,
+        context=(
+            "{ window: { clearInterval, setInterval }, URLSearchParams, "
+            "fetch: async (url, options) => globalThis.__fetch(url, options), console }"
+        ),
+        setup="const factory = context.window.CodexUsageDashboardLive;",
+    )

--- a/tests/dashboard/test_dashboard_diagnostics_snapshots.py
+++ b/tests/dashboard/test_dashboard_diagnostics_snapshots.py
@@ -1,55 +1,8 @@
 from __future__ import annotations
 
-import json
-import shutil
-import subprocess
-from pathlib import Path
-from typing import Any
-
-import pytest
-
-
-def _run_snapshot_renderer_script(script: str) -> dict[str, Any]:
-    node = shutil.which("node")
-    if node is None:
-        pytest.skip("node is required for dashboard diagnostic snapshot renderer tests")
-    repo_root = Path(__file__).resolve().parents[2]
-    script_path = (
-        repo_root
-        / "src"
-        / "codex_usage_tracker"
-        / "plugin_data"
-        / "dashboard"
-        / "dashboard_diagnostics_snapshots.js"
-    )
-    wrapped = f"""
-const fs = require('fs');
-const vm = require('vm');
-const code = fs.readFileSync({json.dumps(str(script_path))}, 'utf8');
-const context = {{
-  window: {{}},
-  console,
-}};
-vm.createContext(context);
-vm.runInContext(code, context);
-const factory = context.window.CodexUsageDashboardDiagnosticSnapshots;
-function escapeHtml(value) {{
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}}
-{script}
-"""
-    result = subprocess.run(
-        [node, "-e", wrapped],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return json.loads(result.stdout)
+from tests.dashboard.dashboard_node_test_helpers import (
+    run_snapshot_renderer_script as _run_snapshot_renderer_script,
+)
 
 
 def test_dashboard_commands_snapshot_renders_collapsible_children() -> None:

--- a/tests/dashboard/test_dashboard_live.py
+++ b/tests/dashboard/test_dashboard_live.py
@@ -1,49 +1,10 @@
 from __future__ import annotations
 
-import json
-import shutil
-import subprocess
 from pathlib import Path
-from typing import Any
 
-import pytest
-
-
-def _run_dashboard_live_script(script: str) -> dict[str, Any]:
-    node = shutil.which("node")
-    if node is None:
-        pytest.skip("node is required for dashboard live helper tests")
-    repo_root = Path(__file__).resolve().parents[2]
-    script_path = (
-        repo_root
-        / "src"
-        / "codex_usage_tracker"
-        / "plugin_data"
-        / "dashboard"
-        / "dashboard_live.js"
-    )
-    wrapped = f"""
-const fs = require('fs');
-const vm = require('vm');
-const code = fs.readFileSync({json.dumps(str(script_path))}, 'utf8');
-const context = {{
-  window: {{ clearInterval, setInterval }},
-  URLSearchParams,
-  fetch: async (url, options) => globalThis.__fetch(url, options),
-  console,
-}};
-vm.createContext(context);
-vm.runInContext(code, context);
-const factory = context.window.CodexUsageDashboardLive;
-{script}
-"""
-    result = subprocess.run(
-        [node, "-e", wrapped],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return json.loads(result.stdout)
+from tests.dashboard.dashboard_node_test_helpers import (
+    run_dashboard_live_script as _run_dashboard_live_script,
+)
 
 
 def test_dashboard_live_reports_available_rows_for_shell_only_views() -> None:

--- a/tests/dashboard/test_dashboard_payload.py
+++ b/tests/dashboard/test_dashboard_payload.py
@@ -7,7 +7,6 @@ import pytest
 
 from codex_usage_tracker.dashboard.api import dashboard_payload, generate_dashboard
 from codex_usage_tracker.store.api import (
-    EVENT_COLUMNS,
     connect,
     export_usage_csv,
     refresh_usage_index,
@@ -776,41 +775,6 @@ def test_dashboard_payload_uses_persisted_call_origin_without_source_scan(
 
     assert by_initiator["user"]["call_initiator_reason"] == "user_message"
     assert by_initiator["user"]["call_initiator_confidence"] == "high"
-
-
-def test_dashboard_payload_and_csv_privacy_mode_redact_project_metadata(tmp_path: Path) -> None:
-    codex_home = _make_codex_home(tmp_path)
-    db_path = tmp_path / "usage.sqlite3"
-    csv_path = tmp_path / "usage-redacted.csv"
-    refresh_usage_index(codex_home=codex_home, db_path=db_path)
-
-    payload = dashboard_payload(db_path=db_path, privacy_mode="strict")
-    exported = export_usage_csv(
-        output_path=csv_path,
-        db_path=db_path,
-        privacy_mode="redacted",
-    )
-    csv_text = csv_path.read_text(encoding="utf-8")
-    csv_header = csv_text.splitlines()[0].split(",")
-    rows = payload["rows"]
-    assert isinstance(rows, list)
-    first_row = rows[0]
-    assert isinstance(first_row, dict)
-    project_privacy = payload["project_metadata_privacy"]
-    assert isinstance(project_privacy, dict)
-
-    assert exported == 4
-    assert payload["privacy_mode"] == "strict"
-    assert project_privacy["cwd_redacted"] is True
-    assert str(first_row["cwd"]).startswith("[redacted cwd:")
-    assert str(first_row["project_name"]).startswith("Project ")
-    assert first_row["project_relative_cwd"] is None
-    assert first_row["git_branch"] is None
-    assert first_row["git_remote_label"] is None
-    assert "/tmp/codex-usage-tracker" not in json.dumps(payload)
-    assert "/tmp/codex-usage-tracker" not in csv_text
-    assert "[redacted cwd:" in csv_text
-    assert csv_header == EVENT_COLUMNS
 
 
 def test_dashboard_guide_link_can_use_docs_url_override(tmp_path: Path, monkeypatch) -> None:

--- a/tests/dashboard/test_dashboard_payload_privacy.py
+++ b/tests/dashboard/test_dashboard_payload_privacy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_usage_tracker.dashboard.api import dashboard_payload
+from codex_usage_tracker.store.api import EVENT_COLUMNS, export_usage_csv, refresh_usage_index
+from tests.store_dashboard_helpers import _make_codex_home
+
+
+def test_dashboard_payload_and_csv_privacy_mode_redact_project_metadata(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    csv_path = tmp_path / "usage-redacted.csv"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    payload = dashboard_payload(db_path=db_path, privacy_mode="strict")
+    exported = export_usage_csv(
+        output_path=csv_path,
+        db_path=db_path,
+        privacy_mode="redacted",
+    )
+    csv_text = csv_path.read_text(encoding="utf-8")
+    csv_header = csv_text.splitlines()[0].split(",")
+    rows = payload["rows"]
+    assert isinstance(rows, list)
+    first_row = rows[0]
+    assert isinstance(first_row, dict)
+    project_privacy = payload["project_metadata_privacy"]
+    assert isinstance(project_privacy, dict)
+
+    assert exported == 4
+    assert payload["privacy_mode"] == "strict"
+    assert project_privacy["cwd_redacted"] is True
+    assert str(first_row["cwd"]).startswith("[redacted cwd:")
+    assert str(first_row["project_name"]).startswith("Project ")
+    assert first_row["project_relative_cwd"] is None
+    assert first_row["git_branch"] is None
+    assert first_row["git_remote_label"] is None
+    assert "/tmp/codex-usage-tracker" not in json.dumps(payload)
+    assert "/tmp/codex-usage-tracker" not in csv_text
+    assert "[redacted cwd:" in csv_text
+    assert csv_header == EVENT_COLUMNS

--- a/tests/usage_drain/model_test_helpers.py
+++ b/tests/usage_drain/model_test_helpers.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def component_credits(
+    *,
+    uncached: int,
+    cached: int,
+    reasoning: int,
+    nonreasoning: int,
+) -> float:
+    return (
+        (uncached * 125.0) + (cached * 12.5) + ((reasoning + nonreasoning) * 750.0)
+    ) / 1_000_000.0
+
+
+def coefficients_by_feature(rows: list[dict[str, object]]) -> dict[str, float | None]:
+    coefficients: dict[str, float | None] = {}
+    for row in rows:
+        coefficient = row["coefficient"]
+        assert coefficient is None or isinstance(coefficient, (int, float))
+        coefficients[str(row["feature"])] = None if coefficient is None else float(coefficient)
+    return coefficients

--- a/tests/usage_drain/test_usage_drain_model.py
+++ b/tests/usage_drain/test_usage_drain_model.py
@@ -13,6 +13,12 @@ from codex_usage_tracker.usage_drain.model import (
     load_fast_proxy_annotations,
     summarize_usage_drain_model,
 )
+from tests.usage_drain.model_test_helpers import (
+    coefficients_by_feature as _coefficients_by_feature,
+)
+from tests.usage_drain.model_test_helpers import (
+    component_credits as _component_credits,
+)
 
 
 def _row(
@@ -602,27 +608,6 @@ def test_token_component_regression_recovers_rate_card_and_fast_weighting() -> N
         "reasoning_output_tokens": 750.0,
         "nonreasoning_output_tokens": 750.0,
     }
-
-
-def _component_credits(
-    *,
-    uncached: int,
-    cached: int,
-    reasoning: int,
-    nonreasoning: int,
-) -> float:
-    return (
-        (uncached * 125.0) + (cached * 12.5) + ((reasoning + nonreasoning) * 750.0)
-    ) / 1_000_000.0
-
-
-def _coefficients_by_feature(rows: list[dict[str, object]]) -> dict[str, float | None]:
-    coefficients: dict[str, float | None] = {}
-    for row in rows:
-        coefficient = row["coefficient"]
-        assert coefficient is None or isinstance(coefficient, (int, float))
-        coefficients[str(row["feature"])] = None if coefficient is None else float(coefficient)
-    return coefficients
 
 
 def test_fit_usage_drain_proxy_recovers_documented_multiplier() -> None:


### PR DESCRIPTION
## Summary
- split context source-scan coverage into its own module
- split MCP runtime compatibility and dashboard payload privacy coverage
- share the dashboard Node execution harness
- extract usage-drain model test helpers
- restore all six ratcheted test modules below their prior file-length ceilings

## Validation
- 47 focused tests passed
- full Pyright: 0 errors
- Ruff check and format check passed
- agent-maintainer precommit profile passed
- git diff --check passed