### PR TITLE
perf: optimize compression candidate publication

### DIFF
--- a/.agent-maintainer/change-plans/compression-candidate-persistence.md
+++ b/.agent-maintainer/change-plans/compression-candidate-persistence.md
@@ -1,0 +1,67 @@
++++
+id = "compression-candidate-persistence"
+kind = "cohesive-migration"
+status = "active"
+base_ref = "origin/main"
+expires = 2026-07-27
+allowed_paths = [".agent-maintainer/change-plans/compression-candidate-persistence.md", "src/codex_usage_tracker/compression/**", "src/codex_usage_tracker/store/compression_*.py", "tests/compression/**", "tests/store/test_compression_runs.py", "tests/store/test_compression_publication.py", "tests/cli/test_cli_benchmarks.py", "scripts/benchmark_compression_lab.py", "scripts/compression_*.py", "docs/compression-lab-roadmap.md", "docs/architecture/decisions/**", "src/codex_usage_tracker/compression/tach.domain.toml"]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 15
+max_changed_lines = 1800
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+# Cohesive Change Plan: compression-candidate-persistence
+
+## Why this change intentionally large
+
+CP5 replaces the candidate hot path from domain allocation through SQLite
+publication. The typed write contract, transaction boundary, run builder,
+rollback tests, benchmark, and roadmap evidence must change together so a
+completed profile can never reference a partial candidate generation.
+
+## Why this should not be split smaller
+
+The domain adapter contract and atomic writer are unsafe to land independently:
+without the writer the contract is unused, while without the contract the writer
+would retain the mapping round trip. The rollback tests and benchmark validate
+the same transaction boundary and must ship with it.
+
+## What allowed to change
+
+- Internal typed candidate and claim persistence rows.
+- Candidate replacement and completed-profile publication transactions.
+- Compression run construction at the persistence boundary.
+- Candidate-heavy benchmark timing and focused store/run-builder tests.
+- Compression roadmap status and measured evidence.
+- Tach policy and its ADR only if the implementation changes a domain boundary.
+
+## What must not change
+
+- Public candidate and profile payloads, fingerprints, IDs, ranking, and overlap
+  allocation.
+- Existing generic mapping-based store APIs used by compatibility callers.
+- MCP, CLI, dashboard, parser, pricing, privacy, and release behavior.
+- Revision-vector cache identity established by CP4.
+
+## Verification plan
+
+- Start with rollback tests that inject failures between candidate, claim, and
+  profile writes and prove no cacheable mixed-generation run is visible.
+- Compare typed and mapping persistence results and canonical fingerprints.
+- Measure a candidate-heavy persistence workload against the CP1-compatible
+  path and require at least a 40 percent improvement.
+- Run focused tests, Ruff, Mypy, Tach, the full Python suite, release checks,
+  and the full Agent Maintainer verifier before opening the PR.
+
+## Rollback plan
+
+Revert the CP5 squash commit. The schema remains compatible and the retained
+mapping API can continue writing the existing candidate and claim rows.
+
+## Follow-up ratchet work
+
+Keep publication and benchmark responsibilities in separate modules. CP6 must
+not expand this plan to cover parallel parsing, MCP contracts, or dashboard work.

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -260,11 +260,13 @@ Exit gates:
 
 ### CP4: Revision-State And Incremental Invalidation
 
-Status: implementation complete; PR open
+Status: complete
 
 Issue: [#232](https://github.com/douglasmonsky/codex-usage-tracker/issues/232)
 
 PR: [#233](https://github.com/douglasmonsky/codex-usage-tracker/pull/233)
+
+Merge: `0809875`
 
 Deliverables:
 
@@ -285,7 +287,9 @@ Exit gates:
 
 ### CP5: Candidate Persistence Pipeline
 
-Status: pending
+Status: implementation complete; PR pending
+
+Issue: [#234](https://github.com/douglasmonsky/codex-usage-tracker/issues/234)
 
 Deliverables:
 
@@ -411,15 +415,28 @@ whole-pipeline timing or equivalence claim.
   Agent Perf run `20260713T070642Z-044ace6a` attributed the next material work
   to fact folding and candidate/claim persistence, confirming CP5 as the next
   optimization boundary.
+- 2026-07-13: CP4 merged through PR #233 at `0809875`. CP5 replaced the hot
+  public-mapping round trip with a read-only structural write protocol. The
+  store consumes validated allocated candidates directly without importing the
+  compression domain, and bounded canonical-JSON caches reuse repeated detector
+  metadata while preserving decoded payloads and fingerprints.
+- 2026-07-13: Candidate rows, claim rows, prior-run supersession, and completed
+  aggregate/public profiles now publish in one SQLite transaction. Synthetic
+  claim failure proves rollback leaves the prior cacheable generation intact;
+  retry coverage proves the same run can publish cleanly after the fault clears.
+- 2026-07-13: The 100,000-call CP5 gate measured 44.884 percent faster
+  candidate-heavy persistence, 3.555-second cold analysis, and 3.737 ms exact
+  reuse. Candidate/profile fingerprints remained unchanged, one-event JSONL
+  append refresh remained 20.0 ms, and peak RSS fell to 320.484 MiB.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/compression-pricing-revision`
+Branch: `feature/compression-candidate-persistence`
 
-CP3 merged through PR #231 at `29f6cad`. CP4 is committed at `bf9bfdf` and open
-for review in PR #233 after passing the precommit and full verifier profiles.
+CP4 merged through PR #233 at `0809875`. CP5 issue #234 is implemented locally
+and awaiting final ratchet verification, commit, and PR.
 
 Validated behavior at this checkpoint:
 
@@ -437,6 +454,14 @@ Validated behavior at this checkpoint:
   records and threads after a relevant revision changes.
 - Public compression schema version and candidate/profile payloads remain
   unchanged.
+- Completed profiles and their candidate/claim generations publish atomically.
+- The compatibility mapping writer remains available for existing callers;
+  the run builder uses the structural typed path without `candidate.as_dict()`.
+- Bounded multi-row statements stay within SQLite's conservative variable
+  limit, while 4,096-entry canonical-JSON caches avoid repeated immutable-field
+  encoding.
+- Estimation still runs immediately after each detector while evidence is
+  resident. Global overlap allocation remains intentionally portfolio-wide.
 
 Latest CP3 real-data benchmark (`include_archived=true`, all-history scope):
 
@@ -462,6 +487,16 @@ Latest CP4 synthetic gate (100,000 calls, 500,000 normalized evidence rows):
 - Canonical profile fingerprint:
   `96afabe6c8cfdeea77c708570939c1157a43f333b0cfc49e6173f107861ceeeb`.
 
+Latest CP5 synthetic gate (100,000 calls, 500,000 normalized evidence rows):
+
+- Candidate-heavy 5,000-row mapping path: 192.169 ms; typed atomic path:
+  105.916 ms.
+- Persistence improvement: 44.884 percent against the 40 percent exit gate.
+- Cold build: 3.555 seconds; exact warm reuse: 3.737 ms; peak RSS: 320.484 MiB.
+- Revision lookup median: 0.989 ms; aggregate append: 0.295 seconds; actual
+  one-event JSONL append refresh: 20.0 ms.
+- Canonical candidate and profile fingerprints match CP2-CP4 exactly.
+
 Measured optimizations:
 
 - Removed quadratic claim-to-record membership validation during candidate estimation.
@@ -484,10 +519,9 @@ Measured optimizations:
 
 Resume in this order:
 
-1. Finish CP4 verification, leave `.idea/` unstaged, and merge the focused
-   revision-state PR.
-2. Land CP5 serially because candidate persistence consumes CP4 cache identity.
-3. Add CP6 only after a fresh profile identifies the dominant remaining
+1. Finish CP5 verification, leave `.idea/` unstaged, and merge the focused
+   candidate-persistence PR.
+2. Add CP6 only after a fresh profile identifies the dominant remaining
    first-build stages; explicit fact preparation is currently a measured
    parallelization/ingestion-time target.
 

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -287,9 +287,11 @@ Exit gates:
 
 ### CP5: Candidate Persistence Pipeline
 
-Status: implementation complete; PR pending
+Status: implementation complete; PR open
 
 Issue: [#234](https://github.com/douglasmonsky/codex-usage-tracker/issues/234)
+
+PR: [#235](https://github.com/douglasmonsky/codex-usage-tracker/pull/235)
 
 Deliverables:
 
@@ -435,8 +437,8 @@ Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
 Branch: `feature/compression-candidate-persistence`
 
-CP4 merged through PR #233 at `0809875`. CP5 issue #234 is implemented locally
-and awaiting final ratchet verification, commit, and PR.
+CP4 merged through PR #233 at `0809875`. CP5 is committed at `0fccb04` and open
+for review in PR #235 after passing the precommit and full verifier profiles.
 
 Validated behavior at this checkpoint:
 

--- a/scripts/benchmark_compression_lab.py
+++ b/scripts/benchmark_compression_lab.py
@@ -22,6 +22,7 @@ SRC_PATH = REPO_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
+import compression_persistence_benchmark as persistence_benchmark  # noqa: E402
 from benchmark_synthetic_history import _synthetic_events  # noqa: E402
 from compression_revision_benchmark import (  # noqa: E402
     benchmark_revision_and_append,
@@ -101,8 +102,10 @@ def main() -> int:
             with_normalized_evidence=args.with_normalized_evidence,
         )
         run_payload = _run_in_child(db_path)
-        revision_payload = benchmark_revision_and_append(db_path, rows=args.rows)
-        run_payload["revision_state"] = revision_payload
+        run_payload["revision_state"] = benchmark_revision_and_append(db_path, rows=args.rows)
+        run_payload["candidate_persistence"] = persistence_benchmark.benchmark_persistence(
+            db_path, rows=args.rows
+        )
         if args.benchmark_source_append:
             run_payload["source_append_refresh"] = benchmark_source_append(db_dir)
         failures = _threshold_failures(
@@ -471,6 +474,7 @@ def _threshold_failures(
     if max_peak_rss_mb is not None and peak_rss_mb > max_peak_rss_mb:
         failures.append(f"cold_build.peak_rss_mb {peak_rss_mb:.3f} exceeded {max_peak_rss_mb:.3f}")
     failures.extend(revision_threshold_failures(payload))
+    failures.extend(persistence_benchmark.persistence_threshold_failures(payload))
     return failures
 
 

--- a/scripts/compression_persistence_benchmark.py
+++ b/scripts/compression_persistence_benchmark.py
@@ -1,0 +1,182 @@
+"""Candidate-heavy benchmark helpers for Compression Lab CP5."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.compression.models import (
+    CandidateDraft,
+    ComponentClaim,
+    ComponentExposure,
+    CompressionCandidate,
+    EstimateRange,
+)
+from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
+from codex_usage_tracker.store.compression_publication import publish_compression_run
+from codex_usage_tracker.store.compression_runs import (
+    create_compression_run,
+    update_compression_run,
+)
+
+DEFAULT_MIN_IMPROVEMENT_PERCENT = 40.0
+
+
+def benchmark_persistence(db_path: Path, *, rows: int) -> dict[str, Any]:
+    """Compare CP1-compatible mapping writes with typed atomic publication."""
+    candidate_count = min(10_000, max(5_000, rows // 20))
+    candidates = tuple(_candidate(index) for index in range(candidate_count))
+    mapping_db = _copy_database(db_path, "mapping")
+    typed_db = _copy_database(db_path, "typed")
+    try:
+        _create_run(mapping_db, "benchmark-mapping")
+        _create_run(typed_db, "benchmark-typed")
+
+        mapping_started = time.perf_counter()
+        replace_compression_candidates(
+            mapping_db,
+            run_id="benchmark-mapping",
+            candidates=(candidate.as_dict() for candidate in candidates),
+        )
+        update_compression_run(
+            mapping_db,
+            run_id="benchmark-mapping",
+            status="completed",
+            progress_percent=100.0,
+            stage="complete",
+            completed_detectors=1,
+            total_detectors=1,
+            aggregate_profile={"candidate_count": candidate_count},
+            public_profile={"candidate_count": candidate_count},
+        )
+        mapping_seconds = time.perf_counter() - mapping_started
+
+        typed_started = time.perf_counter()
+        publish_compression_run(
+            typed_db,
+            run_id="benchmark-typed",
+            candidates=candidates,
+            status="completed",
+            completed_detectors=1,
+            total_detectors=1,
+            aggregate_profile={"candidate_count": candidate_count},
+            public_profile={"candidate_count": candidate_count},
+            source_generation=1,
+        )
+        typed_seconds = time.perf_counter() - typed_started
+
+        mapping_fingerprint = _candidate_fingerprint(mapping_db)
+        typed_fingerprint = _candidate_fingerprint(typed_db)
+        improvement = 100.0 * (mapping_seconds - typed_seconds) / mapping_seconds
+        return {
+            "candidate_count": candidate_count,
+            "mapping_seconds": round(mapping_seconds, 6),
+            "typed_seconds": round(typed_seconds, 6),
+            "improvement_percent": round(improvement, 3),
+            "equivalent": mapping_fingerprint == typed_fingerprint,
+            "candidate_fingerprint": typed_fingerprint,
+        }
+    finally:
+        mapping_db.unlink(missing_ok=True)
+        typed_db.unlink(missing_ok=True)
+
+
+def persistence_threshold_failures(payload: dict[str, Any]) -> list[str]:
+    benchmark = payload["candidate_persistence"]
+    failures: list[str] = []
+    if not bool(benchmark["equivalent"]):
+        failures.append("candidate_persistence outputs differed")
+    improvement = float(benchmark["improvement_percent"])
+    if improvement < DEFAULT_MIN_IMPROVEMENT_PERCENT:
+        failures.append(
+            "candidate_persistence.improvement_percent "
+            f"{improvement:.3f} was below {DEFAULT_MIN_IMPROVEMENT_PERCENT:.3f}"
+        )
+    return failures
+
+
+def _copy_database(db_path: Path, label: str) -> Path:
+    copy_path = db_path.with_name(f".{db_path.stem}-{label}-{uuid.uuid4().hex}.sqlite3")
+    with sqlite3.connect(db_path) as source, sqlite3.connect(copy_path) as target:
+        source.backup(target)
+    return copy_path
+
+
+def _create_run(db_path: Path, run_id: str) -> None:
+    create_compression_run(
+        db_path,
+        run_id=run_id,
+        source_revision="benchmark-revision",
+        scope_hash="benchmark-scope",
+        detector_set_version="benchmark-detectors",
+        estimator_version="benchmark-estimator",
+        compression_schema_version=1,
+        scope={"include_archived": True},
+        status="running",
+    )
+
+
+def _candidate(index: int) -> CompressionCandidate:
+    candidate_id = f"benchmark_candidate_{index:06d}"
+    record_id = f"benchmark_record_{index:06d}"
+    likely = 20 + index % 11
+    estimate = EstimateRange(low=10, likely=likely, high=40)
+    draft = CandidateDraft(
+        candidate_id=candidate_id,
+        family="benchmark",
+        pattern="Synthetic candidate persistence benchmark",
+        pattern_key=f"benchmark:{index:06d}",
+        detector_version="benchmark-v1",
+        estimator_version="benchmark-v1",
+        record_ids=(record_id,),
+        thread_keys=(f"thread-{index % 50}",),
+        observation_count=1,
+        observed_exposure=ComponentExposure(uncached_input=100),
+        claims=(
+            ComponentClaim(
+                record_id=record_id,
+                component="uncached_input",
+                exposure_tokens=100,
+                estimate=estimate,
+            ),
+        ),
+        gross_estimate=estimate,
+        confidence_grade="medium",
+        confidence_score=0.7,
+        confidence_reasons=("synthetic benchmark",),
+        estimator_tier="benchmark",
+        estimator_name="benchmark",
+        estimator_assumptions=("synthetic only",),
+        evidence_handles=({"record_id": record_id},),
+        intervention={"family": "benchmark"},
+        verification={"tool": "benchmark"},
+    )
+    return CompressionCandidate(draft=draft, adjusted_estimate=estimate)
+
+
+def _candidate_fingerprint(db_path: Path) -> str:
+    digest = hashlib.sha256()
+    with sqlite3.connect(db_path) as conn:
+        for row in conn.execute(
+            """
+            SELECT candidate_id, adjusted_low, adjusted_likely, adjusted_high
+            FROM compression_candidates
+            WHERE candidate_id LIKE 'benchmark_candidate_%'
+            ORDER BY candidate_id
+            """
+        ):
+            digest.update(repr(tuple(row)).encode())
+        for row in conn.execute(
+            """
+            SELECT candidate_id, record_id, component, estimate_low, estimate_likely, estimate_high
+            FROM compression_candidate_records
+            WHERE candidate_id LIKE 'benchmark_candidate_%'
+            ORDER BY candidate_id, record_id, component
+            """
+        ):
+            digest.update(repr(tuple(row)).encode())
+    return digest.hexdigest()

--- a/scripts/compression_persistence_benchmark.py
+++ b/scripts/compression_persistence_benchmark.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+import statistics
 import time
 import uuid
 from pathlib import Path
@@ -24,6 +25,7 @@ from codex_usage_tracker.store.compression_runs import (
 )
 
 DEFAULT_MIN_IMPROVEMENT_PERCENT = 40.0
+_BENCHMARK_ROUNDS = 3
 
 
 def benchmark_persistence(db_path: Path, *, rows: int) -> dict[str, Any]:
@@ -36,44 +38,24 @@ def benchmark_persistence(db_path: Path, *, rows: int) -> dict[str, Any]:
         _create_run(mapping_db, "benchmark-mapping")
         _create_run(typed_db, "benchmark-typed")
 
-        mapping_started = time.perf_counter()
-        replace_compression_candidates(
-            mapping_db,
-            run_id="benchmark-mapping",
-            candidates=(candidate.as_dict() for candidate in candidates),
-        )
-        update_compression_run(
-            mapping_db,
-            run_id="benchmark-mapping",
-            status="completed",
-            progress_percent=100.0,
-            stage="complete",
-            completed_detectors=1,
-            total_detectors=1,
-            aggregate_profile={"candidate_count": candidate_count},
-            public_profile={"candidate_count": candidate_count},
-        )
-        mapping_seconds = time.perf_counter() - mapping_started
-
-        typed_started = time.perf_counter()
-        publish_compression_run(
-            typed_db,
-            run_id="benchmark-typed",
-            candidates=candidates,
-            status="completed",
-            completed_detectors=1,
-            total_detectors=1,
-            aggregate_profile={"candidate_count": candidate_count},
-            public_profile={"candidate_count": candidate_count},
-            source_generation=1,
-        )
-        typed_seconds = time.perf_counter() - typed_started
+        mapping_timings: list[float] = []
+        typed_timings: list[float] = []
+        for _ in range(_BENCHMARK_ROUNDS):
+            _reset_candidate_rows(mapping_db)
+            mapping_timings.append(
+                _time_mapping_publication(mapping_db, candidates, candidate_count)
+            )
+            _reset_candidate_rows(typed_db)
+            typed_timings.append(_time_typed_publication(typed_db, candidates, candidate_count))
+        mapping_seconds = statistics.median(mapping_timings)
+        typed_seconds = statistics.median(typed_timings)
 
         mapping_fingerprint = _candidate_fingerprint(mapping_db)
         typed_fingerprint = _candidate_fingerprint(typed_db)
         improvement = 100.0 * (mapping_seconds - typed_seconds) / mapping_seconds
         return {
             "candidate_count": candidate_count,
+            "rounds": _BENCHMARK_ROUNDS,
             "mapping_seconds": round(mapping_seconds, 6),
             "typed_seconds": round(typed_seconds, 6),
             "improvement_percent": round(improvement, 3),
@@ -83,6 +65,57 @@ def benchmark_persistence(db_path: Path, *, rows: int) -> dict[str, Any]:
     finally:
         mapping_db.unlink(missing_ok=True)
         typed_db.unlink(missing_ok=True)
+
+
+def _time_mapping_publication(
+    db_path: Path,
+    candidates: tuple[CompressionCandidate, ...],
+    candidate_count: int,
+) -> float:
+    started = time.perf_counter()
+    replace_compression_candidates(
+        db_path,
+        run_id="benchmark-mapping",
+        candidates=(candidate.as_dict() for candidate in candidates),
+    )
+    update_compression_run(
+        db_path,
+        run_id="benchmark-mapping",
+        status="completed",
+        progress_percent=100.0,
+        stage="complete",
+        completed_detectors=1,
+        total_detectors=1,
+        aggregate_profile={"candidate_count": candidate_count},
+        public_profile={"candidate_count": candidate_count},
+    )
+    return time.perf_counter() - started
+
+
+def _time_typed_publication(
+    db_path: Path,
+    candidates: tuple[CompressionCandidate, ...],
+    candidate_count: int,
+) -> float:
+    started = time.perf_counter()
+    publish_compression_run(
+        db_path,
+        run_id="benchmark-typed",
+        candidates=candidates,
+        status="completed",
+        completed_detectors=1,
+        total_detectors=1,
+        aggregate_profile={"candidate_count": candidate_count},
+        public_profile={"candidate_count": candidate_count},
+        source_generation=1,
+    )
+    return time.perf_counter() - started
+
+
+def _reset_candidate_rows(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM compression_candidate_records")
+        conn.execute("DELETE FROM compression_candidates")
 
 
 def persistence_threshold_failures(payload: dict[str, Any]) -> list[str]:

--- a/src/codex_usage_tracker/compression/run_builder.py
+++ b/src/codex_usage_tracker/compression/run_builder.py
@@ -38,7 +38,7 @@ from codex_usage_tracker.compression.run_cache import (
 from codex_usage_tracker.compression.streaming_evidence import (
     load_fact_compression_evidence,
 )
-from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
+from codex_usage_tracker.store.compression_publication import publish_compression_run
 from codex_usage_tracker.store.compression_revisions import (
     current_compression_revision_vector,
 )
@@ -152,19 +152,6 @@ def build_compression_run(
             db_path,
             run_id,
             progress_callback,
-            stage="persistence",
-            percent=92.0,
-        )
-        replace_compression_candidates(
-            db_path,
-            run_id=run_id,
-            candidates=(candidate.as_dict() for candidate in candidates),
-            supersede_run_id=_superseded_run_id(exact, force=force),
-        )
-        _progress(
-            db_path,
-            run_id,
-            progress_callback,
             stage="profile",
             percent=97.0,
         )
@@ -183,12 +170,18 @@ def build_compression_run(
             estimator_index=estimator_index,
         )
         compact_profile = public_profile(stored_profile)
-        update_compression_run(
+        _progress(
+            db_path,
+            run_id,
+            progress_callback,
+            stage="persistence",
+            percent=98.0,
+        )
+        publish_compression_run(
             db_path,
             run_id=run_id,
+            candidates=candidates,
             status=status,
-            progress_percent=100.0,
-            stage="complete",
             completed_detectors=len(detectors) - len(warnings),
             total_detectors=len(detectors),
             cache_reused=cache_mode == "incremental",
@@ -197,6 +190,7 @@ def build_compression_run(
             aggregate_profile=stored_profile,
             public_profile=compact_profile,
             source_generation=source_generation,
+            supersede_run_id=_superseded_run_id(exact, force=force),
         )
         _emit(
             progress_callback,

--- a/src/codex_usage_tracker/store/compression_candidates.py
+++ b/src/codex_usage_tracker/store/compression_candidates.py
@@ -79,6 +79,15 @@ def replace_compression_candidates(
                 (supersede_run_id,),
             )
             conn.execute("DELETE FROM compression_runs WHERE run_id = ?", (supersede_run_id,))
+        conn.execute(
+            """
+            DELETE FROM compression_candidate_records
+            WHERE candidate_id IN (
+                SELECT candidate_id FROM compression_candidates WHERE run_id = ?
+            )
+            """,
+            (run_id,),
+        )
         conn.execute("DELETE FROM compression_candidates WHERE run_id = ?", (run_id,))
         conn.executemany(_CANDIDATE_INSERT_SQL, _candidate_rows(ordered, run_id=run_id))
         conn.executemany(_CLAIM_INSERT_SQL, _claim_rows(ordered))

--- a/src/codex_usage_tracker/store/compression_publication.py
+++ b/src/codex_usage_tracker/store/compression_publication.py
@@ -1,0 +1,382 @@
+"""Typed, atomic publication for completed Compression Lab runs."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from itertools import chain, islice
+from pathlib import Path
+from typing import Any, Protocol
+
+from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store.compression_candidates import (
+    _CANDIDATE_INSERT_SQL,
+    _CLAIM_INSERT_SQL,
+)
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+_CACHEABLE_STATUSES = frozenset({"completed", "completed_with_warnings"})
+
+
+class EstimateWrite(Protocol):
+    @property
+    def low(self) -> int: ...
+
+    @property
+    def likely(self) -> int: ...
+
+    @property
+    def high(self) -> int: ...
+
+
+class ExposureWrite(Protocol):
+    def as_dict(self) -> dict[str, int]: ...
+
+
+class ClaimWrite(Protocol):
+    @property
+    def record_id(self) -> str: ...
+
+    @property
+    def component(self) -> str: ...
+
+    @property
+    def exposure_tokens(self) -> int: ...
+
+    @property
+    def estimate(self) -> EstimateWrite: ...
+
+
+class CandidateDraftWrite(Protocol):
+    @property
+    def family(self) -> str: ...
+
+    @property
+    def pattern(self) -> str: ...
+
+    @property
+    def pattern_key(self) -> str: ...
+
+    @property
+    def confidence_grade(self) -> str: ...
+
+    @property
+    def confidence_score(self) -> float: ...
+
+    @property
+    def confidence_reasons(self) -> tuple[str, ...]: ...
+
+    @property
+    def observation_count(self) -> int: ...
+
+    @property
+    def observed_exposure(self) -> ExposureWrite: ...
+
+    @property
+    def gross_estimate(self) -> EstimateWrite: ...
+
+    @property
+    def detector_version(self) -> str: ...
+
+    @property
+    def estimator_version(self) -> str: ...
+
+    @property
+    def estimator_tier(self) -> str: ...
+
+    @property
+    def estimator_name(self) -> str: ...
+
+    @property
+    def estimator_assumptions(self) -> tuple[str, ...]: ...
+
+    @property
+    def evidence_handles(self) -> tuple[dict[str, Any], ...]: ...
+
+    @property
+    def intervention(self) -> dict[str, Any]: ...
+
+    @property
+    def verification(self) -> dict[str, Any]: ...
+
+    @property
+    def data_quality_warnings(self) -> tuple[str, ...]: ...
+
+    @property
+    def thread_keys(self) -> tuple[str, ...]: ...
+
+    @property
+    def first_seen(self) -> str | None: ...
+
+    @property
+    def last_seen(self) -> str | None: ...
+
+    @property
+    def claims(self) -> tuple[ClaimWrite, ...]: ...
+
+
+class CandidateWrite(Protocol):
+    @property
+    def candidate_id(self) -> str: ...
+
+    @property
+    def draft(self) -> CandidateDraftWrite: ...
+
+    @property
+    def adjusted_estimate(self) -> EstimateWrite: ...
+
+    @property
+    def overlapping_candidate_ids(self) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _RunCompletion:
+    status: str
+    completed_detectors: int
+    total_detectors: int
+    cache_reused: bool
+    timing: Mapping[str, Any]
+    error_summary: Mapping[str, Any]
+    aggregate_profile: Mapping[str, Any]
+    public_profile: Mapping[str, Any]
+    source_generation: int
+
+
+def publish_compression_run(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    run_id: str,
+    candidates: Iterable[CandidateWrite],
+    status: str,
+    completed_detectors: int,
+    total_detectors: int,
+    aggregate_profile: Mapping[str, Any],
+    public_profile: Mapping[str, Any],
+    source_generation: int,
+    cache_reused: bool = False,
+    timing: Mapping[str, Any] | None = None,
+    error_summary: Mapping[str, Any] | None = None,
+    supersede_run_id: str | None = None,
+) -> int:
+    """Atomically persist candidates, claims, and one cacheable profile."""
+    if status not in _CACHEABLE_STATUSES:
+        raise ValueError(f"publication status must be cacheable: {status}")
+    ordered = sorted(
+        candidates,
+        key=lambda candidate: (-candidate.adjusted_estimate.likely, candidate.candidate_id),
+    )
+    completion = _RunCompletion(
+        status=status,
+        completed_detectors=completed_detectors,
+        total_detectors=total_detectors,
+        cache_reused=cache_reused,
+        timing=timing or {},
+        error_summary=error_summary or {},
+        aggregate_profile=aggregate_profile,
+        public_profile=public_profile,
+        source_generation=source_generation,
+    )
+    with connect(db_path) as conn:
+        init_db(conn)
+        _replace_candidate_rows(
+            conn,
+            run_id=run_id,
+            candidates=ordered,
+            supersede_run_id=supersede_run_id or "",
+        )
+        _complete_run(conn, run_id=run_id, candidate_count=len(ordered), values=completion)
+    return len(ordered)
+
+
+def _replace_candidate_rows(
+    conn: sqlite3.Connection,
+    *,
+    run_id: str,
+    candidates: list[CandidateWrite],
+    supersede_run_id: str,
+) -> None:
+    if not _run_exists(conn, run_id):
+        raise KeyError(f"unknown compression run: {run_id}")
+    if supersede_run_id and supersede_run_id != run_id:
+        _delete_run(conn, supersede_run_id)
+    _delete_run_candidates(conn, run_id)
+    _bounded_insert(
+        conn,
+        _CANDIDATE_INSERT_SQL,
+        (
+            _candidate_row(candidate, run_id=run_id, rank=rank)
+            for rank, candidate in enumerate(candidates, 1)
+        ),
+        batch_size=25,
+    )
+    _bounded_insert(
+        conn,
+        _CLAIM_INSERT_SQL,
+        (
+            _claim_row(candidate.candidate_id, claim)
+            for candidate in candidates
+            for claim in candidate.draft.claims
+        ),
+        batch_size=100,
+    )
+
+
+def _complete_run(
+    conn: sqlite3.Connection,
+    *,
+    run_id: str,
+    candidate_count: int,
+    values: _RunCompletion,
+) -> None:
+    now = _utc_now()
+    updated = conn.execute(
+        """
+        UPDATE compression_runs
+        SET status = ?, progress_percent = 100.0, stage = 'complete',
+            current_detector = NULL, completed_detectors = ?, total_detectors = ?,
+            candidate_count = ?, cache_reused = ?, timing_json = ?,
+            error_summary_json = ?, aggregate_profile_json = ?, public_profile_json = ?,
+            source_generation = ?, completed_at = ?, last_accessed_at = ?
+        WHERE run_id = ?
+        """,
+        (
+            values.status,
+            int(values.completed_detectors),
+            int(values.total_detectors),
+            candidate_count,
+            int(values.cache_reused),
+            _json_dump(values.timing),
+            _json_dump(values.error_summary),
+            _json_dump(values.aggregate_profile),
+            _json_dump(values.public_profile),
+            int(values.source_generation),
+            now,
+            now,
+            run_id,
+        ),
+    )
+    if updated.rowcount != 1:
+        raise RuntimeError(f"compression run publication failed: {run_id}")
+
+
+def _delete_run_candidates(conn: sqlite3.Connection, run_id: str) -> None:
+    conn.execute(
+        """
+        DELETE FROM compression_candidate_records
+        WHERE candidate_id IN (
+            SELECT candidate_id FROM compression_candidates WHERE run_id = ?
+        )
+        """,
+        (run_id,),
+    )
+    conn.execute("DELETE FROM compression_candidates WHERE run_id = ?", (run_id,))
+
+
+def _candidate_row(candidate: CandidateWrite, *, run_id: str, rank: int) -> tuple[Any, ...]:
+    draft = candidate.draft
+    exposure = draft.observed_exposure.as_dict()
+    gross = draft.gross_estimate
+    adjusted = candidate.adjusted_estimate
+    return (
+        candidate.candidate_id,
+        run_id,
+        draft.family,
+        draft.pattern,
+        draft.pattern_key,
+        rank,
+        draft.confidence_grade,
+        draft.confidence_score,
+        draft.observation_count,
+        sum(exposure.values()),
+        _json_dump_int_items(tuple(exposure.items())),
+        gross.low,
+        gross.likely,
+        gross.high,
+        adjusted.low,
+        adjusted.likely,
+        adjusted.high,
+        draft.detector_version,
+        draft.estimator_version,
+        draft.estimator_tier,
+        draft.estimator_name,
+        _json_dump_strings(draft.confidence_reasons),
+        _json_dump_strings(draft.estimator_assumptions),
+        _json_dump(draft.evidence_handles),
+        _json_dump(draft.intervention),
+        _json_dump(draft.verification),
+        _json_dump_strings(draft.data_quality_warnings),
+        _json_dump_strings(candidate.overlapping_candidate_ids),
+        _json_dump_strings(draft.thread_keys),
+        draft.first_seen,
+        draft.last_seen,
+    )
+
+
+def _claim_row(candidate_id: str, claim: ClaimWrite) -> tuple[Any, ...]:
+    return (
+        candidate_id,
+        claim.record_id,
+        claim.component,
+        claim.exposure_tokens,
+        claim.estimate.low,
+        claim.estimate.likely,
+        claim.estimate.high,
+        "supporting",
+        _json_dump({"record_id": claim.record_id}),
+    )
+
+
+def _delete_run(conn: sqlite3.Connection, run_id: str) -> None:
+    _delete_run_candidates(conn, run_id)
+    conn.execute("DELETE FROM compression_runs WHERE run_id = ?", (run_id,))
+
+
+def _run_exists(conn: sqlite3.Connection, run_id: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM compression_runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _bounded_insert(
+    conn: sqlite3.Connection,
+    single_row_sql: str,
+    rows: Iterable[tuple[Any, ...]],
+    *,
+    batch_size: int,
+) -> None:
+    """Insert bounded batches without exceeding SQLite's conservative variable limit."""
+    prefix, placeholder = single_row_sql.rsplit("VALUES", maxsplit=1)
+    iterator = iter(rows)
+    while batch := tuple(islice(iterator, batch_size)):
+        values_sql = ",".join(placeholder.strip() for _ in batch)
+        conn.execute(  # nosec B608 - SQL templates are fixed module constants.
+            f"{prefix}VALUES {values_sql}",
+            tuple(chain.from_iterable(batch)),
+        )
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+@lru_cache(maxsize=4_096)
+def _json_dump_strings(values: tuple[str, ...]) -> str:
+    return _json_dump(values)
+
+
+@lru_cache(maxsize=4_096)
+def _json_dump_int_items(values: tuple[tuple[str, int], ...]) -> str:
+    return _json_dump(dict(values))
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -125,6 +125,8 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
     assert payload["warm_build"]["cache_mode"] == "exact"
     assert payload["revision_state"]["lookup_median_seconds"] <= 0.01
     assert payload["revision_state"]["append_refresh_seconds"] <= 1.0
+    assert payload["candidate_persistence"]["equivalent"] is True
+    assert payload["candidate_persistence"]["improvement_percent"] >= 40.0
     assert payload["threshold_failures"] == []
     assert (
         repeated["cold_build"]["candidate_fingerprint"]
@@ -253,6 +255,10 @@ def _run_benchmark_json(args: list[str]) -> dict[str, Any]:
 
 def _subprocess_env() -> dict[str, str]:
     env = dict(os.environ)
+    env.pop("COVERAGE_PROCESS_START", None)
+    for key in tuple(env):
+        if key.startswith("COV_CORE_"):
+            env.pop(key)
     repo_root = Path(__file__).resolve().parents[2]
     src_path = str(repo_root / "src")
     env["PYTHONPATH"] = (

--- a/tests/compression/test_run_builder.py
+++ b/tests/compression/test_run_builder.py
@@ -9,7 +9,7 @@ import pytest
 
 from codex_usage_tracker.compression import run_builder
 from codex_usage_tracker.compression.context_detectors import StaleContextDetector
-from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.models import CompressionCandidate, CompressionScope
 from codex_usage_tracker.compression.run_cache import record_manifest
 from codex_usage_tracker.compression.streaming_evidence import StreamingEvidenceBundle
 from codex_usage_tracker.store.compression_candidates import list_compression_candidates
@@ -81,6 +81,27 @@ def test_build_compression_run_persists_profile_candidates_and_progress(
     assert stored["candidate_count"] == 1
     page = list_compression_candidates(db_path, run_id=profile["run_id"])
     assert page["total"] == 1
+
+
+def test_build_compression_run_does_not_serialize_candidates_before_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    _use_snapshot(monkeypatch, _stale_snapshot("thread-a-1"))
+
+    def unexpected_serialization(candidate: CompressionCandidate) -> dict[str, Any]:
+        raise AssertionError(f"unexpected candidate serialization: {candidate.candidate_id}")
+
+    monkeypatch.setattr(CompressionCandidate, "as_dict", unexpected_serialization)
+
+    profile = run_builder.build_compression_run(
+        db_path,
+        CompressionScope(),
+        detector_families=("stale_context",),
+    )
+
+    assert profile["candidate_count"] == 1
 
 
 def test_build_compression_run_reuses_an_exact_persisted_cache_hit(

--- a/tests/store/test_compression_publication.py
+++ b/tests/store/test_compression_publication.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.store.compression_candidates import (
+    get_compression_candidate,
+    replace_compression_candidates,
+)
+from codex_usage_tracker.store.compression_publication import publish_compression_run
+from codex_usage_tracker.store.compression_runs import (
+    create_compression_run,
+    get_compression_run,
+    update_compression_run,
+)
+from tests.store.test_compression_runs import cache_key, candidate
+
+
+def test_typed_publication_matches_mapping_candidate_detail(tmp_path: Path) -> None:
+    mapping_db = tmp_path / "mapping.sqlite3"
+    typed_db = tmp_path / "typed.sqlite3"
+    model = candidate("cmp_typed", likely=80)
+    create_compression_run(mapping_db, run_id="mapping", **cache_key("rev-1"))
+    create_compression_run(typed_db, run_id="typed", **cache_key("rev-1"))
+
+    replace_compression_candidates(
+        mapping_db,
+        run_id="mapping",
+        candidates=[model.as_dict()],
+    )
+    publish_compression_run(
+        typed_db,
+        run_id="typed",
+        candidates=[model],
+        status="completed",
+        completed_detectors=1,
+        total_detectors=1,
+        aggregate_profile={"run_id": "typed", "candidate_count": 1},
+        public_profile={"run_id": "typed", "candidate_count": 1},
+        source_generation=3,
+    )
+
+    mapping_detail = get_compression_candidate(mapping_db, candidate_id="cmp_typed")
+    typed_detail = get_compression_candidate(typed_db, candidate_id="cmp_typed")
+    assert mapping_detail is not None and typed_detail is not None
+    mapping_detail.pop("run_id")
+    typed_detail.pop("run_id")
+    assert typed_detail == mapping_detail
+    run = get_compression_run(typed_db, run_id="typed")
+    assert run is not None
+    assert run["status"] == "completed"
+    assert run["candidate_count"] == 1
+    assert run["public_profile"] == {"run_id": "typed", "candidate_count": 1}
+
+
+def test_publication_rolls_back_supersede_and_can_retry(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    old_model = candidate("cmp_old", likely=70)
+    new_model = candidate("cmp_new", likely=80)
+    create_compression_run(db_path, run_id="old", **cache_key("rev-1"))
+    replace_compression_candidates(
+        db_path,
+        run_id="old",
+        candidates=[old_model.as_dict()],
+    )
+    update_compression_run(
+        db_path,
+        run_id="old",
+        status="completed",
+        aggregate_profile={"run_id": "old"},
+        public_profile={"run_id": "old"},
+    )
+    create_compression_run(db_path, run_id="new", status="running", **cache_key("rev-2"))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER fail_compression_claim
+            BEFORE INSERT ON compression_candidate_records
+            BEGIN
+                SELECT RAISE(ABORT, 'synthetic claim failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="synthetic claim failure"):
+        publish_compression_run(
+            db_path,
+            run_id="new",
+            candidates=[new_model],
+            status="completed",
+            completed_detectors=1,
+            total_detectors=1,
+            aggregate_profile={"run_id": "new"},
+            public_profile={"run_id": "new"},
+            source_generation=4,
+            supersede_run_id="old",
+        )
+
+    old_run = get_compression_run(db_path, run_id="old")
+    new_run = get_compression_run(db_path, run_id="new")
+    assert old_run is not None and old_run["status"] == "completed"
+    assert new_run is not None and new_run["status"] == "running"
+    assert get_compression_candidate(db_path, candidate_id="cmp_old") is not None
+    assert get_compression_candidate(db_path, candidate_id="cmp_new") is None
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TRIGGER fail_compression_claim")
+    publish_compression_run(
+        db_path,
+        run_id="new",
+        candidates=[new_model],
+        status="completed",
+        completed_detectors=1,
+        total_detectors=1,
+        aggregate_profile={"run_id": "new"},
+        public_profile={"run_id": "new"},
+        source_generation=4,
+        supersede_run_id="old",
+    )
+
+    assert get_compression_run(db_path, run_id="old") is None
+    assert get_compression_candidate(db_path, candidate_id="cmp_old") is None
+    assert get_compression_candidate(db_path, candidate_id="cmp_new") is not None

--- a/tests/store/test_compression_runs.py
+++ b/tests/store/test_compression_runs.py
@@ -88,6 +88,7 @@ def test_candidate_replace_lists_compact_rows_and_reconstructs_detail(tmp_path: 
     ]
 
     assert replace_compression_candidates(db_path, run_id="run-1", candidates=candidates) == 2
+    assert replace_compression_candidates(db_path, run_id="run-1", candidates=candidates) == 2
 
     page = list_compression_candidates(
         db_path,


### PR DESCRIPTION
## Summary
- replace the candidate public-mapping round trip with a read-only structural write protocol
- atomically publish candidates, claims, supersession, and completed profiles in one SQLite transaction
- add bounded multi-row writes, canonical JSON caches, rollback/retry tests, and a durable candidate-heavy benchmark

## Performance
- 5,000-candidate mapping path: 192.169 ms
- typed atomic path: 105.916 ms
- improvement: 44.884% (40% gate)
- 100k-call cold analysis: 3.555 s
- exact warm reuse: 3.737 ms
- canonical candidate/profile fingerprints unchanged

## Validation
- focused tests: 19 passed
- full suite: 746 passed
- 100k-call benchmark: PASS
- JetBrains inspections: clean on changed production modules
- Agent Maintainer precommit: PASS
- Agent Maintainer full: PASS
- Ruff, mypy, Tach, Xenon, release, security, and diff checks pass

Closes #234