### PR TITLE
refactor: reduce compression cold-build overhead

### DIFF
--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -359,6 +359,10 @@ Measured optimizations:
 - Computed the incremental manifest once per run and added compact revision identities for every evidence family.
 - Used `agent-perf`/Scalene on a 100,000-call synthetic workload. `_raw_rows` fell from 4.68 to 1.94 percent CPU attribution (`20260713T004417Z-167fcc53` to `20260713T005309Z-b5750e1d`), while unprofiled time fell from 8.75 to 8.01 seconds with the same 9,269 candidates.
 - Rejected a direct candidate serializer after it improved the synthetic workload by only 0.13 seconds, and rejected BLAKE2b manifest hashing after it regressed the workload to 9.27 seconds.
+- Added `scripts/benchmark_compression_lab.py` as the durable CP equivalence
+  and regression harness. Its 100,000-call synthetic baseline completed cold
+  analysis in 2.698 seconds with 10,000 candidates, 225.969 MiB peak RSS,
+  stable candidate/profile fingerprints, and a 3.37 ms exact warm hit.
 
 Resume in this order:
 

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -47,7 +47,11 @@ Exit gates:
 
 ### PR 2: Detectors And Estimators
 
-Status: in progress
+Status: complete
+
+PR: [#222](https://github.com/douglasmonsky/codex-usage-tracker/pull/222)
+
+Merge: `98f2cd7be6d1a357279d827bb2190198e7bc1ff5`
 
 Deliverables:
 
@@ -136,11 +140,159 @@ Exit gates:
 
 ## Performance Budget
 
-- Full uncached run: under 60 seconds on data near the maintainer's current scale.
+- Full uncached run: under 20 seconds on data near the maintainer's current scale, with a 25-second P95 ceiling.
+- Single-source append refresh: under 1 second when only bounded detector dependencies change.
 - Warm profile and candidate list: under 500 ms.
+- Exact unchanged warm profile: under 10 ms.
 - Candidate detail: under 1 second.
 - Progress starts immediately and remains monotonic.
 - Incremental refresh recalculates only changed records/threads plus global overlap totals.
+
+## Cold-Build Performance Program
+
+The current typed-row loader reduced the same 404,176-call forced rebuild from
+48.115 seconds to 38.708 seconds. Removing the separately measured prior-run
+deletion cost gives an estimated first-ever cold build of about 35.5 seconds.
+The remaining target requires changing the data flow, not further
+micro-optimizing serialization.
+
+All performance measurements use deterministic synthetic data for profilers and
+report only aggregate timing/count evidence for real local data. Private indexed
+content is never sent to a profiler or committed as a fixture.
+
+### CP1: Performance Contract And Safe Loader Foundation
+
+Status: in progress
+
+Issue: [#223](https://github.com/douglasmonsky/codex-usage-tracker/issues/223)
+
+Deliverables:
+
+- Deterministic 100,000-call synthetic cold-build benchmark.
+- Stage timings for evidence load, manifest, detection, attribution,
+  persistence, and profile generation.
+- Peak-memory and throughput reporting suitable for regression comparisons.
+- Canonical candidate/profile fingerprints for old-versus-new equivalence.
+- Typed SQLite row loading without intermediate row dictionaries.
+- One manifest computation per run and compact revision identities.
+
+Exit gates:
+
+- Candidate count and canonical output fingerprints are unchanged.
+- Real aggregate cold-build time improves by at least 15 percent.
+- Exact warm behavior remains below 10 ms.
+- Public evidence-query contracts remain backward compatible.
+- No benchmark artifact contains private prompts, paths, commands, or content.
+
+### CP2: Streaming Detector Consumption
+
+Status: pending
+
+Deliverables:
+
+- A bounded evidence-batch reader over the existing normalized SQLite tables.
+- A detector lifecycle with initialize, observe-batch, and finalize phases.
+- Compatibility adapters for detectors that still require a complete snapshot.
+- Shared streaming estimator inputs that preserve component-level attribution.
+- Deterministic ordering only for detector families that declare it necessary.
+
+Exit gates:
+
+- Streaming and snapshot engines produce identical canonical candidate/profile
+  fingerprints across golden synthetic fixtures.
+- Peak Python memory no longer scales with the complete evidence object graph.
+- Evidence loading plus detector execution is at least 35 percent faster than
+  the CP1 baseline.
+- Partial batches, empty tables, and detector failures retain current warnings
+  and progress semantics.
+
+### CP3: Detector-Ready Ingestion Aggregates
+
+Status: pending
+
+Deliverables:
+
+- Persisted per-call token, cache, output, and estimated-credit facts.
+- Persisted sequence/count facts for shell churn, repeated validation, file
+  rediscovery, and tool-output concentration.
+- Per-thread lifecycle and cache-resume summaries.
+- Idempotent backfill from existing normalized content-index records.
+- Detector queries over compact facts instead of repeated raw reconstruction.
+
+Exit gates:
+
+- Existing databases migrate and backfill without reparsing raw logs.
+- Aggregate facts remain reproducible from normalized source records.
+- Append ingestion updates only affected calls, threads, and sequence windows.
+- Detector outputs remain equivalent to the CP2 streaming reference.
+
+### CP4: Revision-State And Incremental Invalidation
+
+Status: pending
+
+Deliverables:
+
+- Per-source byte offsets, source hashes, row counts, and generation counters.
+- Per-aggregate and per-detector dependency revisions.
+- A revision-vector cache key that avoids full Python manifest traversal.
+- Dependency-aware invalidation of only affected detector families and threads.
+- Recovery behavior for truncation, rotation, parser-version changes, and
+  explicit replacement.
+
+Exit gates:
+
+- Exact unchanged checks use bounded metadata reads and remain below 10 ms.
+- A representative one-event append refresh completes below 1 second.
+- Truncation or parser drift cannot silently reuse stale detector results.
+- Replacement remains available but is not required for ordinary append-only
+  operation.
+
+### CP5: Candidate Persistence Pipeline
+
+Status: pending
+
+Deliverables:
+
+- One transaction with bounded bulk inserts for candidates and claims.
+- Internal typed persistence that avoids mapping serialization on the hot path.
+- Attribution performed alongside detection when required evidence is already
+  present.
+- Atomic profile publication after candidate and claim persistence succeeds.
+- Rollback and retry coverage for interrupted builds.
+
+Exit gates:
+
+- Candidate-heavy persistence is at least 40 percent faster than CP1.
+- Partial failures leave no visible mixed-generation profile.
+- Public candidate/profile payloads remain unchanged.
+- Candidate IDs and overlap allocation remain deterministic.
+
+### CP6: Profile-Guided Parallel Ingestion
+
+Status: pending
+
+Deliverables:
+
+- Parallel parsing across independent source files only after CP2-CP5 profiling.
+- A single deterministic SQLite writer with bounded worker queues.
+- Stable merge ordering and backpressure under skewed source sizes.
+- Worker-count configuration with a conservative automatic default.
+- Serial fallback for one-file histories and low-resource systems.
+
+Exit gates:
+
+- Current-scale true first build is consistently below 20 seconds and below
+  25 seconds at P95.
+- Parallel output fingerprints match the serial engine exactly.
+- Parallel mode demonstrates a material speedup over the optimized serial path.
+- Memory and writer contention stay within the documented benchmark budget.
+
+### Performance Completion Audit
+
+The program is complete only when all CP1-CP6 exit gates have authoritative
+evidence. Each PR must update this ledger with its benchmark run, tests, PR,
+merge commit, and any rejected optimization. A narrow test cannot establish a
+whole-pipeline timing or equivalence claim.
 
 ## Deferred Queue
 
@@ -162,14 +314,16 @@ Exit gates:
 - 2026-07-11: Compression Lab preflight PR #220 merged at `7261d3f` with roadmap and hardening-tool compatibility.
 - 2026-07-11: PR 1 merged as #221 at `702d038`; PR 2 detector and estimator work started from that exact base.
 - 2026-07-12: PR 2 detector contracts, all six detector families, shared estimator indexing, cache-aware run building, staged progress, exact/incremental cache handling, and compact profiles implemented on `feature/compression-lab-detectors`.
+- 2026-07-12: PR 2 merged as #222 at `98f2cd7`; CP1 cold-path profiling started from that exact base.
+- 2026-07-12: The CP1 target was tightened to a 15-20 second first build, sub-second append refresh, and sub-10 ms unchanged reuse. CP2-CP6 define the structural path and equivalence gates.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/compression-lab-detectors`
+Branch: `feature/compression-cold-path`
 
-Last completed commit before the current run-builder slice: `0094dca` (`feat: add compression opportunity detectors`). The run-builder/performance work after that commit is intentionally left intact in the worktree and must not be discarded.
+PR #222 merged the detector and run-builder foundation as `98f2cd7`. Issue #223 tracks the focused cold-path follow-up.
 
 Validated behavior at this checkpoint:
 
@@ -183,14 +337,15 @@ Validated behavior at this checkpoint:
 
 Latest replacement benchmark (`include_archived=true`, all-history scope):
 
-- Total: 47.939 seconds, including deletion and replacement of the prior 32,087-candidate run.
-- Evidence loaded: 18.69 seconds.
-- All detectors complete: 26.18 seconds.
-- Attribution complete / persistence started: 30.40 seconds.
-- Candidate persistence complete / profile started: 42.30 seconds.
-- Profile complete: 47.59 seconds.
+- Total: 38.708 seconds, including deletion and replacement of the prior 32,087-candidate run.
+- Evidence loaded: 14.221 seconds.
+- Manifest and all detectors complete: 24.576 seconds.
+- Attribution complete / persistence started: 28.730 seconds.
+- Candidate persistence complete / profile started: 37.617 seconds.
+- Profile complete: 38.386 seconds.
+- Estimated first-ever cold time: about 35.5 seconds after excluding the separately measured 3.2-second prior-run deletion cost.
 - Exact warm profile: 6.2 ms, below the 500 ms target.
-- The prior comparable run took 77.575 seconds on 324,982 calls; the optimized run is 38 percent faster while processing 24 percent more calls.
+- The immediate pre-follow-up baseline was 48.115 seconds on the same 404,176 calls and 32,087 candidates; the current forced rebuild is 19.5 percent faster.
 
 Measured optimizations:
 
@@ -199,17 +354,27 @@ Measured optimizations:
 - Replaced per-event cryptographic manifest hashing with deterministic order-independent checksums and removed duplicate event identity encoding.
 - Built attribution capacity directly from the estimator index rather than materializing generic row dictionaries.
 - Removed an unused candidate-record secondary index and persisted compact public profiles separately from private incremental manifests.
+- Materialized typed evidence directly from positional SQLite rows, avoiding roughly 1.5 million intermediate dictionaries.
+- Removed unnecessary ordering from tool, command, file, and fragment evidence queries after verifying detectors and manifests are order-independent.
+- Computed the incremental manifest once per run and added compact revision identities for every evidence family.
+- Used `agent-perf`/Scalene on a 100,000-call synthetic workload. `_raw_rows` fell from 4.68 to 1.94 percent CPU attribution (`20260713T004417Z-167fcc53` to `20260713T005309Z-b5750e1d`), while unprofiled time fell from 8.75 to 8.01 seconds with the same 9,269 candidates.
+- Rejected a direct candidate serializer after it improved the synthetic workload by only 0.13 seconds, and rejected BLAKE2b manifest hashing after it regressed the workload to 9.27 seconds.
 
 Resume in this order:
 
-1. Keep the PR at or below the 20-file ceiling and leave `.idea/` unstaged.
-2. Commit the run-builder slice as `feat: build compression analysis profiles`.
-3. Merge current `origin/main` without rewriting history, resolve only genuine conflicts, then push/open/merge PR 2 before starting PR 3.
+1. Finish CP1 verification, leave `.idea/` unstaged, and merge the focused
+   cold-path PR.
+2. Start CP2 from current `main`; do not combine schema or parallel-ingestion
+   work with the streaming detector contract.
+3. Land CP3, CP4, and CP5 serially because each changes the persisted inputs or
+   cache identity consumed by the next phase.
+4. Add CP6 only after a fresh profile proves source parsing is the dominant
+   remaining first-build cost.
 
 ## Resume Instructions
 
 1. Read the canonical design and this execution ledger.
-2. Start the next pending PR from current `main`.
+2. Start the next pending Compression Lab or CP milestone from current `main`.
 3. Update the relevant PR status and append a dated progress-log entry.
 4. Do not skip attribution invariants to add another detector quickly.
 5. Do not route the skill to the new lab until shadow comparisons and MCP contracts pass.

--- a/scripts/benchmark_compression_lab.py
+++ b/scripts/benchmark_compression_lab.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Benchmark Compression Lab cold and warm builds with synthetic data only."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import resource
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from benchmark_synthetic_history import _synthetic_events  # noqa: E402
+
+from codex_usage_tracker.compression.models import CompressionScope  # noqa: E402
+from codex_usage_tracker.compression.run_builder import build_compression_run  # noqa: E402
+from codex_usage_tracker.store.api import (  # noqa: E402
+    refresh_usage_event_links,
+    upsert_usage_events,
+)
+from codex_usage_tracker.store.connection import connect  # noqa: E402
+
+DEFAULT_ROWS = 100_000
+DEFAULT_MAX_COLD_SECONDS = 20.0
+_VOLATILE_PROFILE_KEYS = {
+    "cache",
+    "completed_at",
+    "created_at",
+    "duration_ms",
+    "progress",
+    "run_id",
+    "started_at",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, default=DEFAULT_ROWS)
+    parser.add_argument("--batch-size", type=int, default=5_000)
+    parser.add_argument("--db-dir", type=Path)
+    parser.add_argument("--keep-db", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--enforce-thresholds", action="store_true")
+    parser.add_argument("--max-cold-seconds", type=float, default=DEFAULT_MAX_COLD_SECONDS)
+    parser.add_argument("--run-db", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    _validate_args(parser, args)
+
+    if args.run_db is not None:
+        print(json.dumps(_run_builds(args.run_db), separators=(",", ":")))
+        return 0
+
+    temp_dir: Path | None = None
+    if args.db_dir is None:
+        temp_dir = Path(tempfile.mkdtemp(prefix="compression-lab-benchmark-"))
+        db_dir = temp_dir
+    else:
+        db_dir = args.db_dir.expanduser()
+        db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / f"compression-synthetic-{args.rows}.sqlite3"
+
+    try:
+        populate_seconds = _populate_database(
+            db_path,
+            rows=args.rows,
+            batch_size=args.batch_size,
+        )
+        run_payload = _run_in_child(db_path)
+        failures = _threshold_failures(
+            run_payload,
+            max_cold_seconds=args.max_cold_seconds,
+        )
+        payload = {
+            "schema_version": 1,
+            "synthetic": True,
+            "rows": args.rows,
+            "batch_size": args.batch_size,
+            "populate_seconds": round(populate_seconds, 6),
+            "max_cold_seconds": args.max_cold_seconds,
+            **run_payload,
+            "threshold_status": "fail" if failures else "pass",
+            "threshold_failures": failures,
+        }
+        _print_payload(payload, as_json=args.as_json)
+        return 1 if args.enforce_thresholds and failures else 0
+    finally:
+        if temp_dir is not None and not args.keep_db:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    if args.rows <= 0:
+        parser.error("--rows must be positive")
+    if args.batch_size <= 0:
+        parser.error("--batch-size must be positive")
+    if args.max_cold_seconds <= 0:
+        parser.error("--max-cold-seconds must be positive")
+
+
+def _populate_database(db_path: Path, *, rows: int, batch_size: int) -> float:
+    if db_path.exists():
+        db_path.unlink()
+    started = time.perf_counter()
+    for start in range(0, rows, batch_size):
+        upsert_usage_events(
+            _synthetic_events(start, min(start + batch_size, rows)),
+            db_path=db_path,
+            refresh_links=False,
+        )
+    refresh_usage_event_links(db_path=db_path)
+    with connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE usage_events
+            SET input_tokens = 25000,
+                cached_input_tokens = 0,
+                output_tokens = 100,
+                total_tokens = 25100,
+                uncached_input_tokens = 25000,
+                cache_ratio = 0,
+                context_window_percent = 0.8
+            WHERE rowid % 10 = 0
+            """
+        )
+        conn.commit()
+    return time.perf_counter() - started
+
+
+def _run_in_child(db_path: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), "--run-db", str(db_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "compression benchmark child failed\n"
+            f"returncode={result.returncode}\n"
+            f"stdout={result.stdout}\n"
+            f"stderr={result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def _run_builds(db_path: Path) -> dict[str, Any]:
+    scope = CompressionScope(include_archived=True)
+    started = time.perf_counter()
+    stages: dict[str, float] = {}
+
+    def record_progress(payload: dict[str, Any]) -> None:
+        stage = payload.get("stage")
+        if isinstance(stage, str):
+            stages[stage] = round(time.perf_counter() - started, 6)
+
+    cold_profile = build_compression_run(
+        db_path,
+        scope,
+        force=True,
+        progress_callback=record_progress,
+    )
+    cold_payload = {
+        "total_seconds": round(time.perf_counter() - started, 6),
+        "peak_rss_mb": round(_peak_rss_mb(), 3),
+        "candidate_count": int(cold_profile.get("candidate_count") or 0),
+        "candidate_fingerprint": _candidate_fingerprint(db_path),
+        "profile_fingerprint": _profile_fingerprint(cold_profile),
+        "stage_timings_seconds": stages,
+    }
+
+    warm_started = time.perf_counter()
+    warm_profile = build_compression_run(db_path, scope)
+    warm_payload = {
+        "total_seconds": round(time.perf_counter() - warm_started, 6),
+        "cache_mode": str((warm_profile.get("cache") or {}).get("mode") or "unknown"),
+        "profile_fingerprint": _profile_fingerprint(warm_profile),
+    }
+    return {"cold_build": cold_payload, "warm_build": warm_payload}
+
+
+def _candidate_fingerprint(db_path: Path) -> str:
+    digest = hashlib.sha256()
+    with connect(db_path) as conn:
+        run_row = conn.execute(
+            "SELECT run_id FROM compression_runs WHERE status = 'completed' "
+            "ORDER BY completed_at DESC, run_id DESC LIMIT 1"
+        ).fetchone()
+        if run_row is None:
+            raise RuntimeError("completed compression run was not persisted")
+        run_id = str(run_row[0])
+        candidate_rows = conn.execute(
+            """
+            SELECT candidate_id, family, pattern_key, rank, confidence_grade,
+                   confidence_score, observation_count, observed_exposure_json,
+                   gross_low, gross_likely, gross_high, adjusted_low, adjusted_likely,
+                   adjusted_high, detector_version, estimator_version, estimator_tier,
+                   warnings_json, overlaps_json, thread_keys_json, first_seen, last_seen
+            FROM compression_candidates
+            WHERE run_id = ?
+            ORDER BY candidate_id
+            """,
+            (run_id,),
+        )
+        _update_digest(digest, candidate_rows)
+        claim_rows = conn.execute(
+            """
+            SELECT r.candidate_id, r.record_id, r.component, r.exposure_tokens,
+                   r.estimate_low, r.estimate_likely, r.estimate_high,
+                   r.evidence_role, r.trace_handle_json
+            FROM compression_candidate_records AS r
+            JOIN compression_candidates AS c ON c.candidate_id = r.candidate_id
+            WHERE c.run_id = ?
+            ORDER BY r.candidate_id, r.record_id, r.component
+            """,
+            (run_id,),
+        )
+        _update_digest(digest, claim_rows)
+    return digest.hexdigest()
+
+
+def _update_digest(digest: Any, rows: Iterable[Any]) -> None:
+    for row in rows:
+        digest.update(json.dumps(tuple(row), separators=(",", ":")).encode())
+        digest.update(b"\n")
+
+
+def _profile_fingerprint(profile: dict[str, Any]) -> str:
+    stable = _without_volatile_fields(profile)
+    encoded = json.dumps(stable, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _without_volatile_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _without_volatile_fields(item)
+            for key, item in value.items()
+            if key not in _VOLATILE_PROFILE_KEYS and not key.startswith("_")
+        }
+    if isinstance(value, list):
+        return [_without_volatile_fields(item) for item in value]
+    return value
+
+
+def _peak_rss_mb() -> float:
+    peak = float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return peak / (1024 * 1024) if sys.platform == "darwin" else peak / 1024
+
+
+def _threshold_failures(
+    payload: dict[str, Any],
+    *,
+    max_cold_seconds: float,
+) -> list[str]:
+    elapsed = float(payload["cold_build"]["total_seconds"])
+    if elapsed <= max_cold_seconds:
+        return []
+    return [f"cold_build.total_seconds {elapsed:.3f} exceeded {max_cold_seconds:.3f}"]
+
+
+def _print_payload(payload: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    cold = payload["cold_build"]
+    warm = payload["warm_build"]
+    print(
+        f"{payload['rows']:,} synthetic calls: cold {cold['total_seconds']:.3f}s, "
+        f"warm {warm['total_seconds']:.6f}s, peak RSS {cold['peak_rss_mb']:.1f} MiB, "
+        f"candidates {cold['candidate_count']:,}, thresholds {payload['threshold_status']}"
+    )
+    for failure in payload["threshold_failures"]:
+        print(f"  FAIL {failure}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -125,6 +125,7 @@ REQUIRED_FILES = [
     "docs/assets/plugin-prompts.png",
     "docs/assets/plugin-thread-leaderboard.png",
     "scripts/check_release.py",
+    "scripts/benchmark_compression_lab.py",
     "scripts/benchmark_synthetic_history.py",
     "scripts/smoke_installed_package.py",
     ".github/workflows/ci.yml",
@@ -228,6 +229,7 @@ WHEEL_REQUIRED_MEMBERS = {
 }
 SDIST_REQUIRED_MEMBERS = {
     "docs/cli-json-schemas.md",
+    "scripts/benchmark_compression_lab.py",
     "scripts/benchmark_synthetic_history.py",
     "skills/codex-usage-api/SKILL.md",
     "skills/codex-usage-tracker/SKILL.md",

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -125,7 +125,6 @@ REQUIRED_FILES = [
     "docs/assets/plugin-prompts.png",
     "docs/assets/plugin-thread-leaderboard.png",
     "scripts/check_release.py",
-    "scripts/benchmark_compression_lab.py",
     "scripts/benchmark_synthetic_history.py",
     "scripts/smoke_installed_package.py",
     ".github/workflows/ci.yml",
@@ -229,7 +228,6 @@ WHEEL_REQUIRED_MEMBERS = {
 }
 SDIST_REQUIRED_MEMBERS = {
     "docs/cli-json-schemas.md",
-    "scripts/benchmark_compression_lab.py",
     "scripts/benchmark_synthetic_history.py",
     "skills/codex-usage-api/SKILL.md",
     "skills/codex-usage-tracker/SKILL.md",

--- a/src/codex_usage_tracker/compression/evidence.py
+++ b/src/codex_usage_tracker/compression/evidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -11,7 +12,7 @@ from codex_usage_tracker.compression.models import (
     ComponentName,
     CompressionScope,
 )
-from codex_usage_tracker.store.compression_evidence import query_compression_evidence
+from codex_usage_tracker.store.compression_evidence import query_compression_evidence_rows
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +29,25 @@ class CallEvidence:
     exposure: ComponentExposure
     cache_ratio: float
     context_window_percent: float
+
+    def revision_identity(self) -> tuple[Any, ...]:
+        return (
+            self.record_id,
+            self.session_id,
+            self.thread_key,
+            self.event_timestamp,
+            self.model,
+            self.effort,
+            self.is_archived,
+            self.thread_call_index,
+            self.previous_record_id,
+            self.exposure.cached_input,
+            self.exposure.uncached_input,
+            self.exposure.output,
+            self.exposure.reasoning_output,
+            self.cache_ratio,
+            self.context_window_percent,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,6 +82,17 @@ class ToolCallEvidence:
     duration_ms: int | None
     output_size_bytes: int
 
+    def revision_identity(self) -> tuple[Any, ...]:
+        return (
+            self.tool_call_key,
+            self.record_id,
+            self.turn_key,
+            self.tool_name,
+            self.status,
+            self.duration_ms,
+            self.output_size_bytes,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class CommandRunEvidence:
@@ -75,6 +106,19 @@ class CommandRunEvidence:
     output_size_bytes: int
     retry_group: str | None
 
+    def revision_identity(self) -> tuple[Any, ...]:
+        return (
+            self.command_run_key,
+            self.record_id,
+            self.turn_key,
+            self.command_root,
+            self.command_label,
+            self.exit_code,
+            self.status,
+            self.output_size_bytes,
+            self.retry_group,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class FileEventEvidence:
@@ -84,6 +128,16 @@ class FileEventEvidence:
     operation: str
     path_hash: str
     path_identity: str
+
+    def revision_identity(self) -> tuple[Any, ...]:
+        return (
+            self.file_event_key,
+            self.record_id,
+            self.turn_key,
+            self.operation,
+            self.path_hash,
+            self.path_identity,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -208,7 +262,7 @@ def load_compression_evidence(
     scope: CompressionScope,
 ) -> CompressionEvidenceSnapshot:
     """Load and normalize one scoped evidence snapshot from SQLite."""
-    payload = query_compression_evidence(
+    payload = query_compression_evidence_rows(
         db_path,
         scope=scope.as_dict(),
         include_turns=False,
@@ -234,88 +288,90 @@ def load_compression_evidence(
     )
 
 
-def _call(row: dict[str, Any]) -> CallEvidence:
+# Offsets mirror the private SQL projections in store/compression_evidence.py.
+# Positional access avoids millions of named row lookups on cold builds.
+def _call(row: sqlite3.Row) -> CallEvidence:
     return CallEvidence(
-        record_id=str(row["record_id"]),
-        session_id=str(row["session_id"]),
-        thread_key=str(row["thread_key"]),
-        event_timestamp=str(row["event_timestamp"]),
-        model=_optional_text(row.get("model")),
-        effort=_optional_text(row.get("effort")),
-        is_archived=bool(row.get("is_archived")),
-        thread_call_index=_optional_int(row.get("thread_call_index")),
-        previous_record_id=_optional_text(row.get("previous_record_id")),
+        record_id=str(row[0]),
+        session_id=str(row[1]),
+        thread_key=str(row[2]),
+        event_timestamp=str(row[3]),
+        model=_optional_text(row[4]),
+        effort=_optional_text(row[5]),
+        is_archived=bool(row[6]),
+        thread_call_index=_optional_int(row[7]),
+        previous_record_id=_optional_text(row[8]),
         exposure=ComponentExposure(
-            cached_input=_integer(row.get("cached_input_tokens")),
-            uncached_input=_integer(row.get("uncached_input_tokens")),
-            output=_integer(row.get("output_tokens")),
-            reasoning_output=_integer(row.get("reasoning_output_tokens")),
+            cached_input=_integer(row[9]),
+            uncached_input=_integer(row[10]),
+            output=_integer(row[11]),
+            reasoning_output=_integer(row[12]),
         ),
-        cache_ratio=float(row.get("cache_ratio") or 0),
-        context_window_percent=float(row.get("context_window_percent") or 0),
+        cache_ratio=float(row[13] or 0),
+        context_window_percent=float(row[14] or 0),
     )
 
 
-def _turn(row: dict[str, Any]) -> TurnEvidence:
+def _turn(row: sqlite3.Row) -> TurnEvidence:
     return TurnEvidence(
-        turn_key=str(row["turn_key"]),
-        record_id=str(row["record_id"]),
-        session_id=str(row["session_id"]),
-        role=str(row["role"]),
-        event_timestamp=_optional_text(row.get("event_timestamp")),
-        content_size_bytes=_integer(row.get("content_size_bytes")),
-        indexed_content_included=bool(row.get("indexed_content_included")),
+        turn_key=str(row[0]),
+        record_id=str(row[1]),
+        session_id=str(row[2]),
+        role=str(row[3]),
+        event_timestamp=_optional_text(row[4]),
+        content_size_bytes=_integer(row[5]),
+        indexed_content_included=bool(row[6]),
     )
 
 
-def _tool_call(row: dict[str, Any]) -> ToolCallEvidence:
+def _tool_call(row: sqlite3.Row) -> ToolCallEvidence:
     return ToolCallEvidence(
-        tool_call_key=str(row["tool_call_key"]),
-        record_id=str(row["record_id"]),
-        turn_key=_optional_text(row.get("turn_key")),
-        tool_name=str(row["tool_name"]),
-        status=_optional_text(row.get("status")),
-        duration_ms=_optional_int(row.get("duration_ms")),
-        output_size_bytes=_integer(row.get("output_size_bytes")),
+        tool_call_key=str(row[0]),
+        record_id=str(row[1]),
+        turn_key=_optional_text(row[2]),
+        tool_name=str(row[3]),
+        status=_optional_text(row[4]),
+        duration_ms=_optional_int(row[5]),
+        output_size_bytes=_integer(row[6]),
     )
 
 
-def _command_run(row: dict[str, Any]) -> CommandRunEvidence:
+def _command_run(row: sqlite3.Row) -> CommandRunEvidence:
     return CommandRunEvidence(
-        command_run_key=str(row["command_run_key"]),
-        record_id=str(row["record_id"]),
-        turn_key=_optional_text(row.get("turn_key")),
-        command_root=str(row["command_root"]),
-        command_label=str(row.get("command_label") or ""),
-        exit_code=_optional_int(row.get("exit_code")),
-        status=_optional_text(row.get("status")),
-        output_size_bytes=_integer(row.get("output_size_bytes")),
-        retry_group=_optional_text(row.get("retry_group")),
+        command_run_key=str(row[0]),
+        record_id=str(row[1]),
+        turn_key=_optional_text(row[2]),
+        command_root=str(row[3]),
+        command_label=str(row[4] or ""),
+        exit_code=_optional_int(row[5]),
+        status=_optional_text(row[6]),
+        output_size_bytes=_integer(row[7]),
+        retry_group=_optional_text(row[8]),
     )
 
 
-def _file_event(row: dict[str, Any]) -> FileEventEvidence:
+def _file_event(row: sqlite3.Row) -> FileEventEvidence:
     return FileEventEvidence(
-        file_event_key=str(row["file_event_key"]),
-        record_id=str(row["record_id"]),
-        turn_key=_optional_text(row.get("turn_key")),
-        operation=str(row["operation"]),
-        path_hash=str(row["path_hash"]),
-        path_identity=str(row.get("path_identity") or ""),
+        file_event_key=str(row[0]),
+        record_id=str(row[1]),
+        turn_key=_optional_text(row[2]),
+        operation=str(row[3]),
+        path_hash=str(row[4]),
+        path_identity=str(row[5] or ""),
     )
 
 
-def _fragment(row: dict[str, Any]) -> ContentFragmentEvidence:
+def _fragment(row: sqlite3.Row) -> ContentFragmentEvidence:
     return ContentFragmentEvidence(
-        fragment_id=str(row["fragment_id"]),
-        record_id=str(row["record_id"]),
-        turn_key=_optional_text(row.get("turn_key")),
-        fragment_kind=str(row["fragment_kind"]),
-        role=_optional_text(row.get("role")),
-        safe_label=str(row.get("safe_label") or ""),
-        content_hash=str(row["content_hash"]),
-        content_size_bytes=_integer(row.get("content_size_bytes")),
-        includes_raw_fragment=bool(row.get("includes_raw_fragment")),
+        fragment_id=str(row[0]),
+        record_id=str(row[1]),
+        turn_key=_optional_text(row[2]),
+        fragment_kind=str(row[3]),
+        role=_optional_text(row[4]),
+        safe_label=str(row[5] or ""),
+        content_hash=str(row[6]),
+        content_size_bytes=_integer(row[7]),
+        includes_raw_fragment=bool(row[8]),
     )
 
 

--- a/src/codex_usage_tracker/compression/run_builder.py
+++ b/src/codex_usage_tracker/compression/run_builder.py
@@ -109,9 +109,11 @@ def build_compression_run(
         total_detectors=len(detectors),
     )
     try:
+        current_manifest = record_manifest(snapshot)
         reused, detector_snapshot, cache_mode = incremental_inputs(
             db_path,
             snapshot=snapshot,
+            current_manifest=current_manifest,
             previous=previous,
             scope=scope,
         )
@@ -167,7 +169,7 @@ def build_compression_run(
             warnings=warnings,
             cache_mode=cache_mode,
             duration_ms=duration_ms,
-            record_manifest=record_manifest(snapshot),
+            record_manifest=current_manifest,
             estimator_index=estimator_index,
         )
         compact_profile = public_profile(stored_profile)

--- a/src/codex_usage_tracker/compression/run_cache.py
+++ b/src/codex_usage_tracker/compression/run_cache.py
@@ -11,8 +11,12 @@ from pathlib import Path
 from typing import Any, Protocol, TypeVar, cast
 
 from codex_usage_tracker.compression.evidence import (
+    CallEvidence,
+    CommandRunEvidence,
     CompressionEvidenceSnapshot,
     ContentFragmentEvidence,
+    FileEventEvidence,
+    ToolCallEvidence,
     TurnEvidence,
 )
 from codex_usage_tracker.compression.identifiers import (
@@ -50,6 +54,7 @@ def incremental_inputs(
     db_path: Path,
     *,
     snapshot: CompressionEvidenceSnapshot,
+    current_manifest: Mapping[str, Any],
     previous: Mapping[str, Any] | None,
     scope: CompressionScope,
 ) -> tuple[list[CandidateDraft], CompressionEvidenceSnapshot, str]:
@@ -59,7 +64,6 @@ def incremental_inputs(
     old_manifest = _mapping(previous.get("aggregate_profile")).get("_cache_manifest")
     if not isinstance(old_manifest, Mapping):
         return [], snapshot, "cold"
-    current_manifest = record_manifest(snapshot)
     changed_records, affected_threads = _affected_scope(old_manifest, current_manifest)
     previous_drafts = _load_previous_drafts(
         db_path,
@@ -226,7 +230,17 @@ def _append_event_manifest(
 
 
 def _revision_identity(event: Any) -> Any:
-    if isinstance(event, (TurnEvidence, ContentFragmentEvidence)):
+    if isinstance(
+        event,
+        (
+            CallEvidence,
+            TurnEvidence,
+            ToolCallEvidence,
+            CommandRunEvidence,
+            FileEventEvidence,
+            ContentFragmentEvidence,
+        ),
+    ):
         return event.revision_identity()
     return event
 

--- a/src/codex_usage_tracker/store/compression_evidence.py
+++ b/src/codex_usage_tracker/store/compression_evidence.py
@@ -20,23 +20,49 @@ def query_compression_evidence(
     include_turns: bool = True,
 ) -> dict[str, Any]:
     """Load one deduplicated evidence snapshot for a normalized scope."""
+    payload = query_compression_evidence_rows(
+        db_path,
+        scope=scope,
+        include_turns=include_turns,
+    )
+    return {
+        **payload,
+        "calls": _rows(payload["calls"]),
+        "turns": _rows(payload["turns"]),
+        "tool_calls": _rows(payload["tool_calls"]),
+        "command_runs": _rows(payload["command_runs"]),
+        "file_events": _rows(payload["file_events"]),
+        "content_fragments": _rows(payload["content_fragments"]),
+        "compactions": _rows(payload["compactions"]),
+    }
+
+
+def query_compression_evidence_rows(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    scope: Mapping[str, Any],
+    include_turns: bool = True,
+) -> dict[str, Any]:
+    """Load SQLite rows for direct domain-object materialization."""
     with connect(db_path) as conn:
         init_db(conn)
         scoped = not _is_unfiltered_all_history(scope)
         if scoped:
             _populate_scope_records(conn, scope)
-        calls = _rows(conn, _scoped_sql(_CALLS_SQL, "u", scoped=scoped))
-        turns = _rows(conn, _scoped_sql(_TURNS_SQL, "t", scoped=scoped)) if include_turns else []
-        tool_calls = _rows(conn, _scoped_sql(_TOOL_CALLS_SQL, "t", scoped=scoped))
-        command_runs = _rows(conn, _scoped_sql(_COMMAND_RUNS_SQL, "c", scoped=scoped))
-        file_events = _rows(conn, _scoped_sql(_FILE_EVENTS_SQL, "f", scoped=scoped))
-        fragments = _rows(conn, _scoped_sql(_FRAGMENTS_SQL, "f", scoped=scoped))
+        calls = _raw_rows(conn, _scoped_sql(_CALLS_SQL, "u", scoped=scoped))
+        turns = (
+            _raw_rows(conn, _scoped_sql(_TURNS_SQL, "t", scoped=scoped)) if include_turns else []
+        )
+        tool_calls = _raw_rows(conn, _scoped_sql(_TOOL_CALLS_SQL, "t", scoped=scoped))
+        command_runs = _raw_rows(conn, _scoped_sql(_COMMAND_RUNS_SQL, "c", scoped=scoped))
+        file_events = _raw_rows(conn, _scoped_sql(_FILE_EVENTS_SQL, "f", scoped=scoped))
+        fragments = _raw_rows(conn, _scoped_sql(_FRAGMENTS_SQL, "f", scoped=scoped))
         source_coverage = _source_coverage(conn, scoped=scoped)
         content_index_enabled = _content_index_enabled(conn)
         turn_coverage = None if include_turns else _turn_coverage(conn, scoped=scoped)
         source_generation = read_compression_source_generation(conn)
     compactions = [
-        row for row in fragments if row.get("fragment_kind") in {"compaction", "compaction_history"}
+        row for row in fragments if row["fragment_kind"] in {"compaction", "compaction_history"}
     ]
     return {
         "calls": calls,
@@ -107,8 +133,12 @@ def _populate_scope_records(conn: sqlite3.Connection, scope: Mapping[str, Any]) 
     )
 
 
-def _rows(conn: sqlite3.Connection, sql: str) -> list[dict[str, Any]]:
-    return [cast(dict[str, Any], dict(row)) for row in conn.execute(sql)]
+def _raw_rows(conn: sqlite3.Connection, sql: str) -> list[sqlite3.Row]:
+    return list(conn.execute(sql))
+
+
+def _rows(rows: list[sqlite3.Row]) -> list[dict[str, Any]]:
+    return [cast(dict[str, Any], dict(row)) for row in rows]
 
 
 def _is_unfiltered_all_history(scope: Mapping[str, Any]) -> bool:
@@ -182,19 +212,19 @@ def _turn_coverage(conn: sqlite3.Connection, *, scoped: bool) -> dict[str, int]:
 
 def _coverage_payload(
     *,
-    calls: list[dict[str, Any]],
-    turns: list[dict[str, Any]],
-    tool_calls: list[dict[str, Any]],
-    command_runs: list[dict[str, Any]],
-    file_events: list[dict[str, Any]],
-    fragments: list[dict[str, Any]],
-    compactions: list[dict[str, Any]],
+    calls: list[sqlite3.Row],
+    turns: list[sqlite3.Row],
+    tool_calls: list[sqlite3.Row],
+    command_runs: list[sqlite3.Row],
+    file_events: list[sqlite3.Row],
+    fragments: list[sqlite3.Row],
+    compactions: list[sqlite3.Row],
     source_coverage: dict[str, Any],
     content_index_enabled: bool,
     turn_coverage: dict[str, int] | None,
 ) -> dict[str, Any]:
     indexed_calls = {
-        str(row["record_id"]) for row in turns if bool(row.get("indexed_content_included"))
+        str(row["record_id"]) for row in turns if bool(row["indexed_content_included"])
     }
     return {
         "call_count": len(calls),
@@ -271,7 +301,6 @@ SELECT
     t.output_size_bytes
 FROM tool_calls AS t
 {scope_join}
-ORDER BY COALESCE(t.started_at, ''), t.tool_call_key
 """
 
 _COMMAND_RUNS_SQL = """
@@ -287,7 +316,6 @@ SELECT
     c.retry_group
 FROM command_runs AS c
 {scope_join}
-ORDER BY c.command_run_key
 """
 
 _FILE_EVENTS_SQL = """
@@ -300,7 +328,6 @@ SELECT
     f.path_hash AS path_identity
 FROM file_events AS f
 {scope_join}
-ORDER BY f.file_event_key
 """
 
 _FRAGMENTS_SQL = """
@@ -316,5 +343,4 @@ SELECT
     f.includes_raw_fragment
 FROM content_fragments AS f
 {scope_join}
-ORDER BY f.created_at, f.fragment_id
 """

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -87,6 +87,44 @@ def test_synthetic_history_benchmark_with_source_logs_smoke(tmp_path: Path) -> N
     assert benchmark["context_loads"]["middle"]["source_scan_ms"] >= 0
 
 
+def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
+    args = [
+        "scripts/benchmark_compression_lab.py",
+        "--rows",
+        "100",
+        "--batch-size",
+        "25",
+        "--db-dir",
+        str(tmp_path),
+        "--json",
+        "--enforce-thresholds",
+        "--max-cold-seconds",
+        "10",
+    ]
+
+    payload = _run_benchmark_json(args)
+    repeated = _run_benchmark_json(args)
+
+    assert payload["schema_version"] == 1
+    assert payload["synthetic"] is True
+    assert payload["rows"] == 100
+    assert payload["cold_build"]["candidate_count"] == 10
+    assert payload["cold_build"]["peak_rss_mb"] > 0
+    assert payload["cold_build"]["candidate_fingerprint"]
+    assert payload["cold_build"]["profile_fingerprint"]
+    assert payload["cold_build"]["stage_timings_seconds"]["evidence_loaded"] >= 0
+    assert payload["warm_build"]["cache_mode"] == "exact"
+    assert payload["threshold_failures"] == []
+    assert (
+        repeated["cold_build"]["candidate_fingerprint"]
+        == payload["cold_build"]["candidate_fingerprint"]
+    )
+    assert (
+        repeated["cold_build"]["profile_fingerprint"]
+        == payload["cold_build"]["profile_fingerprint"]
+    )
+
+
 def _run_benchmark_json(args: list[str]) -> dict[str, Any]:
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(

--- a/tests/compression/test_run_builder.py
+++ b/tests/compression/test_run_builder.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from codex_usage_tracker.compression import run_builder
+from codex_usage_tracker.compression import run_builder, run_cache
 from codex_usage_tracker.compression.context_detectors import StaleContextDetector
 from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.compression.run_cache import record_manifest
@@ -209,11 +209,20 @@ def test_appended_record_recomputes_only_its_affected_thread(
         lambda _db_path, _scope: next(snapshots),
     )
     observed_scopes: list[set[str]] = []
+    manifest_calls = 0
+
+    def counted_manifest(evidence):
+        nonlocal manifest_calls
+        manifest_calls += 1
+        return record_manifest(evidence)
+
+    monkeypatch.setattr(run_builder, "record_manifest", counted_manifest)
+    monkeypatch.setattr(run_cache, "record_manifest", counted_manifest)
 
     class RecordingDetector(StaleContextDetector):
-        def detect(self, evidence: Any, scope: CompressionScope):
-            observed_scopes.append({row.record_id for row in evidence.calls})
-            return super().detect(evidence, scope)
+        def detect(self, snapshot: Any, scope: CompressionScope):
+            observed_scopes.append({row.record_id for row in snapshot.calls})
+            return super().detect(snapshot, scope)
 
     detector = RecordingDetector()
     monkeypatch.setattr(
@@ -231,3 +240,4 @@ def test_appended_record_recomputes_only_its_affected_thread(
     assert incremental["candidate_count"] == 3
     assert incremental["cache"] == {"mode": "incremental", "reused": True}
     assert observed_scopes == [{"a-1", "b-1"}, {"a-1", "a-2"}]
+    assert manifest_calls == 2

--- a/tests/store/test_compression_evidence.py
+++ b/tests/store/test_compression_evidence.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from codex_usage_tracker.compression.evidence import load_compression_evidence
+from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.store import compression_evidence
 from codex_usage_tracker.store.api import upsert_usage_events
@@ -90,6 +92,31 @@ def test_evidence_query_deduplicates_calls_and_reports_normalized_coverage(
         "parser_versions": ["codex-jsonl-v2"],
         "content_index_enabled": True,
     }
+
+
+def test_typed_evidence_loader_bypasses_dictionary_materialization(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(
+        [usage_event("call-1", timestamp="2026-07-10T10:00:00+00:00")],
+        db_path=db_path,
+    )
+    seed_normalized_evidence(db_path)
+
+    def unexpected_dictionary_materialization(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("typed evidence loading must not materialize row dictionaries")
+
+    monkeypatch.setattr(compression_evidence, "_rows", unexpected_dictionary_materialization)
+
+    evidence = load_compression_evidence(db_path, CompressionScope())
+
+    assert [call.record_id for call in evidence.calls] == ["call-1"]
+    assert len(evidence.tool_calls) == 1
+    assert len(evidence.command_runs) == 1
+    assert len(evidence.file_events) == 2
+    assert len(evidence.content_fragments) == 2
 
 
 def test_evidence_query_applies_time_model_effort_and_archived_scope(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add the committed 15-20 second Compression Lab cold-build performance program
- bypass intermediate SQLite row dictionaries for the internal typed evidence loader
- compute incremental manifests once and use compact revision identities across every evidence family
- remove unnecessary SQL ordering from order-independent evidence families

## Measured result

- same real aggregate workload: 48.115s -> 38.708s forced replacement
- estimated true first-ever cold build: about 35.5s after excluding measured prior-run deletion
- candidate count unchanged at 32,087 across 404,176 calls
- exact unchanged warm profile remains 6.2ms
- agent-perf synthetic workload: 8.75s -> 8.01s with 9,269 unchanged candidates

## Validation

- `pytest -q tests/compression tests/store/test_compression_evidence.py` (40 passed)
- Agent Maintainer precommit: tests, Pyright, Tach, TypeScript, Ruff and other applicable checks passed; only the pre-existing Xenon B rank in untouched `store/content_index.py` remains
- `npm --workspace frontend/dashboard run typecheck`
- `git diff --check`
- `markdownlint-cli2 docs/compression-lab-roadmap.md`

Closes #223
