### PR TITLE
Enforce a low-noise Pylint hardening gate

### DIFF
--- a/docs/complexity-hardening-roadmap.md
+++ b/docs/complexity-hardening-roadmap.md
@@ -50,26 +50,41 @@ full-tree cleanup.
 
 ### 4. Waste Candidate Diagnostics
 
-- [ ] Reduce repeated-file, shell-churn, and large-low-output candidate builders
+- [x] Reduce repeated-file, shell-churn, and large-low-output candidate builders
   through shared metric and explanation helpers.
 - Exit: all candidate functions rank B or better and diagnostic payload schemas
   remain unchanged.
 
 ### 5. Allowance And Isolated Utilities
 
-- [ ] Reduce allowance analysis/readiness and nonparametric statistical branch
+- [x] Reduce allowance analysis/readiness and nonparametric statistical branch
   complexity while preserving evidence grades and exact test results.
-- [ ] Reduce doctor formatting and command-wrapper classification.
+- [x] Reduce doctor formatting and command-wrapper classification.
 - Exit: every remaining C/E function ranks B or better.
 
 ### 6. Maintained Gates
 
-- [ ] Add Xenon B/A/A to hardening CI only after the full source tree passes.
-- [ ] Audit Pylint messages into correctness, maintainability, and convention
+- [x] Add Xenon B/A/A to hardening CI only after the full source tree passes.
+- [x] Audit Pylint messages into correctness, maintainability, and convention
   groups.
-- [ ] Enable a reviewed low-noise Pylint selection or changed-code ratchet; do
+- [x] Enable a reviewed low-noise Pylint selection or changed-code ratchet; do
   not add broad suppressions to manufacture a green full-tree score.
 - [ ] Run the full CI, security, package, and release validation matrix.
+
+The 2026-07-11 Pylint audit counted 1,448 default findings. Most were legacy
+convention or broad design signals already owned by Ruff, file-length, Xenon,
+Tach, or focused refactors: 342 missing function docstrings, 270 duplicate-code
+reports, 229 too-many-argument reports, 184 line-length reports, and 120
+useless-import-alias reports. The maintained Pylint gate now selects fatal and
+error messages plus a reviewed set of high-signal control-flow, exception,
+subprocess, finite-number, and comparison checks. The eight findings exposed by
+that selection were fixed in code. This is repository-level configuration, not
+inline suppression, and the historical audit remains available for future
+advisory cleanup.
+
+The complete source tree also passes the configured Xenon B/A/A gate. That
+result closes the original 21-function C/E backlog and makes complexity drift a
+maintained hardening failure instead of a periodic advisory scan.
 
 ## Validation Pattern
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,32 @@ target-version = "py310"
 select = ["E", "F", "I", "UP", "B", "SIM"]
 ignore = ["E501"]
 
+[tool.pylint."messages control"]
+disable = ["all"]
+enable = [
+  "F",
+  "E",
+  "W0101", # unreachable
+  "W0102", # dangerous-default-value
+  "W0120", # useless-else-on-loop
+  "W0123", # eval-used
+  "W0129", # assert-on-string-literal
+  "W0150", # lost-exception
+  "W0199", # assert-on-tuple
+  "W0702", # bare-except
+  "W0705", # duplicate-except
+  "W0707", # raise-missing-from
+  "W0711", # binary-op-exception
+  "W1404", # implicit-str-concat
+  "W1501", # bad-open-mode
+  "W1508", # invalid-envvar-default
+  "W1510", # subprocess-run-check
+  "R0124", # comparison-with-itself
+  "R1716", # chained-comparison
+  "R1730", # consider-using-min-builtin
+  "R1731", # consider-using-max-builtin
+]
+
 [tool.agent_maintainer]
 mode = "legacy-ratchet"
 architecture_tool = "tach"

--- a/src/codex_usage_tracker/core/redaction.py
+++ b/src/codex_usage_tracker/core/redaction.py
@@ -6,7 +6,7 @@ import re
 
 SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"sk-[A-Za-z0-9_-]{10,}"), "[REDACTED_OPENAI_KEY]"),
-    (re.compile(r"github" r"_pat_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
     (re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "[REDACTED_GITHUB_TOKEN]"),
     (re.compile(r"\bA(?:KI|SI)A[0-9A-Z]{16}\b"), "[REDACTED_AWS_ACCESS_KEY]"),
     (

--- a/src/codex_usage_tracker/core/threads.py
+++ b/src/codex_usage_tracker/core/threads.py
@@ -59,10 +59,8 @@ def _build_parent_candidates(rows: list[dict[str, Any]]) -> dict[str, dict[str, 
                 latest=event_timestamp,
             ),
         )
-        if event_timestamp < candidate.first:
-            candidate.first = event_timestamp
-        if event_timestamp > candidate.latest:
-            candidate.latest = event_timestamp
+        candidate.first = min(candidate.first, event_timestamp)
+        candidate.latest = max(candidate.latest, event_timestamp)
 
     for candidate in by_session.values():
         if not candidate.cwd:

--- a/src/codex_usage_tracker/diagnostics/mcp.py
+++ b/src/codex_usage_tracker/diagnostics/mcp.py
@@ -226,6 +226,7 @@ def _run_mcp_import_check(
         capture_output=True,
         text=True,
         timeout=20,
+        check=False,
     )
 
 

--- a/src/codex_usage_tracker/reports/visualization_support.py
+++ b/src/codex_usage_tracker/reports/visualization_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import isfinite
 from typing import Any
 
 VISUALIZATION_SPEC_SCHEMA = "codex-usage-visualization/v1"
@@ -235,4 +236,4 @@ def _optional_number(value: Any) -> float | None:
         number = float(value)
     except (TypeError, ValueError):
         return None
-    return number if number == number and abs(number) != float("inf") else None
+    return number if isfinite(number) else None

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -102,7 +102,7 @@ def _source_metadata_matches(row: sqlite3.Row, metadata: dict[str, int]) -> bool
 def _can_incrementally_parse_source(metadata: dict[str, int], row: sqlite3.Row) -> bool:
     previous_size = int(row["size_bytes"])
     previous_byte = int(row["parsed_until_byte"])
-    return metadata["size_bytes"] > previous_size and 0 < previous_byte <= previous_size
+    return 0 < previous_byte <= previous_size < metadata["size_bytes"]
 
 
 def upsert_source_file_metadata(

--- a/src/codex_usage_tracker/usage_drain/allowance_breakpoints.py
+++ b/src/codex_usage_tracker/usage_drain/allowance_breakpoints.py
@@ -177,16 +177,20 @@ def _best_allowance_capacity_split(
         right_sse = _allowance_capacity_sse(rows, split_index, end)
         combined_sse = left_sse + right_sse
         reduction = parent_sse - combined_sse
-        if best_split is None or reduction > _number(best_split["sse_reduction"]):
-            best_split = {
-                "start": start,
-                "end": end,
-                "split_index": split_index,
-                "parent_sse": parent_sse,
-                "piecewise_sse": combined_sse,
-                "sse_reduction": reduction,
-                "sse_reduction_share": reduction / parent_sse,
-            }
+        previous_reduction = (
+            float("-inf") if best_split is None else _number(best_split["sse_reduction"])
+        )
+        if reduction <= previous_reduction:
+            continue
+        best_split = {
+            "start": start,
+            "end": end,
+            "split_index": split_index,
+            "parent_sse": parent_sse,
+            "piecewise_sse": combined_sse,
+            "sse_reduction": reduction,
+            "sse_reduction_share": reduction / parent_sse,
+        }
     return best_split
 
 

--- a/src/codex_usage_tracker/usage_drain/reports.py
+++ b/src/codex_usage_tracker/usage_drain/reports.py
@@ -373,26 +373,26 @@ def _best_allowance_split(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
         left_sse = _range_sse(prefix_sum, prefix_square, 0, split)
         right_sse = _range_sse(prefix_sum, prefix_square, split, len(values))
         reduction = parent_sse - left_sse - right_sse
-        if best is None or reduction > _number(best["sse_reduction"]):
-            left = rows[:split]
-            right = rows[split:]
-            best = {
-                "split_index": split,
-                "left_n": len(left),
-                "right_n": len(right),
-                "left_start_event_timestamp": left[0]["start_event_timestamp"],
-                "left_end_event_timestamp": left[-1]["end_event_timestamp"],
-                "right_start_event_timestamp": right[0]["start_event_timestamp"],
-                "right_end_event_timestamp": right[-1]["end_event_timestamp"],
-                "left_mean_credits_per_percent": _rounded(
-                    _mean([_number(row["credits_per_visible_percent"]) for row in left])
-                ),
-                "right_mean_credits_per_percent": _rounded(
-                    _mean([_number(row["credits_per_visible_percent"]) for row in right])
-                ),
-                "sse_reduction_share": _rounded(reduction / parent_sse),
-                "sse_reduction": reduction,
-            }
+        if reduction <= (_number(best["sse_reduction"]) if best else float("-inf")):
+            continue
+        left, right = rows[:split], rows[split:]
+        best = {
+            "split_index": split,
+            "left_n": len(left),
+            "right_n": len(right),
+            "left_start_event_timestamp": left[0]["start_event_timestamp"],
+            "left_end_event_timestamp": left[-1]["end_event_timestamp"],
+            "right_start_event_timestamp": right[0]["start_event_timestamp"],
+            "right_end_event_timestamp": right[-1]["end_event_timestamp"],
+            "left_mean_credits_per_percent": _rounded(
+                _mean([_number(row["credits_per_visible_percent"]) for row in left])
+            ),
+            "right_mean_credits_per_percent": _rounded(
+                _mean([_number(row["credits_per_visible_percent"]) for row in right])
+            ),
+            "sse_reduction_share": _rounded(reduction / parent_sse),
+            "sse_reduction": reduction,
+        }
     return best
 
 

--- a/tests/reports/test_visualization.py
+++ b/tests/reports/test_visualization.py
@@ -8,6 +8,7 @@ from codex_usage_tracker.reports.visualization import (
     build_visualization_result,
     suggest_visualizations,
 )
+from codex_usage_tracker.reports.visualization_support import _optional_number
 
 
 def test_visualization_suggestions_rank_question_cues() -> None:
@@ -59,6 +60,12 @@ def test_allowance_visualization_preserves_backend_grade_and_candidate() -> None
     assert spec["scope"]["historyScope"] == "all"
     assert spec["data"]["rows"][0]["capacity_proxy"] == 800.0
     assert spec["annotations"][0]["id"] == "candidate-regime-shift"
+
+
+def test_visualization_numbers_reject_non_finite_values() -> None:
+    assert _optional_number(float("nan")) is None
+    assert _optional_number(float("inf")) is None
+    assert _optional_number("12.5") == 12.5
 
 
 def test_thread_call_visualization_uses_chronological_call_shape() -> None:

--- a/tests/reports/test_visualization.py
+++ b/tests/reports/test_visualization.py
@@ -65,6 +65,7 @@ def test_allowance_visualization_preserves_backend_grade_and_candidate() -> None
 def test_visualization_numbers_reject_non_finite_values() -> None:
     assert _optional_number(float("nan")) is None
     assert _optional_number(float("inf")) is None
+    assert _optional_number("not-a-number") is None
     assert _optional_number("12.5") == 12.5
 
 

--- a/tests/usage_drain/test_usage_drain_model.py
+++ b/tests/usage_drain/test_usage_drain_model.py
@@ -13,7 +13,6 @@ from codex_usage_tracker.usage_drain.model import (
     load_fast_proxy_annotations,
     summarize_usage_drain_model,
 )
-from codex_usage_tracker.usage_drain.reports import _best_allowance_split
 from tests.usage_drain.model_test_helpers import (
     coefficients_by_feature as _coefficients_by_feature,
 )
@@ -544,24 +543,6 @@ def test_allowance_breakpoint_analysis_detects_capacity_denominator_change() -> 
     assert breakpoint_diagnostics["known_breakpoint_row_count"] == 1
     assert breakpoint_diagnostics["known_breakpoint_abs_error_share"] == 1.0
     assert breakpoint_diagnostics["non_breakpoint_mae"] == 0.0
-
-
-def test_best_allowance_split_selects_the_strongest_capacity_change() -> None:
-    rows = [
-        {
-            "credits_per_visible_percent": 10.0 if index < 15 else 40.0,
-            "start_event_timestamp": f"start-{index:02d}",
-            "end_event_timestamp": f"end-{index:02d}",
-        }
-        for index in range(30)
-    ]
-
-    split = _best_allowance_split(rows)
-
-    assert split is not None
-    assert split["split_index"] == 15
-    assert split["left_mean_credits_per_percent"] == 10.0
-    assert split["right_mean_credits_per_percent"] == 40.0
 
 
 def test_token_component_regression_recovers_rate_card_and_fast_weighting() -> None:

--- a/tests/usage_drain/test_usage_drain_model.py
+++ b/tests/usage_drain/test_usage_drain_model.py
@@ -13,6 +13,7 @@ from codex_usage_tracker.usage_drain.model import (
     load_fast_proxy_annotations,
     summarize_usage_drain_model,
 )
+from codex_usage_tracker.usage_drain.reports import _best_allowance_split
 from tests.usage_drain.model_test_helpers import (
     coefficients_by_feature as _coefficients_by_feature,
 )
@@ -543,6 +544,24 @@ def test_allowance_breakpoint_analysis_detects_capacity_denominator_change() -> 
     assert breakpoint_diagnostics["known_breakpoint_row_count"] == 1
     assert breakpoint_diagnostics["known_breakpoint_abs_error_share"] == 1.0
     assert breakpoint_diagnostics["non_breakpoint_mae"] == 0.0
+
+
+def test_best_allowance_split_selects_the_strongest_capacity_change() -> None:
+    rows = [
+        {
+            "credits_per_visible_percent": 10.0 if index < 15 else 40.0,
+            "start_event_timestamp": f"start-{index:02d}",
+            "end_event_timestamp": f"end-{index:02d}",
+        }
+        for index in range(30)
+    ]
+
+    split = _best_allowance_split(rows)
+
+    assert split is not None
+    assert split["split_index"] == 15
+    assert split["left_mean_credits_per_percent"] == 10.0
+    assert split["right_mean_credits_per_percent"] == 40.0
 
 
 def test_token_component_regression_recovers_rate_card_and_fast_weighting() -> None:

--- a/tests/usage_drain/test_usage_drain_report_helpers.py
+++ b/tests/usage_drain/test_usage_drain_report_helpers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from codex_usage_tracker.usage_drain.reports import _best_allowance_split
+
+
+def test_best_allowance_split_selects_the_strongest_capacity_change() -> None:
+    rows = [
+        {
+            "credits_per_visible_percent": 10.0 if index < 15 else 40.0,
+            "start_event_timestamp": f"start-{index:02d}",
+            "end_event_timestamp": f"end-{index:02d}",
+        }
+        for index in range(30)
+    ]
+
+    split = _best_allowance_split(rows)
+
+    assert split is not None
+    assert split["split_index"] == 15
+    assert split["left_mean_credits_per_percent"] == 10.0
+    assert split["right_mean_credits_per_percent"] == 40.0


### PR DESCRIPTION
## Summary
- replace the advisory all-message Pylint run with a reviewed fatal/error and high-signal correctness selection
- fix all eight findings exposed by that selection without inline suppressions
- record the 1,448-finding legacy audit and close the Xenon B/A/A backlog in the complexity roadmap

Part of #201.

## Validation
- `pylint src --score=n`
- `xenon --max-absolute B --max-modules A --max-average A src`
- 54 focused tests across redaction, threads, source refresh, allowance analysis, visualization, MCP, and CLI release contracts
- `just vp`
- Ruff, Taplo, markdownlint, and `git diff --check`