### PR TITLE
refactor: compact compression detector evidence

### DIFF
--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -194,6 +194,10 @@ Status: in progress
 
 Issue: [#225](https://github.com/douglasmonsky/codex-usage-tracker/issues/225)
 
+Foundation PR: [#226](https://github.com/douglasmonsky/codex-usage-tracker/pull/226)
+
+Foundation merge: `d0db081f77434e13e4874a56e89b69f577633fb6`
+
 Deliverables:
 
 - A bounded evidence-batch reader over the existing normalized SQLite tables.

--- a/src/codex_usage_tracker/compression/estimators.py
+++ b/src/codex_usage_tracker/compression/estimators.py
@@ -61,8 +61,16 @@ class EstimatorIndex:
     def __init__(self, snapshot: CompressionEvidenceSnapshot) -> None:
         self._snapshot = snapshot
         self._calls = {call.record_id: call for call in snapshot.calls}
-        self._content = _content_totals(snapshot)
-        self._tool_output = _tool_output_totals(snapshot)
+        self._content = (
+            dict(snapshot.content_exposure_by_record)
+            if snapshot.content_exposure_by_record
+            else _content_totals(snapshot)
+        )
+        self._tool_output = (
+            dict(snapshot.tool_output_exposure_by_record)
+            if snapshot.tool_output_exposure_by_record
+            else _tool_output_totals(snapshot)
+        )
         self._groups: dict[ComponentName, dict[_GroupKey, tuple[int, ...]]] = {}
         self._threads: dict[ComponentName, dict[tuple[_GroupKey, str], tuple[int, ...]]] = {}
         self._peer_cache: dict[

--- a/src/codex_usage_tracker/compression/evidence.py
+++ b/src/codex_usage_tracker/compression/evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -215,6 +216,21 @@ class CompressionEvidenceSnapshot:
     compactions: tuple[ContentFragmentEvidence, ...]
     coverage: EvidenceCoverage
     source_revision: str
+    content_exposure_by_record: Mapping[str, int] = field(
+        default_factory=dict,
+        repr=False,
+        compare=False,
+    )
+    content_exposure_by_turn: Mapping[tuple[str, str], int] = field(
+        default_factory=dict,
+        repr=False,
+        compare=False,
+    )
+    tool_output_exposure_by_record: Mapping[str, int] = field(
+        default_factory=dict,
+        repr=False,
+        compare=False,
+    )
 
     def call(self, record_id: str) -> CallEvidence | None:
         return next((row for row in self.calls if row.record_id == record_id), None)
@@ -224,8 +240,12 @@ class CompressionEvidenceSnapshot:
         if call is not None and component in _CALL_COMPONENTS:
             return call.exposure.value(component)
         if component == "content_fragment":
+            if record_id in self.content_exposure_by_record:
+                return self.content_exposure_by_record[record_id]
             return _content_fragment_exposure(self.content_fragments, record_id)
         if component == "tool_output":
+            if record_id in self.tool_output_exposure_by_record:
+                return self.tool_output_exposure_by_record[record_id]
             return _tool_output_exposure(self.tool_calls, self.command_runs, record_id)
         return 0
 

--- a/src/codex_usage_tracker/compression/repetition_detectors.py
+++ b/src/codex_usage_tracker/compression/repetition_detectors.py
@@ -11,7 +11,6 @@ from codex_usage_tracker.compression.evidence import (
     CallEvidence,
     CommandRunEvidence,
     CompressionEvidenceSnapshot,
-    ContentFragmentEvidence,
     FileEventEvidence,
 )
 from codex_usage_tracker.compression.models import (
@@ -40,7 +39,7 @@ class FileRediscoveryDetector:
     ) -> list[CandidateDraft]:
         calls = {call.record_id: call for call in snapshot.calls}
         groups = _file_groups(snapshot.file_events, calls)
-        fragment_index = _fragment_exposure_index(snapshot.content_fragments)
+        fragment_index = _fragment_exposure_index(snapshot)
         candidates = (
             _file_candidate(
                 detector=self,
@@ -328,11 +327,16 @@ class _FragmentExposureIndex:
 
 
 def _fragment_exposure_index(
-    fragments: tuple[ContentFragmentEvidence, ...],
+    snapshot: CompressionEvidenceSnapshot,
 ) -> _FragmentExposureIndex:
+    if snapshot.content_exposure_by_record or snapshot.content_exposure_by_turn:
+        return _FragmentExposureIndex(
+            dict(snapshot.content_exposure_by_record),
+            dict(snapshot.content_exposure_by_turn),
+        )
     by_record: dict[str, int] = defaultdict(int)
     by_turn: dict[tuple[str, str], int] = defaultdict(int)
-    for fragment in fragments:
+    for fragment in snapshot.content_fragments:
         by_record[fragment.record_id] += fragment.estimated_tokens
         if fragment.turn_key is not None:
             by_turn[(fragment.record_id, fragment.turn_key)] += fragment.estimated_tokens

--- a/src/codex_usage_tracker/compression/run_builder.py
+++ b/src/codex_usage_tracker/compression/run_builder.py
@@ -24,10 +24,7 @@ from codex_usage_tracker.compression.estimators import (
     build_estimator_index,
     estimate_candidate,
 )
-from codex_usage_tracker.compression.evidence import (
-    CompressionEvidenceSnapshot,
-    load_compression_evidence,
-)
+from codex_usage_tracker.compression.evidence import CompressionEvidenceSnapshot
 from codex_usage_tracker.compression.identifiers import stable_scope_hash
 from codex_usage_tracker.compression.models import (
     CandidateDraft,
@@ -37,7 +34,9 @@ from codex_usage_tracker.compression.profile import build_profile, public_profil
 from codex_usage_tracker.compression.run_cache import (
     incremental_inputs,
     latest_compatible_run,
-    record_manifest,
+)
+from codex_usage_tracker.compression.streaming_evidence import (
+    load_streaming_compression_evidence,
 )
 from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
 from codex_usage_tracker.store.compression_runs import (
@@ -76,7 +75,9 @@ def build_compression_run(
         _emit(progress_callback, stage="complete", progress_percent=100.0, cache_reused=True)
         return cached_profile
 
-    snapshot = load_compression_evidence(db_path, scope)
+    loaded_evidence = load_streaming_compression_evidence(db_path, scope)
+    snapshot = loaded_evidence.snapshot
+    current_manifest = loaded_evidence.record_manifest
     cache_identity = _cache_identity(snapshot, scope_hash, detector_version)
     exact = find_compression_run(db_path, **cache_identity)
     if exact is not None and not force:
@@ -109,7 +110,6 @@ def build_compression_run(
         total_detectors=len(detectors),
     )
     try:
-        current_manifest = record_manifest(snapshot)
         reused, detector_snapshot, cache_mode = incremental_inputs(
             db_path,
             snapshot=snapshot,

--- a/src/codex_usage_tracker/compression/run_cache.py
+++ b/src/codex_usage_tracker/compression/run_cache.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import zlib
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Protocol, TypeVar, cast
@@ -106,38 +106,66 @@ def latest_compatible_run(
     return get_compression_run(db_path, run_id=str(row["run_id"]))
 
 
+class RecordManifestBuilder:
+    """Accumulate the existing order-independent manifest without retaining events."""
+
+    def __init__(self) -> None:
+        self._threads: dict[str, str] = {}
+        self._accumulators: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0])
+        self._metadata: dict[str, dict[str, str]] = {}
+
+    def add_call(self, call: CallEvidence) -> None:
+        self._threads[call.record_id] = call.thread_key
+        manifest_key = _manifest_key(call.record_id, call.thread_key)
+        self._metadata[manifest_key] = {
+            "thread_key": call.thread_key,
+            "record_id": "",
+        }
+        _accumulate(self._accumulators[manifest_key], "call", call)
+
+    def add_event(self, kind: str, event: Any) -> None:
+        self.add_identity(kind, str(event.record_id), _revision_identity(event))
+
+    def add_identity(self, kind: str, record_id: str, identity: Any) -> None:
+        thread_key = self._threads.get(record_id, "")
+        manifest_key = _manifest_key(record_id, thread_key)
+        self._metadata.setdefault(
+            manifest_key,
+            {
+                "thread_key": thread_key,
+                "record_id": record_id if not thread_key else "",
+            },
+        )
+        _accumulate(
+            self._accumulators[manifest_key],
+            kind,
+            identity,
+        )
+
+    def build(self) -> dict[str, dict[str, str]]:
+        return {
+            key: {**self._metadata[key], "revision": _manifest_hash(accumulator)}
+            for key, accumulator in sorted(self._accumulators.items())
+        }
+
+
 def record_manifest(
     snapshot: CompressionEvidenceSnapshot,
 ) -> dict[str, dict[str, str]]:
     """Hash bounded evidence metadata per thread for incremental invalidation."""
-    threads = {call.record_id: call.thread_key for call in snapshot.calls}
-    accumulators: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0])
-    metadata: dict[str, dict[str, str]] = {}
+    builder = RecordManifestBuilder()
     for call in snapshot.calls:
-        manifest_key = _manifest_key(call.record_id, call.thread_key)
-        metadata[manifest_key] = {"thread_key": call.thread_key, "record_id": ""}
-        _accumulate(accumulators[manifest_key], "call", call)
-    _append_event_manifest(accumulators, metadata, threads, "tool", snapshot.tool_calls)
-    _append_event_manifest(accumulators, metadata, threads, "turn", snapshot.turns)
-    _append_event_manifest(
-        accumulators,
-        metadata,
-        threads,
-        "command",
-        snapshot.command_runs,
-    )
-    _append_event_manifest(accumulators, metadata, threads, "file", snapshot.file_events)
-    _append_event_manifest(
-        accumulators,
-        metadata,
-        threads,
-        "fragment",
-        snapshot.content_fragments,
-    )
-    return {
-        key: {**metadata[key], "revision": _manifest_hash(accumulator)}
-        for key, accumulator in sorted(accumulators.items())
-    }
+        builder.add_call(call)
+    for kind, events in (
+        ("tool", snapshot.tool_calls),
+        ("turn", snapshot.turns),
+        ("command", snapshot.command_runs),
+        ("file", snapshot.file_events),
+        ("fragment", snapshot.content_fragments),
+    ):
+        for event in events:
+            builder.add_event(kind, event)
+    return builder.build()
 
 
 def _load_previous_drafts(
@@ -205,28 +233,6 @@ def _draft_from_stored(
         last_seen=_optional_text(payload.get("last_seen")),
         data_quality_warnings=tuple(str(row) for row in payload.get("data_quality_warnings", [])),
     )
-
-
-def _append_event_manifest(
-    accumulators: dict[str, list[int]],
-    metadata: dict[str, dict[str, str]],
-    threads: Mapping[str, str],
-    kind: str,
-    events: Sequence[Any],
-) -> None:
-    for event in events:
-        record_id = str(event.record_id)
-        thread_key = threads.get(record_id, "")
-        manifest_key = _manifest_key(record_id, thread_key)
-        metadata.setdefault(
-            manifest_key,
-            {"thread_key": thread_key, "record_id": record_id if not thread_key else ""},
-        )
-        _accumulate(
-            accumulators[manifest_key],
-            kind,
-            _revision_identity(event),
-        )
 
 
 def _revision_identity(event: Any) -> Any:
@@ -312,6 +318,21 @@ def _subset_snapshot(
         file_events=_matching_records(snapshot.file_events, record_ids),
         content_fragments=_matching_records(snapshot.content_fragments, record_ids),
         compactions=_matching_records(snapshot.compactions, record_ids),
+        content_exposure_by_record={
+            record_id: exposure
+            for record_id, exposure in snapshot.content_exposure_by_record.items()
+            if record_id in record_ids
+        },
+        content_exposure_by_turn={
+            key: exposure
+            for key, exposure in snapshot.content_exposure_by_turn.items()
+            if key[0] in record_ids
+        },
+        tool_output_exposure_by_record={
+            record_id: exposure
+            for record_id, exposure in snapshot.tool_output_exposure_by_record.items()
+            if record_id in record_ids
+        },
     )
 
 

--- a/src/codex_usage_tracker/compression/streaming_evidence.py
+++ b/src/codex_usage_tracker/compression/streaming_evidence.py
@@ -1,0 +1,221 @@
+"""Bounded evidence loading for Compression Lab cold builds."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from codex_usage_tracker.compression.evidence import (
+    CallEvidence,
+    CommandRunEvidence,
+    CompressionEvidenceSnapshot,
+    FileEventEvidence,
+    ToolCallEvidence,
+    _call,
+    _command_run,
+    _coverage,
+    _file_event,
+    _tool_call,
+)
+from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.output_detectors import ToolOutputBloatDetector
+from codex_usage_tracker.compression.repetition_detectors import (
+    _SHELL_ROOTS,
+    _VALIDATION_ROOTS,
+)
+from codex_usage_tracker.compression.run_cache import RecordManifestBuilder
+from codex_usage_tracker.store.compression_evidence import (
+    fold_compression_evidence_rows,
+)
+
+_RELEVANT_COMMAND_ROOTS = _SHELL_ROOTS | _VALIDATION_ROOTS
+_MIN_TOOL_OUTPUT_BYTES = (ToolOutputBloatDetector().min_output_tokens * 4) - 3
+
+
+@dataclass(frozen=True, slots=True)
+class StreamingEvidenceBundle:
+    """Compact detector snapshot plus the manifest built from every raw row."""
+
+    snapshot: CompressionEvidenceSnapshot
+    record_manifest: dict[str, dict[str, str]]
+
+
+@dataclass(slots=True)
+class _StreamingAccumulator:
+    calls: list[CallEvidence] = field(default_factory=list)
+    tool_calls: dict[str, ToolCallEvidence] = field(default_factory=dict)
+    command_runs: dict[str, CommandRunEvidence] = field(default_factory=dict)
+    file_events: dict[str, FileEventEvidence] = field(default_factory=dict)
+    content_exposure: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    content_exposure_by_turn: dict[tuple[str, str], int] = field(
+        default_factory=lambda: defaultdict(int)
+    )
+    tool_exposure: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    command_exposure: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    manifest: RecordManifestBuilder = field(default_factory=RecordManifestBuilder)
+
+    def consume(self, category: str, rows: list[sqlite3.Row]) -> None:
+        handler = getattr(self, f"_consume_{category}")
+        handler(rows)
+
+    def _consume_calls(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            call = _call(row)
+            self.calls.append(call)
+            self.manifest.add_call(call)
+
+    def _consume_turns(self, rows: list[sqlite3.Row]) -> None:
+        if rows:
+            raise AssertionError("streaming compression loads omit conversation turns")
+
+    def _consume_tool_calls(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            record_id = str(row[1])
+            output_size_bytes = int(row[6] or 0)
+            self.manifest.add_identity("tool", record_id, _tool_identity(row))
+            self.tool_exposure[record_id] += _output_tokens(output_size_bytes)
+            if output_size_bytes >= _MIN_TOOL_OUTPUT_BYTES:
+                tool_call = _tool_call(row)
+                self.tool_calls[tool_call.tool_call_key] = tool_call
+
+    def _consume_command_runs(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            record_id = str(row[1])
+            command_root = str(row[3])
+            self.manifest.add_identity("command", record_id, _command_identity(row))
+            self.command_exposure[record_id] += _output_tokens(int(row[7] or 0))
+            if command_root in _RELEVANT_COMMAND_ROOTS:
+                command = _command_run(row)
+                self.command_runs[command.command_run_key] = command
+
+    def _consume_file_events(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            record_id = str(row[1])
+            operation = str(row[3])
+            path_hash = str(row[4])
+            self.manifest.add_identity("file", record_id, _file_identity(row))
+            if operation == "read" and path_hash:
+                event = _file_event(row)
+                self.file_events[event.file_event_key] = event
+
+    def _consume_content_fragments(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            record_id = str(row[1])
+            turn_key = None if row[2] is None else str(row[2])
+            self.manifest.add_identity("fragment", record_id, _fragment_identity(row))
+            tokens = _output_tokens(int(row[7] or 0))
+            self.content_exposure[record_id] += tokens
+            if turn_key is not None:
+                self.content_exposure_by_turn[(record_id, turn_key)] += tokens
+
+    def tool_output_exposure(self) -> dict[str, int]:
+        return {
+            record_id: max(
+                self.tool_exposure.get(record_id, 0),
+                self.command_exposure.get(record_id, 0),
+            )
+            for record_id in set(self.tool_exposure).union(self.command_exposure)
+        }
+
+
+def load_streaming_compression_evidence(
+    db_path: Path,
+    scope: CompressionScope,
+    *,
+    batch_size: int = 4_096,
+) -> StreamingEvidenceBundle:
+    """Fold raw evidence into a detector-equivalent compact snapshot."""
+    accumulator = _StreamingAccumulator()
+    metadata = fold_compression_evidence_rows(
+        db_path,
+        scope=scope.as_dict(),
+        include_turns=False,
+        batch_size=batch_size,
+        consumer=accumulator.consume,
+    )
+    snapshot = CompressionEvidenceSnapshot(
+        calls=tuple(accumulator.calls),
+        turns=(),
+        tool_calls=tuple(accumulator.tool_calls.values()),
+        command_runs=tuple(accumulator.command_runs.values()),
+        file_events=tuple(accumulator.file_events.values()),
+        content_fragments=(),
+        compactions=(),
+        coverage=_coverage(metadata["coverage"]),
+        source_revision=f"generation:{int(metadata['source_generation'])}",
+        content_exposure_by_record=dict(accumulator.content_exposure),
+        content_exposure_by_turn=dict(accumulator.content_exposure_by_turn),
+        tool_output_exposure_by_record=accumulator.tool_output_exposure(),
+    )
+    return StreamingEvidenceBundle(
+        snapshot=snapshot,
+        record_manifest=accumulator.manifest.build(),
+    )
+
+
+def _output_tokens(output_size_bytes: int) -> int:
+    return (output_size_bytes + 3) // 4
+
+
+def _tool_identity(row: sqlite3.Row) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        _optional_text(row[2]),
+        str(row[3]),
+        _optional_text(row[4]),
+        _optional_int(row[5]),
+        int(row[6] or 0),
+    )
+
+
+def _command_identity(row: sqlite3.Row) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        _optional_text(row[2]),
+        str(row[3]),
+        str(row[4] or ""),
+        _optional_int(row[5]),
+        _optional_text(row[6]),
+        int(row[7] or 0),
+        _optional_text(row[8]),
+    )
+
+
+def _file_identity(row: sqlite3.Row) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        _optional_text(row[2]),
+        str(row[3]),
+        str(row[4]),
+        str(row[5] or ""),
+    )
+
+
+def _fragment_identity(row: sqlite3.Row) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        _optional_text(row[2]),
+        str(row[3]),
+        _optional_text(row[4]),
+        str(row[5] or ""),
+        str(row[6]),
+        int(row[7] or 0),
+        bool(row[8]),
+    )
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    return None if value is None else int(str(value))

--- a/src/codex_usage_tracker/compression/streaming_evidence.py
+++ b/src/codex_usage_tracker/compression/streaming_evidence.py
@@ -57,8 +57,15 @@ class _StreamingAccumulator:
     manifest: RecordManifestBuilder = field(default_factory=RecordManifestBuilder)
 
     def consume(self, category: str, rows: list[sqlite3.Row]) -> None:
-        handler = getattr(self, f"_consume_{category}")
-        handler(rows)
+        handlers = {
+            "calls": self._consume_calls,
+            "turns": self._consume_turns,
+            "tool_calls": self._consume_tool_calls,
+            "command_runs": self._consume_command_runs,
+            "file_events": self._consume_file_events,
+            "content_fragments": self._consume_content_fragments,
+        }
+        handlers[category](rows)
 
     def _consume_calls(self, rows: list[sqlite3.Row]) -> None:
         for row in rows:

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -112,6 +112,14 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
     assert payload["cold_build"]["peak_rss_mb"] > 0
     assert payload["cold_build"]["candidate_fingerprint"]
     assert payload["cold_build"]["profile_fingerprint"]
+    assert (
+        payload["cold_build"]["candidate_fingerprint"]
+        == "2dd80ca48382546f39943c4567124038e5e50f44d833a18073bf69aa7dd85de3"
+    )
+    assert (
+        payload["cold_build"]["profile_fingerprint"]
+        == "a04e19e6e6cb127ee3b879d963b8995d9426908dc25737078b61e2ba799e9983"
+    )
     assert payload["cold_build"]["stage_timings_seconds"]["evidence_loaded"] >= 0
     assert payload["warm_build"]["cache_mode"] == "exact"
     assert payload["threshold_failures"] == []

--- a/tests/compression/test_run_builder.py
+++ b/tests/compression/test_run_builder.py
@@ -7,10 +7,11 @@ from typing import Any
 
 import pytest
 
-from codex_usage_tracker.compression import run_builder, run_cache
+from codex_usage_tracker.compression import run_builder
 from codex_usage_tracker.compression.context_detectors import StaleContextDetector
 from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.compression.run_cache import record_manifest
+from codex_usage_tracker.compression.streaming_evidence import StreamingEvidenceBundle
 from codex_usage_tracker.store.compression_candidates import list_compression_candidates
 from codex_usage_tracker.store.compression_runs import get_compression_run
 from codex_usage_tracker.store.compression_schema import touch_compression_source_generation
@@ -35,14 +36,18 @@ def _stale_snapshot(*record_ids: str, source_revision: str = "revision-1"):
     return replace(evidence, source_revision=source_revision)
 
 
+def _bundle(evidence: Any) -> StreamingEvidenceBundle:
+    return StreamingEvidenceBundle(evidence, record_manifest(evidence))
+
+
 def _use_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     evidence: Any,
 ) -> None:
     monkeypatch.setattr(
         run_builder,
-        "load_compression_evidence",
-        lambda _db_path, _scope: evidence,
+        "load_streaming_compression_evidence",
+        lambda _db_path, _scope: _bundle(evidence),
     )
 
 
@@ -93,7 +98,11 @@ def test_build_compression_run_reuses_an_exact_persisted_cache_hit(
     def unexpected_evidence_load(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("exact cache hits must not rebuild normalized evidence")
 
-    monkeypatch.setattr(run_builder, "load_compression_evidence", unexpected_evidence_load)
+    monkeypatch.setattr(
+        run_builder,
+        "load_streaming_compression_evidence",
+        unexpected_evidence_load,
+    )
     warm = run_builder.build_compression_run(
         db_path,
         CompressionScope(),
@@ -201,23 +210,19 @@ def test_appended_record_recomputes_only_its_affected_thread(
 ) -> None:
     first = _stale_snapshot("a-1", "b-1", source_revision="revision-1")
     second = _stale_snapshot("a-1", "b-1", "a-2", source_revision="revision-2")
-    snapshots = iter((first, second))
+    third = replace(
+        second,
+        tool_calls=(tool("a-event", "a-2", output_bytes=400),),
+        source_revision="revision-3",
+    )
+    snapshots = iter((first, second, third))
     db_path = tmp_path / "usage.sqlite3"
     monkeypatch.setattr(
         run_builder,
-        "load_compression_evidence",
-        lambda _db_path, _scope: next(snapshots),
+        "load_streaming_compression_evidence",
+        lambda _db_path, _scope: _bundle(next(snapshots)),
     )
     observed_scopes: list[set[str]] = []
-    manifest_calls = 0
-
-    def counted_manifest(evidence):
-        nonlocal manifest_calls
-        manifest_calls += 1
-        return record_manifest(evidence)
-
-    monkeypatch.setattr(run_builder, "record_manifest", counted_manifest)
-    monkeypatch.setattr(run_cache, "record_manifest", counted_manifest)
 
     class RecordingDetector(StaleContextDetector):
         def detect(self, snapshot: Any, scope: CompressionScope):
@@ -235,9 +240,17 @@ def test_appended_record_recomputes_only_its_affected_thread(
     with connect(db_path) as conn:
         touch_compression_source_generation(conn)
     incremental = run_builder.build_compression_run(db_path, CompressionScope())
+    with connect(db_path) as conn:
+        touch_compression_source_generation(conn)
+    event_incremental = run_builder.build_compression_run(db_path, CompressionScope())
 
     assert cold["candidate_count"] == 2
     assert incremental["candidate_count"] == 3
     assert incremental["cache"] == {"mode": "incremental", "reused": True}
-    assert observed_scopes == [{"a-1", "b-1"}, {"a-1", "a-2"}]
-    assert manifest_calls == 2
+    assert event_incremental["candidate_count"] == 3
+    assert event_incremental["cache"] == {"mode": "incremental", "reused": True}
+    assert observed_scopes == [
+        {"a-1", "b-1"},
+        {"a-1", "a-2"},
+        {"a-1", "a-2"},
+    ]

--- a/tests/compression/test_streaming_evidence.py
+++ b/tests/compression/test_streaming_evidence.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.compression.detector_registry import default_detectors
+from codex_usage_tracker.compression.estimators import (
+    build_estimator_index,
+    estimate_candidate,
+)
+from codex_usage_tracker.compression.evidence import load_compression_evidence
+from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.run_cache import record_manifest
+from codex_usage_tracker.compression.streaming_evidence import (
+    load_streaming_compression_evidence,
+)
+from codex_usage_tracker.core.models import UsageEvent
+from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+
+def test_streaming_evidence_preserves_manifest_and_detector_output(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(_usage_events(), db_path=db_path)
+    _seed_normalized_evidence(db_path)
+    scope = CompressionScope(include_archived=True)
+
+    legacy = load_compression_evidence(db_path, scope)
+    streamed = load_streaming_compression_evidence(db_path, scope, batch_size=2)
+
+    assert streamed.record_manifest == record_manifest(legacy)
+    assert streamed.snapshot.coverage == legacy.coverage
+    assert streamed.snapshot.source_revision == legacy.source_revision
+    assert streamed.snapshot.calls == legacy.calls
+    assert len(streamed.snapshot.tool_calls) < len(legacy.tool_calls)
+    assert len(streamed.snapshot.content_fragments) < len(legacy.content_fragments)
+    assert _detected_candidates(streamed.snapshot, scope) == _detected_candidates(legacy, scope)
+
+
+def _detected_candidates(snapshot: Any, scope: CompressionScope) -> list[dict[str, Any]]:
+    index = build_estimator_index(snapshot)
+    return sorted(
+        (
+            estimate_candidate(candidate, snapshot, index=index).as_dict()
+            for detector in default_detectors()
+            for candidate in detector.detect(snapshot, scope)
+        ),
+        key=lambda candidate: str(candidate["candidate_id"]),
+    )
+
+
+def _usage_events() -> list[UsageEvent]:
+    events = []
+    for index in range(3):
+        timestamp = f"2026-07-10T10:0{index}:00+00:00"
+        events.append(
+            UsageEvent(
+                record_id=f"call-{index}",
+                session_id="session-1",
+                thread_name="one",
+                session_updated_at=timestamp,
+                event_timestamp=timestamp,
+                source_file="/tmp/synthetic/session.jsonl",
+                line_number=index + 1,
+                turn_id=f"turn-{index}",
+                turn_timestamp=timestamp,
+                cwd="/tmp/project",
+                model="gpt-5.5",
+                effort="high",
+                current_date="2026-07-10",
+                timezone="UTC",
+                call_initiator="user",
+                call_initiator_reason="user_message",
+                call_initiator_confidence="high",
+                is_archived=0,
+                thread_key="thread:one",
+                thread_call_index=index + 1,
+                previous_record_id=f"call-{index - 1}" if index else None,
+                next_record_id=f"call-{index + 1}" if index < 2 else None,
+                thread_source="user",
+                subagent_type=None,
+                agent_role=None,
+                agent_nickname=None,
+                parent_session_id=None,
+                parent_thread_name=None,
+                parent_session_updated_at=None,
+                model_context_window=100_000,
+                input_tokens=80_000,
+                cached_input_tokens=70_000 if index == 0 else 1_000,
+                output_tokens=100,
+                reasoning_output_tokens=20,
+                total_tokens=80_100,
+                cumulative_input_tokens=80_000 * (index + 1),
+                cumulative_cached_input_tokens=70_000 + (1_000 * index),
+                cumulative_output_tokens=100 * (index + 1),
+                cumulative_reasoning_output_tokens=20 * (index + 1),
+                cumulative_total_tokens=80_100 * (index + 1),
+            )
+        )
+    return events
+
+
+def _seed_normalized_evidence(db_path: Path) -> None:
+    with connect(db_path) as conn:
+        init_db(conn)
+        conn.executemany(
+            """
+            INSERT INTO tool_calls (
+                tool_call_key, record_id, turn_key, tool_name, status,
+                output_size_bytes, parser_adapter, parser_version, parse_warnings_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("tool-small", "call-0", "turn-0", "exec", " ", 400, "test", "1", "[]"),
+                (
+                    "tool-large",
+                    "call-1",
+                    "turn-1",
+                    "exec",
+                    "completed",
+                    20_000,
+                    "test",
+                    "1",
+                    "[]",
+                ),
+            ],
+        )
+        command_rows = []
+        for root, group in (("rg", "shell-group"), ("pytest", "test-group")):
+            for index in range(3):
+                command_rows.append(
+                    (
+                        f"{root}-{index}",
+                        f"call-{index}",
+                        f"turn-{index}",
+                        root,
+                        f"{root} synthetic",
+                        0,
+                        "completed",
+                        400,
+                        group,
+                        "test",
+                        "1",
+                        "[]",
+                    )
+                )
+        conn.executemany(
+            """
+            INSERT INTO command_runs (
+                command_run_key, record_id, turn_key, command_root, command_label,
+                exit_code, status, output_size_bytes, retry_group,
+                parser_adapter, parser_version, parse_warnings_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            command_rows,
+        )
+        conn.executemany(
+            """
+            INSERT INTO file_events (
+                file_event_key, record_id, turn_key, operation, path_hash,
+                path_basename, path_extension, path_identity,
+                parser_adapter, parser_version, parse_warnings_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    f"file-{index}",
+                    f"call-{index}",
+                    f"turn-{index}",
+                    "read",
+                    "path-hash",
+                    "example.py",
+                    ".py",
+                    "path:path-hash",
+                    "test",
+                    "1",
+                    "[]",
+                )
+                for index in range(3)
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO content_fragments (
+                fragment_id, record_id, turn_key, fragment_kind, role, safe_label,
+                content_hash, content_size_bytes, fragment_text, includes_raw_fragment,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    f"fragment-{index}-{part}",
+                    f"call-{index}",
+                    f"turn-{index}",
+                    "tool_output",
+                    "tool",
+                    "synthetic",
+                    f"hash-{index}-{part}",
+                    400 + part,
+                    "",
+                    0,
+                    f"2026-07-10T10:0{index}:0{part}+00:00",
+                )
+                for index in range(3)
+                for part in range(2)
+            ],
+        )


### PR DESCRIPTION
## Summary\n\n- fold every normalized evidence row through bounded batches while retaining only detector-relevant objects\n- build incremental manifests directly during the fold without retaining discarded rows\n- carry exact content/tool exposure maps for estimators and incremental subsets\n- preserve existing detector/public payload behavior through a compact snapshot adapter\n- add golden legacy-versus-streaming detector, manifest, fingerprint, and event-only incremental tests\n\n## Measured result\n\nClean CP1 versus compact-engine comparisons:\n\n- normalized synthetic peak RSS: 539.828 MiB -> 332.781 MiB (38.4% lower)\n- current-scale aggregate peak RSS: 1,706.766 MiB -> 1,340.469 MiB (21.5% lower)\n- normalized synthetic cold: 7.800s -> 7.239s\n- current-scale aggregate cold: 37.333s -> 36.854s\n- all candidate/profile fingerprints and 32,087 real-data candidates unchanged\n- exact warm remains about 4ms\n\nThe larger scan-elimination speed gate remains assigned to CP3 persisted aggregates.\n\n## Validation\n\n- 46 focused compression/store/benchmark tests passed\n- Agent Maintainer precommit passed tests, Pyright, file-length, Tach, TypeScript, Ruff and applicable gates; only the pre-existing Xenon B rank in untouched store/content_index.py remains\n- Serena inspections: no warnings in the new streaming loader or run builder\n- independent review: no blocking finding; optional-text parity and event-only incremental gaps fixed\n- python scripts/check_release.py\n- markdownlint and git diff --check\n\nContinues #225.