### PR TITLE
test: benchmark normalized compression evidence

### DIFF
--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -198,6 +198,10 @@ Foundation PR: [#226](https://github.com/douglasmonsky/codex-usage-tracker/pull/
 
 Foundation merge: `d0db081f77434e13e4874a56e89b69f577633fb6`
 
+Engine PR: [#227](https://github.com/douglasmonsky/codex-usage-tracker/pull/227)
+
+Engine merge: `b253a97a6615b609ba0d31bc7cc47d9b45f0a620`
+
 Deliverables:
 
 - A bounded evidence-batch reader over the existing normalized SQLite tables.
@@ -337,6 +341,11 @@ whole-pipeline timing or equivalence claim.
   1,340.469 MiB on the current-scale aggregate workload. Runtime improved
   modestly, so the 35 percent scan-elimination gate moved to CP3 rather than
   being weakened or claimed without evidence.
+- 2026-07-12: CP2's durable normalized benchmark generated 500,000 evidence
+  rows for 100,000 calls. Against the same database, CP1 used 562.156 MiB and
+  7.325 seconds; CP2 used 337.938 MiB and 6.704 seconds with identical 15,030
+  candidates and canonical fingerprints. The isolated exact warm hit was
+  3.831 ms.
 
 ## Current Restart Checkpoint
 

--- a/scripts/benchmark_compression_lab.py
+++ b/scripts/benchmark_compression_lab.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import resource
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -53,6 +54,8 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", dest="as_json")
     parser.add_argument("--enforce-thresholds", action="store_true")
     parser.add_argument("--max-cold-seconds", type=float, default=DEFAULT_MAX_COLD_SECONDS)
+    parser.add_argument("--max-peak-rss-mb", type=float)
+    parser.add_argument("--with-normalized-evidence", action="store_true")
     parser.add_argument("--run-db", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     _validate_args(parser, args)
@@ -71,15 +74,17 @@ def main() -> int:
     db_path = db_dir / f"compression-synthetic-{args.rows}.sqlite3"
 
     try:
-        populate_seconds = _populate_database(
+        populate_seconds, normalized_evidence_rows = _populate_database(
             db_path,
             rows=args.rows,
             batch_size=args.batch_size,
+            with_normalized_evidence=args.with_normalized_evidence,
         )
         run_payload = _run_in_child(db_path)
         failures = _threshold_failures(
             run_payload,
             max_cold_seconds=args.max_cold_seconds,
+            max_peak_rss_mb=args.max_peak_rss_mb,
         )
         payload = {
             "schema_version": 1,
@@ -87,7 +92,10 @@ def main() -> int:
             "rows": args.rows,
             "batch_size": args.batch_size,
             "populate_seconds": round(populate_seconds, 6),
+            "normalized_evidence": args.with_normalized_evidence,
+            "normalized_evidence_rows": normalized_evidence_rows,
             "max_cold_seconds": args.max_cold_seconds,
+            "max_peak_rss_mb": args.max_peak_rss_mb,
             **run_payload,
             "threshold_status": "fail" if failures else "pass",
             "threshold_failures": failures,
@@ -106,9 +114,17 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
         parser.error("--batch-size must be positive")
     if args.max_cold_seconds <= 0:
         parser.error("--max-cold-seconds must be positive")
+    if args.max_peak_rss_mb is not None and args.max_peak_rss_mb <= 0:
+        parser.error("--max-peak-rss-mb must be positive")
 
 
-def _populate_database(db_path: Path, *, rows: int, batch_size: int) -> float:
+def _populate_database(
+    db_path: Path,
+    *,
+    rows: int,
+    batch_size: int,
+    with_normalized_evidence: bool,
+) -> tuple[float, int]:
     if db_path.exists():
         db_path.unlink()
     started = time.perf_counter()
@@ -133,8 +149,123 @@ def _populate_database(db_path: Path, *, rows: int, batch_size: int) -> float:
             WHERE rowid % 10 = 0
             """
         )
+        normalized_evidence_rows = (
+            _seed_normalized_evidence(conn) if with_normalized_evidence else 0
+        )
         conn.commit()
-    return time.perf_counter() - started
+    return time.perf_counter() - started, normalized_evidence_rows
+
+
+def _seed_normalized_evidence(conn: sqlite3.Connection) -> int:
+    conn.executescript(
+        """
+        INSERT INTO tool_calls (
+            tool_call_key, record_id, turn_key, tool_name, status,
+            output_size_bytes, parser_adapter, parser_version, parse_warnings_json
+        )
+        SELECT
+            'benchmark-tool-' || record_id,
+            record_id,
+            turn_id,
+            'exec_command',
+            'completed',
+            CASE WHEN line_number % 20 = 0 THEN 20000 ELSE 800 END,
+            'synthetic-benchmark',
+            '1',
+            '[]'
+        FROM usage_events;
+
+        INSERT INTO command_runs (
+            command_run_key, record_id, turn_key, command_root, command_label,
+            exit_code, status, output_size_bytes, retry_group,
+            parser_adapter, parser_version, parse_warnings_json
+        )
+        SELECT
+            'benchmark-command-' || record_id,
+            record_id,
+            turn_id,
+            CASE WHEN line_number % 10 = 0 THEN 'rg' ELSE 'echo' END,
+            'synthetic benchmark command',
+            0,
+            'completed',
+            400,
+            CASE
+                WHEN line_number % 10 = 0 THEN 'rg-' || (line_number % 4)
+                ELSE NULL
+            END,
+            'synthetic-benchmark',
+            '1',
+            '[]'
+        FROM usage_events;
+
+        INSERT INTO file_events (
+            file_event_key, record_id, turn_key, operation, path_hash,
+            path_basename, path_extension, path_identity,
+            parser_adapter, parser_version, parse_warnings_json
+        )
+        SELECT
+            'benchmark-file-' || record_id,
+            record_id,
+            turn_id,
+            CASE WHEN line_number % 5 = 0 THEN 'read' ELSE 'write' END,
+            'path-' || (line_number % 7),
+            'synthetic.py',
+            '.py',
+            'path:path-' || (line_number % 7),
+            'synthetic-benchmark',
+            '1',
+            '[]'
+        FROM usage_events;
+
+        INSERT INTO content_fragments (
+            fragment_id, record_id, turn_key, fragment_kind, role, safe_label,
+            content_hash, content_size_bytes, fragment_text, includes_raw_fragment,
+            created_at
+        )
+        SELECT
+            'benchmark-fragment-a-' || record_id,
+            record_id,
+            turn_id,
+            'tool_output',
+            'tool',
+            'synthetic output',
+            'content-a-' || record_id,
+            400,
+            '',
+            0,
+            event_timestamp
+        FROM usage_events;
+
+        INSERT INTO content_fragments (
+            fragment_id, record_id, turn_key, fragment_kind, role, safe_label,
+            content_hash, content_size_bytes, fragment_text, includes_raw_fragment,
+            created_at
+        )
+        SELECT
+            'benchmark-fragment-b-' || record_id,
+            record_id,
+            turn_id,
+            'assistant_message',
+            'assistant',
+            'synthetic response',
+            'content-b-' || record_id,
+            240,
+            '',
+            0,
+            event_timestamp
+        FROM usage_events;
+        """
+    )
+    row = conn.execute(
+        """
+        SELECT
+            (SELECT COUNT(*) FROM tool_calls)
+          + (SELECT COUNT(*) FROM command_runs)
+          + (SELECT COUNT(*) FROM file_events)
+          + (SELECT COUNT(*) FROM content_fragments)
+        """
+    ).fetchone()
+    return int(row[0]) if row is not None else 0
 
 
 def _run_in_child(db_path: Path) -> dict[str, Any]:
@@ -263,11 +394,16 @@ def _threshold_failures(
     payload: dict[str, Any],
     *,
     max_cold_seconds: float,
+    max_peak_rss_mb: float | None,
 ) -> list[str]:
+    failures = []
     elapsed = float(payload["cold_build"]["total_seconds"])
-    if elapsed <= max_cold_seconds:
-        return []
-    return [f"cold_build.total_seconds {elapsed:.3f} exceeded {max_cold_seconds:.3f}"]
+    if elapsed > max_cold_seconds:
+        failures.append(f"cold_build.total_seconds {elapsed:.3f} exceeded {max_cold_seconds:.3f}")
+    peak_rss_mb = float(payload["cold_build"]["peak_rss_mb"])
+    if max_peak_rss_mb is not None and peak_rss_mb > max_peak_rss_mb:
+        failures.append(f"cold_build.peak_rss_mb {peak_rss_mb:.3f} exceeded {max_peak_rss_mb:.3f}")
+    return failures
 
 
 def _print_payload(payload: dict[str, Any], *, as_json: bool) -> None:

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -133,6 +133,33 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
     )
 
 
+def test_compression_lab_benchmark_with_normalized_evidence(tmp_path: Path) -> None:
+    payload = _run_benchmark_json(
+        [
+            "scripts/benchmark_compression_lab.py",
+            "--rows",
+            "100",
+            "--batch-size",
+            "25",
+            "--db-dir",
+            str(tmp_path),
+            "--with-normalized-evidence",
+            "--max-peak-rss-mb",
+            "512",
+            "--json",
+            "--enforce-thresholds",
+            "--max-cold-seconds",
+            "10",
+        ],
+    )
+
+    assert payload["normalized_evidence"] is True
+    assert payload["normalized_evidence_rows"] == 500
+    assert payload["cold_build"]["candidate_count"] > 10
+    assert payload["cold_build"]["peak_rss_mb"] <= 512
+    assert payload["threshold_failures"] == []
+
+
 def _run_benchmark_json(args: list[str]) -> dict[str, Any]:
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(


### PR DESCRIPTION
## Summary

- add deterministic normalized evidence seeding to the Compression Lab benchmark
- generate 500,000 tool/command/file/fragment rows for the default 100,000-call workload
- add an enforceable isolated-child peak-RSS budget
- record the reproducible CP1-versus-CP2 memory and timing comparison

## Reproducible comparison

Same generated database and canonical outputs:

- CP1: 562.156 MiB peak RSS, 7.325s cold
- CP2: 337.938 MiB peak RSS, 6.704s cold
- peak memory reduction: 39.9%
- 15,030 candidates and candidate/profile fingerprints identical
- CP2 exact warm: 3.831ms

Command: `python scripts/benchmark_compression_lab.py --rows 100000 --with-normalized-evidence --max-peak-rss-mb 384 --max-cold-seconds 20 --enforce-thresholds --json`

## Validation

- 4 benchmark CLI tests passed
- Agent Maintainer precommit passed all applicable gates except the pre-existing Xenon advisory in untouched `store/content_index.py`
- Ruff, release readiness, markdownlint, and git diff checks passed

Completed by #226, #227, and #228.