### PR TITLE
feat: persist detector-ready compression facts

### DIFF
--- a/.agent-maintainer/change-plans/compression-detector-facts.md
+++ b/.agent-maintainer/change-plans/compression-detector-facts.md
@@ -1,0 +1,74 @@
++++
+id = "compression-detector-facts"
+kind = "cohesive-migration"
+status = "active"
+base_ref = "origin/main"
+expires = 2026-07-27
+allowed_paths = [".agent-maintainer/change-plans/compression-detector-facts.md", "src/**", "tests/**", "docs/**", "scripts/benchmark_compression_lab.py"]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 23
+max_changed_lines = 2500
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+# Cohesive Change Plan: compression-detector-facts
+
+## Why this change intentionally large
+This pull request persists detector-ready compression facts as part of the
+canonical SQLite refresh transaction. The change necessarily spans the schema,
+migration, incremental refresh hooks, full backfill, read path, benchmark, and
+contract tests. Shipping only part of that chain would either create stale fact
+tables or make the detector path depend on data that existing databases cannot
+produce.
+
+## Why this should not be split smaller
+The schema and writers are not useful without the guarded reader, while the
+reader is unsafe without generation and manifest integrity checks. The reset,
+source-replacement, content-index, and incremental-refresh hooks must land with
+the initial schema so every supported mutation preserves the same invariant.
+The new modules already separate contracts, queries, synchronization, and full
+backfill into reviewable ownership boundaries; splitting those boundaries over
+multiple deployable commits would increase migration and rollback risk.
+
+## What allowed to change
+- Compression fact schema and migration code.
+- Full and targeted fact synchronization during existing store mutations.
+- Compression evidence loading, run construction, and cache identity checks.
+- The compression domain dependency declaration when imports are removed.
+- The existing Tach boundary decision note for that dependency contraction.
+- The synthetic benchmark and focused migration, store, CLI, and compression
+  tests.
+- The compression-lab roadmap evidence for this checkpoint.
+
+## What must not change
+- Existing MCP, CLI, dashboard, and persisted-record payload contracts.
+- Detector ranking, candidate identity, profile identity, or thresholds.
+- Pricing behavior, source parser behavior, privacy boundaries, or raw content
+  retention.
+- Production configuration, credentials, release metadata, or unrelated
+  architecture.
+
+## Verification plan
+- Prove migration, incremental synchronization, replacement/reset cleanup,
+  transaction rollback, stale-manifest fallback, and canonical detector output
+  with focused tests and the full Python suite.
+- Run Ruff, Mypy, Tach, Bandit, Xenon, dashboard typecheck, release checks, and
+  the full Agent Maintainer verifier.
+- Compare fact-backed and fallback detector candidate/profile fingerprints.
+- Enforce the 100k-call benchmark threshold and record cold, warm, and real-data
+  temporary-copy measurements without exposing private content.
+
+## Rollback plan
+Revert this squash commit before any dependent compression-lab checkpoint is
+merged. Existing databases remain readable because the migration is additive;
+the previous evidence loader does not consult the new tables. If a runtime
+integrity check fails before rollback, the guarded reader falls back to the CP2
+evidence query rather than returning partial facts.
+
+## Follow-up ratchet work
+Keep each fact module below the repository source-size limits and preserve the
+static SQL target whitelist. Subsequent checkpoints must add their own focused
+tests and may not expand this plan to cover revision-aware pricing, MCP/API
+surfaces, simulator work, or dashboard changes.

--- a/docs/architecture/decisions/0003-domain-level-tach-boundaries.md
+++ b/docs/architecture/decisions/0003-domain-level-tach-boundaries.md
@@ -29,3 +29,11 @@ truth.
 positives. New cross-domain imports require an explicit contract change, and
 the store-to-diagnostics cycle found during migration is removed rather than
 allowlisted.
+
+## 2026-07-13 Amendment
+
+The compression domain no longer declares a dependency on `core`. Detector-ready
+fact loading now depends only on the store contract, and no compression module
+imports `core`. Removing the stale edge keeps the declared graph aligned with
+the implementation and lets Tach continue detecting accidental dependency
+growth.

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -227,9 +227,11 @@ Exit gates:
 
 ### CP3: Detector-Ready Ingestion Aggregates
 
-Status: implementation complete; PR pending
+Status: implementation complete; PR open
 
 Issue: [#230](https://github.com/douglasmonsky/codex-usage-tracker/issues/230)
+
+PR: [#231](https://github.com/douglasmonsky/codex-usage-tracker/pull/231)
 
 Deliverables:
 
@@ -391,8 +393,8 @@ Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
 Branch: `feature/compression-detector-facts`
 
-CP2 merged through PR #228 at `980b954`. Issue #230 tracks CP3, which is
-implemented locally and awaiting final verification, commit, and PR.
+CP2 merged through PR #228 at `980b954`. CP3 is committed at `83af336` and open
+for review in PR #231 after passing the precommit and full verifier profiles.
 
 Validated behavior at this checkpoint:
 
@@ -444,8 +446,7 @@ Measured optimizations:
 
 Resume in this order:
 
-1. Finish CP3 verification, leave `.idea/` unstaged, and merge the focused
-   detector-fact PR.
+1. Merge CP3 PR #231 after its remote checks pass, leaving `.idea/` unstaged.
 2. Start CP4 from updated `main` and add revision-aware invalidation, including
    a pricing/rate-card revision before derived costs or credits are persisted.
 3. Land CP5 serially because candidate persistence consumes CP4 cache identity.

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -190,7 +190,7 @@ Exit gates:
 
 ### CP2: Streaming Detector Consumption
 
-Status: in progress
+Status: complete
 
 Issue: [#225](https://github.com/douglasmonsky/codex-usage-tracker/issues/225)
 
@@ -201,6 +201,10 @@ Foundation merge: `d0db081f77434e13e4874a56e89b69f577633fb6`
 Engine PR: [#227](https://github.com/douglasmonsky/codex-usage-tracker/pull/227)
 
 Engine merge: `b253a97a6615b609ba0d31bc7cc47d9b45f0a620`
+
+Benchmark PR: [#228](https://github.com/douglasmonsky/codex-usage-tracker/pull/228)
+
+Benchmark merge: `980b9546131427a3e2f4411b1975590bfd6dc787`
 
 Deliverables:
 
@@ -223,20 +227,27 @@ Exit gates:
 
 ### CP3: Detector-Ready Ingestion Aggregates
 
-Status: pending
+Status: implementation complete; PR pending
+
+Issue: [#230](https://github.com/douglasmonsky/codex-usage-tracker/issues/230)
 
 Deliverables:
 
-- Persisted per-call token, cache, output, and estimated-credit facts.
+- Persisted per-call token, cache, and output facts. Cost and credit columns are
+  intentionally nullable until CP4 can bind derived pricing to a rate-card
+  revision instead of persisting silently stale estimates.
 - Persisted sequence/count facts for shell churn, repeated validation, file
   rediscovery, and tool-output concentration.
 - Per-thread lifecycle and cache-resume summaries.
-- Idempotent backfill from existing normalized content-index records.
+- Fast schema-only migration plus an explicit idempotent backfill from existing
+  normalized content-index records. Automatic initialization never pays the
+  full historical backfill cost.
 - Detector queries over compact facts instead of repeated raw reconstruction.
 
 Exit gates:
 
-- Existing databases migrate and backfill without reparsing raw logs.
+- Existing databases migrate immediately and can be explicitly backfilled
+  without reparsing raw logs.
 - Aggregate facts remain reproducible from normalized source records.
 - Append ingestion updates only affected calls, threads, and sequence windows.
 - Detector outputs remain equivalent to the CP2 streaming reference.
@@ -346,36 +357,70 @@ whole-pipeline timing or equivalence claim.
   7.325 seconds; CP2 used 337.938 MiB and 6.704 seconds with identical 15,030
   candidates and canonical fingerprints. The isolated exact warm hit was
   3.831 ms.
+- 2026-07-13: CP3 added schema v16 detector-ready record, sequence, and thread
+  facts with targeted ingestion/content-index maintenance and a safe CP2
+  fallback whenever fact state is incomplete or stale. Automatic migration is
+  schema-only after profiling showed an eager real-data backfill would add
+  52.625 seconds to unrelated database initialization.
+- 2026-07-13: Independent CP3 review reproduced stale-cache risk after content
+  changes, orphan facts after reset/source replacement with SQLite foreign keys
+  disabled, and partial sequence-store acceptance. The branch now advances
+  generation during content synchronization, explicitly clears/replaces facts,
+  stores integrity counts in fact state, and falls back whenever any persisted
+  fact family is incomplete or version-mismatched. Benchmark fixtures compare
+  fallback and fact-backed fingerprints on the same normalized database.
+- 2026-07-13: On the current 404,176-call aggregate database, the final CP3
+  comparison completed the fallback rebuild in 36.613 seconds and the prepared
+  fact-backed rebuild in 27.598 seconds. Evidence loading plus detectors fell
+  from 24.815 to 15.473 seconds, 37.7 percent, while both paths produced the
+  same 32,087 candidates and canonical candidate/profile fingerprints. Exact
+  reuse completed in 4.219 ms.
+- 2026-07-13: Explicit fact preparation completed in 72.968 seconds after
+  replacing planner-hostile target predicates and rebuilding secondary indexes
+  once around the bulk load. This one-time, opt-in path spent 26.620 seconds on
+  record facts, 15.652 on sequence facts, 10.960 on index creation, and 9.731
+  on manifests; ordinary schema migration remains immediate and backfill-free.
+  The final normalized 100,000-call gate completed in 3.861 seconds total with
+  329.156 MiB peak RSS; evidence loading plus detectors took 2.237 seconds,
+  58.8 percent below CP1's 5.428-second baseline while preserving CP2's exact
+  candidate and profile fingerprints.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/compression-cold-path`
+Branch: `feature/compression-detector-facts`
 
-PR #222 merged the detector and run-builder foundation as `98f2cd7`. Issue #223 tracks the focused cold-path follow-up.
+CP2 merged through PR #228 at `980b954`. Issue #230 tracks CP3, which is
+implemented locally and awaiting final verification, commit, and PR.
 
 Validated behavior at this checkpoint:
 
-- Cold success, zero findings, structured partial detector failure, exact cache reuse, forced replacement, and appended-record incremental recomputation.
-- Deterministic per-thread cache manifests and candidate IDs.
-- Staged progress through evidence, each detector, attribution, persistence, profile, and completion.
-- Focused checkpoint: 66 compression/store tests passed; the full suite passed all 722 tests after keeping the unreleased schema at v15.
-- Real local aggregate dogfood completed with 404,176 calls, 32,087 candidates, no detector warnings, and no raw content printed or committed.
-- Exact cache hits use a compact public profile plus a transaction-level source generation, so they do not rebuild evidence or decode the private incremental manifest.
-- All-history evidence reads bypass temporary scope materialization only when the scope is truly unfiltered.
+- Schema v16 creates detector fact tables without blocking ordinary commands on
+  a historical backfill.
+- Record, relevant sequence, and thread facts reproduce CP2 snapshots,
+  compaction coverage, manifests, candidates, and public profiles.
+- Usage and content-index writes refresh only affected records and threads; a
+  trigger-backed append test rejects accidental full record-fact rebuilds.
+- Incomplete, stale, or version-mismatched fact stores fail closed to the CP2
+  streaming loader.
+- Reset and source replacement explicitly clear affected facts rather than
+  relying on disabled SQLite foreign-key cascades.
+- A hidden benchmark preparation mode measures explicit normalized backfill
+  separately from cold analysis and warm reuse.
+- Public compression schema version remains 1 because CP3 changes only internal
+  evidence representation, not public profile or candidate contracts.
 
-Latest replacement benchmark (`include_archived=true`, all-history scope):
+Latest CP3 real-data benchmark (`include_archived=true`, all-history scope):
 
-- Total: 38.708 seconds, including deletion and replacement of the prior 32,087-candidate run.
-- Evidence loaded: 14.221 seconds.
-- Manifest and all detectors complete: 24.576 seconds.
-- Attribution complete / persistence started: 28.730 seconds.
-- Candidate persistence complete / profile started: 37.617 seconds.
-- Profile complete: 38.386 seconds.
-- Estimated first-ever cold time: about 35.5 seconds after excluding the separately measured 3.2-second prior-run deletion cost.
-- Exact warm profile: 6.2 ms, below the 500 ms target.
-- The immediate pre-follow-up baseline was 48.115 seconds on the same 404,176 calls and 32,087 candidates; the current forced rebuild is 19.5 percent faster.
+- Calls: 404,176; normalized sequence facts: 714,571; candidates: 32,087.
+- Reviewed safe migration plus CP2 fallback rebuild: 36.613 seconds.
+- Reviewed explicit fact preparation: 72.968 seconds, paid only when requested.
+- Reviewed prepared fact-backed rebuild: 27.598 seconds; evidence 9.640
+  seconds; evidence plus detectors 15.473 seconds.
+- Reviewed exact warm profile: 4.219 ms.
+- Fact-backed and fallback runs produced identical candidate and stable public
+  profile fingerprints.
 
 Measured optimizations:
 
@@ -387,6 +432,9 @@ Measured optimizations:
 - Materialized typed evidence directly from positional SQLite rows, avoiding roughly 1.5 million intermediate dictionaries.
 - Removed unnecessary ordering from tool, command, file, and fragment evidence queries after verifying detectors and manifests are order-independent.
 - Computed the incremental manifest once per run and added compact revision identities for every evidence family.
+- Replaced planner-hostile bound target predicates with a fixed internal SQL
+  fragment whitelist and rebuilt fact-table secondary indexes once around full
+  backfills. Incremental refreshes retain their targeted indexed updates.
 - Used `agent-perf`/Scalene on a 100,000-call synthetic workload. `_raw_rows` fell from 4.68 to 1.94 percent CPU attribution (`20260713T004417Z-167fcc53` to `20260713T005309Z-b5750e1d`), while unprofiled time fell from 8.75 to 8.01 seconds with the same 9,269 candidates.
 - Rejected a direct candidate serializer after it improved the synthetic workload by only 0.13 seconds, and rejected BLAKE2b manifest hashing after it regressed the workload to 9.27 seconds.
 - Added `scripts/benchmark_compression_lab.py` as the durable CP equivalence
@@ -396,14 +444,14 @@ Measured optimizations:
 
 Resume in this order:
 
-1. Finish CP1 verification, leave `.idea/` unstaged, and merge the focused
-   cold-path PR.
-2. Start CP2 from current `main`; do not combine schema or parallel-ingestion
-   work with the streaming detector contract.
-3. Land CP3, CP4, and CP5 serially because each changes the persisted inputs or
-   cache identity consumed by the next phase.
-4. Add CP6 only after a fresh profile proves source parsing is the dominant
-   remaining first-build cost.
+1. Finish CP3 verification, leave `.idea/` unstaged, and merge the focused
+   detector-fact PR.
+2. Start CP4 from updated `main` and add revision-aware invalidation, including
+   a pricing/rate-card revision before derived costs or credits are persisted.
+3. Land CP5 serially because candidate persistence consumes CP4 cache identity.
+4. Add CP6 only after a fresh profile identifies the dominant remaining
+   first-build stages; explicit fact preparation is currently a measured
+   parallelization/ingestion-time target.
 
 ## Resume Instructions
 

--- a/scripts/benchmark_compression_lab.py
+++ b/scripts/benchmark_compression_lab.py
@@ -30,10 +30,15 @@ from codex_usage_tracker.store.api import (  # noqa: E402
     refresh_usage_event_links,
     upsert_usage_events,
 )
+from codex_usage_tracker.store.compression_facts import (  # noqa: E402
+    backfill_compression_detector_facts,
+)
 from codex_usage_tracker.store.connection import connect  # noqa: E402
+from codex_usage_tracker.store.schema import init_db  # noqa: E402
 
 DEFAULT_ROWS = 100_000
 DEFAULT_MAX_COLD_SECONDS = 20.0
+DEFAULT_MAX_EVIDENCE_DETECTOR_SECONDS = 3.53
 _VOLATILE_PROFILE_KEYS = {
     "cache",
     "completed_at",
@@ -54,12 +59,21 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", dest="as_json")
     parser.add_argument("--enforce-thresholds", action="store_true")
     parser.add_argument("--max-cold-seconds", type=float, default=DEFAULT_MAX_COLD_SECONDS)
+    parser.add_argument(
+        "--max-evidence-detector-seconds",
+        type=float,
+        default=DEFAULT_MAX_EVIDENCE_DETECTOR_SECONDS,
+    )
     parser.add_argument("--max-peak-rss-mb", type=float)
     parser.add_argument("--with-normalized-evidence", action="store_true")
     parser.add_argument("--run-db", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--prepare-facts-db", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     _validate_args(parser, args)
 
+    if args.prepare_facts_db is not None:
+        print(json.dumps(_prepare_facts(args.prepare_facts_db), separators=(",", ":")))
+        return 0
     if args.run_db is not None:
         print(json.dumps(_run_builds(args.run_db), separators=(",", ":")))
         return 0
@@ -84,6 +98,7 @@ def main() -> int:
         failures = _threshold_failures(
             run_payload,
             max_cold_seconds=args.max_cold_seconds,
+            max_evidence_detector_seconds=args.max_evidence_detector_seconds,
             max_peak_rss_mb=args.max_peak_rss_mb,
         )
         payload = {
@@ -95,6 +110,7 @@ def main() -> int:
             "normalized_evidence": args.with_normalized_evidence,
             "normalized_evidence_rows": normalized_evidence_rows,
             "max_cold_seconds": args.max_cold_seconds,
+            "max_evidence_detector_seconds": args.max_evidence_detector_seconds,
             "max_peak_rss_mb": args.max_peak_rss_mb,
             **run_payload,
             "threshold_status": "fail" if failures else "pass",
@@ -114,6 +130,8 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
         parser.error("--batch-size must be positive")
     if args.max_cold_seconds <= 0:
         parser.error("--max-cold-seconds must be positive")
+    if args.max_evidence_detector_seconds <= 0:
+        parser.error("--max-evidence-detector-seconds must be positive")
     if args.max_peak_rss_mb is not None and args.max_peak_rss_mb <= 0:
         parser.error("--max-peak-rss-mb must be positive")
 
@@ -152,6 +170,7 @@ def _populate_database(
         normalized_evidence_rows = (
             _seed_normalized_evidence(conn) if with_normalized_evidence else 0
         )
+        backfill_compression_detector_facts(conn)
         conn.commit()
     return time.perf_counter() - started, normalized_evidence_rows
 
@@ -321,6 +340,36 @@ def _run_builds(db_path: Path) -> dict[str, Any]:
     return {"cold_build": cold_payload, "warm_build": warm_payload}
 
 
+def _prepare_facts(db_path: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    stage_started = started
+    stage_timings: dict[str, float] = {}
+
+    def record_stage(stage: str) -> None:
+        nonlocal stage_started
+        now = time.perf_counter()
+        stage_timings[stage] = round(now - stage_started, 6)
+        stage_started = now
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        record_stage("init")
+        backfill_compression_detector_facts(conn, stage_callback=record_stage)
+        record_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        )
+        sequence_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_sequence_facts").fetchone()[0]
+        )
+        conn.commit()
+    return {
+        "total_seconds": round(time.perf_counter() - started, 6),
+        "record_count": record_count,
+        "sequence_count": sequence_count,
+        "stage_timings_seconds": stage_timings,
+    }
+
+
 def _candidate_fingerprint(db_path: Path) -> str:
     digest = hashlib.sha256()
     with connect(db_path) as conn:
@@ -394,12 +443,20 @@ def _threshold_failures(
     payload: dict[str, Any],
     *,
     max_cold_seconds: float,
+    max_evidence_detector_seconds: float,
     max_peak_rss_mb: float | None,
 ) -> list[str]:
     failures = []
     elapsed = float(payload["cold_build"]["total_seconds"])
     if elapsed > max_cold_seconds:
         failures.append(f"cold_build.total_seconds {elapsed:.3f} exceeded {max_cold_seconds:.3f}")
+    evidence_detector_seconds = float(payload["cold_build"]["stage_timings_seconds"]["detectors"])
+    if evidence_detector_seconds > max_evidence_detector_seconds:
+        failures.append(
+            "cold_build.stage_timings_seconds.detectors "
+            f"{evidence_detector_seconds:.3f} exceeded "
+            f"{max_evidence_detector_seconds:.3f}"
+        )
     peak_rss_mb = float(payload["cold_build"]["peak_rss_mb"])
     if max_peak_rss_mb is not None and peak_rss_mb > max_peak_rss_mb:
         failures.append(f"cold_build.peak_rss_mb {peak_rss_mb:.3f} exceeded {max_peak_rss_mb:.3f}")

--- a/src/codex_usage_tracker/compression/run_builder.py
+++ b/src/codex_usage_tracker/compression/run_builder.py
@@ -36,7 +36,7 @@ from codex_usage_tracker.compression.run_cache import (
     latest_compatible_run,
 )
 from codex_usage_tracker.compression.streaming_evidence import (
-    load_streaming_compression_evidence,
+    load_fact_compression_evidence,
 )
 from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
 from codex_usage_tracker.store.compression_runs import (
@@ -75,7 +75,7 @@ def build_compression_run(
         _emit(progress_callback, stage="complete", progress_percent=100.0, cache_reused=True)
         return cached_profile
 
-    loaded_evidence = load_streaming_compression_evidence(db_path, scope)
+    loaded_evidence = load_fact_compression_evidence(db_path, scope)
     snapshot = loaded_evidence.snapshot
     current_manifest = loaded_evidence.record_manifest
     cache_identity = _cache_identity(snapshot, scope_hash, detector_version)

--- a/src/codex_usage_tracker/compression/run_cache.py
+++ b/src/codex_usage_tracker/compression/run_cache.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import zlib
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import replace
@@ -36,6 +34,7 @@ from codex_usage_tracker.store.compression_candidates import (
     get_compression_candidate,
     list_compression_candidates,
 )
+from codex_usage_tracker.store.compression_fact_contract import ManifestAccumulator
 from codex_usage_tracker.store.compression_runs import get_compression_run
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.schema import init_db
@@ -47,7 +46,6 @@ class _RecordEvidence(Protocol):
 
 
 _RecordEvidenceT = TypeVar("_RecordEvidenceT", bound=_RecordEvidence)
-_HASH_MODULUS = 1 << 256
 
 
 def incremental_inputs(
@@ -111,7 +109,7 @@ class RecordManifestBuilder:
 
     def __init__(self) -> None:
         self._threads: dict[str, str] = {}
-        self._accumulators: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0])
+        self._accumulators: dict[str, ManifestAccumulator] = defaultdict(ManifestAccumulator)
         self._metadata: dict[str, dict[str, str]] = {}
 
     def add_call(self, call: CallEvidence) -> None:
@@ -121,7 +119,7 @@ class RecordManifestBuilder:
             "thread_key": call.thread_key,
             "record_id": "",
         }
-        _accumulate(self._accumulators[manifest_key], "call", call)
+        self._accumulators[manifest_key].add("call", call.revision_identity())
 
     def add_event(self, kind: str, event: Any) -> None:
         self.add_identity(kind, str(event.record_id), _revision_identity(event))
@@ -136,15 +134,11 @@ class RecordManifestBuilder:
                 "record_id": record_id if not thread_key else "",
             },
         )
-        _accumulate(
-            self._accumulators[manifest_key],
-            kind,
-            identity,
-        )
+        self._accumulators[manifest_key].add(kind, identity)
 
     def build(self) -> dict[str, dict[str, str]]:
         return {
-            key: {**self._metadata[key], "revision": _manifest_hash(accumulator)}
+            key: {**self._metadata[key], "revision": accumulator.revision()}
             for key, accumulator in sorted(self._accumulators.items())
         }
 
@@ -253,19 +247,6 @@ def _revision_identity(event: Any) -> Any:
 
 def _manifest_key(record_id: str, thread_key: str) -> str:
     return f"thread:{thread_key}" if thread_key else f"record:{record_id}"
-
-
-def _accumulate(accumulator: list[int], *parts: Any) -> None:
-    encoded = "\x1f".join(repr(part) for part in parts).encode("utf-8")
-    value = (zlib.crc32(encoded) << 32) | zlib.adler32(encoded)
-    accumulator[0] += 1
-    accumulator[1] = (accumulator[1] + value) % _HASH_MODULUS
-    accumulator[2] ^= value
-
-
-def _manifest_hash(accumulator: list[int]) -> str:
-    encoded = f"{accumulator[0]}:{accumulator[1]:064x}:{accumulator[2]:064x}".encode()
-    return hashlib.sha256(encoded).hexdigest()[:24]
 
 
 def _affected_scope(

--- a/src/codex_usage_tracker/compression/streaming_evidence.py
+++ b/src/codex_usage_tracker/compression/streaming_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -20,18 +21,25 @@ from codex_usage_tracker.compression.evidence import (
     _tool_call,
 )
 from codex_usage_tracker.compression.models import CompressionScope
-from codex_usage_tracker.compression.output_detectors import ToolOutputBloatDetector
-from codex_usage_tracker.compression.repetition_detectors import (
-    _SHELL_ROOTS,
-    _VALIDATION_ROOTS,
-)
 from codex_usage_tracker.compression.run_cache import RecordManifestBuilder
 from codex_usage_tracker.store.compression_evidence import (
     fold_compression_evidence_rows,
 )
+from codex_usage_tracker.store.compression_fact_contract import (
+    MIN_TOOL_OUTPUT_BYTES,
+    RELEVANT_COMMAND_ROOTS,
+    ManifestAccumulator,
+    command_revision_identity,
+    file_revision_identity,
+    fragment_revision_identity,
+    tool_revision_identity,
+)
+from codex_usage_tracker.store.compression_fact_queries import (
+    fold_compression_detector_facts,
+)
 
-_RELEVANT_COMMAND_ROOTS = _SHELL_ROOTS | _VALIDATION_ROOTS
-_MIN_TOOL_OUTPUT_BYTES = (ToolOutputBloatDetector().min_output_tokens * 4) - 3
+_RELEVANT_COMMAND_ROOTS = RELEVANT_COMMAND_ROOTS
+_MIN_TOOL_OUTPUT_BYTES = MIN_TOOL_OUTPUT_BYTES
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,7 +65,7 @@ class _StreamingAccumulator:
     manifest: RecordManifestBuilder = field(default_factory=RecordManifestBuilder)
 
     def consume(self, category: str, rows: list[sqlite3.Row]) -> None:
-        handlers = {
+        handlers: dict[str, Callable[[list[sqlite3.Row]], None]] = {
             "calls": self._consume_calls,
             "turns": self._consume_turns,
             "tool_calls": self._consume_tool_calls,
@@ -127,6 +135,109 @@ class _StreamingAccumulator:
         }
 
 
+@dataclass(slots=True)
+class _FactAccumulator:
+    calls: list[CallEvidence] = field(default_factory=list)
+    tool_calls: list[ToolCallEvidence] = field(default_factory=list)
+    command_runs: list[CommandRunEvidence] = field(default_factory=list)
+    file_events: list[FileEventEvidence] = field(default_factory=list)
+    content_exposure: dict[str, int] = field(default_factory=dict)
+    content_exposure_by_turn: dict[tuple[str, str], int] = field(default_factory=dict)
+    tool_output_exposure: dict[str, int] = field(default_factory=dict)
+    manifests: dict[str, ManifestAccumulator] = field(default_factory=dict)
+
+    def consume(self, category: str, rows: list[sqlite3.Row]) -> None:
+        if category == "records":
+            self._consume_records(rows)
+            return
+        self._consume_sequences(rows)
+
+    def _consume_records(self, rows: list[sqlite3.Row]) -> None:
+        for row in rows:
+            call = _call(row)
+            self.calls.append(call)
+            self.content_exposure[call.record_id] = int(row[15] or 0)
+            self.tool_output_exposure[call.record_id] = int(row[16] or 0)
+            manifest_key = (
+                f"thread:{call.thread_key}" if call.thread_key else f"record:{call.record_id}"
+            )
+            accumulator = self.manifests.setdefault(manifest_key, ManifestAccumulator())
+            accumulator.merge(ManifestAccumulator.from_storage(row[17], row[18], row[19]))
+
+    def _consume_sequences(self, rows: list[sqlite3.Row]) -> None:
+        consumers: dict[str, Callable[[sqlite3.Row], None]] = {
+            "tool_output": self._consume_tool_sequence,
+            "command": self._consume_command_sequence,
+            "file_read": self._consume_file_sequence,
+            "content_turn": self._consume_content_sequence,
+        }
+        for row in rows:
+            consumer = consumers.get(str(row[4]))
+            if consumer is not None:
+                consumer(row)
+
+    def _consume_tool_sequence(self, row: sqlite3.Row) -> None:
+        self.tool_calls.append(
+            ToolCallEvidence(
+                tool_call_key=str(row[0]).removeprefix("tool:"),
+                record_id=str(row[1]),
+                turn_key=_optional_text(row[3]),
+                tool_name=str(row[5]),
+                status=_optional_text(row[6]),
+                duration_ms=_optional_int(row[7]),
+                output_size_bytes=int(row[8] or 0),
+            )
+        )
+
+    def _consume_command_sequence(self, row: sqlite3.Row) -> None:
+        self.command_runs.append(
+            CommandRunEvidence(
+                command_run_key=str(row[0]).removeprefix("command:"),
+                record_id=str(row[1]),
+                turn_key=_optional_text(row[3]),
+                command_root=str(row[5]),
+                command_label=str(row[9] or ""),
+                exit_code=_optional_int(row[10]),
+                status=_optional_text(row[6]),
+                output_size_bytes=int(row[8] or 0),
+                retry_group=_optional_text(row[11]),
+            )
+        )
+
+    def _consume_file_sequence(self, row: sqlite3.Row) -> None:
+        self.file_events.append(
+            FileEventEvidence(
+                file_event_key=str(row[0]).removeprefix("file:"),
+                record_id=str(row[1]),
+                turn_key=_optional_text(row[3]),
+                operation="read",
+                path_hash=str(row[5]),
+                path_identity=str(row[12] or ""),
+            )
+        )
+
+    def _consume_content_sequence(self, row: sqlite3.Row) -> None:
+        turn_key = _optional_text(row[3])
+        if turn_key is not None:
+            self.content_exposure_by_turn[(str(row[1]), turn_key)] = int(row[13] or 0)
+
+    def record_manifest(self) -> dict[str, dict[str, str]]:
+        calls_by_manifest = {
+            (f"thread:{call.thread_key}" if call.thread_key else f"record:{call.record_id}"): call
+            for call in self.calls
+        }
+        return {
+            key: {
+                "thread_key": calls_by_manifest[key].thread_key,
+                "record_id": ""
+                if calls_by_manifest[key].thread_key
+                else calls_by_manifest[key].record_id,
+                "revision": accumulator.revision(),
+            }
+            for key, accumulator in sorted(self.manifests.items())
+        }
+
+
 def load_streaming_compression_evidence(
     db_path: Path,
     scope: CompressionScope,
@@ -162,59 +273,60 @@ def load_streaming_compression_evidence(
     )
 
 
+def load_fact_compression_evidence(
+    db_path: Path,
+    scope: CompressionScope,
+    *,
+    batch_size: int = 4_096,
+) -> StreamingEvidenceBundle:
+    """Load detector-ready facts, falling back when their revision is stale."""
+    accumulator = _FactAccumulator()
+    metadata = fold_compression_detector_facts(
+        db_path,
+        scope=scope.as_dict(),
+        batch_size=batch_size,
+        consumer=accumulator.consume,
+    )
+    if not metadata["ready"]:
+        return load_streaming_compression_evidence(db_path, scope, batch_size=batch_size)
+    snapshot = CompressionEvidenceSnapshot(
+        calls=tuple(accumulator.calls),
+        turns=(),
+        tool_calls=tuple(accumulator.tool_calls),
+        command_runs=tuple(accumulator.command_runs),
+        file_events=tuple(accumulator.file_events),
+        content_fragments=(),
+        compactions=(),
+        coverage=_coverage(metadata["coverage"]),
+        source_revision=f"generation:{int(metadata['source_generation'])}",
+        content_exposure_by_record=accumulator.content_exposure,
+        content_exposure_by_turn=accumulator.content_exposure_by_turn,
+        tool_output_exposure_by_record=accumulator.tool_output_exposure,
+    )
+    return StreamingEvidenceBundle(
+        snapshot=snapshot,
+        record_manifest=accumulator.record_manifest(),
+    )
+
+
 def _output_tokens(output_size_bytes: int) -> int:
     return (output_size_bytes + 3) // 4
 
 
 def _tool_identity(row: sqlite3.Row) -> tuple[object, ...]:
-    return (
-        str(row[0]),
-        str(row[1]),
-        _optional_text(row[2]),
-        str(row[3]),
-        _optional_text(row[4]),
-        _optional_int(row[5]),
-        int(row[6] or 0),
-    )
+    return tool_revision_identity(row)
 
 
 def _command_identity(row: sqlite3.Row) -> tuple[object, ...]:
-    return (
-        str(row[0]),
-        str(row[1]),
-        _optional_text(row[2]),
-        str(row[3]),
-        str(row[4] or ""),
-        _optional_int(row[5]),
-        _optional_text(row[6]),
-        int(row[7] or 0),
-        _optional_text(row[8]),
-    )
+    return command_revision_identity(row)
 
 
 def _file_identity(row: sqlite3.Row) -> tuple[object, ...]:
-    return (
-        str(row[0]),
-        str(row[1]),
-        _optional_text(row[2]),
-        str(row[3]),
-        str(row[4]),
-        str(row[5] or ""),
-    )
+    return file_revision_identity(row)
 
 
 def _fragment_identity(row: sqlite3.Row) -> tuple[object, ...]:
-    return (
-        str(row[0]),
-        str(row[1]),
-        _optional_text(row[2]),
-        str(row[3]),
-        _optional_text(row[4]),
-        str(row[5] or ""),
-        str(row[6]),
-        int(row[7] or 0),
-        bool(row[8]),
-    )
+    return fragment_revision_identity(row)
 
 
 def _optional_text(value: object) -> str | None:

--- a/src/codex_usage_tracker/compression/tach.domain.toml
+++ b/src/codex_usage_tracker/compression/tach.domain.toml
@@ -1,5 +1,4 @@
 [root]
 depends_on = [
-  "//codex_usage_tracker.core",
   "//codex_usage_tracker.store",
 ]

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -26,6 +26,11 @@ from codex_usage_tracker.store.allowance_observations import (
 from codex_usage_tracker.store.allowance_observations import (
     sync_allowance_observations_for_record_ids,
 )
+from codex_usage_tracker.store.compression_fact_sync import (
+    clear_compression_detector_facts,
+    delete_compression_facts_for_source_files,
+    sync_compression_detector_facts,
+)
 from codex_usage_tracker.store.compression_schema import touch_compression_source_generation
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.content_index import (
@@ -173,6 +178,7 @@ def reset_usage_database(db_path: Path = DEFAULT_DB_PATH) -> dict[str, Any]:
         row = conn.execute("SELECT COUNT(*) AS count FROM usage_events").fetchone()
         deleted_rows = int(row["count"] if row is not None else 0)
         clear_content_index_rows(conn)
+        clear_compression_detector_facts(conn)
         conn.execute("DELETE FROM call_diagnostic_facts")
         conn.execute("DELETE FROM diagnostic_snapshots")
         conn.execute("DELETE FROM allowance_observations")
@@ -517,6 +523,11 @@ def upsert_usage_events(
             )
             if source_files_to_replace:
                 touch_compression_source_generation(conn)
+                sync_compression_detector_facts(
+                    conn,
+                    record_ids=(),
+                    affected_thread_keys=affected_thread_keys,
+                )
             return 0
         affected_thread_keys.update(_thread_keys_for_usage_rows(rows))
         _delete_diagnostic_facts_for_record_ids(conn, _usage_event_record_ids(rows))
@@ -531,6 +542,11 @@ def upsert_usage_events(
             affected_thread_keys=affected_thread_keys,
         )
         touch_compression_source_generation(conn)
+        sync_compression_detector_facts(
+            conn,
+            record_ids=record_ids,
+            affected_thread_keys=affected_thread_keys,
+        )
         return len(rows)
 
 
@@ -559,6 +575,10 @@ def _delete_usage_events_for_source_files(
         conn,
         placeholders=placeholders,
         source_files_to_replace=source_files_to_replace,
+    )
+    delete_compression_facts_for_source_files(
+        conn,
+        source_files=source_files_to_replace,
     )
     conn.execute(
         f"""

--- a/src/codex_usage_tracker/store/compression_fact_contract.py
+++ b/src/codex_usage_tracker/store/compression_fact_contract.py
@@ -1,0 +1,142 @@
+"""Versioned detector-fact and manifest contracts owned by the usage store."""
+
+from __future__ import annotations
+
+import hashlib
+import zlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+COMPRESSION_FACTS_VERSION = 1
+MIN_TOOL_OUTPUT_TOKENS = 4_096
+MIN_TOOL_OUTPUT_BYTES = (MIN_TOOL_OUTPUT_TOKENS * 4) - 3
+SHELL_ROOTS = frozenset({"git", "nl", "rg", "sed"})
+VALIDATION_ROOTS = frozenset(
+    {"mypy", "npm", "npx", "pytest", "pyright", "ruff", "test", "unittest"}
+)
+RELEVANT_COMMAND_ROOTS = SHELL_ROOTS | VALIDATION_ROOTS
+_HASH_MODULUS = 1 << 256
+
+
+@dataclass(slots=True)
+class ManifestAccumulator:
+    """Combine evidence identities without retaining their object graph."""
+
+    count: int = 0
+    total: int = 0
+    xor: int = 0
+
+    def add(self, kind: str, identity: Any) -> None:
+        encoded = "\x1f".join(repr(part) for part in (kind, identity)).encode("utf-8")
+        value = (zlib.crc32(encoded) << 32) | zlib.adler32(encoded)
+        self.count += 1
+        self.total = (self.total + value) % _HASH_MODULUS
+        self.xor ^= value
+
+    def merge(self, other: ManifestAccumulator) -> None:
+        self.count += other.count
+        self.total = (self.total + other.total) % _HASH_MODULUS
+        self.xor ^= other.xor
+
+    def storage_values(self) -> tuple[int, str, str]:
+        return self.count, f"{self.total:064x}", f"{self.xor:064x}"
+
+    @classmethod
+    def from_storage(
+        cls,
+        count: int,
+        total_hex: str,
+        xor_hex: str,
+    ) -> ManifestAccumulator:
+        return cls(
+            count=int(count),
+            total=int(total_hex or "0", 16),
+            xor=int(xor_hex or "0", 16),
+        )
+
+    def revision(self) -> str:
+        encoded = f"{self.count}:{self.total:064x}:{self.xor:064x}".encode()
+        return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def call_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        str(row[2]),
+        str(row[3]),
+        optional_text(row[4]),
+        optional_text(row[5]),
+        bool(row[6]),
+        optional_int(row[7]),
+        optional_text(row[8]),
+        int(row[9] or 0),
+        int(row[10] or 0),
+        int(row[11] or 0),
+        int(row[12] or 0),
+        float(row[13] or 0),
+        float(row[14] or 0),
+    )
+
+
+def tool_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        optional_text(row[2]),
+        str(row[3]),
+        optional_text(row[4]),
+        optional_int(row[5]),
+        int(row[6] or 0),
+    )
+
+
+def command_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        optional_text(row[2]),
+        str(row[3]),
+        str(row[4] or ""),
+        optional_int(row[5]),
+        optional_text(row[6]),
+        int(row[7] or 0),
+        optional_text(row[8]),
+    )
+
+
+def file_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        optional_text(row[2]),
+        str(row[3]),
+        str(row[4]),
+        str(row[5] or ""),
+    )
+
+
+def fragment_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
+    return (
+        str(row[0]),
+        str(row[1]),
+        optional_text(row[2]),
+        str(row[3]),
+        optional_text(row[4]),
+        str(row[5] or ""),
+        str(row[6]),
+        int(row[7] or 0),
+        bool(row[8]),
+    )
+
+
+def optional_text(value: object) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None
+
+
+def optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return value if isinstance(value, int) else int(str(value))

--- a/src/codex_usage_tracker/store/compression_fact_queries.py
+++ b/src/codex_usage_tracker/store/compression_fact_queries.py
@@ -1,0 +1,289 @@
+"""Bounded reads over persisted detector-ready compression facts."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.store.compression_evidence import (
+    _content_index_enabled,
+    _is_unfiltered_all_history,
+    _populate_scope_records,
+    _scoped_sql,
+)
+from codex_usage_tracker.store.compression_fact_contract import (
+    COMPRESSION_FACTS_VERSION,
+    RELEVANT_COMMAND_ROOTS,
+)
+from codex_usage_tracker.store.compression_schema import read_compression_source_generation
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+FactConsumer = Callable[[str, list[sqlite3.Row]], None]
+
+_TARGET_SCOPES = {
+    "__TARGET_RECORD__": (
+        "WHERE record_id IN (SELECT record_id FROM compression_fact_targets)",
+        "",
+    ),
+    "__TARGET_U_RECORD__": (
+        "WHERE u.record_id IN (SELECT record_id FROM compression_fact_targets)",
+        "",
+    ),
+    "__TARGET_T_RECORD_AND__": (
+        "WHERE t.record_id IN (SELECT record_id FROM compression_fact_targets) AND",
+        "WHERE",
+    ),
+    "__TARGET_C_RECORD_AND__": (
+        "WHERE c.record_id IN (SELECT record_id FROM compression_fact_targets) AND",
+        "WHERE",
+    ),
+    "__TARGET_F_RECORD_AND__": (
+        "WHERE f.record_id IN (SELECT record_id FROM compression_fact_targets) AND",
+        "WHERE",
+    ),
+    "__TARGET_R_THREAD__": (
+        "WHERE r.thread_key IN (SELECT thread_key FROM compression_fact_thread_targets)",
+        "",
+    ),
+}
+
+
+def target_mode_sql(query: str, *, targeted: bool) -> str:
+    """Resolve fixed internal scope markers without accepting SQL identifiers."""
+    replacement_index = 0 if targeted else 1
+    for marker, replacements in _TARGET_SCOPES.items():
+        query = query.replace(marker, replacements[replacement_index])
+    return query
+
+
+def fold_compression_detector_facts(
+    db_path: Path,
+    *,
+    scope: Mapping[str, Any],
+    batch_size: int,
+    consumer: FactConsumer,
+) -> dict[str, Any]:
+    """Fold ready facts into a caller-owned accumulator without raw event scans."""
+    with connect(db_path) as conn:
+        init_db(conn)
+        scoped = not _is_unfiltered_all_history(scope)
+        if scoped:
+            _populate_scope_records(conn, scope)
+        metadata = _fact_metadata(conn, scoped=scoped)
+        if not metadata["ready"]:
+            return metadata
+        _fold_query(
+            conn,
+            _scoped_sql(_RECORD_FACTS_SQL, "r", scoped=scoped),
+            category="records",
+            batch_size=batch_size,
+            consumer=consumer,
+        )
+        _fold_query(
+            conn,
+            _scoped_sql(_SEQUENCE_FACTS_SQL, "s", scoped=scoped),
+            category="sequences",
+            batch_size=batch_size,
+            consumer=consumer,
+        )
+        return metadata
+
+
+def _fold_query(
+    conn: sqlite3.Connection,
+    sql: str,
+    *,
+    category: str,
+    batch_size: int,
+    consumer: FactConsumer,
+) -> None:
+    cursor = conn.execute(sql, (COMPRESSION_FACTS_VERSION,))
+    while rows := cursor.fetchmany(batch_size):
+        consumer(category, rows)
+
+
+def _fact_metadata(conn: sqlite3.Connection, *, scoped: bool) -> dict[str, Any]:
+    expected_count = conn.execute(
+        "SELECT COUNT(*) FROM compression_scope_records"
+        if scoped
+        else "SELECT COUNT(*) FROM usage_events"
+    ).fetchone()[0]
+    row = conn.execute(
+        _scoped_sql(_COVERAGE_SQL, "r", scoped=scoped),
+        (COMPRESSION_FACTS_VERSION,),
+    ).fetchone()
+    state = conn.execute(
+        """
+        SELECT facts_version, source_generation,
+               record_count, sequence_count, thread_count
+        FROM compression_fact_state WHERE singleton = 1
+        """
+    ).fetchone()
+    integrity = conn.execute(
+        """
+        SELECT
+            (SELECT COUNT(*) FROM compression_record_facts WHERE facts_version = ?)
+                AS record_count,
+            (SELECT COUNT(*) FROM compression_sequence_facts WHERE facts_version = ?)
+                AS sequence_count,
+            (SELECT COUNT(*) FROM compression_thread_facts WHERE facts_version = ?)
+                AS thread_count
+        """,
+        (COMPRESSION_FACTS_VERSION,) * 3,
+    ).fetchone()
+    generation = read_compression_source_generation(conn)
+    fact_count = int(row["call_count"] or 0) if row is not None else 0
+    integrity_counts = (
+        tuple(int(integrity[key]) for key in ("record_count", "sequence_count", "thread_count"))
+        if integrity is not None
+        else (-1, -1, -1)
+    )
+    state_signature = (
+        (
+            int(state["facts_version"]),
+            int(state["source_generation"]),
+            int(state["record_count"]),
+            int(state["sequence_count"]),
+            int(state["thread_count"]),
+        )
+        if state is not None
+        else None
+    )
+    ready = bool(
+        fact_count == int(expected_count)
+        and state_signature == (COMPRESSION_FACTS_VERSION, generation, *integrity_counts)
+    )
+    coverage = dict(row) if row is not None else {}
+    coverage.update(
+        {
+            "parser_adapters": _csv_values(coverage.get("parser_adapters")),
+            "parser_versions": _csv_values(coverage.get("parser_versions")),
+            "content_index_enabled": _content_index_enabled(conn),
+        }
+    )
+    return {
+        "ready": ready,
+        "source_generation": generation,
+        "coverage": coverage,
+    }
+
+
+def _csv_values(value: object) -> list[str]:
+    if not value:
+        return []
+    return sorted(part for part in str(value).split(",") if part)
+
+
+_RECORD_FACTS_SQL = """
+SELECT
+    r.record_id,
+    r.session_id,
+    r.thread_key,
+    r.event_timestamp,
+    r.model,
+    r.effort,
+    r.is_archived,
+    r.thread_call_index,
+    r.previous_record_id,
+    r.cached_input_tokens,
+    r.uncached_input_tokens,
+    r.output_tokens,
+    r.reasoning_output_tokens,
+    r.cache_ratio,
+    r.context_window_percent,
+    r.content_exposure_tokens,
+    r.tool_output_exposure_tokens,
+    r.manifest_count,
+    r.manifest_sum_hex,
+    r.manifest_xor_hex
+FROM compression_record_facts AS r
+{scope_join}
+WHERE r.facts_version = ?
+ORDER BY r.event_timestamp, r.record_id
+"""
+
+_SEQUENCE_FACTS_SQL = """
+SELECT
+    s.fact_key,
+    s.record_id,
+    s.thread_key,
+    s.turn_key,
+    s.fact_kind,
+    s.category,
+    s.status,
+    s.duration_ms,
+    s.output_size_bytes,
+    s.command_label,
+    s.exit_code,
+    s.retry_group,
+    s.path_identity,
+    s.exposure_tokens
+FROM compression_sequence_facts AS s
+{scope_join}
+WHERE s.facts_version = ?
+ORDER BY
+    CASE s.fact_kind
+        WHEN 'tool_output' THEN 0
+        WHEN 'command' THEN 1
+        WHEN 'file_read' THEN 2
+        ELSE 3
+    END,
+    s.source_order
+"""
+
+_COVERAGE_SQL = """
+SELECT
+    COUNT(*) AS call_count,
+    SUM(r.turn_count) AS turn_count,
+    SUM(r.tool_call_count) AS tool_call_count,
+    SUM(r.command_run_count) AS command_run_count,
+    SUM(r.file_event_count) AS file_event_count,
+    SUM(r.content_fragment_count) AS content_fragment_count,
+    SUM(r.compaction_count) AS compaction_count,
+    SUM(r.indexed_call) AS indexed_call_count,
+    SUM(r.source_record_count) AS source_record_count,
+    SUM(r.parser_warning_record_count) AS parser_warning_record_count,
+    GROUP_CONCAT(DISTINCT r.parser_adapter) AS parser_adapters,
+    GROUP_CONCAT(DISTINCT r.parser_version) AS parser_versions
+FROM compression_record_facts AS r
+{scope_join}
+WHERE r.facts_version = ?
+"""
+
+
+def ensure_empty_target_tables(conn: sqlite3.Connection) -> None:
+    """Create the temp tables referenced by static full-backfill queries."""
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_fact_targets (
+            record_id TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_fact_thread_targets (
+            thread_key TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute("DELETE FROM compression_fact_targets")
+    conn.execute("DELETE FROM compression_fact_thread_targets")
+
+
+def populate_relevant_command_roots(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_relevant_command_roots (
+            command_root TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute("DELETE FROM compression_relevant_command_roots")
+    conn.executemany(
+        "INSERT INTO compression_relevant_command_roots(command_root) VALUES (?)",
+        ((root,) for root in sorted(RELEVANT_COMMAND_ROOTS)),
+    )

--- a/src/codex_usage_tracker/store/compression_fact_sync.py
+++ b/src/codex_usage_tracker/store/compression_fact_sync.py
@@ -1,0 +1,223 @@
+"""Incrementally maintain detector facts inside aggregate write transactions."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+
+from codex_usage_tracker.store.compression_fact_contract import COMPRESSION_FACTS_VERSION
+from codex_usage_tracker.store.compression_facts import (
+    _insert_record_facts,
+    _insert_sequence_facts,
+    _insert_thread_facts,
+    _update_record_manifests,
+    _update_thread_manifests,
+)
+from codex_usage_tracker.store.compression_schema import (
+    stamp_compression_fact_state,
+    touch_compression_source_generation,
+)
+from codex_usage_tracker.store.content_index_models import ContentIndexPlan
+from codex_usage_tracker.store.sources import SourceParsePlan
+
+
+def content_index_plans(
+    plans: Iterable[SourceParsePlan],
+) -> tuple[ContentIndexPlan, ...]:
+    """Materialize content plans for indexing followed by fact synchronization."""
+    return tuple(
+        ContentIndexPlan(
+            source_path=plan.path,
+            replace_existing=plan.replace_existing,
+            start_byte=plan.start_byte,
+            start_line=plan.start_line,
+        )
+        for plan in plans
+    )
+
+
+def sync_compression_detector_facts(
+    conn: sqlite3.Connection,
+    *,
+    record_ids: Iterable[str],
+    affected_thread_keys: Iterable[str],
+) -> None:
+    """Refresh only changed records and their surviving thread summaries."""
+    targets = {str(record_id) for record_id in record_ids if str(record_id)}
+    threads = {str(thread_key) for thread_key in affected_thread_keys if str(thread_key)}
+    _populate_record_targets(conn, targets)
+    threads.update(_target_thread_keys(conn, table="compression_record_facts"))
+    threads.update(_target_thread_keys(conn, table="usage_events"))
+
+    if targets:
+        conn.execute(
+            """
+            DELETE FROM compression_sequence_facts
+            WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+            """
+        )
+        conn.execute(
+            """
+            DELETE FROM compression_record_facts
+            WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+            """
+        )
+        _insert_record_facts(conn, targeted=True)
+        _update_record_manifests(conn, targeted=True)
+        _insert_sequence_facts(conn, targeted=True)
+
+    _populate_thread_targets(conn, threads)
+    if threads:
+        conn.execute(
+            """
+            DELETE FROM compression_thread_facts
+            WHERE thread_key IN (
+                SELECT thread_key FROM compression_fact_thread_targets
+            )
+            """
+        )
+        _insert_thread_facts(conn, targeted=True)
+        _update_thread_manifests(conn, targeted=True)
+    stamp_compression_fact_state(conn, facts_version=COMPRESSION_FACTS_VERSION)
+
+
+def sync_content_plan_compression_facts(
+    conn: sqlite3.Connection,
+    *,
+    plans: Iterable[ContentIndexPlan],
+) -> None:
+    """Refresh fact rows whose normalized content changed in this refresh."""
+    content_plans = tuple(plans)
+    if not content_plans:
+        return
+    touch_compression_source_generation(conn)
+    record_ids: set[str] = set()
+    for plan in content_plans:
+        minimum_line = 0 if plan.replace_existing else plan.start_line + 1
+        rows = conn.execute(
+            """
+            SELECT record_id FROM usage_events
+            WHERE source_file = ? AND line_number >= ?
+            """,
+            (str(plan.source_path), minimum_line),
+        )
+        record_ids.update(str(row["record_id"]) for row in rows if row["record_id"])
+    sync_compression_detector_facts(
+        conn,
+        record_ids=record_ids,
+        affected_thread_keys=(),
+    )
+
+
+def delete_compression_facts_for_source_files(
+    conn: sqlite3.Connection,
+    *,
+    source_files: Iterable[str],
+) -> None:
+    """Delete record and sequence facts before their usage rows are replaced."""
+    paths = tuple(dict.fromkeys(str(path) for path in source_files if str(path)))
+    if not paths:
+        return
+    _populate_source_file_targets(conn, paths)
+    record_ids = {
+        str(row["record_id"])
+        for row in conn.execute(
+            """
+            SELECT record_id FROM usage_events
+            WHERE source_file IN (
+                SELECT source_file FROM compression_fact_source_targets
+            )
+            """
+        )
+    }
+    _populate_record_targets(conn, record_ids)
+    conn.execute(
+        """
+        DELETE FROM compression_sequence_facts
+        WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+        """
+    )
+    conn.execute(
+        """
+        DELETE FROM compression_record_facts
+        WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+        """
+    )
+
+
+def clear_compression_detector_facts(conn: sqlite3.Connection) -> None:
+    """Clear all detector-ready facts and their integrity stamp."""
+    conn.execute("DELETE FROM compression_sequence_facts")
+    conn.execute("DELETE FROM compression_thread_facts")
+    conn.execute("DELETE FROM compression_record_facts")
+    conn.execute("DELETE FROM compression_fact_state")
+
+
+def _populate_record_targets(conn: sqlite3.Connection, record_ids: set[str]) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_fact_targets (
+            record_id TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute("DELETE FROM compression_fact_targets")
+    conn.executemany(
+        "INSERT INTO compression_fact_targets(record_id) VALUES (?)",
+        ((record_id,) for record_id in sorted(record_ids)),
+    )
+
+
+def _target_thread_keys(conn: sqlite3.Connection, *, table: str) -> set[str]:
+    if table == "compression_record_facts":
+        rows = conn.execute(
+            """
+            SELECT DISTINCT thread_key
+            FROM compression_record_facts
+            WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+            """
+        )
+    elif table == "usage_events":
+        rows = conn.execute(
+            """
+            SELECT DISTINCT COALESCE(thread_key, thread_name, session_id) AS thread_key
+            FROM usage_events
+            WHERE record_id IN (SELECT record_id FROM compression_fact_targets)
+            """
+        )
+    else:
+        raise ValueError(f"unsupported fact thread table: {table}")
+    return {str(row["thread_key"]) for row in rows if row["thread_key"]}
+
+
+def _populate_source_file_targets(
+    conn: sqlite3.Connection,
+    source_files: tuple[str, ...],
+) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_fact_source_targets (
+            source_file TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute("DELETE FROM compression_fact_source_targets")
+    conn.executemany(
+        "INSERT INTO compression_fact_source_targets(source_file) VALUES (?)",
+        ((source_file,) for source_file in source_files),
+    )
+
+
+def _populate_thread_targets(conn: sqlite3.Connection, thread_keys: set[str]) -> None:
+    conn.execute(
+        """
+        CREATE TEMP TABLE IF NOT EXISTS compression_fact_thread_targets (
+            thread_key TEXT PRIMARY KEY
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute("DELETE FROM compression_fact_thread_targets")
+    conn.executemany(
+        "INSERT INTO compression_fact_thread_targets(thread_key) VALUES (?)",
+        ((thread_key,) for thread_key in sorted(thread_keys)),
+    )

--- a/src/codex_usage_tracker/store/compression_facts.py
+++ b/src/codex_usage_tracker/store/compression_facts.py
@@ -1,0 +1,464 @@
+"""Materialize compact detector facts from normalized usage records."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+
+from codex_usage_tracker.store.compression_fact_contract import (
+    COMPRESSION_FACTS_VERSION,
+    MIN_TOOL_OUTPUT_BYTES,
+    ManifestAccumulator,
+    call_revision_identity,
+    command_revision_identity,
+    file_revision_identity,
+    fragment_revision_identity,
+    tool_revision_identity,
+)
+from codex_usage_tracker.store.compression_fact_queries import (
+    ensure_empty_target_tables,
+    populate_relevant_command_roots,
+    target_mode_sql,
+)
+from codex_usage_tracker.store.compression_schema import (
+    create_compression_fact_indexes,
+    drop_compression_fact_indexes,
+    stamp_compression_fact_state,
+)
+
+FactStageCallback = Callable[[str], None]
+
+
+def backfill_compression_detector_facts(
+    conn: sqlite3.Connection,
+    *,
+    stage_callback: FactStageCallback | None = None,
+) -> None:
+    """Rebuild detector facts without reopening raw Codex logs."""
+    ensure_empty_target_tables(conn)
+    drop_compression_fact_indexes(conn)
+    try:
+        conn.execute("DELETE FROM compression_sequence_facts")
+        conn.execute("DELETE FROM compression_thread_facts")
+        conn.execute("DELETE FROM compression_record_facts")
+        _mark_stage(stage_callback, "clear")
+        _insert_record_facts(conn)
+        _mark_stage(stage_callback, "record_facts")
+        _update_record_manifests(conn)
+        _mark_stage(stage_callback, "record_manifests")
+        _insert_sequence_facts(conn)
+        _mark_stage(stage_callback, "sequence_facts")
+        _insert_thread_facts(conn)
+        _update_thread_manifests(conn)
+        _mark_stage(stage_callback, "thread_facts")
+    finally:
+        create_compression_fact_indexes(conn)
+    _mark_stage(stage_callback, "indexes")
+    stamp_compression_fact_state(conn, facts_version=COMPRESSION_FACTS_VERSION)
+    _mark_stage(stage_callback, "state")
+
+
+def _mark_stage(callback: FactStageCallback | None, stage: str) -> None:
+    if callback is not None:
+        callback(stage)
+
+
+def _insert_record_facts(conn: sqlite3.Connection, *, targeted: bool = False) -> None:
+    query = target_mode_sql(
+        """
+        INSERT INTO compression_record_facts (
+            record_id, source_file, session_id, thread_key, event_timestamp,
+            model, effort, is_archived, thread_call_index, previous_record_id,
+            cached_input_tokens, uncached_input_tokens, output_tokens,
+            reasoning_output_tokens, estimated_cost_usd, usage_credits,
+            cache_ratio, context_window_percent, turn_count, indexed_call,
+            tool_call_count, command_run_count, file_event_count,
+            content_fragment_count, compaction_count, source_record_count,
+            parser_warning_record_count, parser_adapter, parser_version,
+            content_exposure_tokens,
+            tool_output_exposure_tokens, manifest_count, manifest_sum_hex,
+            manifest_xor_hex, facts_version, updated_at
+        )
+        WITH
+        content AS (
+            SELECT
+                record_id,
+                COUNT(*) AS fact_count,
+                SUM((content_size_bytes + 3) / 4) AS tokens,
+                SUM(CASE WHEN fragment_kind IN ('compaction', 'compaction_history')
+                    THEN 1 ELSE 0 END)
+                    AS compaction_count
+            FROM content_fragments
+                __TARGET_RECORD__
+            GROUP BY record_id
+        ),
+        tools AS (
+            SELECT
+                record_id,
+                COUNT(*) AS fact_count,
+                SUM((output_size_bytes + 3) / 4) AS tokens
+            FROM tool_calls
+                __TARGET_RECORD__
+            GROUP BY record_id
+        ),
+        commands AS (
+            SELECT
+                record_id,
+                COUNT(*) AS fact_count,
+                SUM((output_size_bytes + 3) / 4) AS tokens
+            FROM command_runs
+                __TARGET_RECORD__
+            GROUP BY record_id
+        ),
+        files AS (
+            SELECT record_id, COUNT(*) AS fact_count
+            FROM file_events
+                __TARGET_RECORD__
+            GROUP BY record_id
+        ),
+        turns AS (
+            SELECT
+                record_id,
+                COUNT(*) AS fact_count,
+                MAX(indexed_content_included) AS indexed_call
+            FROM conversation_turns
+                __TARGET_RECORD__
+            GROUP BY record_id
+        ),
+        sources AS (
+            SELECT
+                record_id,
+                1 AS fact_count,
+                CASE WHEN parse_warnings_json NOT IN ('', '[]') THEN 1 ELSE 0 END
+                    AS warning_count,
+                parser_adapter,
+                parser_version
+            FROM source_records
+                __TARGET_RECORD__
+        )
+        SELECT
+            u.record_id,
+            u.source_file,
+            u.session_id,
+            COALESCE(u.thread_key, u.thread_name, u.session_id),
+            u.event_timestamp,
+            u.model,
+            u.effort,
+            u.is_archived,
+            u.thread_call_index,
+            u.previous_record_id,
+            u.cached_input_tokens,
+            u.uncached_input_tokens,
+            u.output_tokens,
+            u.reasoning_output_tokens,
+            NULL,
+            NULL,
+            u.cache_ratio,
+            u.context_window_percent,
+            COALESCE(turns.fact_count, 0),
+            COALESCE(turns.indexed_call, 0),
+            COALESCE(tools.fact_count, 0),
+            COALESCE(commands.fact_count, 0),
+            COALESCE(files.fact_count, 0),
+            COALESCE(content.fact_count, 0),
+            COALESCE(content.compaction_count, 0),
+            COALESCE(sources.fact_count, 0),
+            COALESCE(sources.warning_count, 0),
+            sources.parser_adapter,
+            sources.parser_version,
+            COALESCE(content.tokens, 0),
+            MAX(COALESCE(tools.tokens, 0), COALESCE(commands.tokens, 0)),
+            0,
+            '',
+            '',
+            :facts_version,
+            u.event_timestamp
+        FROM usage_events AS u
+        LEFT JOIN content ON content.record_id = u.record_id
+        LEFT JOIN tools ON tools.record_id = u.record_id
+        LEFT JOIN commands ON commands.record_id = u.record_id
+        LEFT JOIN files ON files.record_id = u.record_id
+        LEFT JOIN turns ON turns.record_id = u.record_id
+        LEFT JOIN sources ON sources.record_id = u.record_id
+            __TARGET_U_RECORD__
+        """,
+        targeted=targeted,
+    )
+    conn.execute(
+        query,
+        {"facts_version": COMPRESSION_FACTS_VERSION},
+    )
+
+
+def _insert_sequence_facts(conn: sqlite3.Connection, *, targeted: bool = False) -> None:
+    populate_relevant_command_roots(conn)
+    query = target_mode_sql(
+        """
+        INSERT INTO compression_sequence_facts (
+            fact_key, record_id, thread_key, turn_key, source_order,
+            fact_kind, category,
+            status, duration_ms, output_size_bytes, command_label, exit_code,
+            retry_group, path_identity, exposure_tokens, facts_version
+        )
+        SELECT
+            'tool:' || t.tool_call_key,
+            t.record_id,
+            COALESCE(u.thread_key, u.thread_name, u.session_id),
+            t.turn_key,
+            t.rowid,
+            'tool_output',
+            t.tool_name,
+            t.status,
+            t.duration_ms,
+            t.output_size_bytes,
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            (t.output_size_bytes + 3) / 4,
+            :facts_version
+        FROM tool_calls AS t
+        JOIN usage_events AS u ON u.record_id = t.record_id
+        __TARGET_T_RECORD_AND__
+        t.output_size_bytes >= :min_tool_output_bytes
+        UNION ALL
+        SELECT
+            'command:' || c.command_run_key,
+            c.record_id,
+            COALESCE(u.thread_key, u.thread_name, u.session_id),
+            c.turn_key,
+            c.rowid,
+            'command',
+            c.command_root,
+            c.status,
+            NULL,
+            c.output_size_bytes,
+            c.command_root,
+            c.exit_code,
+            c.retry_group,
+            NULL,
+            (c.output_size_bytes + 3) / 4,
+            :facts_version
+        FROM command_runs AS c
+        JOIN usage_events AS u ON u.record_id = c.record_id
+        __TARGET_C_RECORD_AND__
+        c.command_root IN (
+            SELECT command_root FROM compression_relevant_command_roots
+        )
+        UNION ALL
+        SELECT
+            'file:' || f.file_event_key,
+            f.record_id,
+            COALESCE(u.thread_key, u.thread_name, u.session_id),
+            f.turn_key,
+            f.rowid,
+            'file_read',
+            f.path_hash,
+            NULL,
+            NULL,
+            0,
+            NULL,
+            NULL,
+            NULL,
+            f.path_hash,
+            0,
+            :facts_version
+        FROM file_events AS f
+        JOIN usage_events AS u ON u.record_id = f.record_id
+        __TARGET_F_RECORD_AND__
+        f.operation = 'read' AND f.path_hash <> ''
+        UNION ALL
+        SELECT
+            'content:' || f.record_id || ':' || f.turn_key,
+            f.record_id,
+            COALESCE(u.thread_key, u.thread_name, u.session_id),
+            f.turn_key,
+            MIN(f.rowid),
+            'content_turn',
+            '',
+            NULL,
+            NULL,
+            SUM(f.content_size_bytes),
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            SUM((f.content_size_bytes + 3) / 4),
+            :facts_version
+        FROM content_fragments AS f
+        JOIN usage_events AS u ON u.record_id = f.record_id
+        __TARGET_F_RECORD_AND__
+        f.turn_key IS NOT NULL
+        GROUP BY f.record_id, f.turn_key
+        """,
+        targeted=targeted,
+    )
+    conn.execute(
+        query,
+        {
+            "facts_version": COMPRESSION_FACTS_VERSION,
+            "min_tool_output_bytes": MIN_TOOL_OUTPUT_BYTES,
+        },
+    )
+
+
+def _update_record_manifests(conn: sqlite3.Connection, *, targeted: bool = False) -> None:
+    accumulators: dict[str, ManifestAccumulator] = {}
+    call_query = target_mode_sql(
+        """
+        SELECT
+            record_id, session_id, thread_key, event_timestamp, model, effort,
+            is_archived, thread_call_index, previous_record_id,
+            cached_input_tokens, uncached_input_tokens, output_tokens,
+            reasoning_output_tokens, cache_ratio, context_window_percent
+        FROM compression_record_facts
+        __TARGET_RECORD__
+        """,
+        targeted=targeted,
+    )
+    call_rows = conn.execute(
+        call_query,
+    )
+    for row in call_rows:
+        record_id = str(row[0])
+        accumulator = ManifestAccumulator()
+        accumulator.add("call", call_revision_identity(row))
+        accumulators[record_id] = accumulator
+
+    evidence_queries = (
+        (
+            "tool",
+            """
+            SELECT tool_call_key, record_id, turn_key, tool_name, status,
+                   duration_ms, output_size_bytes
+            FROM tool_calls
+            __TARGET_RECORD__
+            """,
+            tool_revision_identity,
+        ),
+        (
+            "command",
+            """
+            SELECT command_run_key, record_id, turn_key, command_root,
+                   command_root AS command_label, exit_code, status,
+                   output_size_bytes, retry_group
+            FROM command_runs
+            __TARGET_RECORD__
+            """,
+            command_revision_identity,
+        ),
+        (
+            "file",
+            """
+            SELECT file_event_key, record_id, turn_key, operation, path_hash,
+                   path_hash AS path_identity
+            FROM file_events
+            __TARGET_RECORD__
+            """,
+            file_revision_identity,
+        ),
+        (
+            "fragment",
+            """
+            SELECT fragment_id, record_id, turn_key, fragment_kind, role,
+                   fragment_kind AS safe_label, content_hash, content_size_bytes,
+                   includes_raw_fragment
+            FROM content_fragments
+            __TARGET_RECORD__
+            """,
+            fragment_revision_identity,
+        ),
+    )
+    for kind, query, identity_builder in evidence_queries:
+        scoped_query = target_mode_sql(query, targeted=targeted)
+        for row in conn.execute(scoped_query):
+            record_accumulator = accumulators.get(str(row[1]))
+            if record_accumulator is not None:
+                record_accumulator.add(kind, identity_builder(row))
+
+    conn.executemany(
+        """
+        UPDATE compression_record_facts
+        SET manifest_count = ?, manifest_sum_hex = ?, manifest_xor_hex = ?
+        WHERE record_id = ?
+        """,
+        (
+            (*accumulator.storage_values(), record_id)
+            for record_id, accumulator in accumulators.items()
+        ),
+    )
+
+
+def _insert_thread_facts(conn: sqlite3.Connection, *, targeted: bool = False) -> None:
+    query = target_mode_sql(
+        """
+        INSERT INTO compression_thread_facts (
+            manifest_key, thread_key, record_id, call_count, first_event_at,
+            last_event_at, cached_input_tokens, uncached_input_tokens,
+            output_tokens, reasoning_output_tokens, estimated_cost_usd,
+            usage_credits, cache_break_count, manifest_count, manifest_sum_hex,
+            manifest_xor_hex, manifest_revision, facts_version, updated_at
+        )
+        SELECT
+            'thread:' || r.thread_key,
+            r.thread_key,
+            '',
+            COUNT(*),
+            MIN(event_timestamp),
+            MAX(event_timestamp),
+            SUM(cached_input_tokens),
+            SUM(uncached_input_tokens),
+            SUM(output_tokens),
+            SUM(reasoning_output_tokens),
+            SUM(estimated_cost_usd),
+            SUM(usage_credits),
+            0,
+            SUM(manifest_count),
+            '',
+            '',
+            '',
+            :facts_version,
+            MAX(updated_at)
+        FROM compression_record_facts AS r
+        __TARGET_R_THREAD__
+        GROUP BY r.thread_key
+        """,
+        targeted=targeted,
+    )
+    conn.execute(
+        query,
+        {"facts_version": COMPRESSION_FACTS_VERSION},
+    )
+
+
+def _update_thread_manifests(conn: sqlite3.Connection, *, targeted: bool = False) -> None:
+    accumulators: dict[str, ManifestAccumulator] = {}
+    query = target_mode_sql(
+        """
+        SELECT r.record_id, r.thread_key, r.manifest_count, r.manifest_sum_hex,
+               r.manifest_xor_hex
+        FROM compression_record_facts AS r
+        __TARGET_R_THREAD__
+        """,
+        targeted=targeted,
+    )
+    for row in conn.execute(
+        query,
+    ):
+        thread_key = str(row[1])
+        manifest_key = f"thread:{thread_key}" if thread_key else f"record:{row[0]}"
+        accumulator = accumulators.setdefault(manifest_key, ManifestAccumulator())
+        accumulator.merge(ManifestAccumulator.from_storage(row[2], row[3], row[4]))
+
+    conn.executemany(
+        """
+        UPDATE compression_thread_facts
+        SET manifest_count = ?, manifest_sum_hex = ?, manifest_xor_hex = ?,
+            manifest_revision = ?
+        WHERE manifest_key = ?
+        """,
+        (
+            (*accumulator.storage_values(), accumulator.revision(), manifest_key)
+            for manifest_key, accumulator in accumulators.items()
+        ),
+    )

--- a/src/codex_usage_tracker/store/compression_schema.py
+++ b/src/codex_usage_tracker/store/compression_schema.py
@@ -4,6 +4,138 @@ from __future__ import annotations
 
 import sqlite3
 
+_COMPRESSION_FACT_INDEX_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS idx_compression_record_facts_scope "
+    "ON compression_record_facts(is_archived, event_timestamp, record_id)",
+    "CREATE INDEX IF NOT EXISTS idx_compression_record_facts_thread "
+    "ON compression_record_facts(thread_key, thread_call_index, event_timestamp, record_id)",
+    "CREATE INDEX IF NOT EXISTS idx_compression_sequence_facts_scope "
+    "ON compression_sequence_facts(fact_kind, thread_key, record_id, fact_key)",
+    "CREATE INDEX IF NOT EXISTS idx_compression_sequence_facts_category "
+    "ON compression_sequence_facts(fact_kind, category, thread_key, record_id)",
+    "CREATE INDEX IF NOT EXISTS idx_compression_thread_facts_activity "
+    "ON compression_thread_facts(last_event_at DESC, manifest_key)",
+)
+_COMPRESSION_FACT_INDEX_DROP_STATEMENTS = (
+    "DROP INDEX IF EXISTS idx_compression_record_facts_scope",
+    "DROP INDEX IF EXISTS idx_compression_record_facts_thread",
+    "DROP INDEX IF EXISTS idx_compression_sequence_facts_scope",
+    "DROP INDEX IF EXISTS idx_compression_sequence_facts_category",
+    "DROP INDEX IF EXISTS idx_compression_thread_facts_activity",
+)
+
+
+def create_compression_fact_tables(conn: sqlite3.Connection) -> None:
+    """Create detector-ready record, sequence, and thread fact tables."""
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS compression_record_facts (
+            record_id TEXT PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            thread_key TEXT NOT NULL DEFAULT '',
+            event_timestamp TEXT NOT NULL,
+            model TEXT,
+            effort TEXT,
+            is_archived INTEGER NOT NULL DEFAULT 0,
+            thread_call_index INTEGER,
+            previous_record_id TEXT,
+            cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            uncached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL,
+            usage_credits REAL,
+            cache_ratio REAL NOT NULL DEFAULT 0,
+            context_window_percent REAL NOT NULL DEFAULT 0,
+            turn_count INTEGER NOT NULL DEFAULT 0,
+            indexed_call INTEGER NOT NULL DEFAULT 0,
+            tool_call_count INTEGER NOT NULL DEFAULT 0,
+            command_run_count INTEGER NOT NULL DEFAULT 0,
+            file_event_count INTEGER NOT NULL DEFAULT 0,
+            content_fragment_count INTEGER NOT NULL DEFAULT 0,
+            compaction_count INTEGER NOT NULL DEFAULT 0,
+            source_record_count INTEGER NOT NULL DEFAULT 0,
+            parser_warning_record_count INTEGER NOT NULL DEFAULT 0,
+            parser_adapter TEXT,
+            parser_version TEXT,
+            content_exposure_tokens INTEGER NOT NULL DEFAULT 0,
+            tool_output_exposure_tokens INTEGER NOT NULL DEFAULT 0,
+            manifest_count INTEGER NOT NULL DEFAULT 0,
+            manifest_sum_hex TEXT NOT NULL DEFAULT '',
+            manifest_xor_hex TEXT NOT NULL DEFAULT '',
+            facts_version INTEGER NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(record_id) REFERENCES usage_events(record_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS compression_sequence_facts (
+            fact_key TEXT PRIMARY KEY,
+            record_id TEXT NOT NULL,
+            thread_key TEXT NOT NULL DEFAULT '',
+            turn_key TEXT,
+            source_order INTEGER NOT NULL,
+            fact_kind TEXT NOT NULL,
+            category TEXT NOT NULL,
+            status TEXT,
+            duration_ms INTEGER,
+            output_size_bytes INTEGER NOT NULL DEFAULT 0,
+            command_label TEXT,
+            exit_code INTEGER,
+            retry_group TEXT,
+            path_identity TEXT,
+            exposure_tokens INTEGER NOT NULL DEFAULT 0,
+            facts_version INTEGER NOT NULL,
+            FOREIGN KEY(record_id) REFERENCES usage_events(record_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS compression_thread_facts (
+            manifest_key TEXT PRIMARY KEY,
+            thread_key TEXT NOT NULL DEFAULT '',
+            record_id TEXT NOT NULL DEFAULT '',
+            call_count INTEGER NOT NULL DEFAULT 0,
+            first_event_at TEXT,
+            last_event_at TEXT,
+            cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            uncached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL,
+            usage_credits REAL,
+            cache_break_count INTEGER NOT NULL DEFAULT 0,
+            manifest_count INTEGER NOT NULL DEFAULT 0,
+            manifest_sum_hex TEXT NOT NULL DEFAULT '',
+            manifest_xor_hex TEXT NOT NULL DEFAULT '',
+            manifest_revision TEXT NOT NULL DEFAULT '',
+            facts_version INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS compression_fact_state (
+            singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+            facts_version INTEGER NOT NULL,
+            source_generation INTEGER NOT NULL,
+            record_count INTEGER NOT NULL DEFAULT 0,
+            sequence_count INTEGER NOT NULL DEFAULT 0,
+            thread_count INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+    create_compression_fact_indexes(conn)
+
+
+def create_compression_fact_indexes(conn: sqlite3.Connection) -> None:
+    """Create secondary indexes used by detector-ready fact queries."""
+    for statement in _COMPRESSION_FACT_INDEX_STATEMENTS:
+        conn.execute(statement)
+
+
+def drop_compression_fact_indexes(conn: sqlite3.Connection) -> None:
+    """Drop secondary fact indexes before an explicit full rebuild."""
+    for statement in _COMPRESSION_FACT_INDEX_DROP_STATEMENTS:
+        conn.execute(statement)
+
 
 def create_compression_run_tables(conn: sqlite3.Connection) -> None:
     """Create persistent run, candidate, and component-claim tables."""
@@ -138,6 +270,46 @@ def touch_compression_source_generation(conn: sqlite3.Connection) -> int:
         "UPDATE compression_source_state SET generation = generation + 1 WHERE singleton = 1"
     )
     return read_compression_source_generation(conn)
+
+
+def stamp_compression_fact_state(
+    conn: sqlite3.Connection,
+    *,
+    facts_version: int,
+) -> None:
+    """Record fact-table integrity counts at the current source generation."""
+    counts = conn.execute(
+        """
+        SELECT
+            (SELECT COUNT(*) FROM compression_record_facts),
+            (SELECT COUNT(*) FROM compression_sequence_facts),
+            (SELECT COUNT(*) FROM compression_thread_facts),
+            (SELECT COALESCE(MAX(updated_at), '') FROM compression_record_facts)
+        """
+    ).fetchone()
+    conn.execute(
+        """
+        INSERT INTO compression_fact_state (
+            singleton, facts_version, source_generation,
+            record_count, sequence_count, thread_count, updated_at
+        ) VALUES (1, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(singleton) DO UPDATE SET
+            facts_version = excluded.facts_version,
+            source_generation = excluded.source_generation,
+            record_count = excluded.record_count,
+            sequence_count = excluded.sequence_count,
+            thread_count = excluded.thread_count,
+            updated_at = excluded.updated_at
+        """,
+        (
+            facts_version,
+            read_compression_source_generation(conn),
+            int(counts[0]),
+            int(counts[1]),
+            int(counts[2]),
+            str(counts[3] or ""),
+        ),
+    )
 
 
 def _ensure_compression_storage(conn: sqlite3.Connection) -> None:

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -342,6 +342,37 @@ def _configured_parallel_content_index_workers() -> int | None:
         return None
 
 
+def _stream_content_rows(
+    conn: sqlite3.Connection,
+    *,
+    source_path: Path,
+    start_byte: int,
+    start_line: int,
+    usage_rows: dict[int, sqlite3.Row],
+) -> _StreamingContentAccumulator | None:
+    accumulator = _StreamingContentAccumulator()
+    try:
+        with source_path.open("rb") as handle:
+            if start_byte > 0:
+                handle.seek(start_byte)
+            for line_number, raw_line in enumerate(handle, start_line + 1):
+                decoded = _decode_content_envelope(raw_line)
+                if decoded is None:
+                    accumulator.parse_warnings += 1
+                    continue
+                envelope, payload = decoded
+                accumulator.consume(
+                    conn,
+                    envelope=envelope,
+                    payload=payload,
+                    line_number=line_number,
+                    usage_row=usage_rows.get(line_number),
+                )
+    except OSError:
+        return None
+    return accumulator
+
+
 def _index_content_for_source_file(
     conn: sqlite3.Connection,
     *,
@@ -368,25 +399,14 @@ def _index_content_for_source_file(
             source_files_to_replace=[str(source_path)],
             sync_fts=sync_fts,
         )
-    accumulator = _StreamingContentAccumulator()
-    try:
-        with source_path.open("rb") as handle:
-            if start_byte > 0:
-                handle.seek(start_byte)
-            for line_number, raw_line in enumerate(handle, start_line + 1):
-                decoded = _decode_content_envelope(raw_line)
-                if decoded is None:
-                    accumulator.parse_warnings += 1
-                    continue
-                envelope, payload = decoded
-                accumulator.consume(
-                    conn,
-                    envelope=envelope,
-                    payload=payload,
-                    line_number=line_number,
-                    usage_row=usage_rows.get(line_number),
-                )
-    except OSError:
+    accumulator = _stream_content_rows(
+        conn,
+        source_path=source_path,
+        start_byte=start_byte,
+        start_line=start_line,
+        usage_rows=usage_rows,
+    )
+    if accumulator is None:
         return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
 
     _flush_pending_content_rows(conn, accumulator.rows)

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -28,11 +28,12 @@ from codex_usage_tracker.store.api import (
     record_source_file_metadata,
     upsert_usage_events,
 )
-from codex_usage_tracker.store.connection import connect
-from codex_usage_tracker.store.content_index import (
-    ContentIndexPlan,
-    index_content_for_source_plans,
+from codex_usage_tracker.store.compression_fact_sync import (
+    content_index_plans,
+    sync_content_plan_compression_facts,
 )
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.content_index import index_content_for_source_plans
 from codex_usage_tracker.store.sources import (
     ParsedSourceFile,
     SourceParsePlan,
@@ -169,21 +170,15 @@ def refresh_usage_index(
         message="Updated source metadata",
     )
     if not aggregate_only:
+        content_plans = content_index_plans(parse_plans)
         with connect(db_path) as conn:
             init_db(conn)
             index_content_for_source_plans(
                 conn,
-                plans=(
-                    ContentIndexPlan(
-                        source_path=plan.path,
-                        replace_existing=plan.replace_existing,
-                        start_byte=plan.start_byte,
-                        start_line=plan.start_line,
-                    )
-                    for plan in parse_plans
-                ),
+                plans=content_plans,
                 progress_callback=progress_callback,
             )
+            sync_content_plan_compression_facts(conn, plans=content_plans)
     else:
         _emit_refresh_progress(
             progress_callback,

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -6,15 +6,15 @@ import sqlite3
 from collections.abc import Callable
 from datetime import datetime, timezone
 
+import codex_usage_tracker.store.compression_schema as compression_schema
 from codex_usage_tracker.core.schema import (
     USAGE_EVENT_COLUMN_NAMES,
     USAGE_EVENT_CREATE_COLUMNS_SQL,
     USAGE_EVENT_REPAIR_COLUMNS,
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
-from codex_usage_tracker.store.compression_schema import create_compression_run_tables
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -31,6 +31,7 @@ MIGRATION_NAMES = {
     13: "create normalized content index tables",
     14: "persist investigation run summaries",
     15: "persist compression analysis runs",
+    16: "persist compression detector facts",
 }
 CALL_ORIGIN_REPAIR_COLUMNS = {
     "call_initiator": "TEXT",
@@ -100,7 +101,8 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         (12, _migrate_v12),
         (13, _migrate_v13),
         (14, _migrate_v14),
-        (15, create_compression_run_tables),
+        (15, compression_schema.create_compression_run_tables),
+        (16, compression_schema.create_compression_fact_tables),
     )
 
 

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -157,7 +158,59 @@ def test_compression_lab_benchmark_with_normalized_evidence(tmp_path: Path) -> N
     assert payload["normalized_evidence_rows"] == 500
     assert payload["cold_build"]["candidate_count"] > 10
     assert payload["cold_build"]["peak_rss_mb"] <= 512
+    assert payload["max_evidence_detector_seconds"] > 0
+    assert (
+        payload["cold_build"]["stage_timings_seconds"]["detectors"]
+        <= payload["max_evidence_detector_seconds"]
+    )
     assert payload["threshold_failures"] == []
+
+    db_path = tmp_path / "compression-synthetic-100.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            DROP TABLE compression_fact_state;
+            DROP TABLE compression_thread_facts;
+            DROP TABLE compression_sequence_facts;
+            DROP TABLE compression_record_facts;
+            DELETE FROM schema_migrations WHERE version = 16;
+            PRAGMA user_version = 15;
+            """
+        )
+
+    fallback = _run_benchmark_json(
+        ["scripts/benchmark_compression_lab.py", "--run-db", str(db_path)]
+    )
+    prepared = _run_benchmark_json(
+        [
+            "scripts/benchmark_compression_lab.py",
+            "--prepare-facts-db",
+            str(db_path),
+        ],
+    )
+    assert prepared["record_count"] == 100
+    assert prepared["sequence_count"] > 0
+    assert set(prepared["stage_timings_seconds"]) == {
+        "init",
+        "clear",
+        "record_facts",
+        "record_manifests",
+        "sequence_facts",
+        "thread_facts",
+        "indexes",
+        "state",
+    }
+    fact_backed = _run_benchmark_json(
+        ["scripts/benchmark_compression_lab.py", "--run-db", str(db_path)]
+    )
+    assert (
+        fact_backed["cold_build"]["candidate_fingerprint"]
+        == fallback["cold_build"]["candidate_fingerprint"]
+    )
+    assert (
+        fact_backed["cold_build"]["profile_fingerprint"]
+        == fallback["cold_build"]["profile_fingerprint"]
+    )
 
 
 def _run_benchmark_json(args: list[str]) -> dict[str, Any]:

--- a/tests/compression/test_run_builder.py
+++ b/tests/compression/test_run_builder.py
@@ -46,7 +46,7 @@ def _use_snapshot(
 ) -> None:
     monkeypatch.setattr(
         run_builder,
-        "load_streaming_compression_evidence",
+        "load_fact_compression_evidence",
         lambda _db_path, _scope: _bundle(evidence),
     )
 
@@ -100,7 +100,7 @@ def test_build_compression_run_reuses_an_exact_persisted_cache_hit(
 
     monkeypatch.setattr(
         run_builder,
-        "load_streaming_compression_evidence",
+        "load_fact_compression_evidence",
         unexpected_evidence_load,
     )
     warm = run_builder.build_compression_run(
@@ -219,7 +219,7 @@ def test_appended_record_recomputes_only_its_affected_thread(
     db_path = tmp_path / "usage.sqlite3"
     monkeypatch.setattr(
         run_builder,
-        "load_streaming_compression_evidence",
+        "load_fact_compression_evidence",
         lambda _db_path, _scope: _bundle(next(snapshots)),
     )
     observed_scopes: list[set[str]] = []

--- a/tests/compression/test_streaming_evidence.py
+++ b/tests/compression/test_streaming_evidence.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+from codex_usage_tracker.compression import streaming_evidence as streaming_evidence_module
 from codex_usage_tracker.compression.detector_registry import default_detectors
 from codex_usage_tracker.compression.estimators import (
     build_estimator_index,
@@ -10,13 +12,20 @@ from codex_usage_tracker.compression.estimators import (
 )
 from codex_usage_tracker.compression.evidence import load_compression_evidence
 from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.run_builder import build_compression_run
 from codex_usage_tracker.compression.run_cache import record_manifest
 from codex_usage_tracker.compression.streaming_evidence import (
     load_streaming_compression_evidence,
 )
 from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.compression_fact_sync import (
+    sync_content_plan_compression_facts,
+)
+from codex_usage_tracker.store.compression_facts import backfill_compression_detector_facts
+from codex_usage_tracker.store.compression_schema import read_compression_source_generation
 from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.content_index_models import ContentIndexPlan
 from codex_usage_tracker.store.schema import init_db
 
 
@@ -28,6 +37,24 @@ def test_streaming_evidence_preserves_manifest_and_detector_output(tmp_path: Pat
 
     legacy = load_compression_evidence(db_path, scope)
     streamed = load_streaming_compression_evidence(db_path, scope, batch_size=2)
+    with connect(db_path) as conn:
+        backfill_compression_detector_facts(conn)
+        fact_indexes = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_compression_%_facts_%'"
+            )
+        }
+    assert {
+        "idx_compression_record_facts_scope",
+        "idx_compression_record_facts_thread",
+        "idx_compression_sequence_facts_scope",
+        "idx_compression_sequence_facts_category",
+        "idx_compression_thread_facts_activity",
+    } <= fact_indexes
+    fact_loader = getattr(streaming_evidence_module, "load_fact_compression_evidence", None)
+    assert fact_loader is not None, "fact-backed compression loader is missing"
+    fact_backed = fact_loader(db_path, scope)
 
     assert streamed.record_manifest == record_manifest(legacy)
     assert streamed.snapshot.coverage == legacy.coverage
@@ -36,6 +63,200 @@ def test_streaming_evidence_preserves_manifest_and_detector_output(tmp_path: Pat
     assert len(streamed.snapshot.tool_calls) < len(legacy.tool_calls)
     assert len(streamed.snapshot.content_fragments) < len(legacy.content_fragments)
     assert _detected_candidates(streamed.snapshot, scope) == _detected_candidates(legacy, scope)
+    assert fact_backed.snapshot == streamed.snapshot
+    assert fact_backed.record_manifest == streamed.record_manifest
+    assert _detected_candidates(fact_backed.snapshot, scope) == _detected_candidates(
+        streamed.snapshot, scope
+    )
+
+
+def test_v16_migration_defers_detector_fact_backfill(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(_usage_events(), db_path=db_path)
+    _seed_normalized_evidence(db_path)
+    expected_manifest = load_streaming_compression_evidence(
+        db_path, CompressionScope(include_archived=True)
+    ).record_manifest
+
+    with connect(db_path) as conn:
+        conn.executescript(
+            """
+            DROP TABLE compression_record_facts;
+            DROP TABLE compression_sequence_facts;
+            DROP TABLE compression_thread_facts;
+            DELETE FROM schema_migrations WHERE version = 16;
+            PRAGMA user_version = 15;
+            """
+        )
+        init_db(conn)
+        assert conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM compression_sequence_facts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM compression_thread_facts").fetchone()[0] == 0
+
+        backfill_compression_detector_facts(conn)
+        backfill_compression_detector_facts(conn)
+        record_count = conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        sequence_count = conn.execute("SELECT COUNT(*) FROM compression_sequence_facts").fetchone()[
+            0
+        ]
+        thread_count = conn.execute("SELECT COUNT(*) FROM compression_thread_facts").fetchone()[0]
+        thread_fact = conn.execute(
+            """
+            SELECT manifest_count, manifest_revision
+            FROM compression_thread_facts
+            WHERE manifest_key = 'thread:thread:one'
+            """
+        ).fetchone()
+
+    assert record_count == 3
+    assert sequence_count == 13
+    assert thread_count == 1
+    assert thread_fact is not None
+    assert thread_fact["manifest_count"] == 21
+    assert thread_fact["manifest_revision"] == expected_manifest["thread:thread:one"]["revision"]
+
+
+def test_usage_upsert_keeps_detector_facts_at_the_current_generation(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+
+    upsert_usage_events(_usage_events(), db_path=db_path)
+
+    with connect(db_path) as conn:
+        record_count = conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        state = conn.execute(
+            """
+            SELECT facts_version, source_generation
+            FROM compression_fact_state WHERE singleton = 1
+            """
+        ).fetchone()
+        generation = read_compression_source_generation(conn)
+
+    assert record_count == 3
+    assert state is not None
+    assert state["source_generation"] == generation
+
+
+def test_usage_append_only_rebuilds_the_affected_record_facts(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    events = _usage_events()
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TRIGGER protect_existing_compression_facts
+            BEFORE DELETE ON compression_record_facts
+            WHEN OLD.record_id != 'call-3'
+            BEGIN
+                SELECT RAISE(ABORT, 'existing fact was rebuilt');
+            END;
+            """
+        )
+
+    appended_at = "2026-07-10T10:03:00+00:00"
+    appended = replace(
+        events[-1],
+        record_id="call-3",
+        event_timestamp=appended_at,
+        line_number=4,
+        previous_record_id="call-2",
+        session_updated_at=appended_at,
+        thread_call_index=4,
+        turn_id="turn-3",
+        turn_timestamp=appended_at,
+    )
+    upsert_usage_events([appended], db_path=db_path)
+
+    with connect(db_path) as conn:
+        record_ids = {
+            str(row[0]) for row in conn.execute("SELECT record_id FROM compression_record_facts")
+        }
+    assert record_ids == {"call-0", "call-1", "call-2", "call-3"}
+
+
+def test_content_fact_sync_invalidates_an_exact_cached_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(_usage_events(), db_path=db_path)
+    _seed_normalized_evidence(db_path)
+    with connect(db_path) as conn:
+        backfill_compression_detector_facts(conn)
+
+    scope = CompressionScope(include_archived=True)
+    first = build_compression_run(db_path, scope)
+    with connect(db_path) as conn:
+        generation_before = read_compression_source_generation(conn)
+        conn.execute(
+            """
+            INSERT INTO content_fragments (
+                fragment_id, record_id, turn_key, fragment_kind, role, safe_label,
+                content_hash, content_size_bytes, fragment_text, includes_raw_fragment,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "fragment-cache-invalidation",
+                "call-2",
+                "turn-2",
+                "tool_output",
+                "tool",
+                "tool_output",
+                "hash-cache-invalidation",
+                20_000,
+                "",
+                0,
+                "2026-07-10T10:02:10+00:00",
+            ),
+        )
+        sync_content_plan_compression_facts(
+            conn,
+            plans=(ContentIndexPlan(source_path=Path("/tmp/synthetic/session.jsonl")),),
+        )
+        generation_after = read_compression_source_generation(conn)
+
+    second = build_compression_run(db_path, scope)
+    assert generation_after > generation_before
+    assert second["run_id"] != first["run_id"]
+    assert second["cache"]["mode"] != "exact"
+
+
+def test_source_replacement_removes_orphaned_detector_facts(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(_usage_events(), db_path=db_path)
+
+    upsert_usage_events(
+        [],
+        db_path=db_path,
+        replace_source_files=[Path("/tmp/synthetic/session.jsonl")],
+    )
+
+    with connect(db_path) as conn:
+        counts = {
+            table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in (
+                "compression_record_facts",
+                "compression_sequence_facts",
+                "compression_thread_facts",
+            )
+        }
+    assert counts == {
+        "compression_record_facts": 0,
+        "compression_sequence_facts": 0,
+        "compression_thread_facts": 0,
+    }
+
+
+def test_partial_sequence_facts_fall_back_to_streaming_evidence(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(_usage_events(), db_path=db_path)
+    _seed_normalized_evidence(db_path)
+    scope = CompressionScope(include_archived=True)
+    expected = load_streaming_compression_evidence(db_path, scope)
+    with connect(db_path) as conn:
+        backfill_compression_detector_facts(conn)
+        conn.execute("DELETE FROM compression_sequence_facts WHERE fact_key = 'command:rg-0'")
+
+    loaded = streaming_evidence_module.load_fact_compression_evidence(db_path, scope)
+    assert loaded.snapshot == expected.snapshot
+    assert loaded.record_manifest == expected.record_manifest
 
 
 def _detected_candidates(snapshot: Any, scope: CompressionScope) -> list[dict[str, Any]]:
@@ -204,5 +425,20 @@ def _seed_normalized_evidence(db_path: Path) -> None:
                 )
                 for index in range(3)
                 for part in range(2)
+            ]
+            + [
+                (
+                    "fragment-compaction-history",
+                    "call-2",
+                    "turn-2",
+                    "compaction_history",
+                    "system",
+                    "compaction_history",
+                    "hash-compaction-history",
+                    800,
+                    "",
+                    0,
+                    "2026-07-10T10:02:09+00:00",
+                )
             ],
         )

--- a/tests/store/test_compression_facts.py
+++ b/tests/store/test_compression_facts.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.store.api import refresh_usage_index, reset_usage_database
+from codex_usage_tracker.store.compression_facts import backfill_compression_detector_facts
+from codex_usage_tracker.store.compression_schema import (
+    read_compression_source_generation,
+)
+from codex_usage_tracker.store.connection import connect
+from tests.store_dashboard_helpers import (
+    _entry,
+    _make_codex_home,
+    _token_event,
+)
+
+
+def test_content_refresh_updates_detector_fact_exposure(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        fact_row = conn.execute(
+            """
+            SELECT SUM(content_exposure_tokens) AS content_exposure_tokens
+            FROM compression_record_facts
+            """
+        ).fetchone()
+        fact_state = conn.execute(
+            "SELECT source_generation FROM compression_fact_state WHERE singleton = 1"
+        ).fetchone()
+        source_generation = read_compression_source_generation(conn)
+
+    assert fact_row is not None
+    assert fact_row["content_exposure_tokens"] > 0
+    assert fact_state is not None
+    assert fact_state["source_generation"] == source_generation
+
+
+def test_append_refresh_does_not_rebuild_historical_detector_facts(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    source_path = next((codex_home / "sessions").glob("**/*.jsonl"))
+
+    with connect(db_path) as conn:
+        initial_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        )
+        conn.executescript(
+            """
+            CREATE TABLE protected_compression_facts (
+                record_id TEXT PRIMARY KEY
+            );
+            INSERT INTO protected_compression_facts
+            SELECT record_id FROM compression_record_facts;
+            CREATE TRIGGER protect_historical_compression_facts
+            BEFORE DELETE ON compression_record_facts
+            WHEN OLD.record_id IN (SELECT record_id FROM protected_compression_facts)
+            BEGIN
+                SELECT RAISE(ABORT, 'historical fact was rebuilt');
+            END;
+            """
+        )
+
+    with source_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "APPENDED FACT"}],
+                    },
+                )
+            )
+            + "\n"
+        )
+        handle.write(json.dumps(_token_event(8_000, 400)) + "\n")
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        final_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        )
+        fact_state = conn.execute(
+            "SELECT source_generation FROM compression_fact_state WHERE singleton = 1"
+        ).fetchone()
+        source_generation = read_compression_source_generation(conn)
+    assert final_count == initial_count + 1
+    assert fact_state is not None
+    assert fact_state["source_generation"] == source_generation
+
+
+def test_reset_clears_all_detector_fact_tables(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    reset_usage_database(db_path=db_path)
+
+    with connect(db_path) as conn:
+        counts = {
+            table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in (
+                "compression_record_facts",
+                "compression_sequence_facts",
+                "compression_thread_facts",
+                "compression_fact_state",
+            )
+        }
+    assert set(counts.values()) == {0}
+
+
+def test_failed_full_backfill_rolls_back_rows_and_indexes(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        original_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        )
+
+    def fail_after_record_facts(stage: str) -> None:
+        if stage == "record_facts":
+            raise RuntimeError("stop after record facts")
+
+    with (
+        pytest.raises(RuntimeError, match="stop after record facts"),
+        connect(db_path) as conn,
+    ):
+        backfill_compression_detector_facts(
+            conn,
+            stage_callback=fail_after_record_facts,
+        )
+
+    with connect(db_path) as conn:
+        restored_count = int(
+            conn.execute("SELECT COUNT(*) FROM compression_record_facts").fetchone()[0]
+        )
+        indexes = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_compression_%_facts_%'"
+            )
+        }
+    assert restored_count == original_count
+    assert "idx_compression_record_facts_scope" in indexes
+    assert "idx_compression_sequence_facts_scope" in indexes

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -79,28 +79,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "15"
+    assert meta["schema_version"] == "16"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 15
+    assert state["schema_version"] == 16
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-    ]
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 17))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -727,7 +711,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 15
+    assert user_version == 16
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -825,24 +809,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 15
-    assert [row["version"] for row in migrations] == [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-    ]
+    assert user_version == 16
+    assert [row["version"] for row in migrations] == list(range(1, 17))
 
 
 def test_latest_observed_usage_prefers_normal_codex_limit_pool(tmp_path: Path) -> None:

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -68,9 +68,9 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 15
+    assert state["schema_version"] == 16
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 16))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 17))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
@@ -101,7 +101,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "15"
+    assert metadata["schema_version"] == "16"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -130,8 +130,8 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
             "SELECT enabled FROM content_index_features WHERE feature_key = 'fts5'"
         ).fetchone()
 
-    assert versions == list(range(1, 16))
-    assert user_version == 15
+    assert versions == list(range(1, 17))
+    assert user_version == 16
     assert {
         "content_index_features",
         "conversation_turns",
@@ -143,6 +143,9 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
         "compression_runs",
         "compression_candidates",
         "compression_candidate_records",
+        "compression_record_facts",
+        "compression_sequence_facts",
+        "compression_thread_facts",
     } <= tables
     assert content_feature is not None
     if int(content_feature["enabled"]):


### PR DESCRIPTION
## Summary
- persist detector-ready record, sequence, thread, and manifest facts during store refreshes
- load validated facts with a guarded fallback to the CP2 evidence query
- cover migrations, incremental sync, replacement/reset cleanup, rollback, stale manifests, and canonical output equivalence
- extend the benchmark with fact preparation and stage timing evidence

## Performance
- synthetic 100k-call evidence + detectors: 2.237s (58.8% below CP1 baseline)
- synthetic warm run: 3.1ms
- real-data temporary-copy evidence + detectors: 15.473s vs 24.815s fallback (37.7% reduction)
- fact-backed and fallback candidate/profile fingerprints match exactly

## Verification
- Agent Maintainer precommit: PASS
- Agent Maintainer full: PASS
- pytest: 738 passed
- Ruff, Mypy, Tach, Bandit, Xenon, dashboard typecheck, and release checks: PASS

Closes #230