### PR TITLE
fix: revalidate React dashboard assets

### DIFF
--- a/src/codex_usage_tracker/server/dashboard_pages.py
+++ b/src/codex_usage_tracker/server/dashboard_pages.py
@@ -53,6 +53,8 @@ class DashboardPageMixin(SimpleHTTPRequestHandler):
     def end_headers(self) -> None:
         if self._is_dashboard_html_request():
             self.send_header("Cache-Control", "no-store")
+        elif urlparse(self.path).path.startswith("/codex-usage-tracker-assets/react/assets/"):
+            self.send_header("Cache-Control", "no-cache")
         self.send_header("X-Content-Type-Options", "nosniff")
         self.send_header("Referrer-Policy", "no-referrer")
         self.send_header(
@@ -86,7 +88,6 @@ class DashboardPageMixin(SimpleHTTPRequestHandler):
         except OSError as exc:
             self._send_exception("Could not read React dashboard shell", exc)
             return
-        html = self._cache_bust_react_asset_urls(html)
         usage_data = json.dumps(payload, ensure_ascii=True).replace("</", "<\\/")
         usage_script = f'<script id="usage-data" type="application/json">{usage_data}</script>'
         if '<div id="root"></div>' in html:
@@ -104,26 +105,6 @@ class DashboardPageMixin(SimpleHTTPRequestHandler):
         finally:
             self.path = original_path
             self._serving_react_dashboard = False
-
-    def _cache_bust_react_asset_urls(self, html: str) -> str:
-        for asset_url in (
-            "/codex-usage-tracker-assets/react/assets/dashboard-react.js",
-            "/codex-usage-tracker-assets/react/assets/index.css",
-        ):
-            version = self._react_asset_version(asset_url)
-            if not version:
-                continue
-            html = html.replace(f'{asset_url}"', f'{asset_url}?v={version}"')
-            html = html.replace(f"{asset_url}'", f"{asset_url}?v={version}'")
-        return html
-
-    def _react_asset_version(self, asset_url: str) -> str:
-        asset_path = Path(self.translate_path(asset_url))
-        try:
-            stat = asset_path.stat()
-        except OSError:
-            return ""
-        return f"{stat.st_mtime_ns:x}-{stat.st_size:x}"
 
     def _is_investigator_dashboard_request(self, path: str, query: str) -> bool:
         if path != f"/{self._dashboard_name}":

--- a/tests/dashboard/test_dashboard_server.py
+++ b/tests/dashboard/test_dashboard_server.py
@@ -175,6 +175,13 @@ def test_dashboard_server_serves_react_dashboard_alias(tmp_path: Path) -> None:
             react_cache_control = response.headers.get("Cache-Control")
 
         with urllib.request.urlopen(  # noqa: S310 - local test server only
+            f"{base_url}/codex-usage-tracker-assets/react/assets/dashboard-react.js",
+            timeout=5,
+        ) as response:
+            react_asset = response.read().decode("utf-8")
+            react_asset_cache_control = response.headers.get("Cache-Control")
+
+        with urllib.request.urlopen(  # noqa: S310 - local test server only
             f"{base_url}/dashboard.html",
             timeout=5,
         ) as response:
@@ -188,7 +195,10 @@ def test_dashboard_server_serves_react_dashboard_alias(tmp_path: Path) -> None:
     assert react_content_type.split(";", 1)[0] == "text/html"
     assert react_cache_control == "no-store"
     assert "Codex Usage Tracker React Dashboard" in react_html
-    assert "/codex-usage-tracker-assets/react/assets/dashboard-react.js?v=" in react_html
+    assert 'src="/codex-usage-tracker-assets/react/assets/dashboard-react.js"' in react_html
+    assert "dashboard-react.js?v=" not in react_html
+    assert react_asset_cache_control == "no-cache"
+    assert "window.__reactDashboard = true" in react_asset
     assert '<script id="usage-data" type="application/json">' in react_html
     react_payload = json.loads(
         react_html.split('<script id="usage-data" type="application/json">', 1)[1].split(


### PR DESCRIPTION
## Summary

- serve React dashboard assets with `Cache-Control: no-cache` so upgrades revalidate every module consistently
- remove the entry-only query-string cache buster that could give the same ES module two browser identities
- add a server regression test for the canonical script URL and asset cache policy

## Why

The post-merge real-data browser audit found transient React `useContext` errors after rebuilds. The HTML versioned only `dashboard-react.js`, while split chunks imported the same file without the query string. Browsers therefore could evaluate two React module instances. A canonical URL plus HTTP revalidation preserves one module graph and still prevents stale upgrades.

## Validation

- `tests/dashboard/test_dashboard_server.py`: 12 passed
- `python3 scripts/check_release.py`: passed
- dashboard source budget: passed
- Agent Maintainer precommit: `20260711T173928290446Z-precommit-98f4e13bee3f`
- clean 1280px in-app browser load: no horizontal overflow, no console errors, parser status clean
- Usage Constellation lazy-load: canvas rendered after scroll with no console errors
