### PR TITLE
feat: add compression revision state

### DIFF
--- a/.agent-maintainer/change-plans/compression-detector-facts.md
+++ b/.agent-maintainer/change-plans/compression-detector-facts.md
@@ -1,7 +1,7 @@
 +++
 id = "compression-detector-facts"
 kind = "cohesive-migration"
-status = "active"
+status = "complete"
 base_ref = "origin/main"
 expires = 2026-07-27
 allowed_paths = [".agent-maintainer/change-plans/compression-detector-facts.md", "src/**", "tests/**", "docs/**", "scripts/benchmark_compression_lab.py"]

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -227,11 +227,13 @@ Exit gates:
 
 ### CP3: Detector-Ready Ingestion Aggregates
 
-Status: implementation complete; PR open
+Status: complete
 
 Issue: [#230](https://github.com/douglasmonsky/codex-usage-tracker/issues/230)
 
 PR: [#231](https://github.com/douglasmonsky/codex-usage-tracker/pull/231)
+
+Merge: `29f6cad`
 
 Deliverables:
 
@@ -258,7 +260,9 @@ Exit gates:
 
 ### CP4: Revision-State And Incremental Invalidation
 
-Status: pending
+Status: implementation complete; PR pending
+
+Issue: [#232](https://github.com/douglasmonsky/codex-usage-tracker/issues/232)
 
 Deliverables:
 
@@ -386,32 +390,51 @@ whole-pipeline timing or equivalence claim.
   329.156 MiB peak RSS; evidence loading plus detectors took 2.237 seconds,
   58.8 percent below CP1's 5.428-second baseline while preserving CP2's exact
   candidate and profile fingerprints.
+- 2026-07-13: CP3 merged through PR #231 at `29f6cad`. CP4 added schema v17
+  source checkpoints with byte/row cursors, per-source generations, device and
+  inode identity, and a bounded 64 KiB parsed-prefix tail hash. Append planning
+  now rejects truncation, rotation, parser drift, and larger in-place
+  replacements before trusting the previous byte cursor.
+- 2026-07-13: CP4 added detector-aware revision vectors for calls, threads,
+  tools, commands, files, and fragments. Exact cache lookup reads one compact
+  state row and hashes only dimensions consumed by the selected detectors;
+  unknown detector families fail closed to the complete vector. The estimator
+  policy revision remains part of every key, while derived cost/credit facts
+  stay nullable until an explicit rate-card-backed estimator consumes them.
+- 2026-07-13: The final 100,000-call CP4 benchmark preserved CP2/CP3's exact
+  candidate and profile fingerprints. Revision lookup median was 0.982 ms,
+  targeted aggregate append refresh was 0.376 seconds, and an actual one-event
+  JSONL append refresh was 19.8 ms. Cold analysis remained 3.935 seconds with
+  evidence plus detectors at 2.238 seconds and exact warm reuse at 3.302 ms.
+  Agent Perf run `20260713T070642Z-044ace6a` attributed the next material work
+  to fact folding and candidate/claim persistence, confirming CP5 as the next
+  optimization boundary.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/compression-detector-facts`
+Branch: `feature/compression-pricing-revision`
 
-CP2 merged through PR #228 at `980b954`. CP3 is committed at `83af336` and open
-for review in PR #231 after passing the precommit and full verifier profiles.
+CP3 merged through PR #231 at `29f6cad`. CP4 issue #232 is implemented locally
+and awaiting final review, commit, and PR.
 
 Validated behavior at this checkpoint:
 
-- Schema v16 creates detector fact tables without blocking ordinary commands on
-  a historical backfill.
-- Record, relevant sequence, and thread facts reproduce CP2 snapshots,
-  compaction coverage, manifests, candidates, and public profiles.
-- Usage and content-index writes refresh only affected records and threads; a
-  trigger-backed append test rejects accidental full record-fact rebuilds.
-- Incomplete, stale, or version-mismatched fact stores fail closed to the CP2
-  streaming loader.
-- Reset and source replacement explicitly clear affected facts rather than
-  relying on disabled SQLite foreign-key cascades.
-- A hidden benchmark preparation mode measures explicit normalized backfill
-  separately from cold analysis and warm reuse.
-- Public compression schema version remains 1 because CP3 changes only internal
-  evidence representation, not public profile or candidate contracts.
+- Schema v17 migrates existing source and compression-run tables additively.
+- Append plans verify stored device/inode identity and a bounded hash at the
+  prior parse boundary before reusing byte and parser-state cursors.
+- Source rows persist byte offsets, row counts, parser revision, bounded source
+  identity, and a generation that advances only when the parsed checkpoint
+  changes.
+- Compression writes advance only the affected call/thread or content fact
+  dimensions; reset and the compatibility generation API advance all dimensions.
+- Exact cache identity includes selected detector dependencies and estimator
+  policy revision without traversing record manifests.
+- Existing manifest comparison still scopes incremental detector work to changed
+  records and threads after a relevant revision changes.
+- Public compression schema version and candidate/profile payloads remain
+  unchanged.
 
 Latest CP3 real-data benchmark (`include_archived=true`, all-history scope):
 
@@ -423,6 +446,19 @@ Latest CP3 real-data benchmark (`include_archived=true`, all-history scope):
 - Reviewed exact warm profile: 4.219 ms.
 - Fact-backed and fallback runs produced identical candidate and stable public
   profile fingerprints.
+
+Latest CP4 synthetic gate (100,000 calls, 500,000 normalized evidence rows):
+
+- Revision lookup median: 0.982 ms against the 10 ms exit gate.
+- Targeted aggregate one-event append: 0.376 seconds against the 1 second gate.
+- Actual JSONL one-event append refresh: 19.8 ms, one source scanned and one
+  usage event inserted or updated.
+- Cold build: 3.935 seconds; evidence plus detectors: 2.238 seconds; warm exact
+  reuse: 3.302 ms; peak RSS: 330.359 MiB.
+- Canonical candidate fingerprint:
+  `566d9962a31e65cdf8b7a3cbba3be23992b4ceb5c457cd418226e33ff8e5cded`.
+- Canonical profile fingerprint:
+  `96afabe6c8cfdeea77c708570939c1157a43f333b0cfc49e6173f107861ceeeb`.
 
 Measured optimizations:
 
@@ -446,11 +482,10 @@ Measured optimizations:
 
 Resume in this order:
 
-1. Merge CP3 PR #231 after its remote checks pass, leaving `.idea/` unstaged.
-2. Start CP4 from updated `main` and add revision-aware invalidation, including
-   a pricing/rate-card revision before derived costs or credits are persisted.
-3. Land CP5 serially because candidate persistence consumes CP4 cache identity.
-4. Add CP6 only after a fresh profile identifies the dominant remaining
+1. Finish CP4 verification, leave `.idea/` unstaged, and merge the focused
+   revision-state PR.
+2. Land CP5 serially because candidate persistence consumes CP4 cache identity.
+3. Add CP6 only after a fresh profile identifies the dominant remaining
    first-build stages; explicit fact preparation is currently a measured
    parallelization/ingestion-time target.
 

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -260,9 +260,11 @@ Exit gates:
 
 ### CP4: Revision-State And Incremental Invalidation
 
-Status: implementation complete; PR pending
+Status: implementation complete; PR open
 
 Issue: [#232](https://github.com/douglasmonsky/codex-usage-tracker/issues/232)
+
+PR: [#233](https://github.com/douglasmonsky/codex-usage-tracker/pull/233)
 
 Deliverables:
 
@@ -416,8 +418,8 @@ Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
 Branch: `feature/compression-pricing-revision`
 
-CP3 merged through PR #231 at `29f6cad`. CP4 issue #232 is implemented locally
-and awaiting final review, commit, and PR.
+CP3 merged through PR #231 at `29f6cad`. CP4 is committed at `bf9bfdf` and open
+for review in PR #233 after passing the precommit and full verifier profiles.
 
 Validated behavior at this checkpoint:
 

--- a/scripts/benchmark_compression_lab.py
+++ b/scripts/benchmark_compression_lab.py
@@ -23,6 +23,11 @@ if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
 from benchmark_synthetic_history import _synthetic_events  # noqa: E402
+from compression_revision_benchmark import (  # noqa: E402
+    benchmark_revision_and_append,
+    benchmark_source_append,
+    revision_threshold_failures,
+)
 
 from codex_usage_tracker.compression.models import CompressionScope  # noqa: E402
 from codex_usage_tracker.compression.run_builder import build_compression_run  # noqa: E402
@@ -66,6 +71,7 @@ def main() -> int:
     )
     parser.add_argument("--max-peak-rss-mb", type=float)
     parser.add_argument("--with-normalized-evidence", action="store_true")
+    parser.add_argument("--benchmark-source-append", action="store_true")
     parser.add_argument("--run-db", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--prepare-facts-db", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
@@ -95,6 +101,10 @@ def main() -> int:
             with_normalized_evidence=args.with_normalized_evidence,
         )
         run_payload = _run_in_child(db_path)
+        revision_payload = benchmark_revision_and_append(db_path, rows=args.rows)
+        run_payload["revision_state"] = revision_payload
+        if args.benchmark_source_append:
+            run_payload["source_append_refresh"] = benchmark_source_append(db_dir)
         failures = _threshold_failures(
             run_payload,
             max_cold_seconds=args.max_cold_seconds,
@@ -460,6 +470,7 @@ def _threshold_failures(
     peak_rss_mb = float(payload["cold_build"]["peak_rss_mb"])
     if max_peak_rss_mb is not None and peak_rss_mb > max_peak_rss_mb:
         failures.append(f"cold_build.peak_rss_mb {peak_rss_mb:.3f} exceeded {max_peak_rss_mb:.3f}")
+    failures.extend(revision_threshold_failures(payload))
     return failures
 
 

--- a/scripts/compression_revision_benchmark.py
+++ b/scripts/compression_revision_benchmark.py
@@ -1,0 +1,113 @@
+"""Focused synthetic benchmarks for compression revision-state gates."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import statistics
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from benchmark_synthetic_history import (
+    _synthetic_events,
+    _synthetic_source_envelopes,
+    _synthetic_source_file,
+    _write_synthetic_source_logs,
+)
+
+from codex_usage_tracker.compression.detector_registry import DETECTOR_FAMILIES
+from codex_usage_tracker.compression.estimators import ESTIMATOR_POLICY_V1
+from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.compression_revisions import (
+    current_compression_revision_vector,
+)
+from codex_usage_tracker.store.refresh import refresh_usage_index
+
+MAX_REVISION_LOOKUP_SECONDS = 0.01
+MAX_APPEND_REFRESH_SECONDS = 1.0
+
+
+def benchmark_revision_and_append(db_path: Path, *, rows: int) -> dict[str, float]:
+    """Measure bounded revision reads and one targeted aggregate append."""
+    lookup_seconds: list[float] = []
+    for _index in range(9):
+        started = time.perf_counter()
+        current_compression_revision_vector(
+            db_path,
+            detector_families=DETECTOR_FAMILIES,
+            estimator_revision=ESTIMATOR_POLICY_V1.version,
+        )
+        lookup_seconds.append(time.perf_counter() - started)
+    append_db = db_path.with_name(f"{db_path.stem}-append{db_path.suffix}")
+    if append_db.exists():
+        append_db.unlink()
+    with sqlite3.connect(db_path) as source, sqlite3.connect(append_db) as target:
+        source.backup(target)
+    append_started = time.perf_counter()
+    try:
+        upsert_usage_events(
+            _synthetic_events(rows, rows + 1),
+            db_path=append_db,
+            refresh_links=True,
+        )
+        return {
+            "lookup_median_seconds": round(statistics.median(lookup_seconds), 6),
+            "append_refresh_seconds": round(time.perf_counter() - append_started, 6),
+        }
+    finally:
+        append_db.unlink(missing_ok=True)
+
+
+def benchmark_source_append(db_dir: Path) -> dict[str, Any]:
+    """Measure one real JSONL append after a representative indexed source."""
+    source_root = db_dir / "cp4-source-append"
+    source_db = db_dir / "cp4-source-append.sqlite3"
+    if source_root.exists():
+        shutil.rmtree(source_root)
+    if source_db.exists():
+        source_db.unlink()
+    _write_synthetic_source_logs(source_root, 499)
+    refresh_usage_index(codex_home=source_root, db_path=source_db)
+    target = _synthetic_source_file(source_root, 499, events_per_file=500)
+    turn_id = "turn-00000499"
+    with target.open("a", encoding="utf-8") as handle:
+        for envelope in _synthetic_source_envelopes(499, turn_id):
+            handle.write(json.dumps(envelope, separators=(",", ":"), sort_keys=True) + "\n")
+    started = time.perf_counter()
+    result = refresh_usage_index(codex_home=source_root, db_path=source_db)
+    return {
+        "seconds": round(time.perf_counter() - started, 6),
+        "parsed_events": result.parsed_events,
+        "inserted_or_updated_events": result.inserted_or_updated_events,
+        "scanned_files": result.scanned_files,
+    }
+
+
+def revision_threshold_failures(payload: Mapping[str, Any]) -> list[str]:
+    """Validate CP4 lookup and append timing gates."""
+    failures: list[str] = []
+    revision_state = payload["revision_state"]
+    revision_lookup = float(revision_state["lookup_median_seconds"])
+    if revision_lookup > MAX_REVISION_LOOKUP_SECONDS:
+        failures.append(
+            "revision_state.lookup_median_seconds "
+            f"{revision_lookup:.3f} exceeded {MAX_REVISION_LOOKUP_SECONDS:.3f}"
+        )
+    append_refresh = float(revision_state["append_refresh_seconds"])
+    if append_refresh > MAX_APPEND_REFRESH_SECONDS:
+        failures.append(
+            "revision_state.append_refresh_seconds "
+            f"{append_refresh:.3f} exceeded {MAX_APPEND_REFRESH_SECONDS:.3f}"
+        )
+    source_append = payload.get("source_append_refresh")
+    if isinstance(source_append, Mapping):
+        source_append_seconds = float(source_append["seconds"])
+        if source_append_seconds > MAX_APPEND_REFRESH_SECONDS:
+            failures.append(
+                "source_append_refresh.seconds "
+                f"{source_append_seconds:.3f} exceeded {MAX_APPEND_REFRESH_SECONDS:.3f}"
+            )
+    return failures

--- a/src/codex_usage_tracker/compression/estimators.py
+++ b/src/codex_usage_tracker/compression/estimators.py
@@ -95,7 +95,11 @@ class EstimatorIndex:
         group = (target.model, target.effort, claim.component)
         values = self._groups[claim.component].get(group, ())
         excluded_threads = tuple(sorted(set(draft.thread_keys)))
-        cache_key = (group, excluded_threads, ())
+        cache_key: tuple[_GroupKey, tuple[str, ...], tuple[str, ...]] = (
+            group,
+            excluded_threads,
+            (),
+        )
         cached = self._peer_cache.get(cache_key)
         if cached is not None:
             return cached

--- a/src/codex_usage_tracker/compression/run_builder.py
+++ b/src/codex_usage_tracker/compression/run_builder.py
@@ -39,9 +39,11 @@ from codex_usage_tracker.compression.streaming_evidence import (
     load_fact_compression_evidence,
 )
 from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
+from codex_usage_tracker.store.compression_revisions import (
+    current_compression_revision_vector,
+)
 from codex_usage_tracker.store.compression_runs import (
     create_compression_run,
-    current_compression_source_generation,
     find_compression_run,
     find_current_compression_profile,
     update_compression_run,
@@ -61,12 +63,19 @@ def build_compression_run(
     """Build, persist, and return one compact compression profile."""
     started = time.perf_counter()
     detectors = select_detectors(detector_families)
+    selected_families = tuple(detector.family for detector in detectors)
     detector_version = _detector_set_version(detectors)
     scope_hash = stable_scope_hash(scope)
-    source_generation = current_compression_source_generation(db_path)
+    revision_vector = current_compression_revision_vector(
+        db_path,
+        detector_families=selected_families,
+        estimator_revision=ESTIMATOR_POLICY_V1.version,
+    )
+    source_generation = revision_vector.generation
     cached_profile = _fast_cached_profile(
         db_path,
-        source_generation=source_generation,
+        revision_key=revision_vector.cache_key,
+        detector_families=selected_families,
         scope_hash=scope_hash,
         detector_version=detector_version,
         force=force,
@@ -97,6 +106,7 @@ def build_compression_run(
         source_generation=source_generation,
         coverage=snapshot.coverage.as_dict(),
         status="running",
+        revision_key=revision_vector.cache_key,
     )
     run_id = str(run["run_id"])
     warnings: list[dict[str, Any]] = []
@@ -209,7 +219,8 @@ def build_compression_run(
 def _fast_cached_profile(
     db_path: Path,
     *,
-    source_generation: int,
+    revision_key: str,
+    detector_families: Sequence[str],
     scope_hash: str,
     detector_version: str,
     force: bool,
@@ -218,7 +229,7 @@ def _fast_cached_profile(
         return None
     cached_profile = find_current_compression_profile(
         db_path,
-        source_generation=source_generation,
+        revision_key=revision_key,
         scope_hash=scope_hash,
         detector_set_version=detector_version,
         estimator_version=ESTIMATOR_POLICY_V1.version,
@@ -226,7 +237,12 @@ def _fast_cached_profile(
     )
     if cached_profile is None:
         return None
-    if current_compression_source_generation(db_path) != source_generation:
+    current_revision = current_compression_revision_vector(
+        db_path,
+        detector_families=detector_families,
+        estimator_revision=ESTIMATOR_POLICY_V1.version,
+    )
+    if current_revision.cache_key != revision_key:
         return None
     return public_profile(cached_profile, cache_mode="exact")
 

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -31,7 +31,7 @@ from codex_usage_tracker.store.compression_fact_sync import (
     delete_compression_facts_for_source_files,
     sync_compression_detector_facts,
 )
-from codex_usage_tracker.store.compression_schema import touch_compression_source_generation
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.content_index import (
     clear_content_index_rows,
@@ -187,7 +187,7 @@ def reset_usage_database(db_path: Path = DEFAULT_DB_PATH) -> dict[str, Any]:
         conn.execute("DELETE FROM thread_summaries")
         conn.execute("DELETE FROM source_files")
         conn.execute("DELETE FROM refresh_meta")
-        touch_compression_source_generation(conn)
+        touch_compression_revisions(conn)
     return {"db_path": str(db_path), "deleted_usage_events": deleted_rows}
 
 
@@ -522,7 +522,7 @@ def upsert_usage_events(
                 affected_thread_keys=affected_thread_keys,
             )
             if source_files_to_replace:
-                touch_compression_source_generation(conn)
+                touch_compression_revisions(conn, {"calls", "threads"})
                 sync_compression_detector_facts(
                     conn,
                     record_ids=(),
@@ -541,7 +541,7 @@ def upsert_usage_events(
             refresh_links=refresh_links,
             affected_thread_keys=affected_thread_keys,
         )
-        touch_compression_source_generation(conn)
+        touch_compression_revisions(conn, {"calls", "threads"})
         sync_compression_detector_facts(
             conn,
             record_ids=record_ids,

--- a/src/codex_usage_tracker/store/compression_fact_sync.py
+++ b/src/codex_usage_tracker/store/compression_fact_sync.py
@@ -13,9 +13,9 @@ from codex_usage_tracker.store.compression_facts import (
     _update_record_manifests,
     _update_thread_manifests,
 )
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.compression_schema import (
     stamp_compression_fact_state,
-    touch_compression_source_generation,
 )
 from codex_usage_tracker.store.content_index_models import ContentIndexPlan
 from codex_usage_tracker.store.sources import SourceParsePlan
@@ -90,7 +90,7 @@ def sync_content_plan_compression_facts(
     content_plans = tuple(plans)
     if not content_plans:
         return
-    touch_compression_source_generation(conn)
+    touch_compression_revisions(conn, {"commands", "files", "fragments", "tools"})
     record_ids: set[str] = set()
     for plan in content_plans:
         minimum_line = 0 if plan.replace_existing else plan.start_line + 1

--- a/src/codex_usage_tracker/store/compression_revisions.py
+++ b/src/codex_usage_tracker/store/compression_revisions.py
@@ -1,0 +1,136 @@
+"""Compact dependency revisions for Compression Lab cache invalidation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Collection, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store.compression_schema import (
+    create_compression_revision_tables,
+)
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+REVISION_DIMENSIONS = frozenset({"calls", "threads", "tools", "commands", "files", "fragments"})
+_DIMENSION_COLUMNS = {
+    "calls": "call_generation",
+    "threads": "thread_generation",
+    "tools": "tool_generation",
+    "commands": "command_generation",
+    "files": "file_generation",
+    "fragments": "fragment_generation",
+}
+_DETECTOR_DEPENDENCIES = {
+    "stale_context": frozenset({"calls", "threads"}),
+    "cache_break_resume": frozenset({"calls", "threads"}),
+    "file_rediscovery": frozenset({"calls", "threads", "files", "fragments"}),
+    "shell_retry": frozenset({"calls", "threads", "commands"}),
+    "validation_repetition": frozenset({"calls", "threads", "commands"}),
+    "tool_output_bloat": frozenset({"calls", "threads", "tools"}),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CompressionRevisionVector:
+    """One bounded cache identity plus its diagnostic global generation."""
+
+    generation: int
+    revisions: tuple[tuple[str, int], ...]
+    estimator_revision: str
+
+    @property
+    def cache_key(self) -> str:
+        payload = {
+            "estimator_revision": self.estimator_revision,
+            "revisions": self.revisions,
+        }
+        encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def current_compression_revision_vector(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    detector_families: Collection[str] | None,
+    estimator_revision: str,
+) -> CompressionRevisionVector:
+    """Read the detector-specific revision vector in one bounded database query."""
+    with connect(db_path) as conn:
+        init_db(conn)
+        return read_compression_revision_vector(
+            conn,
+            detector_families=detector_families,
+            estimator_revision=estimator_revision,
+        )
+
+
+def read_compression_revision_vector(
+    conn: sqlite3.Connection,
+    *,
+    detector_families: Collection[str] | None,
+    estimator_revision: str,
+) -> CompressionRevisionVector:
+    """Build a stable key from only the dimensions selected detectors consume."""
+    row = conn.execute("SELECT * FROM compression_revision_state WHERE singleton = 1").fetchone()
+    if row is None:
+        raise RuntimeError("compression revision state is missing")
+    dimensions = _detector_dimensions(detector_families)
+    revisions = tuple(
+        (dimension, int(row[_DIMENSION_COLUMNS[dimension]])) for dimension in sorted(dimensions)
+    )
+    return CompressionRevisionVector(
+        generation=int(row["generation"]),
+        revisions=revisions,
+        estimator_revision=estimator_revision,
+    )
+
+
+def touch_compression_revisions(
+    conn: sqlite3.Connection,
+    dimensions: Iterable[str] = REVISION_DIMENSIONS,
+) -> int:
+    """Advance the global revision and the explicitly affected dimensions."""
+    selected = frozenset(dimensions)
+    unknown = selected.difference(REVISION_DIMENSIONS)
+    if unknown:
+        raise ValueError(f"unknown compression revision dimensions: {sorted(unknown)}")
+    if not selected:
+        return _read_global_generation(conn)
+    create_compression_revision_tables(conn)
+    assignments = ["generation = generation + 1"]
+    assignments.extend(
+        f"{_DIMENSION_COLUMNS[dimension]} = {_DIMENSION_COLUMNS[dimension]} + 1"
+        for dimension in sorted(selected)
+    )
+    # Every identifier comes from the fixed dimension allowlist above.
+    conn.execute(
+        f"UPDATE compression_revision_state SET {', '.join(assignments)} WHERE singleton = 1"  # nosec B608
+    )
+    conn.execute(
+        "UPDATE compression_source_state SET generation = generation + 1 WHERE singleton = 1"
+    )
+    return _read_global_generation(conn)
+
+
+def _detector_dimensions(detector_families: Collection[str] | None) -> frozenset[str]:
+    if detector_families is None:
+        return REVISION_DIMENSIONS
+    dimensions: set[str] = set()
+    for family in detector_families:
+        dependencies = _DETECTOR_DEPENDENCIES.get(family)
+        if dependencies is None:
+            return REVISION_DIMENSIONS
+        dimensions.update(dependencies)
+    return frozenset(dimensions)
+
+
+def _read_global_generation(conn: sqlite3.Connection) -> int:
+    row = conn.execute(
+        "SELECT generation FROM compression_revision_state WHERE singleton = 1"
+    ).fetchone()
+    return int(row["generation"] if row is not None else 0)

--- a/src/codex_usage_tracker/store/compression_runs.py
+++ b/src/codex_usage_tracker/store/compression_runs.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any
 
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
-from codex_usage_tracker.store.compression_schema import read_compression_source_generation
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.schema import init_db
 
@@ -28,6 +27,7 @@ def create_compression_run(
     estimator_version: str,
     compression_schema_version: int,
     source_generation: int = 0,
+    revision_key: str = "",
     scope: Mapping[str, Any],
     run_id: str | None = None,
     status: str = "pending",
@@ -48,9 +48,10 @@ def create_compression_run(
                 run_id, status, source_revision, scope_hash,
                 detector_set_version, estimator_version, compression_schema_version,
                 scope_json, filters_json, coverage_json, progress_percent, stage,
-                source_generation, created_at, started_at, completed_at, last_accessed_at
+                source_generation, revision_key,
+                created_at, started_at, completed_at, last_accessed_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 resolved_run_id,
@@ -66,6 +67,7 @@ def create_compression_run(
                 100.0 if status in _CACHEABLE_STATUSES else 0.0,
                 "complete" if status in _CACHEABLE_STATUSES else status,
                 int(source_generation),
+                revision_key,
                 timestamp,
                 started_at,
                 completed_at,
@@ -162,17 +164,10 @@ def update_compression_run(
     return _decode_run(row) if row is not None else None
 
 
-def current_compression_source_generation(db_path: Path = DEFAULT_DB_PATH) -> int:
-    """Return the cheap generation used to invalidate exact compression caches."""
-    with connect(db_path) as conn:
-        init_db(conn)
-        return read_compression_source_generation(conn)
-
-
 def find_current_compression_profile(
     db_path: Path = DEFAULT_DB_PATH,
     *,
-    source_generation: int,
+    revision_key: str,
     scope_hash: str,
     detector_set_version: str,
     estimator_version: str,
@@ -185,7 +180,7 @@ def find_current_compression_profile(
             """
             SELECT run_id, public_profile_json
             FROM compression_runs
-            WHERE source_generation = ?
+            WHERE revision_key = ?
                 AND scope_hash = ?
                 AND detector_set_version = ?
                 AND estimator_version = ?
@@ -196,7 +191,7 @@ def find_current_compression_profile(
             LIMIT 1
             """,
             (
-                int(source_generation),
+                revision_key,
                 scope_hash,
                 detector_set_version,
                 estimator_version,

--- a/src/codex_usage_tracker/store/compression_schema.py
+++ b/src/codex_usage_tracker/store/compression_schema.py
@@ -3,6 +3,23 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
+
+MIGRATION_NAMES = {
+    15: "persist compression analysis runs",
+    16: "persist compression detector facts",
+    17: "persist compression revision state",
+}
+
+
+def schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None]], ...]:
+    """Return schema migrations owned by the compression domain."""
+    return (
+        (15, create_compression_run_tables),
+        (16, create_compression_fact_tables),
+        (17, create_compression_revision_tables),
+    )
+
 
 _COMPRESSION_FACT_INDEX_STATEMENTS = (
     "CREATE INDEX IF NOT EXISTS idx_compression_record_facts_scope "
@@ -165,6 +182,7 @@ def create_compression_run_tables(conn: sqlite3.Connection) -> None:
             aggregate_profile_json TEXT NOT NULL DEFAULT '{}',
             public_profile_json TEXT NOT NULL DEFAULT '{}',
             source_generation INTEGER NOT NULL DEFAULT 0,
+            revision_key TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL,
             started_at TEXT,
             completed_at TEXT,
@@ -255,6 +273,71 @@ def create_compression_run_tables(conn: sqlite3.Connection) -> None:
     )
 
 
+def create_compression_revision_tables(conn: sqlite3.Connection) -> None:
+    """Create bounded source checkpoints and detector dependency revisions."""
+    source_columns = {
+        str(row["name"]) for row in conn.execute("PRAGMA table_info(source_files)").fetchall()
+    }
+    source_additions = {
+        "parsed_prefix_tail_hash": "TEXT NOT NULL DEFAULT ''",
+        "parsed_row_count": "INTEGER NOT NULL DEFAULT 0",
+        "source_generation": "INTEGER NOT NULL DEFAULT 0",
+        "source_device": "INTEGER NOT NULL DEFAULT 0",
+        "source_inode": "INTEGER NOT NULL DEFAULT 0",
+    }
+    for column, definition in source_additions.items():
+        if column not in source_columns:
+            conn.execute(f"ALTER TABLE source_files ADD COLUMN {column} {definition}")
+
+    run_columns = {
+        str(row["name"]) for row in conn.execute("PRAGMA table_info(compression_runs)").fetchall()
+    }
+    if "revision_key" not in run_columns:
+        conn.execute(
+            "ALTER TABLE compression_runs ADD COLUMN revision_key TEXT NOT NULL DEFAULT ''"
+        )
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS compression_revision_state (
+            singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+            generation INTEGER NOT NULL DEFAULT 0,
+            call_generation INTEGER NOT NULL DEFAULT 0,
+            thread_generation INTEGER NOT NULL DEFAULT 0,
+            tool_generation INTEGER NOT NULL DEFAULT 0,
+            command_generation INTEGER NOT NULL DEFAULT 0,
+            file_generation INTEGER NOT NULL DEFAULT 0,
+            fragment_generation INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT OR IGNORE INTO compression_revision_state(singleton) VALUES (1);
+        UPDATE compression_revision_state
+        SET generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            call_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            thread_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            tool_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            command_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            file_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1),
+            fragment_generation = (SELECT generation FROM compression_source_state WHERE singleton = 1)
+        WHERE generation = 0
+          AND call_generation = 0
+          AND thread_generation = 0
+          AND tool_generation = 0
+          AND command_generation = 0
+          AND file_generation = 0
+          AND fragment_generation = 0;
+        CREATE INDEX IF NOT EXISTS idx_compression_runs_revision_cache
+        ON compression_runs(
+            revision_key,
+            scope_hash,
+            detector_set_version,
+            estimator_version,
+            compression_schema_version,
+            status,
+            completed_at DESC
+        );
+        """
+    )
+
+
 def read_compression_source_generation(conn: sqlite3.Connection) -> int:
     _ensure_compression_storage(conn)
     row = conn.execute(
@@ -265,11 +348,10 @@ def read_compression_source_generation(conn: sqlite3.Connection) -> int:
 
 def touch_compression_source_generation(conn: sqlite3.Connection) -> int:
     """Invalidate exact compression caches once per aggregate write transaction."""
+    from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
+
     _ensure_compression_storage(conn)
-    conn.execute(
-        "UPDATE compression_source_state SET generation = generation + 1 WHERE singleton = 1"
-    )
-    return read_compression_source_generation(conn)
+    return touch_compression_revisions(conn)
 
 
 def stamp_compression_fact_state(

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from codex_usage_tracker.store.compression_schema import touch_compression_source_generation
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.content_extract import (
     MAX_FRAGMENT_CHARS as MAX_FRAGMENT_CHARS,
 )
@@ -138,7 +138,7 @@ def index_content_for_source_plans(
             progress_callback=progress_callback,
         )
     if source_plans:
-        touch_compression_source_generation(conn)
+        touch_compression_revisions(conn, {"commands", "files", "fragments", "tools"})
     return result
 
 

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -14,7 +14,7 @@ from codex_usage_tracker.core.schema import (
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -30,8 +30,7 @@ MIGRATION_NAMES = {
     12: "persist source record provenance",
     13: "create normalized content index tables",
     14: "persist investigation run summaries",
-    15: "persist compression analysis runs",
-    16: "persist compression detector facts",
+    **compression_schema.MIGRATION_NAMES,
 }
 CALL_ORIGIN_REPAIR_COLUMNS = {
     "call_initiator": "TEXT",
@@ -101,8 +100,7 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         (12, _migrate_v12),
         (13, _migrate_v13),
         (14, _migrate_v14),
-        (15, compression_schema.create_compression_run_tables),
-        (16, compression_schema.create_compression_fact_tables),
+        *compression_schema.schema_migrations(),
     )
 
 

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.parser.state import (
@@ -19,6 +19,8 @@ from codex_usage_tracker.parser.state import (
     parser_state_from_json,
     parser_state_to_json,
 )
+
+_PREFIX_TAIL_BYTES = 64 * 1024
 
 
 @dataclass(frozen=True)
@@ -30,7 +32,7 @@ class SourceParsePlan:
     replace_existing: bool = True
 
 
-ParsedSourceFile = (
+ParsedSourceFile: TypeAlias = (
     tuple[Path, list[UsageEvent], dict[str, int], ParserState]
     | tuple[Path, list[UsageEvent], dict[str, int], ParserState, int]
 )
@@ -60,7 +62,9 @@ def _source_file_parse_row(conn: sqlite3.Connection, path: Path) -> sqlite3.Row 
     return conn.execute(
         """
         SELECT size_bytes, mtime_ns, parsed_until_line
-             , parsed_until_byte, parser_adapter, parser_state_json
+             , parsed_until_byte, parsed_prefix_tail_hash
+             , source_device, source_inode
+             , parser_adapter, parser_state_json
         FROM source_files
         WHERE source_file = ?
         """,
@@ -76,7 +80,7 @@ def _source_parse_plan_from_row(
         return SourceParsePlan(path=path)
     if _source_metadata_matches(row, metadata):
         return None
-    if _can_incrementally_parse_source(metadata, row):
+    if _can_incrementally_parse_source(path, metadata, row):
         return SourceParsePlan(
             path=path,
             start_byte=int(row["parsed_until_byte"]),
@@ -96,13 +100,22 @@ def _source_metadata_matches(row: sqlite3.Row, metadata: dict[str, int]) -> bool
     return (
         int(row["size_bytes"]) == metadata["size_bytes"]
         and int(row["mtime_ns"]) == metadata["mtime_ns"]
+        and int(row["source_device"]) == metadata["source_device"]
+        and int(row["source_inode"]) == metadata["source_inode"]
     )
 
 
-def _can_incrementally_parse_source(metadata: dict[str, int], row: sqlite3.Row) -> bool:
+def _can_incrementally_parse_source(path: Path, metadata: dict[str, int], row: sqlite3.Row) -> bool:
     previous_size = int(row["size_bytes"])
     previous_byte = int(row["parsed_until_byte"])
-    return 0 < previous_byte <= previous_size < metadata["size_bytes"]
+    expected_tail = str(row["parsed_prefix_tail_hash"] or "")
+    return (
+        0 < previous_byte <= previous_size < metadata["size_bytes"]
+        and int(row["source_device"]) == metadata["source_device"]
+        and int(row["source_inode"]) == metadata["source_inode"]
+        and bool(expected_tail)
+        and _parsed_prefix_tail_hash(path, previous_byte) == expected_tail
+    )
 
 
 def upsert_source_file_metadata(
@@ -142,6 +155,11 @@ def upsert_source_file_metadata(
         "mtime_ns",
         "parsed_until_line",
         "parsed_until_byte",
+        "parsed_prefix_tail_hash",
+        "parsed_row_count",
+        "source_generation",
+        "source_device",
+        "source_inode",
         "latest_record_id",
         "latest_event_timestamp",
         "parser_adapter",
@@ -151,8 +169,18 @@ def upsert_source_file_metadata(
     ]
     placeholders = ", ".join("?" for _column in columns)
     update_clause = ", ".join(
-        f"{column}=excluded.{column}" for column in columns if column != "source_file_id"
+        f"{column}=excluded.{column}"
+        for column in columns
+        if column not in {"source_file_id", "source_generation"}
     )
+    update_clause += """,
+        source_generation = source_files.source_generation + CASE
+            WHEN source_files.parsed_until_byte != excluded.parsed_until_byte
+              OR source_files.parsed_until_line != excluded.parsed_until_line
+              OR source_files.parsed_prefix_tail_hash != excluded.parsed_prefix_tail_hash
+              OR source_files.parser_adapter != excluded.parser_adapter
+            THEN 1 ELSE 0 END
+    """
     conn.executemany(
         (
             f"INSERT INTO source_files ({', '.join(columns)}) "
@@ -184,6 +212,8 @@ def _source_file_metadata_row(
     if metadata is None:
         return None
     latest_event = _latest_source_usage_event(events)
+    parsed_until_line = final_line_number or _count_lines(path)
+    parsed_until_byte = int(metadata["size_bytes"])
     return {
         "source_file_id": _source_file_id(path),
         "source_file": str(path),
@@ -191,8 +221,13 @@ def _source_file_metadata_row(
         "is_archived": int(metadata["is_archived"]),
         "size_bytes": int(metadata["size_bytes"]),
         "mtime_ns": int(metadata["mtime_ns"]),
-        "parsed_until_line": final_line_number or _count_lines(path),
-        "parsed_until_byte": int(metadata["size_bytes"]),
+        "parsed_until_line": parsed_until_line,
+        "parsed_until_byte": parsed_until_byte,
+        "parsed_prefix_tail_hash": _parsed_prefix_tail_hash(path, parsed_until_byte),
+        "parsed_row_count": parsed_until_line,
+        "source_generation": 1,
+        "source_device": int(metadata["source_device"]),
+        "source_inode": int(metadata["source_inode"]),
         "latest_record_id": _latest_source_record_id(latest_event, parser_state),
         "latest_event_timestamp": _latest_source_event_timestamp(latest_event, parser_state),
         "parser_adapter": PARSER_ADAPTER_VERSION,
@@ -238,6 +273,8 @@ def _source_file_metadata(path: Path) -> dict[str, int] | None:
     return {
         "size_bytes": int(stat.st_size),
         "mtime_ns": int(stat.st_mtime_ns),
+        "source_device": int(stat.st_dev),
+        "source_inode": int(stat.st_ino),
         "is_archived": _is_archived_source_file(path),
     }
 
@@ -253,6 +290,14 @@ def _source_file_id(path: Path) -> str:
 
 def _source_file_hash(path: Path) -> str:
     return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
+
+
+def _parsed_prefix_tail_hash(path: Path, parsed_until_byte: int) -> str:
+    start = max(0, parsed_until_byte - _PREFIX_TAIL_BYTES)
+    with path.open("rb") as handle:
+        handle.seek(start)
+        payload = handle.read(parsed_until_byte - start)
+    return hashlib.sha256(payload).hexdigest()
 
 
 def _count_lines(path: Path) -> int:

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -123,6 +123,8 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
     )
     assert payload["cold_build"]["stage_timings_seconds"]["evidence_loaded"] >= 0
     assert payload["warm_build"]["cache_mode"] == "exact"
+    assert payload["revision_state"]["lookup_median_seconds"] <= 0.01
+    assert payload["revision_state"]["append_refresh_seconds"] <= 1.0
     assert payload["threshold_failures"] == []
     assert (
         repeated["cold_build"]["candidate_fingerprint"]

--- a/tests/compression/test_run_builder.py
+++ b/tests/compression/test_run_builder.py
@@ -13,6 +13,7 @@ from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.compression.run_cache import record_manifest
 from codex_usage_tracker.compression.streaming_evidence import StreamingEvidenceBundle
 from codex_usage_tracker.store.compression_candidates import list_compression_candidates
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.compression_runs import get_compression_run
 from codex_usage_tracker.store.compression_schema import touch_compression_source_generation
 from codex_usage_tracker.store.connection import connect
@@ -97,6 +98,38 @@ def test_build_compression_run_reuses_an_exact_persisted_cache_hit(
 
     def unexpected_evidence_load(*_args: object, **_kwargs: object) -> None:
         raise AssertionError("exact cache hits must not rebuild normalized evidence")
+
+    monkeypatch.setattr(
+        run_builder,
+        "load_fact_compression_evidence",
+        unexpected_evidence_load,
+    )
+    warm = run_builder.build_compression_run(
+        db_path,
+        CompressionScope(),
+        detector_families=("stale_context",),
+    )
+
+    assert warm["run_id"] == cold["run_id"]
+    assert warm["cache"] == {"mode": "exact", "reused": True}
+
+
+def test_exact_cache_ignores_unrelated_detector_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    _use_snapshot(monkeypatch, _stale_snapshot("thread-a-1"))
+    cold = run_builder.build_compression_run(
+        db_path,
+        CompressionScope(),
+        detector_families=("stale_context",),
+    )
+    with connect(db_path) as conn:
+        touch_compression_revisions(conn, {"files"})
+
+    def unexpected_evidence_load(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("unrelated revisions must retain the exact cache hit")
 
     monkeypatch.setattr(
         run_builder,

--- a/tests/store/test_compression_revisions.py
+++ b/tests/store/test_compression_revisions.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from codex_usage_tracker.store.compression_revisions import (
+    read_compression_revision_vector,
+    touch_compression_revisions,
+)
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+
+def test_revision_key_tracks_only_selected_detector_dependencies(tmp_path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    with connect(db_path) as conn:
+        init_db(conn)
+        baseline = read_compression_revision_vector(
+            conn,
+            detector_families=("stale_context",),
+            estimator_revision="estimator-v1",
+        )
+        touch_compression_revisions(conn, {"files"})
+        unrelated = read_compression_revision_vector(
+            conn,
+            detector_families=("stale_context",),
+            estimator_revision="estimator-v1",
+        )
+        touch_compression_revisions(conn, {"calls"})
+        related = read_compression_revision_vector(
+            conn,
+            detector_families=("stale_context",),
+            estimator_revision="estimator-v1",
+        )
+
+    assert unrelated.generation == baseline.generation + 1
+    assert unrelated.cache_key == baseline.cache_key
+    assert related.cache_key != unrelated.cache_key
+
+
+def test_revision_key_changes_for_each_detector_specific_dependency(tmp_path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    cases = (
+        ("file_rediscovery", "files"),
+        ("shell_retry", "commands"),
+        ("validation_repetition", "commands"),
+        ("tool_output_bloat", "tools"),
+        ("cache_break_resume", "threads"),
+    )
+    with connect(db_path) as conn:
+        init_db(conn)
+        for detector_family, dimension in cases:
+            before = read_compression_revision_vector(
+                conn,
+                detector_families=(detector_family,),
+                estimator_revision="estimator-v1",
+            )
+            touch_compression_revisions(conn, {dimension})
+            after = read_compression_revision_vector(
+                conn,
+                detector_families=(detector_family,),
+                estimator_revision="estimator-v1",
+            )
+            assert after.cache_key != before.cache_key

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -79,12 +79,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "16"
+    assert meta["schema_version"] == "17"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 16
+    assert state["schema_version"] == 17
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 17))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 18))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -711,7 +711,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 16
+    assert user_version == 17
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -809,8 +809,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 16
-    assert [row["version"] for row in migrations] == list(range(1, 17))
+    assert user_version == 17
+    assert [row["version"] for row in migrations] == list(range(1, 18))
 
 
 def test_latest_observed_usage_prefers_normal_codex_limit_pool(tmp_path: Path) -> None:

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -68,9 +68,9 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 16
+    assert state["schema_version"] == 17
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 17))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 18))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
@@ -101,7 +101,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "16"
+    assert metadata["schema_version"] == "17"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -129,9 +129,24 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
         content_feature = conn.execute(
             "SELECT enabled FROM content_index_features WHERE feature_key = 'fts5'"
         ).fetchone()
+        source_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(source_files)").fetchall()
+        }
+        revision_columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(compression_revision_state)").fetchall()
+        }
 
-    assert versions == list(range(1, 17))
-    assert user_version == 16
+    assert versions == list(range(1, 18))
+    assert user_version == 17
+    assert {
+        "parsed_prefix_tail_hash",
+        "parsed_row_count",
+        "source_device",
+        "source_generation",
+        "source_inode",
+    } <= source_columns
+    assert {"call_generation", "command_generation", "file_generation"} <= revision_columns
     assert {
         "content_index_features",
         "conversation_turns",

--- a/tests/store/test_store_sources.py
+++ b/tests/store/test_store_sources.py
@@ -9,7 +9,6 @@ from typing import Any
 from codex_usage_tracker.parser.state import (
     PARSER_ADAPTER_VERSION,
     ParserState,
-    parser_state_to_json,
 )
 from codex_usage_tracker.store.schema import init_db
 from codex_usage_tracker.store.sources import (
@@ -54,17 +53,17 @@ def test_source_logs_requiring_parse_classifies_new_unchanged_and_append_only(
     grown_path = tmp_path / "grown.jsonl"
     new_path.write_text("{}\n", encoding="utf-8")
     unchanged_path.write_text("{}\n", encoding="utf-8")
-    grown_path.write_text("{}\n{}\n", encoding="utf-8")
+    grown_path.write_text("{}\n", encoding="utf-8")
     state = ParserState(session_id="session")
-    _insert_source_metadata(conn.connection, unchanged_path, state=state)
-    _insert_source_metadata(
+    upsert_source_file_metadata(
         conn.connection,
-        grown_path,
-        size_bytes=len("{}\n"),
-        parsed_until_byte=len("{}\n"),
-        parsed_until_line=1,
-        state=state,
+        parsed_files=[
+            (unchanged_path, [], {}, state),
+            (grown_path, [], {}, state),
+        ],
     )
+    with grown_path.open("a", encoding="utf-8") as handle:
+        handle.write("{}\n")
 
     plans = source_logs_requiring_parse(
         conn.connection,
@@ -78,6 +77,67 @@ def test_source_logs_requiring_parse_classifies_new_unchanged_and_append_only(
     assert by_path[grown_path].start_byte == len("{}\n")
     assert by_path[grown_path].start_line == 1
     assert by_path[grown_path].initial_state == state
+
+
+def test_source_logs_requiring_parse_rejects_larger_replacement(
+    tmp_path: Path,
+) -> None:
+    conn = _memory_db()
+    source_path = tmp_path / "rotated.jsonl"
+    source_path.write_text("first\n", encoding="utf-8")
+    state = ParserState(session_id="session")
+    upsert_source_file_metadata(
+        conn.connection,
+        parsed_files=[(source_path, [], {}, state)],
+    )
+    source_path.write_text("second\nreplacement\n", encoding="utf-8")
+
+    plans = source_logs_requiring_parse(conn.connection, [source_path])
+
+    assert len(plans) == 1
+    assert plans[0].replace_existing is True
+    assert plans[0].start_byte == 0
+    assert plans[0].start_line == 0
+
+
+def test_source_metadata_generation_advances_only_for_new_checkpoint(
+    tmp_path: Path,
+) -> None:
+    conn = _memory_db()
+    source_path = tmp_path / "events.jsonl"
+    source_path.write_text("{}\n", encoding="utf-8")
+    state = ParserState(session_id="session")
+
+    upsert_source_file_metadata(
+        conn.connection,
+        parsed_files=[(source_path, [], {}, state)],
+    )
+    first = conn.execute(
+        "SELECT source_generation FROM source_files WHERE source_file = ?",
+        (str(source_path),),
+    ).fetchone()
+    upsert_source_file_metadata(
+        conn.connection,
+        parsed_files=[(source_path, [], {}, state)],
+    )
+    unchanged = conn.execute(
+        "SELECT source_generation FROM source_files WHERE source_file = ?",
+        (str(source_path),),
+    ).fetchone()
+    with source_path.open("a", encoding="utf-8") as handle:
+        handle.write("{}\n")
+    upsert_source_file_metadata(
+        conn.connection,
+        parsed_files=[(source_path, [], {}, state)],
+    )
+    appended = conn.execute(
+        "SELECT source_generation FROM source_files WHERE source_file = ?",
+        (str(source_path),),
+    ).fetchone()
+
+    assert first["source_generation"] == 1
+    assert unchanged["source_generation"] == 1
+    assert appended["source_generation"] == 2
 
 
 def test_upsert_source_file_metadata_records_latest_event_and_parser_state(
@@ -118,6 +178,11 @@ def test_upsert_source_file_metadata_records_latest_event_and_parser_state(
     assert row["latest_event_timestamp"] == "2026-06-01T10:01:00Z"
     assert row["parsed_until_line"] == 2
     assert row["parsed_until_byte"] == source_path.stat().st_size
+    assert row["parsed_row_count"] == 2
+    assert row["source_device"] == source_path.stat().st_dev
+    assert row["source_inode"] == source_path.stat().st_ino
+    assert len(row["parsed_prefix_tail_hash"]) == 64
+    assert row["source_generation"] == 1
     assert row["parser_adapter"] == PARSER_ADAPTER_VERSION
     assert json.loads(row["parser_state_json"])["session_id"] == "session"
 
@@ -147,54 +212,3 @@ def test_upsert_source_file_metadata_uses_parser_state_when_no_events(
         "latest_record_id": "state-record",
         "latest_event_timestamp": "2026-06-01T09:00:00Z",
     }
-
-
-def _insert_source_metadata(
-    conn: sqlite3.Connection,
-    path: Path,
-    *,
-    state: ParserState,
-    size_bytes: int | None = None,
-    parsed_until_byte: int | None = None,
-    parsed_until_line: int = 0,
-) -> None:
-    stat = path.stat()
-    size = int(stat.st_size if size_bytes is None else size_bytes)
-    parsed_byte = int(size if parsed_until_byte is None else parsed_until_byte)
-    conn.execute(
-        """
-        INSERT INTO source_files (
-            source_file_id,
-            source_file,
-            source_file_hash,
-            is_archived,
-            size_bytes,
-            mtime_ns,
-            parsed_until_line,
-            parsed_until_byte,
-            latest_record_id,
-            latest_event_timestamp,
-            parser_adapter,
-            parser_diagnostics_json,
-            parser_state_json,
-            last_indexed_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            path.name,
-            str(path),
-            f"hash-{path.name}",
-            0,
-            size,
-            int(stat.st_mtime_ns),
-            parsed_until_line,
-            parsed_byte,
-            state.latest_record_id,
-            state.latest_event_timestamp,
-            PARSER_ADAPTER_VERSION,
-            "{}",
-            parser_state_to_json(state),
-            "2026-06-01T00:00:00+00:00",
-        ),
-    )


### PR DESCRIPTION
## Summary
- add schema-v17 source identity checkpoints that reject truncation, rotation, parser drift, and in-place replacement before append reuse
- add detector-aware revision vectors and estimator-policy cache identity without changing public compression payloads
- extend the compression benchmark with revision lookup and actual one-event JSONL append gates

## Performance
- revision lookup median: 0.982 ms
- aggregate one-event append refresh: 0.376 s
- actual JSONL one-event append refresh: 19.8 ms
- 100k-call cold build: 3.935 s
- exact warm reuse: 3.302 ms
- candidate and profile fingerprints unchanged

## Validation
- focused suite: 26 passed
- full test suite: 743 passed
- Agent Maintainer precommit: PASS
- Agent Maintainer full: PASS
- Ruff, mypy, Tach, Bandit, Vulture, release check, and staged diff checks pass

Closes #232