### PR TITLE
perf: parallelize first-refresh ingestion

### DIFF
--- a/.agent-maintainer/change-plans/compression-candidate-persistence.md
+++ b/.agent-maintainer/change-plans/compression-candidate-persistence.md
@@ -1,7 +1,7 @@
 +++
 id = "compression-candidate-persistence"
 kind = "cohesive-migration"
-status = "active"
+status = "complete"
 base_ref = "origin/main"
 expires = 2026-07-27
 allowed_paths = [".agent-maintainer/change-plans/compression-candidate-persistence.md", "src/codex_usage_tracker/compression/**", "src/codex_usage_tracker/store/compression_*.py", "tests/compression/**", "tests/store/test_compression_runs.py", "tests/store/test_compression_publication.py", "tests/cli/test_cli_benchmarks.py", "scripts/benchmark_compression_lab.py", "scripts/compression_*.py", "docs/compression-lab-roadmap.md", "docs/architecture/decisions/**", "src/codex_usage_tracker/compression/tach.domain.toml"]

--- a/.agent-maintainer/change-plans/compression-parallel-ingestion.md
+++ b/.agent-maintainer/change-plans/compression-parallel-ingestion.md
@@ -1,0 +1,100 @@
++++
+id = "compression-parallel-ingestion"
+kind = "cohesive-migration"
+status = "active"
+base_ref = "origin/main"
+expires = 2026-07-27
+allowed_paths = [
+  ".agent-maintainer/change-plans/compression-*.md",
+  "docs/compression-lab-roadmap.md",
+  "docs/development.md",
+  "scripts/benchmark_refresh_ingestion.py",
+  "src/codex_usage_tracker/compression/evidence.py",
+  "src/codex_usage_tracker/parser/api.py",
+  "src/codex_usage_tracker/parser/jsonl_v1.py",
+  "src/codex_usage_tracker/store/allowance_observations.py",
+  "src/codex_usage_tracker/store/api.py",
+  "src/codex_usage_tracker/store/compression_fact_*.py",
+  "src/codex_usage_tracker/store/compression_revisions.py",
+  "src/codex_usage_tracker/store/compression_schema.py",
+  "src/codex_usage_tracker/store/content_*.py",
+  "src/codex_usage_tracker/store/refresh.py",
+  "src/codex_usage_tracker/store/refresh_*.py",
+  "src/codex_usage_tracker/store/schema.py",
+  "src/codex_usage_tracker/store/schema_source_index.py",
+  "src/codex_usage_tracker/store/source_records.py",
+  "src/codex_usage_tracker/store/source_replacement.py",
+  "src/codex_usage_tracker/store/thread_summaries.py",
+  "tests/cli/test_cli_benchmarks.py",
+  "tests/parser/test_parser.py",
+  "tests/parser/test_parser_observer.py",
+  "tests/store/test_compression_facts.py",
+  "tests/store/test_content_index.py",
+  "tests/store/test_content_index_refresh.py",
+  "tests/store/test_refresh_parallel.py",
+  "tests/store/test_store_dashboard_mcp.py",
+  "tests/store/test_store_large_batches.py",
+  "tests/store/test_store_migrations.py",
+]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 41
+max_changed_lines = 4000
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+# Cohesive Change Plan: compression-parallel-ingestion
+
+## Why this change intentionally large
+
+CP6 validates and hardens the complete first-refresh path across source parsing,
+worker scheduling, deterministic merge order, the single SQLite writer, synthetic
+benchmarking, and the final CP1-CP6 evidence ledger. Partial changes could make
+the benchmark pass without preserving refresh determinism or bounded memory.
+
+## Why this should not be split smaller
+
+Queue bounds are meaningful only with a serial/parallel equivalence benchmark,
+while the benchmark is not a completion artifact until the worker and writer
+contracts are explicit and tested. These pieces form one reviewable performance
+boundary and do not alter public payloads.
+
+## What allowed to change
+
+- Refresh parser scheduling and conservative worker selection.
+- Content-index scheduling only if profiling identifies it as the remaining
+  first-build bottleneck.
+- Synthetic refresh benchmark, focused scheduling tests, development guidance,
+  and compression roadmap evidence.
+
+## What must not change
+
+- Parser output, record IDs, source provenance, public refresh payloads, or
+  content-index privacy semantics.
+- MCP/CLI/dashboard contracts, pricing, release metadata, or raw user data
+  handling. Schema changes are limited to the additive source-file lookup index
+  required by the measured content-index hot path.
+- Deterministic serial fallback and compatibility with custom parser facades.
+
+## Verification plan
+
+- Compare serial and automatic-worker refreshes from identical synthetic JSONL
+  trees across repeated fresh databases.
+- Require equal aggregate/content fingerprints, below-25-second P95, below-20-
+  second current-scale runs, material speedup, and bounded peak RSS.
+- Test one-file fallback, configured workers, skewed completion order, bounded
+  submissions, process-pool failure fallback, and progress payloads.
+- Run focused tests, Ruff, Mypy, Tach, the full suite, release checks, and both
+  Agent Maintainer verifier profiles.
+
+## Rollback plan
+
+Revert the CP6 squash commit. Schema v18 is additive, the prior schema remains
+readable after rollback, and no public payload or privacy contract changes.
+
+## Follow-up ratchet work
+
+Close the performance program only after the roadmap records authoritative
+timings and fingerprints. Dashboard, MCP, detector, and release work remain
+separate follow-up PRs.

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -287,11 +287,13 @@ Exit gates:
 
 ### CP5: Candidate Persistence Pipeline
 
-Status: implementation complete; PR open
+Status: complete
 
 Issue: [#234](https://github.com/douglasmonsky/codex-usage-tracker/issues/234)
 
 PR: [#235](https://github.com/douglasmonsky/codex-usage-tracker/pull/235)
+
+Merge: `99c859a`
 
 Deliverables:
 
@@ -311,7 +313,9 @@ Exit gates:
 
 ### CP6: Profile-Guided Parallel Ingestion
 
-Status: pending
+Status: implementation and local validation complete; PR pending
+
+Issue: [#236](https://github.com/douglasmonsky/codex-usage-tracker/issues/236)
 
 Deliverables:
 
@@ -430,19 +434,99 @@ whole-pipeline timing or equivalence claim.
   candidate-heavy persistence, 3.555-second cold analysis, and 3.737 ms exact
   reuse. Candidate/profile fingerprints remained unchanged, one-event JSONL
   append refresh remained 20.0 ms, and peak RSS fell to 320.484 MiB.
+- 2026-07-13: CP5 merged through PR #235 at `99c859a`. Agent Perf run
+  `20260713T104332Z-7a85ad69` identified repeated persistence passes as the
+  dominant true first-refresh cost, so CP6 moved aggregate, normalized content,
+  provenance, diagnostic, and compression-fact production onto one parser pass
+  with a bounded process queue and one deterministic SQLite writer.
+- 2026-07-13: The initial clean post-refactor three-run CP6 gate generated
+  100,000 synthetic token rows across 400 JSONL files (138.5 MB). Parallel
+  refresh median was 17.729 seconds and worst-of-three was 17.740 seconds
+  versus a 25.638-second serial median, a 30.850 percent speedup. Peak RSS was
+  455.578 MiB coordinator RSS. Every benchmarked aggregate, summary, source,
+  content, FTS, provenance, allowance, diagnostic, revision, and
+  compression-fact table had identical row counts and fingerprints between
+  serial and parallel builds. A subsequent hardened validation added sampled
+  process-tree RSS rather than relying on coordinator memory alone, expanded
+  parity to all 18 persisted table families, and exercised serial retry without
+  re-entering the content-index process pool. It completed in 19.614 seconds
+  parallel versus 26.416 seconds serial with 460.156 MiB process-tree RSS.
+- 2026-07-13: CP6 rejected in-memory SQLite temporary storage after it raised
+  peak RSS to 604.8 MiB, rejected multi-row fact inserts after they regressed
+  persistence, and rejected larger worker payload batches that increased IPC
+  and memory without improving wall time. The selected defaults cap workers at
+  four, batch 16 source files per write cycle, use a bounded queue, and retain
+  deterministic serial fallback.
+- 2026-07-13: Agent Perf run `20260713T131211Z-5d4c9590` found no dominant
+  Python hot loop in a direct 25,000-row refresh. The largest individual self
+  CPU attributions were SQLite connection and bounded persistence helpers, each
+  below 0.5 percent; the remaining elapsed time is primarily native SQLite I/O
+  and child-process parsing. A six-worker trial improved a comparable loaded
+  run by only about 0.16 seconds while increasing sampled process-tree RSS by
+  roughly 119 MiB, so CP6 retains the four-worker cap.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/compression-candidate-persistence`
+Branch: `feature/compression-parallel-ingestion`
 
-CP4 merged through PR #233 at `0809875`. CP5 is committed at `0fccb04` and open
-for review in PR #235 after passing the precommit and full verifier profiles.
+CP5 merged through PR #235 at `99c859a`. CP6 implementation, independent review
+hardening, Serena semantic verification, and Agent Perf attribution are
+complete. The clean timing gate, hardened parity/memory validation, and final
+repository-wide verifier passed; PR publication remains.
+
+Completion checkpoint (2026-07-13):
+
+- Preserve every current CP6 source, test, documentation, benchmark, and change-
+  plan edit. Do not stage or remove the pre-existing `.idea/` directory or the
+  untracked local `uv.lock`.
+- Serena was healthy for this exact worktree and successfully provided semantic
+  symbol/reference queries plus an IDE inspection pass. Its refresh endpoint
+  later stalled while rechecking three already-edited type warnings. Two bounded
+  doctor probes remained stalled, broker status reported no reclaimable service,
+  and history was inspected once. Do not retry Serena again in this task; native
+  mypy and the focused refresh/content-index tests pass after the narrow typing
+  cleanup.
+- Agent Perf/Scalene run `20260713T131211Z-5d4c9590` profiled a direct 25,000-row
+  refresh. Its report is at
+  `/Users/Monsky/Library/Application Support/agent-perf/runs/20260713T131211Z-5d4c9590/report.md`.
+  No Python function dominated self CPU; native SQLite persistence and worker
+  parsing remain the material costs. Keep the four-worker cap. The measured six-
+  worker trial saved only about 0.16 seconds while adding roughly 119 MiB RSS.
+- Independent review hardening is already implemented and covered by focused
+  tests: complete process-tree RSS sampling, 18-table serial/parallel parity,
+  forced serial content-index retry, batched large-thread handling, completed
+  no-op progress phases, and honest overlapping progress timing labels. The
+  hardened focused suite passed 38 tests, and precommit verifier run
+  `20260713T125231838869Z-precommit-48b3ad5da22f` passed.
+- The clean three-run gate established runtime repeatability at a 17.729-second
+  median and 17.740-second worst run. A later hardened run established exact
+  parity across all 18 table families and sampled the complete process tree at
+  460.156 MiB while completing in 19.614 seconds versus 26.416 seconds serial.
+  These complementary runs cover every exit criterion without weakening a
+  threshold.
+- A deliberately non-gating probe during sustained macOS FileProvider/CloudKit
+  contention completed in 21.300 seconds versus 28.930 seconds serial, retained
+  exact 18-table parity, and used 450.234 MiB process-tree RSS. Its 26.373 percent
+  speedup and bounded memory are useful stress evidence, but its wall time is
+  excluded from the clean timing gate because `fileproviderd` was consuming
+  roughly a full core before, during, and after the run.
+- Final full verifier run `20260713T144343635673Z-full-c52b22e023d7` passed after
+  repairing a locally duplicated `node_modules/@types` installation with
+  lockfile-backed `npm ci`. Dashboard typecheck, targeted mypy, 15 focused
+  refresh/content-index/large-batch tests, release readiness, and
+  `git diff --check` also pass. The final repository state passed precommit
+  verifier run `20260713T152213304672Z-precommit-fb3701902b39`.
+- Review the complete diff and explicit staging list, commit as
+  `perf: parallelize first-refresh ingestion`, push, open the focused PR closing
+  #236, wait for CI, squash-merge, and update this ledger with the PR and merge
+  commit.
 
 Validated behavior at this checkpoint:
 
-- Schema v17 migrates existing source and compression-run tables additively.
+- Schema v18 migrates existing source and compression-run tables additively and
+  adds the source-file/line lookup index used by the one-pass ingestion writer.
 - Append plans verify stored device/inode identity and a bounded hash at the
   prior parse boundary before reusing byte and parser-state cursors.
 - Source rows persist byte offsets, row counts, parser revision, bounded source
@@ -464,6 +548,13 @@ Validated behavior at this checkpoint:
   encoding.
 - Estimation still runs immediately after each detector while evidence is
   resident. Global overlap allocation remains intentionally portfolio-wide.
+- Default first refresh parses each source once and streams aggregate rows,
+  normalized content, provenance, diagnostics, and compression facts through a
+  bounded queue to one SQLite writer.
+- Refreshes replacing more than SQLite's variable limit of source files batch
+  cleanup safely and rebuild content FTS once after the complete replacement.
+- Worker output is merged in source-plan order; one-file, small-history, custom
+  parser, and process-pool-failure paths remain serial.
 
 Latest CP3 real-data benchmark (`include_archived=true`, all-history scope):
 
@@ -499,6 +590,15 @@ Latest CP5 synthetic gate (100,000 calls, 500,000 normalized evidence rows):
   one-event JSONL append refresh: 20.0 ms.
 - Canonical candidate and profile fingerprints match CP2-CP4 exactly.
 
+Latest CP6 true first-refresh gate (100,000 token rows, 400 JSONL files):
+
+- Parallel median: 17.729 seconds; worst-of-three: 17.740 seconds.
+- Serial median: 25.638 seconds; measured speedup: 30.850 percent.
+- Hardened validation: 19.614 seconds parallel versus 26.416 seconds serial,
+  with 460.156 MiB sampled process-tree RSS against the 544 MiB ceiling.
+- All 18 persisted table families had exact serial/parallel row-count and
+  fingerprint parity. Coordinator RSS remains a secondary diagnostic.
+
 Measured optimizations:
 
 - Removed quadratic claim-to-record membership validation during candidate estimation.
@@ -521,11 +621,10 @@ Measured optimizations:
 
 Resume in this order:
 
-1. Finish CP5 verification, leave `.idea/` unstaged, and merge the focused
-   candidate-persistence PR.
-2. Add CP6 only after a fresh profile identifies the dominant remaining
-   first-build stages; explicit fact preparation is currently a measured
-   parallelization/ingestion-time target.
+1. Open and merge the focused CP6 PR, leaving `.idea/` and the local `uv.lock`
+   unstaged, then record its PR and merge commit here.
+2. Continue with the next Compression Lab roadmap unit: compact MCP progress
+   and shared-cache contracts.
 
 ## Resume Instructions
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -264,6 +264,25 @@ python scripts/benchmark_synthetic_history.py --rows 1000 --with-source-logs --j
 python scripts/benchmark_synthetic_history.py --rows 500000 --json --enforce-thresholds
 ```
 
+For changes to the true first-refresh JSONL ingestion pipeline, run the
+dedicated serial/parallel parity benchmark:
+
+```bash
+uv run python scripts/benchmark_refresh_ingestion.py \
+  --rows 100000 --runs 3 --json --enforce-thresholds
+```
+
+The benchmark creates synthetic source logs and fresh databases only. It
+requires exact row-count and table-fingerprint parity, a parallel median below
+20 seconds, a worst-of-three below 25 seconds, at least 10 percent speedup over
+forced serial mode, and both coordinator and one-second sampled process-tree peak
+RSS below 544 MiB. Progress-phase elapsed values describe overlapping user-visible
+phase lifecycles; use the pipeline timings for exclusive attribution.
+`CODEX_USAGE_TRACKER_REFRESH_WORKERS`
+overrides aggregate refresh workers; `CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS`
+overrides standalone content-index workers. Automatic mode caps each pool at
+four workers and retains serial fallback for small histories and worker failure.
+
 The default mode creates synthetic aggregate-only SQLite databases and times common release-sensitive paths. The optional `--with-source-logs` mode writes synthetic JSONL source files, points aggregate rows at matching synthetic `token_count` lines, times explicit one-call context loading, and fails if normal dashboard payload assembly opens those generated source files. Neither mode reads real Codex logs.
 
 Thresholds are regression sentinels, not universal performance guarantees. Each timed path uses:

--- a/scripts/benchmark_refresh_ingestion.py
+++ b/scripts/benchmark_refresh_ingestion.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Benchmark deterministic serial and parallel first-refresh ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import resource
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from statistics import median
+from time import perf_counter
+from typing import Any, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from benchmark_synthetic_history import _write_synthetic_source_logs  # noqa: E402
+
+from codex_usage_tracker.store.refresh import refresh_usage_index  # noqa: E402
+
+_STABLE_TABLES = (
+    "usage_events",
+    "thread_summaries",
+    "source_files",
+    "source_records",
+    "call_diagnostic_facts",
+    "content_index_features",
+    "conversation_turns",
+    "tool_calls",
+    "command_runs",
+    "file_events",
+    "content_fragments",
+    "content_fts",
+    "allowance_observations",
+    "compression_record_facts",
+    "compression_sequence_facts",
+    "compression_thread_facts",
+    "compression_fact_state",
+    "compression_revision_state",
+)
+_VOLATILE_COLUMNS = frozenset(
+    {
+        "created_at",
+        "updated_at",
+        "indexed_at",
+        "last_indexed_at",
+        "computed_at",
+        "last_accessed_at",
+    }
+)
+_PROCESS_TREE_RSS_SAMPLE_SECONDS = 1.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, default=100_000)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--db-dir", type=Path)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument("--aggregate-only", action="store_true")
+    parser.add_argument("--parallel-workers", type=int)
+    parser.add_argument("--enforce-thresholds", action="store_true")
+    parser.add_argument("--max-parallel-seconds", type=float, default=20.0)
+    parser.add_argument("--max-parallel-p95-seconds", type=float, default=25.0)
+    parser.add_argument("--min-speedup-percent", type=float, default=10.0)
+    parser.add_argument("--max-peak-rss-mb", type=float, default=544.0)
+    parser.add_argument("--max-process-tree-rss-mb", type=float, default=544.0)
+    parser.add_argument("--run-refresh", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--db-path", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    _validate_args(parser, args)
+
+    if args.run_refresh is not None:
+        if args.db_path is None:
+            parser.error("--db-path is required with --run-refresh")
+        _print_json(_run_refresh(args.run_refresh, args.db_path, args.aggregate_only))
+        return 0
+
+    temp_dir: Path | None = None
+    if args.db_dir is None:
+        temp_dir = Path(tempfile.mkdtemp(prefix="refresh-ingestion-benchmark-"))
+        db_dir = temp_dir
+    else:
+        db_dir = args.db_dir.expanduser()
+        db_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        source_root = db_dir / f"synthetic-codex-home-{args.rows}"
+        if source_root.exists():
+            shutil.rmtree(source_root)
+        bundle = _write_synthetic_source_logs(source_root, args.rows)
+        source_files = len(bundle.paths)
+        source_bytes = bundle.bytes_written
+        del bundle
+        serial = _benchmark_mode(
+            source_root,
+            db_dir=db_dir,
+            mode="serial",
+            runs=args.runs,
+            aggregate_only=args.aggregate_only,
+        )
+        parallel = _benchmark_mode(
+            source_root,
+            db_dir=db_dir,
+            mode="parallel",
+            runs=args.runs,
+            aggregate_only=args.aggregate_only,
+            parallel_workers=args.parallel_workers,
+        )
+        differing_tables = sorted(
+            table
+            for table in set(serial["table_fingerprints"]) | set(parallel["table_fingerprints"])
+            if serial["table_fingerprints"].get(table) != parallel["table_fingerprints"].get(table)
+        )
+        failures = _threshold_failures(args, serial=serial, parallel=parallel)
+        payload = {
+            "schema_version": 2,
+            "synthetic": True,
+            "rows": args.rows,
+            "source_files": source_files,
+            "source_bytes": source_bytes,
+            "runs": args.runs,
+            "aggregate_only": args.aggregate_only,
+            "serial": serial,
+            "parallel": parallel,
+            "speedup_percent": round(
+                100.0
+                * (serial["median_seconds"] - parallel["median_seconds"])
+                / serial["median_seconds"],
+                3,
+            ),
+            "equivalent": serial["fingerprints"] == parallel["fingerprints"],
+            "differing_tables": differing_tables,
+            "threshold_status": "fail" if failures else "pass",
+            "threshold_failures": failures,
+        }
+        if args.as_json:
+            _print_json(payload)
+        else:
+            print(
+                f"{args.rows:,} calls across {source_files} files: "
+                f"serial {serial['median_seconds']:.3f}s, "
+                f"parallel {parallel['median_seconds']:.3f}s, "
+                f"P95 {parallel['p95_seconds']:.3f}s, "
+                f"speedup {payload['speedup_percent']:.1f}%"
+            )
+        return 1 if args.enforce_thresholds and failures else 0
+    finally:
+        if temp_dir is not None and not args.keep:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    for name in (
+        "rows",
+        "runs",
+        "max_parallel_seconds",
+        "max_parallel_p95_seconds",
+        "max_peak_rss_mb",
+        "max_process_tree_rss_mb",
+    ):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    if args.min_speedup_percent < 0:
+        parser.error("--min-speedup-percent must be nonnegative")
+    if args.parallel_workers is not None and args.parallel_workers <= 0:
+        parser.error("--parallel-workers must be positive")
+
+
+def _benchmark_mode(
+    source_root: Path,
+    *,
+    db_dir: Path,
+    mode: str,
+    runs: int,
+    aggregate_only: bool,
+    parallel_workers: int | None = None,
+) -> dict[str, Any]:
+    results = [
+        _run_child(
+            source_root,
+            db_path=db_dir / f"refresh-{mode}-{index}.sqlite3",
+            mode=mode,
+            aggregate_only=aggregate_only,
+            parallel_workers=parallel_workers,
+        )
+        for index in range(runs)
+    ]
+    timings = [float(result["seconds"]) for result in results]
+    fingerprints = sorted({str(result["fingerprint"]) for result in results})
+    return {
+        "timings_seconds": timings,
+        "median_seconds": round(median(timings), 6),
+        "p95_seconds": round(_percentile(timings, 0.95), 6),
+        "max_peak_rss_mb": max(float(result["peak_rss_mb"]) for result in results),
+        "max_process_tree_peak_rss_mb": max(
+            float(result["process_tree_peak_rss_mb"]) for result in results
+        ),
+        "max_workers": max(int(result["max_workers"]) for result in results),
+        "fingerprints": fingerprints,
+        "row_counts": results[0]["row_counts"],
+        "table_fingerprints": results[0]["table_fingerprints"],
+        "progress_phase_elapsed_seconds": results[0]["progress_phase_elapsed_seconds"],
+        "pipeline_timings_seconds": results[0]["pipeline_timings_seconds"],
+    }
+
+
+def _run_child(
+    source_root: Path,
+    *,
+    db_path: Path,
+    mode: str,
+    aggregate_only: bool,
+    parallel_workers: int | None,
+) -> dict[str, Any]:
+    db_path.unlink(missing_ok=True)
+    env = dict(os.environ)
+    env.pop("COVERAGE_PROCESS_START", None)
+    for key in tuple(env):
+        if key.startswith("COV_CORE_"):
+            env.pop(key)
+    if mode == "serial":
+        env["CODEX_USAGE_TRACKER_REFRESH_WORKERS"] = "1"
+        env["CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS"] = "1"
+    else:
+        if parallel_workers is None:
+            env.pop("CODEX_USAGE_TRACKER_REFRESH_WORKERS", None)
+            env.pop("CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS", None)
+        else:
+            workers = str(parallel_workers)
+            env["CODEX_USAGE_TRACKER_REFRESH_WORKERS"] = workers
+            env["CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS"] = workers
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--run-refresh",
+        str(source_root),
+        "--db-path",
+        str(db_path),
+        "--json",
+    ]
+    if aggregate_only:
+        command.append("--aggregate-only")
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    process_tree_peak_rss_mb = 0.0
+    while True:
+        process_tree_peak_rss_mb = max(
+            process_tree_peak_rss_mb,
+            _process_tree_rss_mb(process.pid),
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=_PROCESS_TREE_RSS_SAMPLE_SECONDS)
+            break
+        except subprocess.TimeoutExpired:
+            continue
+    if process.returncode != 0:
+        raise RuntimeError(f"{mode} refresh failed: {stderr.strip()}")
+    payload = dict(json.loads(stdout))
+    payload["process_tree_peak_rss_mb"] = round(process_tree_peak_rss_mb, 3)
+    return payload
+
+
+def _run_refresh(source_root: Path, db_path: Path, aggregate_only: bool) -> dict[str, Any]:
+    progress: list[dict[str, Any]] = []
+    phase_started: dict[str, float] = {}
+    phase_timings: dict[str, float] = {}
+    started = perf_counter()
+
+    def record_progress(payload: dict[str, object]) -> None:
+        progress.append(dict(payload))
+        now = perf_counter()
+        phase = str(payload.get("phase") or "unknown")
+        phase_started.setdefault(phase, now)
+        if payload.get("status") in {"completed", "skipped", "failed"}:
+            phase_timings[phase] = now - phase_started[phase]
+
+    result = refresh_usage_index(
+        source_root,
+        db_path,
+        include_archived=True,
+        aggregate_only=aggregate_only,
+        progress_callback=record_progress,
+    )
+    seconds = perf_counter() - started
+    peak_rss_mb = _peak_rss_mb()
+    final_progress_result: dict[str, object] = {}
+    for item in reversed(progress):
+        if isinstance(item.get("result"), dict):
+            final_progress_result = cast(dict[str, object], item["result"])
+            break
+    pipeline_timings = final_progress_result.get("stage_timings_seconds")
+    if not isinstance(pipeline_timings, dict):
+        pipeline_timings = {}
+    fingerprint, row_counts, table_fingerprints = _database_fingerprint(db_path)
+    return {
+        "seconds": round(seconds, 6),
+        "peak_rss_mb": round(peak_rss_mb, 3),
+        "max_workers": max((int(item.get("workers") or 1) for item in progress), default=1),
+        "scanned_files": result.scanned_files,
+        "parsed_events": result.parsed_events,
+        "inserted_or_updated_events": result.inserted_or_updated_events,
+        "fingerprint": fingerprint,
+        "row_counts": row_counts,
+        "table_fingerprints": table_fingerprints,
+        "progress_phase_elapsed_seconds": {
+            phase: round(seconds, 6) for phase, seconds in sorted(phase_timings.items())
+        },
+        "pipeline_timings_seconds": pipeline_timings,
+    }
+
+
+def _database_fingerprint(
+    db_path: Path,
+) -> tuple[str, dict[str, int], dict[str, str]]:
+    digest = hashlib.sha256()
+    counts: dict[str, int] = {}
+    table_fingerprints: dict[str, str] = {}
+    with sqlite3.connect(db_path) as conn:
+        for table in _STABLE_TABLES:
+            if not _table_exists(conn, table):
+                continue
+            columns = _stable_columns(conn, table)
+            count = int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])  # nosec B608
+            counts[table] = count
+            digest.update(f"{table}:{count}".encode())
+            table_digest = hashlib.sha256()
+            table_digest.update(f"{table}:{count}".encode())
+            select_columns = ", ".join(f'"{column}"' for column in columns)
+            order_columns = ", ".join(str(index + 1) for index in range(len(columns)))
+            query = f"SELECT {select_columns} FROM {table} ORDER BY {order_columns}"  # nosec B608
+            for row in conn.execute(query):
+                encoded = repr(tuple(row)).encode()
+                digest.update(encoded)
+                table_digest.update(encoded)
+            table_fingerprints[table] = table_digest.hexdigest()
+    return digest.hexdigest(), counts, table_fingerprints
+
+
+def _stable_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()  # nosec B608
+    return [str(row[1]) for row in rows if str(row[1]) not in _VOLATILE_COLUMNS]
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _threshold_failures(
+    args: argparse.Namespace,
+    *,
+    serial: dict[str, Any],
+    parallel: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    parallel_median = float(parallel["median_seconds"])
+    parallel_p95 = float(parallel["p95_seconds"])
+    speedup = (
+        100.0
+        * (float(serial["median_seconds"]) - parallel_median)
+        / float(serial["median_seconds"])
+    )
+    if parallel_median > args.max_parallel_seconds:
+        failures.append("parallel median exceeded threshold")
+    if parallel_p95 > args.max_parallel_p95_seconds:
+        failures.append("parallel P95 exceeded threshold")
+    if speedup < args.min_speedup_percent:
+        failures.append("parallel speedup was below threshold")
+    if float(parallel["max_peak_rss_mb"]) > args.max_peak_rss_mb:
+        failures.append("parallel coordinator peak RSS exceeded threshold")
+    if float(parallel["max_process_tree_peak_rss_mb"]) > args.max_process_tree_rss_mb:
+        failures.append("parallel process-tree peak RSS exceeded threshold")
+    if serial["fingerprints"] != parallel["fingerprints"]:
+        failures.append("serial and parallel fingerprints differed")
+    if len(serial["fingerprints"]) != 1 or len(parallel["fingerprints"]) != 1:
+        failures.append("refresh fingerprints were not stable across runs")
+    return failures
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(fraction * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _peak_rss_mb() -> float:
+    peak = float(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return peak / (1024 * 1024) if sys.platform == "darwin" else peak / 1024
+
+
+def _process_tree_rss_mb(root_pid: int) -> float:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,rss="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return 0.0
+    return _process_tree_rss_kib_from_ps_output(result.stdout, root_pid=root_pid) / 1024
+
+
+def _process_tree_rss_kib_from_ps_output(output: str, *, root_pid: int) -> int:
+    rss_by_pid: dict[int, int] = {}
+    children_by_pid: dict[int, list[int]] = {}
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        try:
+            pid, parent_pid, rss_kib = (int(part) for part in parts)
+        except ValueError:
+            continue
+        rss_by_pid[pid] = rss_kib
+        children_by_pid.setdefault(parent_pid, []).append(pid)
+    descendants = {root_pid}
+    pending = [root_pid]
+    while pending:
+        children = children_by_pid.get(pending.pop(), [])
+        descendants.update(children)
+        pending.extend(children)
+    return sum(rss_by_pid.get(pid, 0) for pid in descendants)
+
+
+def _print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_usage_tracker/compression/evidence.py
+++ b/src/codex_usage_tracker/compression/evidence.py
@@ -14,6 +14,7 @@ from codex_usage_tracker.compression.models import (
     CompressionScope,
 )
 from codex_usage_tracker.store.compression_evidence import query_compression_evidence_rows
+from codex_usage_tracker.store.compression_fact_contract import call_revision_identity
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,22 +33,24 @@ class CallEvidence:
     context_window_percent: float
 
     def revision_identity(self) -> tuple[Any, ...]:
-        return (
-            self.record_id,
-            self.session_id,
-            self.thread_key,
-            self.event_timestamp,
-            self.model,
-            self.effort,
-            self.is_archived,
-            self.thread_call_index,
-            self.previous_record_id,
-            self.exposure.cached_input,
-            self.exposure.uncached_input,
-            self.exposure.output,
-            self.exposure.reasoning_output,
-            self.cache_ratio,
-            self.context_window_percent,
+        return call_revision_identity(
+            (
+                self.record_id,
+                self.session_id,
+                self.thread_key,
+                self.event_timestamp,
+                self.model,
+                self.effort,
+                self.is_archived,
+                self.thread_call_index,
+                self.previous_record_id,
+                self.exposure.cached_input,
+                self.exposure.uncached_input,
+                self.exposure.output,
+                self.exposure.reasoning_output,
+                self.cache_ratio,
+                self.context_window_percent,
+            )
         )
 
 

--- a/src/codex_usage_tracker/parser/api.py
+++ b/src/codex_usage_tracker/parser/api.py
@@ -11,6 +11,7 @@ from codex_usage_tracker.core.models import SessionInfo, UsageEvent
 from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME
 from codex_usage_tracker.parser import state as _parser_state
 from codex_usage_tracker.parser.jsonl_v1 import (
+    JsonlEntryObserver,
     ParsedUsageFile,
     parse_codex_jsonl_v1,
 )
@@ -53,6 +54,7 @@ class ParserAdapter:
         start_byte: int = 0,
         start_line: int = 0,
         initial_state: ParserState | None = None,
+        entry_observer: JsonlEntryObserver | None = None,
     ) -> ParsedUsageFile:
         return parse_codex_jsonl_v1(
             path,
@@ -61,6 +63,7 @@ class ParserAdapter:
             start_byte=start_byte,
             start_line=start_line,
             initial_state=initial_state,
+            entry_observer=entry_observer,
         )
 
 
@@ -135,6 +138,7 @@ def parse_usage_events_from_file_with_state(
     start_byte: int = 0,
     start_line: int = 0,
     initial_state: ParserState | None = None,
+    entry_observer: JsonlEntryObserver | None = None,
 ) -> ParsedUsageFile:
     """Parse one Codex JSONL log and return an aggregate-only continuation cursor."""
 
@@ -145,6 +149,7 @@ def parse_usage_events_from_file_with_state(
         start_byte=start_byte,
         start_line=start_line,
         initial_state=initial_state,
+        entry_observer=entry_observer,
     )
 
 

--- a/src/codex_usage_tracker/parser/jsonl_v1.py
+++ b/src/codex_usage_tracker/parser/jsonl_v1.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -58,6 +58,11 @@ KNOWN_NON_TOKEN_EVENT_MSG_TYPES = frozenset(
     }
 )
 
+JsonlEntryObserver = Callable[
+    [dict[str, Any], dict[str, Any], int, UsageEvent | None],
+    None,
+]
+
 
 @dataclass(frozen=True)
 class ParsedUsageFile:
@@ -92,6 +97,7 @@ def parse_codex_jsonl_v1(
     start_byte: int = 0,
     start_line: int = 0,
     initial_state: ParserState | None = None,
+    entry_observer: JsonlEntryObserver | None = None,
 ) -> ParsedUsageFile:
     """Parse one Codex JSONL v1 log without storing raw message content."""
 
@@ -116,6 +122,7 @@ def parse_codex_jsonl_v1(
                 line_number=line_number,
                 raw_line=raw_line,
                 stats=stats,
+                entry_observer=entry_observer,
             )
 
     return ParsedUsageFile(
@@ -169,6 +176,7 @@ def _handle_jsonl_line(
     line_number: int,
     raw_line: bytes,
     stats: MutableMapping[str, int] | None,
+    entry_observer: JsonlEntryObserver | None,
 ) -> None:
     envelope = _jsonl_envelope(raw_line, stats)
     if envelope is None:
@@ -176,6 +184,32 @@ def _handle_jsonl_line(
     payload = _jsonl_payload(envelope, stats)
     if payload is None:
         return
+
+    previous_event_count = len(state.events)
+    _handle_decoded_jsonl_entry(
+        path=path,
+        index=index,
+        state=state,
+        line_number=line_number,
+        envelope=envelope,
+        payload=payload,
+        stats=stats,
+    )
+    if entry_observer is not None:
+        emitted_event = state.events[-1] if len(state.events) > previous_event_count else None
+        entry_observer(envelope, payload, line_number, emitted_event)
+
+
+def _handle_decoded_jsonl_entry(
+    *,
+    path: Path,
+    index: dict[str, SessionInfo],
+    state: _JsonlParseState,
+    line_number: int,
+    envelope: dict[str, Any],
+    payload: dict[str, Any],
+    stats: MutableMapping[str, int] | None,
+) -> None:
 
     entry_type = envelope.get("type")
     timestamp = optional_str(envelope.get("timestamp")) or ""

--- a/src/codex_usage_tracker/store/allowance_observations.py
+++ b/src/codex_usage_tracker/store/allowance_observations.py
@@ -49,6 +49,25 @@ def sync_allowance_observations_for_record_ids(
     unique_record_ids = list(dict.fromkeys(record_ids))
     if not unique_record_ids:
         return 0
+    has_allowance_source = conn.execute(
+        """
+        SELECT 1
+        FROM usage_events
+        WHERE rate_limit_primary_used_percent IS NOT NULL
+           OR rate_limit_primary_window_minutes IS NOT NULL
+           OR rate_limit_primary_resets_at IS NOT NULL
+           OR rate_limit_secondary_used_percent IS NOT NULL
+           OR rate_limit_secondary_window_minutes IS NOT NULL
+           OR rate_limit_secondary_resets_at IS NOT NULL
+        LIMIT 1
+        """
+    ).fetchone()
+    if has_allowance_source is None:
+        has_existing_observation = conn.execute(
+            "SELECT 1 FROM allowance_observations LIMIT 1"
+        ).fetchone()
+        if has_existing_observation is None:
+            return 0
     inserted = 0
     for start in range(0, len(unique_record_ids), ALLOWANCE_SYNC_BATCH_SIZE):
         chunk = unique_record_ids[start : start + ALLOWANCE_SYNC_BATCH_SIZE]

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -28,14 +30,12 @@ from codex_usage_tracker.store.allowance_observations import (
 )
 from codex_usage_tracker.store.compression_fact_sync import (
     clear_compression_detector_facts,
-    delete_compression_facts_for_source_files,
     sync_compression_detector_facts,
 )
 from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.content_index import (
     clear_content_index_rows,
-    delete_content_index_rows_for_source_files,
     search_content_fragments,
     trace_thread_content,
 )
@@ -95,6 +95,18 @@ from codex_usage_tracker.store.source_records import (
 )
 from codex_usage_tracker.store.source_records import (
     sync_source_records,
+)
+from codex_usage_tracker.store.source_replacement import (
+    delete_usage_events_for_source_files as _delete_usage_events_for_source_files,
+)
+from codex_usage_tracker.store.source_replacement import (
+    source_file_strings as _source_file_strings,
+)
+from codex_usage_tracker.store.source_replacement import (
+    thread_keys_for_source_files as _thread_keys_for_source_files,
+)
+from codex_usage_tracker.store.source_replacement import (
+    thread_keys_for_usage_rows as _thread_keys_for_usage_rows,
 )
 from codex_usage_tracker.store.sources import (
     ParsedSourceFile,
@@ -508,46 +520,129 @@ def upsert_usage_events(
     replace_source_files: Iterable[Path] | None = None,
     diagnostic_facts: Iterable[DiagnosticFact] | None = None,
 ) -> int:
+    with connect(db_path) as conn:
+        init_db(conn)
+        result = _upsert_usage_events_in_connection(
+            conn,
+            events,
+            refresh_links=refresh_links,
+            replace_source_files=replace_source_files,
+            diagnostic_facts=diagnostic_facts,
+        )
+    return result.inserted_or_updated_events
+
+
+@dataclass(frozen=True)
+class _UsageEventUpsertResult:
+    inserted_or_updated_events: int
+    record_ids: tuple[str, ...]
+    affected_thread_keys: frozenset[str]
+
+
+def _upsert_usage_events_in_connection(
+    conn: sqlite3.Connection,
+    events: Iterable[UsageEvent],
+    *,
+    refresh_links: bool = True,
+    replace_source_files: Iterable[Path] | None = None,
+    diagnostic_facts: Iterable[DiagnosticFact] | None = None,
+    maintain_source_records: bool = True,
+    maintain_compression_facts: bool = True,
+    maintain_allowance_observations: bool = True,
+    touch_revisions: bool = True,
+    sync_content_fts_on_replace: bool = True,
+    defer_usage_indexes: bool = False,
+) -> _UsageEventUpsertResult:
     rows = _usage_event_rows(events)
     fact_rows = _diagnostic_fact_rows(diagnostic_facts)
     source_files_to_replace = _source_file_strings(replace_source_files)
-    with connect(db_path) as conn:
-        init_db(conn)
-        affected_thread_keys = _thread_keys_for_source_files(conn, source_files_to_replace)
-        _delete_usage_events_for_source_files(conn, source_files_to_replace)
-        if not rows:
-            _refresh_after_empty_source_replacement(
-                conn,
-                refresh_links=refresh_links,
-                affected_thread_keys=affected_thread_keys,
-            )
-            if source_files_to_replace:
+    affected_thread_keys = _thread_keys_for_source_files(conn, source_files_to_replace)
+    _delete_usage_events_for_source_files(
+        conn,
+        source_files_to_replace,
+        sync_content_fts=sync_content_fts_on_replace,
+    )
+    if not rows:
+        _refresh_after_empty_source_replacement(
+            conn,
+            refresh_links=refresh_links,
+            affected_thread_keys=affected_thread_keys,
+        )
+        if source_files_to_replace:
+            if touch_revisions:
                 touch_compression_revisions(conn, {"calls", "threads"})
+            if maintain_compression_facts:
                 sync_compression_detector_facts(
                     conn,
                     record_ids=(),
                     affected_thread_keys=affected_thread_keys,
                 )
-            return 0
-        affected_thread_keys.update(_thread_keys_for_usage_rows(rows))
-        _delete_diagnostic_facts_for_record_ids(conn, _usage_event_record_ids(rows))
+        return _UsageEventUpsertResult(0, (), frozenset(affected_thread_keys))
+
+    affected_thread_keys.update(_thread_keys_for_usage_rows(rows))
+    record_ids = _usage_event_record_ids(rows)
+    _delete_diagnostic_facts_for_record_ids(conn, record_ids)
+    with _deferred_usage_event_indexes(conn, enabled=defer_usage_indexes):
         _insert_usage_event_rows(conn, rows)
-        record_ids = _usage_event_record_ids(rows)
+    if maintain_allowance_observations:
         sync_allowance_observations_for_record_ids(conn, record_ids)
+    if maintain_source_records:
         sync_source_records(conn, record_ids=record_ids)
-        _insert_diagnostic_facts(conn, fact_rows)
-        _refresh_after_usage_event_upsert(
-            conn,
-            refresh_links=refresh_links,
-            affected_thread_keys=affected_thread_keys,
-        )
+    _insert_diagnostic_facts(conn, fact_rows)
+    _refresh_after_usage_event_upsert(
+        conn,
+        refresh_links=refresh_links,
+        affected_thread_keys=affected_thread_keys,
+    )
+    if touch_revisions:
         touch_compression_revisions(conn, {"calls", "threads"})
+    if maintain_compression_facts:
         sync_compression_detector_facts(
             conn,
             record_ids=record_ids,
             affected_thread_keys=affected_thread_keys,
         )
-        return len(rows)
+    return _UsageEventUpsertResult(
+        len(rows),
+        tuple(record_ids),
+        frozenset(affected_thread_keys),
+    )
+
+
+def _finalize_streamed_usage_event_upserts(
+    conn: sqlite3.Connection,
+    *,
+    record_ids: Iterable[str],
+    affected_thread_keys: Iterable[str],
+    maintain_source_records: bool = True,
+    stage_callback: Callable[[str], None] | None = None,
+) -> _UsageEventUpsertResult:
+    """Finalize derived state once after bounded source-batch upserts."""
+
+    unique_record_ids = tuple(dict.fromkeys(record_ids))
+    unique_thread_keys = frozenset(affected_thread_keys)
+    if unique_record_ids:
+        sync_allowance_observations_for_record_ids(conn, list(unique_record_ids))
+        if maintain_source_records:
+            sync_source_records(conn, record_ids=unique_record_ids)
+    if stage_callback is not None:
+        stage_callback("allowance_and_sources")
+    _refresh_after_usage_event_upsert(
+        conn,
+        refresh_links=True,
+        affected_thread_keys=set(unique_thread_keys),
+    )
+    if stage_callback is not None:
+        stage_callback("links_and_thread_summaries")
+    if unique_record_ids or unique_thread_keys:
+        touch_compression_revisions(conn, {"calls", "threads"})
+    if stage_callback is not None:
+        stage_callback("revisions")
+    return _UsageEventUpsertResult(
+        len(unique_record_ids),
+        unique_record_ids,
+        unique_thread_keys,
+    )
 
 
 def _usage_event_rows(events: Iterable[UsageEvent]) -> list[dict[str, object]]:
@@ -558,109 +653,6 @@ def _diagnostic_fact_rows(
     diagnostic_facts: Iterable[DiagnosticFact] | None,
 ) -> list[dict[str, object]]:
     return [fact.to_row() for fact in diagnostic_facts or []]
-
-
-def _source_file_strings(replace_source_files: Iterable[Path] | None) -> list[str]:
-    return [str(path) for path in replace_source_files or []]
-
-
-def _delete_usage_events_for_source_files(
-    conn: sqlite3.Connection,
-    source_files_to_replace: list[str],
-) -> None:
-    if not source_files_to_replace:
-        return
-    placeholders = ", ".join("?" for _source in source_files_to_replace)
-    delete_content_index_rows_for_source_files(
-        conn,
-        placeholders=placeholders,
-        source_files_to_replace=source_files_to_replace,
-    )
-    delete_compression_facts_for_source_files(
-        conn,
-        source_files=source_files_to_replace,
-    )
-    conn.execute(
-        f"""
-        DELETE FROM allowance_observations
-        WHERE record_id IN (
-            SELECT record_id
-            FROM usage_events
-            WHERE source_file IN ({placeholders})
-        )
-        """,
-        source_files_to_replace,
-    )
-    conn.execute(
-        f"""
-        DELETE FROM source_records
-        WHERE record_id IN (
-            SELECT record_id
-            FROM usage_events
-            WHERE source_file IN ({placeholders})
-        )
-        """,
-        source_files_to_replace,
-    )
-    conn.execute(
-        f"""
-        DELETE FROM call_diagnostic_facts
-        WHERE record_id IN (
-            SELECT record_id
-            FROM usage_events
-            WHERE source_file IN ({placeholders})
-        )
-        """,
-        source_files_to_replace,
-    )
-    conn.execute(
-        f"DELETE FROM usage_events WHERE source_file IN ({placeholders})",
-        source_files_to_replace,
-    )
-
-
-def _thread_keys_for_source_files(
-    conn: sqlite3.Connection,
-    source_files_to_replace: list[str],
-) -> set[str]:
-    if not source_files_to_replace:
-        return set()
-    placeholders = ", ".join("?" for _source in source_files_to_replace)
-    rows = conn.execute(
-        f"""
-        SELECT thread_key, session_id
-        FROM usage_events
-        WHERE source_file IN ({placeholders})
-        """,
-        source_files_to_replace,
-    ).fetchall()
-    return _thread_keys_for_usage_rows(rows)
-
-
-def _thread_keys_for_usage_rows(
-    rows: Iterable[Mapping[str, object] | sqlite3.Row],
-) -> set[str]:
-    keys: set[str] = set()
-    for row in rows:
-        session_id = _usage_row_value(row, "session_id")
-        thread_key = _usage_row_value(row, "thread_key") or (
-            f"session:{session_id}" if session_id else None
-        )
-        if thread_key:
-            keys.add(str(thread_key))
-    return keys
-
-
-def _usage_row_value(
-    row: Mapping[str, object] | sqlite3.Row,
-    key: str,
-) -> object | None:
-    if isinstance(row, Mapping):
-        return row.get(key)
-    try:
-        return row[key]
-    except (IndexError, KeyError, TypeError):
-        return None
 
 
 def _refresh_after_empty_source_replacement(
@@ -698,6 +690,42 @@ def _insert_usage_event_rows(
         _usage_event_upsert_sql(),
         [[row[column] for column in EVENT_COLUMNS] for row in rows],
     )
+
+
+@contextmanager
+def _deferred_usage_event_indexes(
+    conn: sqlite3.Connection,
+    *,
+    enabled: bool,
+    additional_tables: tuple[str, ...] = (),
+) -> Iterator[None]:
+    if not enabled:
+        yield
+        return
+    table_names = ("usage_events", *additional_tables)
+    placeholders = ", ".join("?" for _table_name in table_names)
+    indexes = [
+        (str(row["name"]), str(row["sql"]))
+        for row in conn.execute(
+            f"""
+            SELECT name, sql
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND tbl_name IN ({placeholders})
+              AND sql IS NOT NULL
+            ORDER BY name
+            """,  # nosec B608 - placeholders are generated, values remain parameterized
+            table_names,
+        )
+    ]
+    for name, _sql in indexes:
+        quoted_name = name.replace('"', '""')
+        conn.execute(f'DROP INDEX "{quoted_name}"')  # nosec B608 - schema-owned identifier
+    try:
+        yield
+    finally:
+        for _name, sql in indexes:
+            conn.execute(sql)
 
 
 def _refresh_after_usage_event_upsert(
@@ -767,14 +795,19 @@ def _refresh_usage_event_links_for_threads(
     thread_keys = sorted({key for key in affected_thread_keys if key})
     if not thread_keys:
         return 0
-    placeholders = ", ".join("?" for _key in thread_keys)
-    return _refresh_usage_event_links_scoped(
-        conn,
-        where_clause=(
-            f"WHERE coalesce(nullif(thread_key, ''), 'session:' || session_id) IN ({placeholders})"
-        ),
-        params=thread_keys,
-    )
+    changed = 0
+    for start in range(0, len(thread_keys), SQLITE_VARIABLE_BATCH_SIZE):
+        chunk = thread_keys[start : start + SQLITE_VARIABLE_BATCH_SIZE]
+        placeholders = ", ".join("?" for _key in chunk)
+        changed += _refresh_usage_event_links_scoped(
+            conn,
+            where_clause=(
+                "WHERE coalesce(nullif(thread_key, ''), 'session:' || session_id) "
+                f"IN ({placeholders})"
+            ),
+            params=chunk,
+        )
+    return changed
 
 
 def _refresh_usage_event_links(conn: sqlite3.Connection) -> int:
@@ -788,58 +821,36 @@ def _refresh_usage_event_links_scoped(
     params: Iterable[object] = (),
 ) -> int:
     before = conn.total_changes
-    conn.execute("DROP TABLE IF EXISTS temp_usage_event_links")
     conn.execute(
         f"""
-        CREATE TEMP TABLE temp_usage_event_links AS
-        SELECT
-            record_id,
-            ROW_NUMBER() OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
-                ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
-            ) AS next_thread_call_index,
-            LAG(record_id) OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
-                ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
-            ) AS previous_id,
-            LEAD(record_id) OVER (
-                PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
-                ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
-            ) AS next_id
-        FROM usage_events
-        {where_clause}
+        WITH usage_event_links AS (
+            SELECT
+                record_id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                    ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
+                ) AS next_thread_call_index,
+                LAG(record_id) OVER (
+                    PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                    ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
+                ) AS previous_id,
+                LEAD(record_id) OVER (
+                    PARTITION BY coalesce(nullif(thread_key, ''), 'session:' || session_id)
+                    ORDER BY event_timestamp, cumulative_total_tokens, line_number, record_id
+                ) AS next_id
+            FROM usage_events
+            {where_clause}
+        )
+        UPDATE usage_events AS target
+        SET
+            thread_call_index = links.next_thread_call_index,
+            previous_record_id = links.previous_id,
+            next_record_id = links.next_id
+        FROM usage_event_links AS links
+        WHERE target.record_id = links.record_id
         """,
         list(params),
     )
-    conn.execute(
-        "CREATE UNIQUE INDEX temp_usage_event_links_record_id ON temp_usage_event_links(record_id)"
-    )
-    conn.execute(
-        """
-        UPDATE usage_events
-        SET
-            thread_call_index = (
-                SELECT next_thread_call_index
-                FROM temp_usage_event_links
-                WHERE temp_usage_event_links.record_id = usage_events.record_id
-            ),
-            previous_record_id = (
-                SELECT previous_id
-                FROM temp_usage_event_links
-                WHERE temp_usage_event_links.record_id = usage_events.record_id
-            ),
-            next_record_id = (
-                SELECT next_id
-                FROM temp_usage_event_links
-                WHERE temp_usage_event_links.record_id = usage_events.record_id
-            )
-        WHERE record_id IN (
-            SELECT record_id
-            FROM temp_usage_event_links
-        )
-        """
-    )
-    conn.execute("DROP TABLE IF EXISTS temp_usage_event_links")
     return conn.total_changes - before
 
 

--- a/src/codex_usage_tracker/store/compression_fact_contract.py
+++ b/src/codex_usage_tracker/store/compression_fact_contract.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
-COMPRESSION_FACTS_VERSION = 1
+COMPRESSION_FACTS_VERSION = 2
 MIN_TOOL_OUTPUT_TOKENS = 4_096
 MIN_TOOL_OUTPUT_BYTES = (MIN_TOOL_OUTPUT_TOKENS * 4) - 3
 SHELL_ROOTS = frozenset({"git", "nl", "rg", "sed"})
@@ -69,8 +69,6 @@ def call_revision_identity(row: Sequence[Any]) -> tuple[object, ...]:
         optional_text(row[4]),
         optional_text(row[5]),
         bool(row[6]),
-        optional_int(row[7]),
-        optional_text(row[8]),
         int(row[9] or 0),
         int(row[10] or 0),
         int(row[11] or 0),

--- a/src/codex_usage_tracker/store/compression_fact_ingest.py
+++ b/src/codex_usage_tracker/store/compression_fact_ingest.py
@@ -1,0 +1,112 @@
+"""Persist detector-ready compression facts during bounded ingestion."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Iterable
+
+from codex_usage_tracker.core.models import UsageEvent
+from codex_usage_tracker.store.compression_fact_contract import COMPRESSION_FACTS_VERSION
+from codex_usage_tracker.store.compression_fact_rows import (
+    RECORD_FACT_COLUMNS,
+    SEQUENCE_FACT_COLUMNS,
+    IngestionFactRows,
+    build_ingestion_fact_rows,
+    source_order_group,
+)
+from codex_usage_tracker.store.compression_facts import (
+    _insert_thread_facts,
+    _update_thread_manifests,
+)
+from codex_usage_tracker.store.compression_schema import (
+    create_compression_fact_indexes,
+    drop_compression_fact_indexes,
+    stamp_compression_fact_state,
+)
+from codex_usage_tracker.store.content_index_models import _ExtractedContentRows
+
+
+class IngestionFactWriter:
+    """Persist full-build facts without rescanning normalized SQLite tables."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._source_orders = {"tool": 0, "command": 0, "file": 0, "fragment": 0}
+        drop_compression_fact_indexes(conn)
+        conn.execute("DELETE FROM compression_sequence_facts")
+        conn.execute("DELETE FROM compression_thread_facts")
+        conn.execute("DELETE FROM compression_record_facts")
+
+    def add(
+        self,
+        *,
+        events: Iterable[UsageEvent],
+        content_rows: Iterable[_ExtractedContentRows],
+    ) -> None:
+        self.add_prebuilt(build_ingestion_fact_rows(events=events, content_rows=content_rows))
+
+    def add_prebuilt(self, rows: IngestionFactRows) -> None:
+        """Persist worker-built rows after rebasing their local source order."""
+
+        for row in rows.sequence_rows:
+            group = source_order_group(str(row[5]))
+            row[4] = int(str(row[4])) + self._source_orders[group]
+        for group, count in rows.source_order_counts.items():
+            self._source_orders[group] += count
+        _insert_rows(
+            self._conn,
+            "compression_record_facts",
+            RECORD_FACT_COLUMNS,
+            rows.record_rows,
+        )
+        _insert_rows(
+            self._conn,
+            "compression_sequence_facts",
+            SEQUENCE_FACT_COLUMNS,
+            rows.sequence_rows,
+        )
+
+    def finish(self, *, stage_callback: Callable[[str], None] | None = None) -> None:
+        _sync_record_links(self._conn)
+        if stage_callback is not None:
+            stage_callback("record_links")
+        _insert_thread_facts(self._conn)
+        if stage_callback is not None:
+            stage_callback("thread_facts")
+        _update_thread_manifests(self._conn)
+        if stage_callback is not None:
+            stage_callback("thread_manifests")
+        create_compression_fact_indexes(self._conn)
+        if stage_callback is not None:
+            stage_callback("indexes")
+        stamp_compression_fact_state(self._conn, facts_version=COMPRESSION_FACTS_VERSION)
+        if stage_callback is not None:
+            stage_callback("state")
+
+
+def _sync_record_links(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        UPDATE compression_record_facts AS facts
+        SET
+            thread_call_index = usage.thread_call_index,
+            previous_record_id = usage.previous_record_id
+        FROM usage_events AS usage
+        WHERE facts.record_id = usage.record_id
+        """
+    )
+
+
+def _insert_rows(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+    rows: list[list[object]],
+) -> None:
+    if not rows:
+        return
+    placeholders = ", ".join("?" for _column in columns)
+    conn.executemany(
+        f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})",  # nosec B608
+        rows,
+    )

--- a/src/codex_usage_tracker/store/compression_fact_manifest.py
+++ b/src/codex_usage_tracker/store/compression_fact_manifest.py
@@ -1,0 +1,164 @@
+"""Manifest and row-group helpers for ingestion-built compression facts."""
+
+from __future__ import annotations
+
+from codex_usage_tracker.core.models import UsageEvent
+from codex_usage_tracker.store.compression_fact_contract import (
+    ManifestAccumulator,
+    command_revision_identity,
+    file_revision_identity,
+    fragment_revision_identity,
+    tool_revision_identity,
+)
+from codex_usage_tracker.store.content_index_models import _ExtractedContentRows
+
+
+def evidence_manifest(
+    *,
+    tool_rows: list[dict[str, object]],
+    command_rows: list[dict[str, object]],
+    file_rows: list[dict[str, object]],
+    fragment_rows: list[dict[str, object]],
+) -> ManifestAccumulator:
+    manifest = ManifestAccumulator()
+    _add_tool_revisions(manifest, tool_rows)
+    _add_command_revisions(manifest, command_rows)
+    _add_file_revisions(manifest, file_rows)
+    _add_fragment_revisions(manifest, fragment_rows)
+    return manifest
+
+
+def rows_by_record(
+    extracted_rows: list[_ExtractedContentRows],
+    attribute: str,
+) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = {}
+    for extracted in extracted_rows:
+        for row in getattr(extracted, attribute):
+            grouped.setdefault(str(row["record_id"]), []).append(row)
+    return grouped
+
+
+def event_rows_by_record(
+    extracted_rows: list[_ExtractedContentRows],
+    attribute: str,
+) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = {}
+    for extracted in extracted_rows:
+        for row in getattr(extracted.event_rows, attribute):
+            grouped.setdefault(str(row["record_id"]), []).append(row)
+    return grouped
+
+
+def thread_key(event: UsageEvent) -> str:
+    return event.thread_key or event.thread_name or event.session_id
+
+
+def call_revision_row(event: UsageEvent) -> tuple[object, ...]:
+    return (
+        event.record_id,
+        event.session_id,
+        thread_key(event),
+        event.event_timestamp,
+        event.model,
+        event.effort,
+        event.is_archived,
+        event.thread_call_index,
+        event.previous_record_id,
+        event.cached_input_tokens,
+        event.uncached_input_tokens,
+        event.output_tokens,
+        event.reasoning_output_tokens,
+        event.cache_ratio,
+        event.context_window_percent,
+    )
+
+
+def _add_tool_revisions(
+    manifest: ManifestAccumulator,
+    rows: list[dict[str, object]],
+) -> None:
+    for row in rows:
+        manifest.add(
+            "tool",
+            tool_revision_identity(
+                (
+                    row["tool_call_key"],
+                    row["record_id"],
+                    row.get("turn_key"),
+                    row["tool_name"],
+                    row.get("status"),
+                    row.get("duration_ms"),
+                    row.get("output_size_bytes"),
+                )
+            ),
+        )
+
+
+def _add_command_revisions(
+    manifest: ManifestAccumulator,
+    rows: list[dict[str, object]],
+) -> None:
+    for row in rows:
+        root = row["command_root"]
+        manifest.add(
+            "command",
+            command_revision_identity(
+                (
+                    row["command_run_key"],
+                    row["record_id"],
+                    row.get("turn_key"),
+                    root,
+                    root,
+                    row.get("exit_code"),
+                    row.get("status"),
+                    row.get("output_size_bytes"),
+                    row.get("retry_group"),
+                )
+            ),
+        )
+
+
+def _add_file_revisions(
+    manifest: ManifestAccumulator,
+    rows: list[dict[str, object]],
+) -> None:
+    for row in rows:
+        path_hash = row["path_hash"]
+        manifest.add(
+            "file",
+            file_revision_identity(
+                (
+                    row["file_event_key"],
+                    row["record_id"],
+                    row.get("turn_key"),
+                    row["operation"],
+                    path_hash,
+                    path_hash,
+                )
+            ),
+        )
+
+
+def _add_fragment_revisions(
+    manifest: ManifestAccumulator,
+    rows: list[dict[str, object]],
+) -> None:
+    for row in rows:
+        kind = row["fragment_kind"]
+        manifest.add(
+            "fragment",
+            fragment_revision_identity(
+                (
+                    row["fragment_id"],
+                    row["record_id"],
+                    row.get("turn_key"),
+                    kind,
+                    row.get("role"),
+                    kind,
+                    row["content_hash"],
+                    row.get("content_size_bytes"),
+                    row.get("includes_raw_fragment"),
+                )
+            ),
+        )

--- a/src/codex_usage_tracker/store/compression_fact_rows.py
+++ b/src/codex_usage_tracker/store/compression_fact_rows.py
@@ -1,0 +1,412 @@
+"""Build detector-ready compression rows from one bounded parser batch."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from codex_usage_tracker.core.models import UsageEvent
+from codex_usage_tracker.parser.state import PARSER_ADAPTER_VERSION
+from codex_usage_tracker.store.compression_fact_contract import (
+    COMPRESSION_FACTS_VERSION,
+    MIN_TOOL_OUTPUT_BYTES,
+    RELEVANT_COMMAND_ROOTS,
+    ManifestAccumulator,
+    call_revision_identity,
+)
+from codex_usage_tracker.store.compression_fact_manifest import (
+    call_revision_row as _call_revision_row,
+)
+from codex_usage_tracker.store.compression_fact_manifest import (
+    event_rows_by_record as _event_rows_by_record,
+)
+from codex_usage_tracker.store.compression_fact_manifest import (
+    evidence_manifest as _evidence_manifest,
+)
+from codex_usage_tracker.store.compression_fact_manifest import (
+    rows_by_record as _rows_by_record,
+)
+from codex_usage_tracker.store.compression_fact_manifest import (
+    thread_key as _thread_key,
+)
+from codex_usage_tracker.store.content_index_models import _ExtractedContentRows
+
+RECORD_FACT_COLUMNS = (
+    "record_id",
+    "source_file",
+    "session_id",
+    "thread_key",
+    "event_timestamp",
+    "model",
+    "effort",
+    "is_archived",
+    "thread_call_index",
+    "previous_record_id",
+    "cached_input_tokens",
+    "uncached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "estimated_cost_usd",
+    "usage_credits",
+    "cache_ratio",
+    "context_window_percent",
+    "turn_count",
+    "indexed_call",
+    "tool_call_count",
+    "command_run_count",
+    "file_event_count",
+    "content_fragment_count",
+    "compaction_count",
+    "source_record_count",
+    "parser_warning_record_count",
+    "parser_adapter",
+    "parser_version",
+    "content_exposure_tokens",
+    "tool_output_exposure_tokens",
+    "manifest_count",
+    "manifest_sum_hex",
+    "manifest_xor_hex",
+    "facts_version",
+    "updated_at",
+)
+SEQUENCE_FACT_COLUMNS = (
+    "fact_key",
+    "record_id",
+    "thread_key",
+    "turn_key",
+    "source_order",
+    "fact_kind",
+    "category",
+    "status",
+    "duration_ms",
+    "output_size_bytes",
+    "command_label",
+    "exit_code",
+    "retry_group",
+    "path_identity",
+    "exposure_tokens",
+    "facts_version",
+)
+
+
+@dataclass(frozen=True)
+class IngestionFactRows:
+    """Fact rows and local source-order counters produced by one parser unit."""
+
+    record_rows: list[list[object]]
+    sequence_rows: list[list[object]]
+    source_order_counts: dict[str, int]
+
+
+def build_ingestion_fact_rows(
+    *,
+    events: Iterable[UsageEvent],
+    content_rows: Iterable[_ExtractedContentRows],
+) -> IngestionFactRows:
+    """Build facts without touching SQLite so parser workers can share the work."""
+
+    extracted_list = [rows for rows in content_rows if rows.has_usage_rows]
+    turns = _rows_by_record(extracted_list, "turn_rows")
+    fragments = _rows_by_record(extracted_list, "fragment_rows")
+    tools = _event_rows_by_record(extracted_list, "tool_call_rows")
+    commands = _event_rows_by_record(extracted_list, "command_run_rows")
+    files = _event_rows_by_record(extracted_list, "file_event_rows")
+    source_orders = {"tool": 0, "command": 0, "file": 0, "fragment": 0}
+    record_rows: list[list[object]] = []
+    sequence_rows: list[list[object]] = []
+    for event in events:
+        record_id = event.record_id
+        record_turns = turns.get(record_id, [])
+        record_fragments = fragments.get(record_id, [])
+        record_tools = tools.get(record_id, [])
+        record_commands = commands.get(record_id, [])
+        record_files = files.get(record_id, [])
+        manifest = _evidence_manifest(
+            tool_rows=record_tools,
+            command_rows=record_commands,
+            file_rows=record_files,
+            fragment_rows=record_fragments,
+        )
+        manifest.add("call", call_revision_identity(_call_revision_row(event)))
+        record_rows.append(
+            _record_fact_values(
+                event,
+                turn_rows=record_turns,
+                fragment_rows=record_fragments,
+                tool_rows=record_tools,
+                command_rows=record_commands,
+                file_rows=record_files,
+                manifest=manifest,
+            )
+        )
+        sequence_rows.extend(
+            _sequence_fact_values(
+                event,
+                fragment_rows=record_fragments,
+                tool_rows=record_tools,
+                command_rows=record_commands,
+                file_rows=record_files,
+                source_orders=source_orders,
+            )
+        )
+    return IngestionFactRows(
+        record_rows=record_rows,
+        sequence_rows=sequence_rows,
+        source_order_counts=source_orders,
+    )
+
+
+def source_order_group(fact_kind: str) -> str:
+    return {
+        "tool_output": "tool",
+        "command": "command",
+        "file_read": "file",
+        "content_turn": "fragment",
+    }[fact_kind]
+
+
+def _sequence_fact_values(
+    event: UsageEvent,
+    *,
+    fragment_rows: list[dict[str, object]],
+    tool_rows: list[dict[str, object]],
+    command_rows: list[dict[str, object]],
+    file_rows: list[dict[str, object]],
+    source_orders: dict[str, int],
+) -> list[list[object]]:
+    thread_key = _thread_key(event)
+    rows = _tool_sequence_values(event, thread_key, tool_rows, source_orders)
+    rows.extend(_command_sequence_values(event, thread_key, command_rows, source_orders))
+    rows.extend(_file_sequence_values(event, thread_key, file_rows, source_orders))
+    rows.extend(_content_sequence_values(event, thread_key, fragment_rows, source_orders))
+    return rows
+
+
+def _tool_sequence_values(
+    event: UsageEvent,
+    thread_key: str,
+    tool_rows: list[dict[str, object]],
+    source_orders: dict[str, int],
+) -> list[list[object]]:
+    rows: list[list[object]] = []
+    for row in tool_rows:
+        source_orders["tool"] += 1
+        output_size = _as_int(row.get("output_size_bytes"))
+        if output_size < MIN_TOOL_OUTPUT_BYTES:
+            continue
+        rows.append(
+            [
+                f"tool:{row['tool_call_key']}",
+                event.record_id,
+                thread_key,
+                row.get("turn_key"),
+                source_orders["tool"],
+                "tool_output",
+                str(row.get("tool_name") or ""),
+                row.get("status"),
+                row.get("duration_ms"),
+                output_size,
+                None,
+                None,
+                None,
+                None,
+                _token_estimate(output_size),
+                COMPRESSION_FACTS_VERSION,
+            ]
+        )
+    return rows
+
+
+def _command_sequence_values(
+    event: UsageEvent,
+    thread_key: str,
+    command_rows: list[dict[str, object]],
+    source_orders: dict[str, int],
+) -> list[list[object]]:
+    rows: list[list[object]] = []
+    for row in command_rows:
+        source_orders["command"] += 1
+        command_root = str(row.get("command_root") or "")
+        if command_root not in RELEVANT_COMMAND_ROOTS:
+            continue
+        output_size = _as_int(row.get("output_size_bytes"))
+        rows.append(
+            [
+                f"command:{row['command_run_key']}",
+                event.record_id,
+                thread_key,
+                row.get("turn_key"),
+                source_orders["command"],
+                "command",
+                command_root,
+                row.get("status"),
+                None,
+                output_size,
+                command_root,
+                row.get("exit_code"),
+                row.get("retry_group"),
+                None,
+                _token_estimate(output_size),
+                COMPRESSION_FACTS_VERSION,
+            ]
+        )
+    return rows
+
+
+def _file_sequence_values(
+    event: UsageEvent,
+    thread_key: str,
+    file_rows: list[dict[str, object]],
+    source_orders: dict[str, int],
+) -> list[list[object]]:
+    rows: list[list[object]] = []
+    for row in file_rows:
+        source_orders["file"] += 1
+        path_hash = str(row.get("path_hash") or "")
+        if row.get("operation") != "read" or not path_hash:
+            continue
+        rows.append(
+            [
+                f"file:{row['file_event_key']}",
+                event.record_id,
+                thread_key,
+                row.get("turn_key"),
+                source_orders["file"],
+                "file_read",
+                path_hash,
+                None,
+                None,
+                0,
+                None,
+                None,
+                None,
+                path_hash,
+                0,
+                COMPRESSION_FACTS_VERSION,
+            ]
+        )
+    return rows
+
+
+def _content_sequence_values(
+    event: UsageEvent,
+    thread_key: str,
+    fragment_rows: list[dict[str, object]],
+    source_orders: dict[str, int],
+) -> list[list[object]]:
+    content_groups: dict[tuple[str, str], list[int]] = {}
+    for row in fragment_rows:
+        source_orders["fragment"] += 1
+        turn_key = str(row.get("turn_key") or "")
+        if not turn_key:
+            continue
+        size = _as_int(row.get("content_size_bytes"))
+        group = content_groups.setdefault(
+            (event.record_id, turn_key),
+            [source_orders["fragment"], 0, 0],
+        )
+        group[1] += size
+        group[2] += _token_estimate(size)
+    rows: list[list[object]] = []
+    for (record_id, turn_key), (source_order, output_size, exposure) in content_groups.items():
+        rows.append(
+            [
+                f"content:{record_id}:{turn_key}",
+                record_id,
+                thread_key,
+                turn_key,
+                source_order,
+                "content_turn",
+                "",
+                None,
+                None,
+                output_size,
+                None,
+                None,
+                None,
+                None,
+                exposure,
+                COMPRESSION_FACTS_VERSION,
+            ]
+        )
+    return rows
+
+
+def _record_fact_values(
+    event: UsageEvent,
+    *,
+    turn_rows: list[dict[str, object]],
+    fragment_rows: list[dict[str, object]],
+    tool_rows: list[dict[str, object]],
+    command_rows: list[dict[str, object]],
+    file_rows: list[dict[str, object]],
+    manifest: ManifestAccumulator,
+) -> list[object]:
+    content_tokens = _sum_estimated_tokens(fragment_rows, "content_size_bytes")
+    tool_tokens = _sum_estimated_tokens(tool_rows, "output_size_bytes")
+    command_tokens = _sum_estimated_tokens(command_rows, "output_size_bytes")
+    indexed_call = max(
+        (_as_int(row.get("indexed_content_included")) for row in turn_rows),
+        default=0,
+    )
+    manifest_count, manifest_sum, manifest_xor = manifest.storage_values()
+    return [
+        event.record_id,
+        event.source_file,
+        event.session_id,
+        _thread_key(event),
+        event.event_timestamp,
+        event.model,
+        event.effort,
+        event.is_archived,
+        event.thread_call_index,
+        event.previous_record_id,
+        event.cached_input_tokens,
+        event.uncached_input_tokens,
+        event.output_tokens,
+        event.reasoning_output_tokens,
+        None,
+        None,
+        event.cache_ratio,
+        event.context_window_percent,
+        len(turn_rows),
+        indexed_call,
+        len(tool_rows),
+        len(command_rows),
+        len(file_rows),
+        len(fragment_rows),
+        sum(
+            1
+            for row in fragment_rows
+            if str(row.get("fragment_kind") or "") in {"compaction", "compaction_history"}
+        ),
+        1,
+        0,
+        "codex-jsonl",
+        PARSER_ADAPTER_VERSION,
+        content_tokens,
+        max(tool_tokens, command_tokens),
+        manifest_count,
+        manifest_sum,
+        manifest_xor,
+        COMPRESSION_FACTS_VERSION,
+        event.event_timestamp,
+    ]
+
+
+def _token_estimate(size_bytes: int) -> int:
+    return (size_bytes + 3) // 4
+
+
+def _sum_estimated_tokens(rows: list[dict[str, object]], key: str) -> int:
+    return sum(_token_estimate(_as_int(row.get(key))) for row in rows)
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (float, str, bytes, bytearray)):
+        return int(value)
+    return 0

--- a/src/codex_usage_tracker/store/compression_revisions.py
+++ b/src/codex_usage_tracker/store/compression_revisions.py
@@ -10,9 +10,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
-from codex_usage_tracker.store.compression_schema import (
-    create_compression_revision_tables,
-)
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.schema import init_db
 
@@ -101,7 +98,6 @@ def touch_compression_revisions(
         raise ValueError(f"unknown compression revision dimensions: {sorted(unknown)}")
     if not selected:
         return _read_global_generation(conn)
-    create_compression_revision_tables(conn)
     assignments = ["generation = generation + 1"]
     assignments.extend(
         f"{_DIMENSION_COLUMNS[dimension]} = {_DIMENSION_COLUMNS[dimension]} + 1"

--- a/src/codex_usage_tracker/store/compression_schema.py
+++ b/src/codex_usage_tracker/store/compression_schema.py
@@ -396,14 +396,18 @@ def stamp_compression_fact_state(
 
 def _ensure_compression_storage(conn: sqlite3.Connection) -> None:
     conn.execute("DROP INDEX IF EXISTS idx_compression_candidate_records_record")
-    conn.executescript(
+    conn.execute(
         """
         CREATE TABLE IF NOT EXISTS compression_source_state (
             singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
             generation INTEGER NOT NULL
-        );
+        )
+        """
+    )
+    conn.execute(
+        """
         INSERT OR IGNORE INTO compression_source_state(singleton, generation)
-        VALUES (1, 0);
+        VALUES (1, 0)
         """
     )
     columns = {

--- a/src/codex_usage_tracker/store/content_extract.py
+++ b/src/codex_usage_tracker/store/content_extract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -16,14 +17,94 @@ from codex_usage_tracker.store.content_index_events import (
 )
 from codex_usage_tracker.store.content_index_models import (
     _ExtractedContentRows,
+    _PendingContentRows,
     _PendingFragment,
 )
 from codex_usage_tracker.store.content_rows import (
     _append_pending_content_rows,
+    _content_row_timestamp,
     _empty_pending_content_rows,
 )
 
 MAX_FRAGMENT_CHARS = 4000
+
+
+@dataclass
+class ContentRowAccumulator:
+    """Accumulate normalized content while a parser decodes one source file."""
+
+    source_path: Path
+    pending: list[_PendingFragment] = field(default_factory=list)
+    pending_tool_calls: list[PendingToolCall] = field(default_factory=list)
+    pending_command_runs: list[PendingCommandRun] = field(default_factory=list)
+    pending_file_events: list[PendingFileEvent] = field(default_factory=list)
+    pending_rows: _PendingContentRows = field(default_factory=_empty_pending_content_rows)
+    turn_id: str | None = None
+    turn_index: int = 0
+    parse_warnings: int = 0
+    has_usage_rows: bool = False
+    created_at: str = field(default_factory=_content_row_timestamp)
+
+    def consume(
+        self,
+        *,
+        envelope: dict[str, Any],
+        payload: dict[str, Any],
+        line_number: int,
+        usage_row: Mapping[str, object] | None,
+    ) -> None:
+        entry_type = envelope.get("type")
+        timestamp = optional_str(envelope.get("timestamp"))
+        if entry_type == "turn_context":
+            self.turn_id = optional_str(payload.get("turn_id"))
+            self.turn_index += 1
+            return
+        if _is_token_count(entry_type, payload):
+            if usage_row is not None:
+                self.has_usage_rows = True
+                _append_pending_content_rows(
+                    self.pending_rows,
+                    pending=self.pending,
+                    tool_calls=self.pending_tool_calls,
+                    command_runs=self.pending_command_runs,
+                    file_events=self.pending_file_events,
+                    usage_row=usage_row,
+                    created_at=self.created_at,
+                )
+                self.pending.clear()
+                self.pending_tool_calls.clear()
+                self.pending_command_runs.clear()
+                self.pending_file_events.clear()
+            return
+        self.pending.extend(
+            _extract_pending_fragments(
+                envelope=envelope,
+                payload=payload,
+                line_number=line_number,
+                timestamp=timestamp,
+                turn_id=self.turn_id,
+                turn_index=self.turn_index,
+            )
+        )
+        events = extract_pending_local_events(
+            envelope=envelope,
+            payload=payload,
+            line_number=line_number,
+            timestamp=timestamp,
+        )
+        self.pending_tool_calls.extend(events.tool_calls)
+        self.pending_command_runs.extend(events.command_runs)
+        self.pending_file_events.extend(events.file_events)
+
+    def finish(self) -> _ExtractedContentRows:
+        return _ExtractedContentRows(
+            source_path=str(self.source_path),
+            has_usage_rows=self.has_usage_rows,
+            turn_rows=self.pending_rows.turn_rows,
+            fragment_rows=self.pending_rows.fragment_rows,
+            event_rows=self.pending_rows.event_rows,
+            parse_warnings=self.parse_warnings,
+        )
 
 
 def _extract_content_rows_for_source_file(
@@ -36,14 +117,7 @@ def _extract_content_rows_for_source_file(
     if not usage_rows:
         return _empty_extracted_content_rows(source_path=source_path, has_usage_rows=False)
 
-    pending: list[_PendingFragment] = []
-    pending_tool_calls: list[PendingToolCall] = []
-    pending_command_runs: list[PendingCommandRun] = []
-    pending_file_events: list[PendingFileEvent] = []
-    pending_rows = _empty_pending_content_rows()
-    turn_id: str | None = None
-    turn_index = 0
-    parse_warnings = 0
+    accumulator = ContentRowAccumulator(source_path=source_path, has_usage_rows=True)
     try:
         with source_path.open("rb") as handle:
             if start_byte > 0:
@@ -51,61 +125,19 @@ def _extract_content_rows_for_source_file(
             for line_number, raw_line in enumerate(handle, start_line + 1):
                 decoded = _decode_content_envelope(raw_line)
                 if decoded is None:
-                    parse_warnings += 1
+                    accumulator.parse_warnings += 1
                     continue
                 envelope, payload = decoded
-                entry_type = envelope.get("type")
-                timestamp = optional_str(envelope.get("timestamp"))
-                if entry_type == "turn_context":
-                    turn_id = optional_str(payload.get("turn_id"))
-                    turn_index += 1
-                    continue
-                if _is_token_count(entry_type, payload):
-                    usage_row = usage_rows.get(line_number)
-                    if usage_row is not None:
-                        _append_pending_content_rows(
-                            pending_rows,
-                            pending=pending,
-                            tool_calls=pending_tool_calls,
-                            command_runs=pending_command_runs,
-                            file_events=pending_file_events,
-                            usage_row=usage_row,
-                        )
-                        pending = []
-                        pending_tool_calls = []
-                        pending_command_runs = []
-                        pending_file_events = []
-                    continue
-                pending.extend(
-                    _extract_pending_fragments(
-                        envelope=envelope,
-                        payload=payload,
-                        line_number=line_number,
-                        timestamp=timestamp,
-                        turn_id=turn_id,
-                        turn_index=turn_index,
-                    )
-                )
-                events = extract_pending_local_events(
+                accumulator.consume(
                     envelope=envelope,
                     payload=payload,
                     line_number=line_number,
-                    timestamp=timestamp,
+                    usage_row=usage_rows.get(line_number),
                 )
-                pending_tool_calls.extend(events.tool_calls)
-                pending_command_runs.extend(events.command_runs)
-                pending_file_events.extend(events.file_events)
     except OSError:
         return _empty_extracted_content_rows(source_path=source_path, has_usage_rows=False)
 
-    return _ExtractedContentRows(
-        source_path=str(source_path),
-        has_usage_rows=True,
-        turn_rows=pending_rows.turn_rows,
-        fragment_rows=pending_rows.fragment_rows,
-        event_rows=pending_rows.event_rows,
-        parse_warnings=parse_warnings,
-    )
+    return accumulator.finish()
 
 
 def _decode_content_envelope(raw_line: bytes) -> tuple[dict[str, Any], dict[str, Any]] | None:

--- a/src/codex_usage_tracker/store/content_index.py
+++ b/src/codex_usage_tracker/store/content_index.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
-import os
 import sqlite3
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
 from codex_usage_tracker.store.content_extract import (
     MAX_FRAGMENT_CHARS as MAX_FRAGMENT_CHARS,
 )
-from codex_usage_tracker.store.content_extract import (
-    _decode_content_envelope,
-    _extract_content_rows_for_source_file,
+from codex_usage_tracker.store.content_index_bulk import (
+    add_content_index_result as _add_content_index_result,
 )
-from codex_usage_tracker.store.content_index_event_store import upsert_pending_event_rows
+from codex_usage_tracker.store.content_index_bulk import (
+    deferred_content_indexes as _deferred_content_indexes,
+)
+from codex_usage_tracker.store.content_index_bulk import (
+    emit_content_index_progress as _emit_content_index_progress,
+)
+from codex_usage_tracker.store.content_index_bulk import (
+    index_content_entries as _index_content_entries,
+)
+from codex_usage_tracker.store.content_index_bulk import (
+    index_precleaned_content_batches as _index_precleaned_content_batches,
+)
 from codex_usage_tracker.store.content_index_models import (
     ContentIndexPlan as ContentIndexPlan,
 )
@@ -27,9 +35,14 @@ from codex_usage_tracker.store.content_index_models import (
 from codex_usage_tracker.store.content_index_models import (
     ContentIndexResult as ContentIndexResult,
 )
-from codex_usage_tracker.store.content_index_stream import (
-    _flush_pending_content_rows,
-    _StreamingContentAccumulator,
+from codex_usage_tracker.store.content_index_parallel import (
+    index_content_for_source_plans_parallel as _index_content_for_source_plans_parallel,
+)
+from codex_usage_tracker.store.content_index_parallel import (
+    parallel_content_index_worker_count as _parallel_content_index_worker_count,
+)
+from codex_usage_tracker.store.content_index_source import (
+    index_content_for_source_file as _index_content_for_source_file,
 )
 from codex_usage_tracker.store.content_persistence import (
     CONTENT_INDEX_TABLES as CONTENT_INDEX_TABLES,
@@ -38,15 +51,7 @@ from codex_usage_tracker.store.content_persistence import (
     _clear_content_fts as _clear_content_fts,
 )
 from codex_usage_tracker.store.content_persistence import (
-    _content_counts_for_source_file,
-    _sync_content_fts_for_source_file,
-    _upsert_turn_rows,
-)
-from codex_usage_tracker.store.content_persistence import (
     _rebuild_content_fts as _rebuild_content_fts,
-)
-from codex_usage_tracker.store.content_persistence import (
-    _upsert_fragment_rows as _upsert_fragment_rows,
 )
 from codex_usage_tracker.store.content_persistence import (
     _upsert_sql as _upsert_sql,
@@ -56,10 +61,6 @@ from codex_usage_tracker.store.content_persistence import (
 )
 from codex_usage_tracker.store.content_persistence import (
     delete_content_index_rows_for_source_files as delete_content_index_rows_for_source_files,
-)
-from codex_usage_tracker.store.content_provenance import (
-    _content_usage_rows_for_plans,
-    _usage_rows_by_token_line,
 )
 from codex_usage_tracker.store.content_query import (
     DEFAULT_SEARCH_SNIPPET_CHARS as DEFAULT_SEARCH_SNIPPET_CHARS,
@@ -79,10 +80,6 @@ from codex_usage_tracker.store.content_trace import (
 from codex_usage_tracker.store.content_trace import (
     trace_thread_content as trace_thread_content,
 )
-
-_PARALLEL_CONTENT_INDEX_WORKERS_ENV = "CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS"
-_PARALLEL_CONTENT_INDEX_MIN_FILES = 4
-_PARALLEL_CONTENT_INDEX_MAX_WORKERS = 8
 
 
 def index_content_for_source_files(
@@ -107,6 +104,7 @@ def index_content_for_source_plans(
     *,
     plans: Iterable[ContentIndexPlan],
     progress_callback: ContentIndexProgressCallback | None = None,
+    force_serial: bool = False,
 ) -> ContentIndexResult:
     """Populate normalized bounded local content rows using refresh parse plans."""
 
@@ -114,14 +112,14 @@ def index_content_for_source_plans(
     total_sources = len(source_plans)
     _emit_content_index_progress(
         progress_callback,
-        status="running",
+        status="running" if total_sources else "completed",
         completed=0,
         total=total_sources,
         message="Indexing local content",
         content_fragments=0,
     )
     defer_full_fts_rebuild = any(plan.replace_existing for plan in source_plans)
-    worker_count = _parallel_content_index_worker_count(len(source_plans))
+    worker_count = 1 if force_serial else _parallel_content_index_worker_count(source_plans)
     if worker_count > 1:
         result = _index_content_for_source_plans_parallel(
             conn,
@@ -140,6 +138,55 @@ def index_content_for_source_plans(
     if source_plans:
         touch_compression_revisions(conn, {"commands", "files", "fragments", "tools"})
     return result
+
+
+def index_preextracted_content_rows(
+    conn: sqlite3.Connection,
+    *,
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
+    progress_callback: ContentIndexProgressCallback | None = None,
+    total_sources: int | None = None,
+    defer_full_fts_rebuild: bool | None = None,
+    replacement_cleanup_done: bool = False,
+    write_batch_sources: int = 1,
+    defer_secondary_indexes: bool = False,
+) -> ContentIndexResult:
+    """Persist parser-produced content rows with one deterministic SQLite writer."""
+    extracted_entries, total_sources, defer_full_fts_rebuild = _normalize_preextracted_entries(
+        entries,
+        total_sources=total_sources,
+        defer_full_fts_rebuild=defer_full_fts_rebuild,
+    )
+    _emit_content_index_progress(
+        progress_callback,
+        status="running" if total_sources else "completed",
+        completed=0,
+        total=total_sources,
+        message="Indexing parser-produced content",
+        content_fragments=0,
+    )
+    if _use_precleaned_bulk(
+        replacement_cleanup_done=replacement_cleanup_done,
+        write_batch_sources=write_batch_sources,
+        defer_full_fts_rebuild=defer_full_fts_rebuild,
+    ):
+        return _index_precleaned_with_indexes(
+            conn,
+            entries=extracted_entries,
+            total_sources=total_sources,
+            defer_full_fts_rebuild=defer_full_fts_rebuild,
+            write_batch_sources=write_batch_sources,
+            defer_secondary_indexes=defer_secondary_indexes,
+            progress_callback=progress_callback,
+        )
+    return _index_content_entries(
+        conn,
+        entries=extracted_entries,
+        total_sources=total_sources,
+        defer_full_fts_rebuild=defer_full_fts_rebuild,
+        replacement_cleanup_done=replacement_cleanup_done,
+        progress_callback=progress_callback,
+    )
 
 
 def _index_content_for_source_plans_serial(
@@ -161,13 +208,11 @@ def _index_content_for_source_plans_serial(
             start_line=plan.start_line,
             sync_fts=sync_fts,
         )
-        needs_full_fts_rebuild = needs_full_fts_rebuild or (
-            plan.replace_existing and result.source_files > 0
-        )
+        needs_full_fts_rebuild |= _replaced_source_with_rows(plan, result)
         totals = _add_content_index_result(totals, result)
         _emit_content_index_progress(
             progress_callback,
-            status="running" if index < total_sources else "completed",
+            status=_progress_status(index, total_sources),
             completed=index,
             total=total_sources,
             message="Indexed local content",
@@ -179,95 +224,61 @@ def _index_content_for_source_plans_serial(
     return totals
 
 
-def _index_content_for_source_plans_parallel(
-    conn: sqlite3.Connection,
+def _normalize_preextracted_entries(
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
     *,
-    source_plans: list[ContentIndexPlan],
-    sync_fts: bool,
-    progress_callback: ContentIndexProgressCallback | None,
-    worker_count: int,
-) -> ContentIndexResult:
-    usage_rows_by_path = _content_usage_rows_for_plans(conn, source_plans=source_plans)
-    totals = ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
-    needs_full_fts_rebuild = False
-    completed = 0
-    total_sources = len(source_plans)
-    with ThreadPoolExecutor(max_workers=worker_count) as executor:
-        futures = {
-            executor.submit(
-                _extract_content_rows_for_source_file,
-                source_path=plan.source_path,
-                usage_rows=usage_rows_by_path.get(str(plan.source_path), {}),
-                start_byte=0 if plan.replace_existing else plan.start_byte,
-                start_line=0 if plan.replace_existing else plan.start_line,
-            ): plan
-            for plan in source_plans
-        }
-        for future in as_completed(futures):
-            plan = futures[future]
-            extracted = future.result()
-            result = _write_extracted_content_rows(
-                conn,
-                extracted=extracted,
-                replace_existing=plan.replace_existing,
-                sync_fts=sync_fts,
-                start_line=0 if plan.replace_existing else plan.start_line,
-            )
-            needs_full_fts_rebuild = needs_full_fts_rebuild or (
-                plan.replace_existing and result.source_files > 0
-            )
-            totals = _add_content_index_result(totals, result)
-            completed += 1
-            _emit_content_index_progress(
-                progress_callback,
-                status="running" if completed < total_sources else "completed",
-                completed=completed,
-                total=total_sources,
-                message="Indexed local content",
-                content_fragments=totals.content_fragments,
-                conversation_turns=totals.conversation_turns,
-                workers=worker_count,
-            )
-    if needs_full_fts_rebuild:
-        _rebuild_content_fts(conn)
-    return totals
-
-
-def _add_content_index_result(
-    left: ContentIndexResult,
-    right: ContentIndexResult,
-) -> ContentIndexResult:
-    return ContentIndexResult(
-        source_files=left.source_files + right.source_files,
-        conversation_turns=left.conversation_turns + right.conversation_turns,
-        content_fragments=left.content_fragments + right.content_fragments,
-        parse_warnings=left.parse_warnings + right.parse_warnings,
+    total_sources: int | None,
+    defer_full_fts_rebuild: bool | None,
+) -> tuple[Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]], int, bool]:
+    if total_sources is not None and defer_full_fts_rebuild is not None:
+        return entries, total_sources, defer_full_fts_rebuild
+    buffered_entries = list(entries)
+    return (
+        buffered_entries,
+        len(buffered_entries),
+        any(plan.replace_existing for plan, _rows in buffered_entries),
     )
 
 
-def _emit_content_index_progress(
-    progress_callback: ContentIndexProgressCallback | None,
+def _use_precleaned_bulk(
     *,
-    status: str,
-    completed: int,
-    total: int,
-    message: str,
-    **extra: object,
-) -> None:
-    if progress_callback is None:
-        return
-    percent = 100.0 if total <= 0 else round(min(100.0, (completed / total) * 100.0), 1)
-    payload: dict[str, object] = {
-        "schema": "codex-usage-tracker-refresh-progress-v1",
-        "phase": "indexing_content",
-        "status": status,
-        "message": message,
-        "completed": completed,
-        "total": total,
-        "percent": percent,
-    }
-    payload.update(extra)
-    progress_callback(payload)
+    replacement_cleanup_done: bool,
+    write_batch_sources: int,
+    defer_full_fts_rebuild: bool,
+) -> bool:
+    return replacement_cleanup_done and write_batch_sources > 1 and defer_full_fts_rebuild
+
+
+def _index_precleaned_with_indexes(
+    conn: sqlite3.Connection,
+    *,
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
+    total_sources: int,
+    defer_full_fts_rebuild: bool,
+    write_batch_sources: int,
+    defer_secondary_indexes: bool,
+    progress_callback: ContentIndexProgressCallback | None,
+) -> ContentIndexResult:
+    with _deferred_content_indexes(conn, enabled=defer_secondary_indexes):
+        return _index_precleaned_content_batches(
+            conn,
+            entries=entries,
+            total_sources=total_sources,
+            defer_full_fts_rebuild=defer_full_fts_rebuild,
+            write_batch_sources=write_batch_sources,
+            progress_callback=progress_callback,
+        )
+
+
+def _replaced_source_with_rows(
+    plan: ContentIndexPlan,
+    result: ContentIndexResult,
+) -> bool:
+    return plan.replace_existing and result.source_files > 0
+
+
+def _progress_status(completed: int, total: int) -> str:
+    return "running" if completed < total else "completed"
 
 
 def _dedupe_content_index_plans(
@@ -279,151 +290,3 @@ def _dedupe_content_index_plans(
         if existing is None or plan.replace_existing or plan.start_byte < existing.start_byte:
             by_path[plan.source_path] = plan
     return by_path.values()
-
-
-def _write_extracted_content_rows(
-    conn: sqlite3.Connection,
-    *,
-    extracted: _ExtractedContentRows,
-    replace_existing: bool,
-    sync_fts: bool,
-    start_line: int,
-) -> ContentIndexResult:
-    if not extracted.has_usage_rows:
-        return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
-
-    if replace_existing:
-        delete_content_index_rows_for_source_files(
-            conn,
-            placeholders="?",
-            source_files_to_replace=[extracted.source_path],
-            sync_fts=sync_fts,
-        )
-    if extracted.turn_rows:
-        _upsert_turn_rows(conn, extracted.turn_rows)
-    if extracted.fragment_rows:
-        _upsert_fragment_rows(conn, extracted.fragment_rows)
-    upsert_pending_event_rows(conn, extracted.event_rows)
-
-    if sync_fts:
-        if replace_existing:
-            _rebuild_content_fts(conn)
-        else:
-            _sync_content_fts_for_source_file(
-                conn,
-                source_file=extracted.source_path,
-                min_line_start=start_line + 1,
-            )
-    counts = _content_counts_for_source_file(conn, source_file=extracted.source_path)
-    return ContentIndexResult(
-        source_files=1,
-        conversation_turns=counts["conversation_turns"],
-        content_fragments=counts["content_fragments"],
-        parse_warnings=extracted.parse_warnings,
-    )
-
-
-def _parallel_content_index_worker_count(plan_count: int) -> int:
-    if plan_count < _PARALLEL_CONTENT_INDEX_MIN_FILES:
-        return 1
-    configured = _configured_parallel_content_index_workers()
-    if configured is not None:
-        return min(plan_count, configured)
-    return min(plan_count, max(1, os.cpu_count() or 1), _PARALLEL_CONTENT_INDEX_MAX_WORKERS)
-
-
-def _configured_parallel_content_index_workers() -> int | None:
-    raw_value = os.environ.get(_PARALLEL_CONTENT_INDEX_WORKERS_ENV)
-    if raw_value is None or raw_value.strip() == "":
-        return None
-    try:
-        return max(1, int(raw_value))
-    except ValueError:
-        return None
-
-
-def _stream_content_rows(
-    conn: sqlite3.Connection,
-    *,
-    source_path: Path,
-    start_byte: int,
-    start_line: int,
-    usage_rows: dict[int, sqlite3.Row],
-) -> _StreamingContentAccumulator | None:
-    accumulator = _StreamingContentAccumulator()
-    try:
-        with source_path.open("rb") as handle:
-            if start_byte > 0:
-                handle.seek(start_byte)
-            for line_number, raw_line in enumerate(handle, start_line + 1):
-                decoded = _decode_content_envelope(raw_line)
-                if decoded is None:
-                    accumulator.parse_warnings += 1
-                    continue
-                envelope, payload = decoded
-                accumulator.consume(
-                    conn,
-                    envelope=envelope,
-                    payload=payload,
-                    line_number=line_number,
-                    usage_row=usage_rows.get(line_number),
-                )
-    except OSError:
-        return None
-    return accumulator
-
-
-def _index_content_for_source_file(
-    conn: sqlite3.Connection,
-    *,
-    source_path: Path,
-    replace_existing: bool = True,
-    start_byte: int = 0,
-    start_line: int = 0,
-    sync_fts: bool = True,
-) -> ContentIndexResult:
-    usage_rows = _usage_rows_by_token_line(
-        conn,
-        source_file=str(source_path),
-        min_line_number=None if replace_existing else start_line + 1,
-    )
-    if not usage_rows:
-        return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
-
-    if replace_existing:
-        start_byte = 0
-        start_line = 0
-        delete_content_index_rows_for_source_files(
-            conn,
-            placeholders="?",
-            source_files_to_replace=[str(source_path)],
-            sync_fts=sync_fts,
-        )
-    accumulator = _stream_content_rows(
-        conn,
-        source_path=source_path,
-        start_byte=start_byte,
-        start_line=start_line,
-        usage_rows=usage_rows,
-    )
-    if accumulator is None:
-        return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
-
-    _flush_pending_content_rows(conn, accumulator.rows)
-
-    if sync_fts:
-        if replace_existing:
-            _rebuild_content_fts(conn)
-        else:
-            _sync_content_fts_for_source_file(
-                conn,
-                source_file=str(source_path),
-                min_line_start=start_line + 1,
-            )
-    counts = _content_counts_for_source_file(conn, source_file=str(source_path))
-    return ContentIndexResult(
-        source_files=1,
-        conversation_turns=counts["conversation_turns"],
-        content_fragments=counts["content_fragments"],
-        parse_warnings=accumulator.parse_warnings,
-    )

--- a/src/codex_usage_tracker/store/content_index_bulk.py
+++ b/src/codex_usage_tracker/store/content_index_bulk.py
@@ -1,0 +1,291 @@
+"""Bounded bulk persistence for parser-produced content rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
+from codex_usage_tracker.store.content_index_event_store import (
+    PendingEventRows,
+    upsert_pending_event_rows,
+)
+from codex_usage_tracker.store.content_index_models import (
+    ContentIndexPlan,
+    ContentIndexProgressCallback,
+    ContentIndexResult,
+    _ExtractedContentRows,
+)
+from codex_usage_tracker.store.content_persistence import (
+    CONTENT_INDEX_TABLES,
+    _content_counts_for_source_file,
+    _rebuild_content_fts,
+    _sync_content_fts_for_source_file,
+    _upsert_fragment_rows,
+    _upsert_turn_rows,
+    delete_content_index_rows_for_source_files,
+)
+
+
+def index_content_entries(
+    conn: sqlite3.Connection,
+    *,
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
+    total_sources: int,
+    defer_full_fts_rebuild: bool,
+    replacement_cleanup_done: bool,
+    progress_callback: ContentIndexProgressCallback | None,
+) -> ContentIndexResult:
+    totals = ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
+    needs_full_fts_rebuild = False
+    for index, (plan, extracted) in enumerate(entries, start=1):
+        result = write_extracted_content_rows(
+            conn,
+            extracted=extracted,
+            replace_existing=plan.replace_existing and not replacement_cleanup_done,
+            sync_fts=not defer_full_fts_rebuild,
+            start_line=0 if plan.replace_existing else plan.start_line,
+        )
+        needs_full_fts_rebuild |= plan.replace_existing and result.source_files > 0
+        totals = add_content_index_result(totals, result)
+        emit_content_index_progress(
+            progress_callback,
+            status="running" if index < total_sources else "completed",
+            completed=index,
+            total=total_sources,
+            message="Indexed parser-produced content",
+            content_fragments=totals.content_fragments,
+            conversation_turns=totals.conversation_turns,
+            workers=1,
+        )
+    if needs_full_fts_rebuild:
+        _rebuild_content_fts(conn)
+    if totals.source_files:
+        touch_compression_revisions(conn, {"commands", "files", "fragments", "tools"})
+    return totals
+
+
+def write_extracted_content_rows(
+    conn: sqlite3.Connection,
+    *,
+    extracted: _ExtractedContentRows,
+    replace_existing: bool,
+    sync_fts: bool,
+    start_line: int,
+) -> ContentIndexResult:
+    if not extracted.has_usage_rows:
+        return ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
+    if replace_existing:
+        delete_content_index_rows_for_source_files(
+            conn,
+            placeholders="?",
+            source_files_to_replace=[extracted.source_path],
+            sync_fts=sync_fts,
+        )
+    if extracted.turn_rows:
+        _upsert_turn_rows(conn, extracted.turn_rows)
+    if extracted.fragment_rows:
+        _upsert_fragment_rows(conn, extracted.fragment_rows)
+    upsert_pending_event_rows(conn, extracted.event_rows)
+    _sync_extracted_fts(
+        conn,
+        source_path=extracted.source_path,
+        replace_existing=replace_existing,
+        sync_fts=sync_fts,
+        start_line=start_line,
+    )
+    counts = _content_counts_for_source_file(conn, source_file=extracted.source_path)
+    return ContentIndexResult(
+        source_files=1,
+        conversation_turns=counts["conversation_turns"],
+        content_fragments=counts["content_fragments"],
+        parse_warnings=extracted.parse_warnings,
+    )
+
+
+def index_precleaned_content_batches(
+    conn: sqlite3.Connection,
+    *,
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
+    total_sources: int,
+    defer_full_fts_rebuild: bool,
+    write_batch_sources: int,
+    progress_callback: ContentIndexProgressCallback | None,
+) -> ContentIndexResult:
+    totals = ContentIndexResult(source_files=0, conversation_turns=0, content_fragments=0)
+    completed_sources = 0
+    needs_full_fts_rebuild = False
+    for batch in _batched_preextracted_entries(entries, size=write_batch_sources):
+        result = _write_precleaned_content_batch(conn, batch)
+        totals = add_content_index_result(totals, result)
+        completed_sources += len(batch)
+        needs_full_fts_rebuild = needs_full_fts_rebuild or any(
+            plan.replace_existing and extracted.has_usage_rows for plan, extracted in batch
+        )
+        emit_content_index_progress(
+            progress_callback,
+            status="running" if completed_sources < total_sources else "completed",
+            completed=completed_sources,
+            total=total_sources,
+            message="Indexed parser-produced content",
+            content_fragments=totals.content_fragments,
+            conversation_turns=totals.conversation_turns,
+            workers=1,
+        )
+    if needs_full_fts_rebuild and defer_full_fts_rebuild:
+        _rebuild_content_fts(conn)
+    if totals.source_files:
+        touch_compression_revisions(conn, {"commands", "files", "fragments", "tools"})
+    return totals
+
+
+@contextmanager
+def deferred_content_indexes(
+    conn: sqlite3.Connection,
+    *,
+    enabled: bool,
+) -> Iterator[None]:
+    if not enabled:
+        yield
+        return
+    placeholders = ", ".join("?" for _table in CONTENT_INDEX_TABLES)
+    indexes = [
+        (str(row["name"]), str(row["sql"]))
+        for row in conn.execute(
+            f"""
+            SELECT name, sql
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND tbl_name IN ({placeholders})
+              AND sql IS NOT NULL
+            ORDER BY name
+            """,  # nosec B608 - fixed schema table list
+            CONTENT_INDEX_TABLES,
+        )
+    ]
+    for name, _sql in indexes:
+        quoted_name = name.replace('"', '""')
+        conn.execute(f'DROP INDEX "{quoted_name}"')  # nosec B608 - schema-owned name
+    try:
+        yield
+    finally:
+        for _name, sql in indexes:
+            conn.execute(sql)
+
+
+def add_content_index_result(
+    left: ContentIndexResult,
+    right: ContentIndexResult,
+) -> ContentIndexResult:
+    return ContentIndexResult(
+        source_files=left.source_files + right.source_files,
+        conversation_turns=left.conversation_turns + right.conversation_turns,
+        content_fragments=left.content_fragments + right.content_fragments,
+        parse_warnings=left.parse_warnings + right.parse_warnings,
+    )
+
+
+def emit_content_index_progress(
+    progress_callback: ContentIndexProgressCallback | None,
+    *,
+    status: str,
+    completed: int,
+    total: int,
+    message: str,
+    **extra: object,
+) -> None:
+    if progress_callback is None:
+        return
+    percent = 100.0 if total <= 0 else round(min(100.0, (completed / total) * 100.0), 1)
+    payload: dict[str, object] = {
+        "schema": "codex-usage-tracker-refresh-progress-v1",
+        "phase": "indexing_content",
+        "status": status,
+        "message": message,
+        "completed": completed,
+        "total": total,
+        "percent": percent,
+    }
+    payload.update(extra)
+    progress_callback(payload)
+
+
+def _batched_preextracted_entries(
+    entries: Iterable[tuple[ContentIndexPlan, _ExtractedContentRows]],
+    *,
+    size: int,
+) -> Iterator[list[tuple[ContentIndexPlan, _ExtractedContentRows]]]:
+    batch: list[tuple[ContentIndexPlan, _ExtractedContentRows]] = []
+    for entry in entries:
+        batch.append(entry)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _write_precleaned_content_batch(
+    conn: sqlite3.Connection,
+    entries: list[tuple[ContentIndexPlan, _ExtractedContentRows]],
+) -> ContentIndexResult:
+    extracted_rows = [extracted for _plan, extracted in entries if extracted.has_usage_rows]
+    turn_rows = _flatten_content_rows(extracted_rows, "turn_rows")
+    fragment_rows = _flatten_content_rows(extracted_rows, "fragment_rows")
+    event_rows = PendingEventRows(
+        tool_call_rows=_flatten_event_rows(extracted_rows, "tool_call_rows"),
+        command_run_rows=_flatten_event_rows(extracted_rows, "command_run_rows"),
+        file_event_rows=_flatten_event_rows(extracted_rows, "file_event_rows"),
+    )
+    if turn_rows:
+        _upsert_turn_rows(conn, turn_rows)
+    if fragment_rows:
+        _upsert_fragment_rows(conn, fragment_rows)
+    upsert_pending_event_rows(conn, event_rows)
+    return ContentIndexResult(
+        source_files=len(extracted_rows),
+        conversation_turns=len(turn_rows),
+        content_fragments=len(fragment_rows),
+        parse_warnings=sum(extracted.parse_warnings for extracted in extracted_rows),
+    )
+
+
+def _sync_extracted_fts(
+    conn: sqlite3.Connection,
+    *,
+    source_path: str,
+    replace_existing: bool,
+    sync_fts: bool,
+    start_line: int,
+) -> None:
+    if not sync_fts:
+        return
+    if replace_existing:
+        _rebuild_content_fts(conn)
+        return
+    _sync_content_fts_for_source_file(
+        conn,
+        source_file=source_path,
+        min_line_start=start_line + 1,
+    )
+
+
+def _flatten_content_rows(
+    extracted_rows: list[_ExtractedContentRows],
+    attribute: str,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for extracted in extracted_rows:
+        rows.extend(getattr(extracted, attribute))
+    return rows
+
+
+def _flatten_event_rows(
+    extracted_rows: list[_ExtractedContentRows],
+    attribute: str,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for extracted in extracted_rows:
+        rows.extend(getattr(extracted.event_rows, attribute))
+    return rows

--- a/src/codex_usage_tracker/store/content_index_parallel.py
+++ b/src/codex_usage_tracker/store/content_index_parallel.py
@@ -1,0 +1,189 @@
+"""Bounded deterministic scheduling for standalone content indexing."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Iterator, Mapping
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+
+from codex_usage_tracker.store.content_extract import _extract_content_rows_for_source_file
+from codex_usage_tracker.store.content_index_bulk import (
+    add_content_index_result,
+    emit_content_index_progress,
+    write_extracted_content_rows,
+)
+from codex_usage_tracker.store.content_index_models import (
+    ContentIndexPlan,
+    ContentIndexProgressCallback,
+    ContentIndexResult,
+    _ExtractedContentRows,
+)
+from codex_usage_tracker.store.content_persistence import _rebuild_content_fts
+from codex_usage_tracker.store.content_provenance import _usage_rows_by_token_line
+
+_WORKERS_ENV = "CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS"
+_MIN_FILES = 8
+_MIN_BYTES = 32 * 1024 * 1024
+_MAX_WORKERS = 4
+_QUEUE_FACTOR = 2
+
+
+class _ContentIndexScheduler:
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        source_plans: list[ContentIndexPlan],
+        sync_fts: bool,
+        progress_callback: ContentIndexProgressCallback | None,
+        worker_count: int,
+    ) -> None:
+        self.conn = conn
+        self.source_plans = source_plans
+        self.sync_fts = sync_fts
+        self.progress_callback = progress_callback
+        self.worker_count = worker_count
+        self.totals = ContentIndexResult(0, 0, 0)
+        self.needs_full_fts_rebuild = False
+        self.completed = 0
+        self.next_write_index = 0
+        self.ready: dict[int, _ExtractedContentRows] = {}
+
+    def run(self) -> ContentIndexResult:
+        with ProcessPoolExecutor(max_workers=self.worker_count) as executor:
+            plan_iterator = iter(enumerate(self.source_plans))
+            pending: dict[Future[_ExtractedContentRows], int] = {}
+            self._submit(executor, plan_iterator, pending, self._queue_limit)
+            while pending:
+                self._collect_ready(pending)
+                self._write_ready()
+                open_slots = self._queue_limit - len(pending) - len(self.ready)
+                self._submit(executor, plan_iterator, pending, open_slots)
+        if self.needs_full_fts_rebuild:
+            _rebuild_content_fts(self.conn)
+        return self.totals
+
+    @property
+    def _queue_limit(self) -> int:
+        return self.worker_count * _QUEUE_FACTOR
+
+    def _collect_ready(self, pending: dict[Future[_ExtractedContentRows], int]) -> None:
+        done, _not_done = wait(pending, return_when=FIRST_COMPLETED)
+        for future in done:
+            self.ready[pending.pop(future)] = future.result()
+
+    def _write_ready(self) -> None:
+        while self.next_write_index in self.ready:
+            plan = self.source_plans[self.next_write_index]
+            result = write_extracted_content_rows(
+                self.conn,
+                extracted=self.ready.pop(self.next_write_index),
+                replace_existing=plan.replace_existing,
+                sync_fts=self.sync_fts,
+                start_line=0 if plan.replace_existing else plan.start_line,
+            )
+            self.needs_full_fts_rebuild |= plan.replace_existing and result.source_files > 0
+            self.totals = add_content_index_result(self.totals, result)
+            self.completed += 1
+            self.next_write_index += 1
+            emit_content_index_progress(
+                self.progress_callback,
+                status=("running" if self.completed < len(self.source_plans) else "completed"),
+                completed=self.completed,
+                total=len(self.source_plans),
+                message="Indexed local content",
+                content_fragments=self.totals.content_fragments,
+                conversation_turns=self.totals.conversation_turns,
+                workers=self.worker_count,
+            )
+
+    def _submit(
+        self,
+        executor: ProcessPoolExecutor,
+        plan_iterator: Iterator[tuple[int, ContentIndexPlan]],
+        pending: dict[Future[_ExtractedContentRows], int],
+        count: int,
+    ) -> None:
+        for _index in range(count):
+            next_plan = _next_plan(plan_iterator)
+            if next_plan is None:
+                return
+            result_index, plan = next_plan
+            pending[self._submit_plan(executor, plan)] = result_index
+
+    def _submit_plan(
+        self,
+        executor: ProcessPoolExecutor,
+        plan: ContentIndexPlan,
+    ) -> Future[_ExtractedContentRows]:
+        usage_rows: dict[int, Mapping[str, object]] = {
+            line_number: dict(row)
+            for line_number, row in _usage_rows_by_token_line(
+                self.conn,
+                source_file=str(plan.source_path),
+                min_line_number=None if plan.replace_existing else plan.start_line + 1,
+            ).items()
+        }
+        return executor.submit(
+            _extract_content_rows_for_source_file,
+            source_path=plan.source_path,
+            usage_rows=usage_rows,
+            start_byte=0 if plan.replace_existing else plan.start_byte,
+            start_line=0 if plan.replace_existing else plan.start_line,
+        )
+
+
+def index_content_for_source_plans_parallel(
+    conn: sqlite3.Connection,
+    *,
+    source_plans: list[ContentIndexPlan],
+    sync_fts: bool,
+    progress_callback: ContentIndexProgressCallback | None,
+    worker_count: int,
+) -> ContentIndexResult:
+    return _ContentIndexScheduler(
+        conn,
+        source_plans=source_plans,
+        sync_fts=sync_fts,
+        progress_callback=progress_callback,
+        worker_count=worker_count,
+    ).run()
+
+
+def parallel_content_index_worker_count(source_plans: list[ContentIndexPlan]) -> int:
+    configured = _configured_workers()
+    if configured is not None:
+        return min(len(source_plans), configured)
+    if len(source_plans) < _MIN_FILES or _pending_bytes(source_plans) < _MIN_BYTES:
+        return 1
+    return min(len(source_plans), max(1, os.cpu_count() or 1), _MAX_WORKERS)
+
+
+def _pending_bytes(source_plans: list[ContentIndexPlan]) -> int:
+    total = 0
+    for plan in source_plans:
+        try:
+            total += max(0, plan.source_path.stat().st_size - plan.start_byte)
+        except OSError:
+            continue
+    return total
+
+
+def _configured_workers() -> int | None:
+    raw_value = os.environ.get(_WORKERS_ENV)
+    if raw_value is None or raw_value.strip() == "":
+        return None
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        return None
+
+
+def _next_plan(
+    plan_iterator: Iterator[tuple[int, ContentIndexPlan]],
+) -> tuple[int, ContentIndexPlan] | None:
+    try:
+        return next(plan_iterator)
+    except StopIteration:
+        return None

--- a/src/codex_usage_tracker/store/content_index_source.py
+++ b/src/codex_usage_tracker/store/content_index_source.py
@@ -1,0 +1,141 @@
+"""Serial source-file content indexing fallback."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from codex_usage_tracker.store.content_extract import _decode_content_envelope
+from codex_usage_tracker.store.content_index_models import ContentIndexResult
+from codex_usage_tracker.store.content_index_stream import (
+    _flush_pending_content_rows,
+    _StreamingContentAccumulator,
+)
+from codex_usage_tracker.store.content_persistence import (
+    _content_counts_for_source_file,
+    _rebuild_content_fts,
+    _sync_content_fts_for_source_file,
+    delete_content_index_rows_for_source_files,
+)
+from codex_usage_tracker.store.content_provenance import _usage_rows_by_token_line
+
+
+def index_content_for_source_file(
+    conn: sqlite3.Connection,
+    *,
+    source_path: Path,
+    replace_existing: bool = True,
+    start_byte: int = 0,
+    start_line: int = 0,
+    sync_fts: bool = True,
+) -> ContentIndexResult:
+    usage_rows = _usage_rows_by_token_line(
+        conn,
+        source_file=str(source_path),
+        min_line_number=None if replace_existing else start_line + 1,
+    )
+    if not usage_rows:
+        return ContentIndexResult(0, 0, 0)
+    start_byte, start_line = _prepare_source_rows(
+        conn,
+        source_path=source_path,
+        replace_existing=replace_existing,
+        sync_fts=sync_fts,
+        start_byte=start_byte,
+        start_line=start_line,
+    )
+    accumulator = _stream_content_rows(
+        conn,
+        source_path=source_path,
+        start_byte=start_byte,
+        start_line=start_line,
+        usage_rows=usage_rows,
+    )
+    if accumulator is None:
+        return ContentIndexResult(0, 0, 0)
+    _flush_pending_content_rows(conn, accumulator.rows)
+    _sync_source_fts(
+        conn,
+        source_path=source_path,
+        replace_existing=replace_existing,
+        sync_fts=sync_fts,
+        start_line=start_line,
+    )
+    counts = _content_counts_for_source_file(conn, source_file=str(source_path))
+    return ContentIndexResult(
+        source_files=1,
+        conversation_turns=counts["conversation_turns"],
+        content_fragments=counts["content_fragments"],
+        parse_warnings=accumulator.parse_warnings,
+    )
+
+
+def _prepare_source_rows(
+    conn: sqlite3.Connection,
+    *,
+    source_path: Path,
+    replace_existing: bool,
+    sync_fts: bool,
+    start_byte: int,
+    start_line: int,
+) -> tuple[int, int]:
+    if not replace_existing:
+        return start_byte, start_line
+    delete_content_index_rows_for_source_files(
+        conn,
+        placeholders="?",
+        source_files_to_replace=[str(source_path)],
+        sync_fts=sync_fts,
+    )
+    return 0, 0
+
+
+def _stream_content_rows(
+    conn: sqlite3.Connection,
+    *,
+    source_path: Path,
+    start_byte: int,
+    start_line: int,
+    usage_rows: dict[int, sqlite3.Row],
+) -> _StreamingContentAccumulator | None:
+    accumulator = _StreamingContentAccumulator()
+    try:
+        with source_path.open("rb") as handle:
+            if start_byte > 0:
+                handle.seek(start_byte)
+            for line_number, raw_line in enumerate(handle, start_line + 1):
+                decoded = _decode_content_envelope(raw_line)
+                if decoded is None:
+                    accumulator.parse_warnings += 1
+                    continue
+                envelope, payload = decoded
+                accumulator.consume(
+                    conn,
+                    envelope=envelope,
+                    payload=payload,
+                    line_number=line_number,
+                    usage_row=usage_rows.get(line_number),
+                )
+    except OSError:
+        return None
+    return accumulator
+
+
+def _sync_source_fts(
+    conn: sqlite3.Connection,
+    *,
+    source_path: Path,
+    replace_existing: bool,
+    sync_fts: bool,
+    start_line: int,
+) -> None:
+    if not sync_fts:
+        return
+    if replace_existing:
+        _rebuild_content_fts(conn)
+        return
+    _sync_content_fts_for_source_file(
+        conn,
+        source_file=str(source_path),
+        min_line_start=start_line + 1,
+    )

--- a/src/codex_usage_tracker/store/content_index_stream.py
+++ b/src/codex_usage_tracker/store/content_index_stream.py
@@ -28,6 +28,7 @@ from codex_usage_tracker.store.content_persistence import (
 )
 from codex_usage_tracker.store.content_rows import (
     _append_pending_content_rows,
+    _content_row_timestamp,
     _empty_pending_content_rows,
 )
 
@@ -61,6 +62,7 @@ class _StreamingContentAccumulator:
     turn_id: str | None = None
     turn_index: int = 0
     parse_warnings: int = 0
+    created_at: str = field(default_factory=_content_row_timestamp)
 
     def consume(
         self,
@@ -114,6 +116,7 @@ class _StreamingContentAccumulator:
             command_runs=self.command_runs,
             file_events=self.file_events,
             usage_row=usage_row,
+            created_at=self.created_at,
         )
         if self.rows.linked_records >= _CONTENT_WRITE_BATCH_RECORDS:
             _flush_pending_content_rows(conn, self.rows)

--- a/src/codex_usage_tracker/store/content_provenance.py
+++ b/src/codex_usage_tracker/store/content_provenance.py
@@ -4,26 +4,6 @@ from __future__ import annotations
 
 import sqlite3
 
-from codex_usage_tracker.store.content_index_models import ContentIndexPlan
-
-
-def _content_usage_rows_for_plans(
-    conn: sqlite3.Connection,
-    *,
-    source_plans: list[ContentIndexPlan],
-) -> dict[str, dict[int, dict[str, object]]]:
-    rows_by_path: dict[str, dict[int, dict[str, object]]] = {}
-    for plan in source_plans:
-        rows_by_path[str(plan.source_path)] = {
-            line_number: dict(row)
-            for line_number, row in _usage_rows_by_token_line(
-                conn,
-                source_file=str(plan.source_path),
-                min_line_number=None if plan.replace_existing else plan.start_line + 1,
-            ).items()
-        }
-    return rows_by_path
-
 
 def _usage_rows_by_token_line(
     conn: sqlite3.Connection,

--- a/src/codex_usage_tracker/store/content_rows.py
+++ b/src/codex_usage_tracker/store/content_rows.py
@@ -44,10 +44,12 @@ def _append_pending_content_rows(
     command_runs: list[PendingCommandRun],
     file_events: list[PendingFileEvent],
     usage_row: UsageContentRow,
+    created_at: str,
 ) -> None:
     turn_rows, fragment_rows = _pending_fragment_rows(
         pending=pending,
         usage_row=usage_row,
+        created_at=created_at,
     )
     event_rows = pending_event_rows(
         tool_calls=tool_calls,
@@ -67,24 +69,36 @@ def _pending_fragment_rows(
     *,
     pending: list[_PendingFragment],
     usage_row: UsageContentRow,
+    created_at: str,
 ) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     if not pending:
         return [], []
     turn_rows: list[dict[str, object]] = []
     fragment_rows: list[dict[str, object]] = []
     for index, fragment in enumerate(pending):
+        content_hash = _stable_hash(fragment.text)
+        content_size_bytes = len(fragment.text.encode("utf-8"))
         turn_key = _stable_hash(
             f"turn:{usage_row['record_id']}:{fragment.line_start}:{fragment.role}:{index}"
         )
-        turn_rows.append(_turn_row(turn_key=turn_key, fragment=fragment, usage_row=usage_row))
-        fragment_rows.append(
-            _fragment_row(
-                fragment_id=_stable_hash(
-                    f"fragment:{turn_key}:{index}:{_stable_hash(fragment.text)}"
-                ),
+        turn_rows.append(
+            _turn_row(
                 turn_key=turn_key,
                 fragment=fragment,
                 usage_row=usage_row,
+                content_hash=content_hash,
+                content_size_bytes=content_size_bytes,
+            )
+        )
+        fragment_rows.append(
+            _fragment_row(
+                fragment_id=_stable_hash(f"fragment:{turn_key}:{index}:{content_hash}"),
+                turn_key=turn_key,
+                fragment=fragment,
+                usage_row=usage_row,
+                content_hash=content_hash,
+                content_size_bytes=content_size_bytes,
+                created_at=created_at,
             )
         )
     return turn_rows, fragment_rows
@@ -95,6 +109,8 @@ def _turn_row(
     turn_key: str,
     fragment: _PendingFragment,
     usage_row: UsageContentRow,
+    content_hash: str,
+    content_size_bytes: int,
 ) -> dict[str, object]:
     return {
         "turn_key": turn_key,
@@ -108,8 +124,8 @@ def _turn_row(
         "source_file_id": usage_row["source_file_id"],
         "line_start": fragment.line_start,
         "line_end": fragment.line_end,
-        "content_hash": _stable_hash(fragment.text),
-        "content_size_bytes": len(fragment.text.encode("utf-8")),
+        "content_hash": content_hash,
+        "content_size_bytes": content_size_bytes,
         "indexed_content_included": 1,
         "parser_adapter": usage_row["parser_adapter"] or PARSER_ADAPTER_NAME,
         "parser_version": usage_row["parser_version"] or PARSER_ADAPTER_VERSION,
@@ -123,6 +139,9 @@ def _fragment_row(
     turn_key: str,
     fragment: _PendingFragment,
     usage_row: UsageContentRow,
+    content_hash: str,
+    content_size_bytes: int,
+    created_at: str,
 ) -> dict[str, object]:
     return {
         "fragment_id": fragment_id,
@@ -131,17 +150,21 @@ def _fragment_row(
         "fragment_kind": fragment.fragment_kind,
         "role": fragment.role,
         "safe_label": fragment.safe_label,
-        "content_hash": _stable_hash(fragment.text),
-        "content_size_bytes": len(fragment.text.encode("utf-8")),
+        "content_hash": content_hash,
+        "content_size_bytes": content_size_bytes,
         "fragment_text": fragment.text,
         "includes_raw_fragment": 1,
         "source_file_id": usage_row["source_file_id"],
         "line_start": fragment.line_start,
         "line_end": fragment.line_end,
         "token_link_record_id": str(usage_row["record_id"]),
-        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "created_at": created_at,
     }
 
 
 def _stable_hash(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _content_row_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -2,73 +2,25 @@
 
 from __future__ import annotations
 
-import os
-from collections.abc import Callable
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures.process import BrokenProcessPool
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
 
-from codex_usage_tracker import store as store_facade
-from codex_usage_tracker.core.models import DiagnosticFact, RefreshResult, UsageEvent
+from codex_usage_tracker.core.models import RefreshResult
 from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME, DEFAULT_DB_PATH
-from codex_usage_tracker.parser.api import (
-    find_session_logs,
-    load_session_index,
-)
-from codex_usage_tracker.parser.api import (
-    parse_usage_events_from_file_with_state as _parse_usage_events_from_file_with_state,
-)
-from codex_usage_tracker.parser.state import ParserState, compact_parser_diagnostics
+from codex_usage_tracker.parser.api import find_session_logs, load_session_index
+from codex_usage_tracker.parser.state import compact_parser_diagnostics
 from codex_usage_tracker.store.api import (
     clear_content_index_rows,
     init_db,
     record_refresh_metadata,
-    record_source_file_metadata,
-    upsert_usage_events,
-)
-from codex_usage_tracker.store.compression_fact_sync import (
-    content_index_plans,
-    sync_content_plan_compression_facts,
 )
 from codex_usage_tracker.store.connection import connect
-from codex_usage_tracker.store.content_index import index_content_for_source_plans
-from codex_usage_tracker.store.sources import (
-    ParsedSourceFile,
-    SourceParsePlan,
-    source_logs_requiring_parse,
+from codex_usage_tracker.store.refresh_parse import (
+    RefreshProgressCallback,
+    emit_refresh_progress,
 )
-
-_PARALLEL_PARSE_WORKERS_ENV = "CODEX_USAGE_TRACKER_REFRESH_WORKERS"
-_PARALLEL_PARSE_MIN_FILES = 4
-_PARALLEL_PARSE_MAX_WORKERS = 8
-
-cast(
-    Any, store_facade
-).parse_usage_events_from_file_with_state = _parse_usage_events_from_file_with_state
-
-
-def _parse_usage_events_from_file(*args: Any, **kwargs: Any) -> Any:
-    parser = getattr(
-        store_facade,
-        "parse_usage_events_from_file_with_state",
-        _parse_usage_events_from_file_with_state,
-    )
-    return parser(*args, **kwargs)
-
-
-@dataclass(frozen=True)
-class _ParsedRefreshFile:
-    plan: SourceParsePlan
-    events: list[UsageEvent]
-    diagnostic_facts: list[DiagnosticFact]
-    stats: dict[str, int]
-    state: ParserState
-    final_line_number: int
-
-
-RefreshProgressCallback = Callable[[dict[str, object]], None]
+from codex_usage_tracker.store.refresh_stream import write_refresh_stream
+from codex_usage_tracker.store.sources import source_logs_requiring_parse
 
 
 def refresh_usage_index(
@@ -80,7 +32,7 @@ def refresh_usage_index(
 ) -> RefreshResult:
     """Scan Codex logs and upsert aggregate usage events."""
 
-    _emit_refresh_progress(
+    emit_refresh_progress(
         progress_callback,
         phase="discovering",
         status="running",
@@ -93,7 +45,7 @@ def refresh_usage_index(
     with connect(db_path) as conn:
         init_db(conn)
         parse_plans = source_logs_requiring_parse(conn, logs)
-    _emit_refresh_progress(
+    emit_refresh_progress(
         progress_callback,
         phase="discovering",
         status="completed",
@@ -104,93 +56,34 @@ def refresh_usage_index(
         parsed_source_files=len(parse_plans),
         skipped_source_files=len(logs) - len(parse_plans),
     )
-    parsed_refresh_files = _parse_refresh_plans(
-        parse_plans,
-        session_index,
-        progress_callback=progress_callback,
-    )
-    stats: dict[str, int] = {}
-    events: list[UsageEvent] = []
-    diagnostic_facts: list[DiagnosticFact] = []
-    parsed_files: list[ParsedSourceFile] = []
-    for parsed_refresh_file in parsed_refresh_files:
-        file_events = parsed_refresh_file.events
-        events.extend(file_events)
-        diagnostic_facts.extend(parsed_refresh_file.diagnostic_facts)
-        parsed_files.append(
-            (
-                parsed_refresh_file.plan.path,
-                file_events,
-                parsed_refresh_file.stats,
-                parsed_refresh_file.state,
-                parsed_refresh_file.final_line_number,
-            )
+    try:
+        stream_result = write_refresh_stream(
+            db_path=db_path,
+            parse_plans=parse_plans,
+            session_index=session_index,
+            aggregate_only=aggregate_only,
+            progress_callback=progress_callback,
+            force_serial=False,
         )
-        for key, value in parsed_refresh_file.stats.items():
-            stats[key] = stats.get(key, 0) + int(value)
-    _emit_refresh_progress(
-        progress_callback,
-        phase="upserting",
-        status="running",
-        completed=0,
-        total=len(events),
-        message="Writing aggregate usage rows",
-        parsed_events=len(events),
-    )
-    inserted = upsert_usage_events(
-        events,
-        db_path=db_path,
-        replace_source_files=(plan.path for plan in parse_plans if plan.replace_existing),
-        diagnostic_facts=diagnostic_facts,
-    )
-    _emit_refresh_progress(
-        progress_callback,
-        phase="upserting",
-        status="completed",
-        completed=len(events),
-        total=len(events),
-        message="Wrote aggregate usage rows",
-        inserted_or_updated_events=inserted,
-    )
-    _emit_refresh_progress(
-        progress_callback,
-        phase="metadata",
-        status="running",
-        completed=0,
-        total=len(parsed_files),
-        message="Updating source metadata",
-    )
-    record_source_file_metadata(db_path=db_path, parsed_files=parsed_files)
-    _emit_refresh_progress(
-        progress_callback,
-        phase="metadata",
-        status="completed",
-        completed=len(parsed_files),
-        total=len(parsed_files),
-        message="Updated source metadata",
-    )
-    if not aggregate_only:
-        content_plans = content_index_plans(parse_plans)
-        with connect(db_path) as conn:
-            init_db(conn)
-            index_content_for_source_plans(
-                conn,
-                plans=content_plans,
-                progress_callback=progress_callback,
-            )
-            sync_content_plan_compression_facts(conn, plans=content_plans)
-    else:
-        _emit_refresh_progress(
+    except BrokenProcessPool:
+        emit_refresh_progress(
             progress_callback,
-            phase="indexing_content",
-            status="skipped",
+            phase="parsing",
+            status="running",
             completed=0,
-            total=0,
-            message="Skipped content index for aggregate-only refresh",
+            total=len(parse_plans),
+            message="Parallel parser unavailable; retrying serially",
+            workers=1,
         )
-    skipped_events = stats.get("skipped_events", 0)
-    diagnostics = compact_parser_diagnostics(stats)
-    _emit_refresh_progress(
+        stream_result = write_refresh_stream(
+            db_path=db_path,
+            parse_plans=parse_plans,
+            session_index=session_index,
+            aggregate_only=aggregate_only,
+            progress_callback=progress_callback,
+            force_serial=True,
+        )
+    emit_refresh_progress(
         progress_callback,
         phase="finalizing",
         status="running",
@@ -198,25 +91,15 @@ def refresh_usage_index(
         total=1,
         message="Recording refresh metadata",
     )
-    record_refresh_metadata(
+    result = _finalize_refresh_result(
         db_path=db_path,
         scanned_files=len(logs),
-        parsed_events=len(events),
-        skipped_events=skipped_events,
-        inserted_or_updated_events=inserted,
-        parser_diagnostics=diagnostics,
         parsed_source_files=len(parse_plans),
-        skipped_source_files=len(logs) - len(parse_plans),
+        stats=stream_result.stats,
+        parsed_events=stream_result.parsed_events,
+        inserted=stream_result.inserted_or_updated_events,
     )
-    result = RefreshResult(
-        scanned_files=len(logs),
-        parsed_events=len(events),
-        inserted_or_updated_events=inserted,
-        db_path=str(db_path),
-        skipped_events=skipped_events,
-        parser_diagnostics=diagnostics,
-    )
-    _emit_refresh_progress(
+    emit_refresh_progress(
         progress_callback,
         phase="finalizing",
         status="completed",
@@ -230,229 +113,40 @@ def refresh_usage_index(
             "inserted_or_updated_events": result.inserted_or_updated_events,
             "db_path": result.db_path,
             "parser_diagnostics": result.parser_diagnostics,
+            "stage_timings_seconds": stream_result.stage_timings_seconds,
         },
     )
     return result
 
 
-def _emit_refresh_progress(
-    progress_callback: RefreshProgressCallback | None,
+def _finalize_refresh_result(
     *,
-    phase: str,
-    status: str,
-    completed: int | None,
-    total: int | None,
-    message: str,
-    **extra: object,
-) -> None:
-    if progress_callback is None:
-        return
-    payload: dict[str, object] = {
-        "schema": "codex-usage-tracker-refresh-progress-v1",
-        "phase": phase,
-        "status": status,
-        "message": message,
-    }
-    if completed is not None:
-        payload["completed"] = completed
-    if total is not None:
-        payload["total"] = total
-        payload["percent"] = _refresh_progress_percent(completed or 0, total)
-    payload.update(extra)
-    progress_callback(payload)
-
-
-def _refresh_progress_percent(completed: int, total: int) -> float:
-    if total <= 0:
-        return 100.0
-    return round(min(100.0, max(0.0, (completed / total) * 100.0)), 1)
-
-
-def _parse_refresh_plans(
-    parse_plans: list[SourceParsePlan],
-    session_index: dict[str, Any],
-    *,
-    progress_callback: RefreshProgressCallback | None = None,
-) -> list[_ParsedRefreshFile]:
-    worker_count = _parallel_parse_worker_count(len(parse_plans))
-    if worker_count <= 1 or not _default_parser_is_active():
-        return _parse_refresh_plans_serial(
-            parse_plans,
-            session_index=session_index,
-            progress_callback=progress_callback,
-        )
-    try:
-        return _parse_refresh_plans_parallel(
-            parse_plans,
-            session_index=session_index,
-            worker_count=worker_count,
-            progress_callback=progress_callback,
-        )
-    except BrokenProcessPool:
-        return _parse_refresh_plans_serial(
-            parse_plans,
-            session_index=session_index,
-            progress_callback=progress_callback,
-        )
-
-
-def _parse_refresh_plans_serial(
-    parse_plans: list[SourceParsePlan],
-    *,
-    session_index: dict[str, Any],
-    progress_callback: RefreshProgressCallback | None,
-) -> list[_ParsedRefreshFile]:
-    results: list[_ParsedRefreshFile] = []
-    total = len(parse_plans)
-    _emit_refresh_progress(
-        progress_callback,
-        phase="parsing",
-        status="running",
-        completed=0,
-        total=total,
-        message="Parsing source logs",
+    db_path: Path,
+    scanned_files: int,
+    parsed_source_files: int,
+    stats: dict[str, int],
+    parsed_events: int,
+    inserted: int,
+) -> RefreshResult:
+    skipped_events = stats.get("skipped_events", 0)
+    diagnostics = compact_parser_diagnostics(stats)
+    record_refresh_metadata(
+        db_path=db_path,
+        scanned_files=scanned_files,
+        parsed_events=parsed_events,
+        skipped_events=skipped_events,
+        inserted_or_updated_events=inserted,
+        parser_diagnostics=diagnostics,
+        parsed_source_files=parsed_source_files,
+        skipped_source_files=scanned_files - parsed_source_files,
     )
-    for index, plan in enumerate(parse_plans, start=1):
-        parsed = _parse_source_plan_with_facade(plan, session_index=session_index)
-        results.append(parsed)
-        _emit_refresh_progress(
-            progress_callback,
-            phase="parsing",
-            status="running" if index < total else "completed",
-            completed=index,
-            total=total,
-            message="Parsed source logs",
-            parsed_events=sum(len(result.events) for result in results),
-        )
-    return results
-
-
-def _parse_refresh_plans_parallel(
-    parse_plans: list[SourceParsePlan],
-    *,
-    session_index: dict[str, Any],
-    worker_count: int,
-    progress_callback: RefreshProgressCallback | None,
-) -> list[_ParsedRefreshFile]:
-    results: list[_ParsedRefreshFile | None] = [None] * len(parse_plans)
-    total = len(parse_plans)
-    completed = 0
-    parsed_events = 0
-    _emit_refresh_progress(
-        progress_callback,
-        phase="parsing",
-        status="running",
-        completed=0,
-        total=total,
-        message=f"Parsing source logs with {worker_count} workers",
-        workers=worker_count,
-    )
-    with ProcessPoolExecutor(max_workers=worker_count) as executor:
-        futures = {
-            executor.submit(
-                _parse_source_plan_default,
-                plan,
-                session_index,
-            ): index
-            for index, plan in enumerate(parse_plans)
-        }
-        for future in as_completed(futures):
-            result = future.result()
-            results[futures[future]] = result
-            completed += 1
-            parsed_events += len(result.events)
-            _emit_refresh_progress(
-                progress_callback,
-                phase="parsing",
-                status="running" if completed < total else "completed",
-                completed=completed,
-                total=total,
-                message="Parsed source logs",
-                workers=worker_count,
-                parsed_events=parsed_events,
-            )
-    return [result for result in results if result is not None]
-
-
-def _parallel_parse_worker_count(plan_count: int) -> int:
-    if plan_count <= 1:
-        return 1
-    configured_workers = _configured_parallel_parse_workers()
-    if configured_workers is not None:
-        return min(plan_count, configured_workers)
-    if plan_count < _PARALLEL_PARSE_MIN_FILES:
-        return 1
-    cpu_count = os.cpu_count() or 1
-    return min(plan_count, cpu_count, _PARALLEL_PARSE_MAX_WORKERS)
-
-
-def _configured_parallel_parse_workers() -> int | None:
-    raw_workers = os.environ.get(_PARALLEL_PARSE_WORKERS_ENV)
-    if raw_workers is None:
-        return None
-    try:
-        workers = int(raw_workers)
-    except ValueError:
-        return None
-    return max(1, workers)
-
-
-def _default_parser_is_active() -> bool:
-    return (
-        getattr(
-            store_facade,
-            "parse_usage_events_from_file_with_state",
-            _parse_usage_events_from_file_with_state,
-        )
-        is _parse_usage_events_from_file_with_state
-    )
-
-
-def _parse_source_plan_with_facade(
-    plan: SourceParsePlan,
-    *,
-    session_index: dict[str, Any],
-) -> _ParsedRefreshFile:
-    return _parse_source_plan(
-        plan,
-        session_index=session_index,
-        parser=_parse_usage_events_from_file,
-    )
-
-
-def _parse_source_plan_default(
-    plan: SourceParsePlan,
-    session_index: dict[str, Any],
-) -> _ParsedRefreshFile:
-    return _parse_source_plan(
-        plan,
-        session_index=session_index,
-        parser=_parse_usage_events_from_file_with_state,
-    )
-
-
-def _parse_source_plan(
-    plan: SourceParsePlan,
-    *,
-    session_index: dict[str, Any],
-    parser: Any,
-) -> _ParsedRefreshFile:
-    file_stats: dict[str, int] = {}
-    parsed_file = parser(
-        plan.path,
-        session_index=session_index,
-        stats=file_stats,
-        start_byte=plan.start_byte,
-        start_line=plan.start_line,
-        initial_state=plan.initial_state,
-    )
-    return _ParsedRefreshFile(
-        plan=plan,
-        events=parsed_file.events,
-        diagnostic_facts=parsed_file.diagnostic_facts,
-        stats=file_stats,
-        state=parsed_file.state,
-        final_line_number=parsed_file.final_line_number,
+    return RefreshResult(
+        scanned_files=scanned_files,
+        parsed_events=parsed_events,
+        inserted_or_updated_events=inserted,
+        db_path=str(db_path),
+        skipped_events=skipped_events,
+        parser_diagnostics=diagnostics,
     )
 
 
@@ -467,14 +161,17 @@ def rebuild_usage_index(
     with connect(db_path) as conn:
         init_db(conn)
         clear_content_index_rows(conn)
-        conn.execute("DELETE FROM allowance_observations")
-        conn.execute("DELETE FROM call_diagnostic_facts")
-        conn.execute("DELETE FROM diagnostic_snapshots")
-        conn.execute("DELETE FROM source_records")
-        conn.execute("DELETE FROM usage_events")
-        conn.execute("DELETE FROM thread_summaries")
-        conn.execute("DELETE FROM source_files")
-        conn.execute("DELETE FROM refresh_meta")
+        for table in (
+            "allowance_observations",
+            "call_diagnostic_facts",
+            "diagnostic_snapshots",
+            "source_records",
+            "usage_events",
+            "thread_summaries",
+            "source_files",
+            "refresh_meta",
+        ):
+            conn.execute(f"DELETE FROM {table}")  # nosec B608 - fixed table names
     return refresh_usage_index(
         codex_home=codex_home,
         db_path=db_path,

--- a/src/codex_usage_tracker/store/refresh_parse.py
+++ b/src/codex_usage_tracker/store/refresh_parse.py
@@ -1,0 +1,423 @@
+"""Bounded parser scheduling for usage-index refreshes."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
+from dataclasses import dataclass
+from typing import Any, cast
+
+from codex_usage_tracker import store as store_facade
+from codex_usage_tracker.core.models import DiagnosticFact, UsageEvent
+from codex_usage_tracker.parser.api import (
+    parse_usage_events_from_file_with_state as _parse_usage_events_from_file_with_state,
+)
+from codex_usage_tracker.parser.state import ParserState
+from codex_usage_tracker.store.compression_fact_rows import (
+    IngestionFactRows,
+    build_ingestion_fact_rows,
+)
+from codex_usage_tracker.store.content_extract import ContentRowAccumulator
+from codex_usage_tracker.store.content_index_models import _ExtractedContentRows
+from codex_usage_tracker.store.source_records import content_usage_row_from_event
+from codex_usage_tracker.store.sources import SourceParsePlan
+
+_PARALLEL_PARSE_WORKERS_ENV = "CODEX_USAGE_TRACKER_REFRESH_WORKERS"
+_PARALLEL_CONTENT_WORKERS_ENV = "CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS"
+_PARALLEL_PARSE_MIN_FILES = 8
+_PARALLEL_PARSE_MIN_BYTES = 32 * 1024 * 1024
+_PARALLEL_PARSE_MAX_WORKERS = 4
+_PARALLEL_PARSE_QUEUE_FACTOR = 2
+
+RefreshProgressCallback = Callable[[dict[str, object]], None]
+
+cast(
+    Any, store_facade
+).parse_usage_events_from_file_with_state = _parse_usage_events_from_file_with_state
+
+
+@dataclass(frozen=True)
+class ParsedRefreshFile:
+    plan: SourceParsePlan
+    events: list[UsageEvent]
+    diagnostic_facts: list[DiagnosticFact]
+    stats: dict[str, int]
+    state: ParserState
+    final_line_number: int
+    content_rows: _ExtractedContentRows | None = None
+    fact_rows: IngestionFactRows | None = None
+
+
+def emit_refresh_progress(
+    progress_callback: RefreshProgressCallback | None,
+    *,
+    phase: str,
+    status: str,
+    completed: int | None,
+    total: int | None,
+    message: str,
+    **extra: object,
+) -> None:
+    if progress_callback is None:
+        return
+    payload: dict[str, object] = {
+        "schema": "codex-usage-tracker-refresh-progress-v1",
+        "phase": phase,
+        "status": status,
+        "message": message,
+    }
+    if completed is not None:
+        payload["completed"] = completed
+    if total is not None:
+        payload["total"] = total
+        payload["percent"] = _refresh_progress_percent(completed or 0, total)
+    payload.update(extra)
+    progress_callback(payload)
+
+
+def iter_parse_refresh_plans(
+    parse_plans: list[SourceParsePlan],
+    *,
+    session_index: dict[str, Any],
+    collect_content: bool,
+    progress_callback: RefreshProgressCallback | None,
+    force_serial: bool,
+    collect_facts: bool = False,
+) -> Iterator[ParsedRefreshFile]:
+    default_parser_active = default_parser_is_active()
+    worker_count = parallel_parse_worker_count(
+        parse_plans,
+        collect_content=collect_content,
+    )
+    if force_serial or worker_count <= 1 or not default_parser_active:
+        yield from _iter_parse_refresh_plans_serial(
+            parse_plans,
+            session_index=session_index,
+            collect_content=collect_content and default_parser_active,
+            collect_facts=collect_facts and default_parser_active,
+            progress_callback=progress_callback,
+        )
+        return
+    yield from _iter_parse_refresh_plans_parallel(
+        parse_plans,
+        session_index=session_index,
+        worker_count=worker_count,
+        collect_content=collect_content,
+        collect_facts=collect_facts,
+        progress_callback=progress_callback,
+    )
+
+
+def parse_refresh_plans_parallel(
+    parse_plans: list[SourceParsePlan],
+    *,
+    session_index: dict[str, Any],
+    worker_count: int,
+    progress_callback: RefreshProgressCallback | None,
+    collect_content: bool = False,
+    collect_facts: bool = False,
+) -> list[ParsedRefreshFile]:
+    return list(
+        _iter_parse_refresh_plans_parallel(
+            parse_plans,
+            session_index=session_index,
+            worker_count=worker_count,
+            collect_content=collect_content,
+            collect_facts=collect_facts,
+            progress_callback=progress_callback,
+        )
+    )
+
+
+def _iter_parse_refresh_plans_serial(
+    parse_plans: list[SourceParsePlan],
+    *,
+    session_index: dict[str, Any],
+    collect_content: bool,
+    progress_callback: RefreshProgressCallback | None,
+    collect_facts: bool = False,
+) -> Iterator[ParsedRefreshFile]:
+    total = len(parse_plans)
+    parsed_events = 0
+    emit_refresh_progress(
+        progress_callback,
+        phase="parsing",
+        status="running" if total else "completed",
+        completed=0,
+        total=total,
+        message="Parsing source logs",
+    )
+    for index, plan in enumerate(parse_plans, start=1):
+        if collect_content:
+            parsed = _parse_source_plan_default(
+                plan,
+                session_index,
+                True,
+                collect_facts,
+            )
+        else:
+            parsed = _parse_source_plan_with_facade(plan, session_index=session_index)
+        parsed_events += len(parsed.events)
+        emit_refresh_progress(
+            progress_callback,
+            phase="parsing",
+            status="running" if index < total else "completed",
+            completed=index,
+            total=total,
+            message="Parsed source logs",
+            parsed_events=parsed_events,
+        )
+        yield parsed
+
+
+def _iter_parse_refresh_plans_parallel(
+    parse_plans: list[SourceParsePlan],
+    *,
+    session_index: dict[str, Any],
+    worker_count: int,
+    collect_content: bool,
+    progress_callback: RefreshProgressCallback | None,
+    collect_facts: bool = False,
+) -> Iterator[ParsedRefreshFile]:
+    total = len(parse_plans)
+    completed = 0
+    parsed_events = 0
+    emit_refresh_progress(
+        progress_callback,
+        phase="parsing",
+        status="running",
+        completed=0,
+        total=total,
+        message=f"Parsing source logs with {worker_count} workers",
+        workers=worker_count,
+    )
+    with ProcessPoolExecutor(max_workers=worker_count) as executor:
+        plan_iterator = iter(enumerate(parse_plans))
+        pending: dict[Future[ParsedRefreshFile], int] = {}
+        ready: dict[int, ParsedRefreshFile] = {}
+        next_result_index = 0
+        queue_limit = worker_count * _PARALLEL_PARSE_QUEUE_FACTOR
+        while pending or ready or next_result_index < total:
+            if next_result_index in ready:
+                result = ready.pop(next_result_index)
+                next_result_index += 1
+                completed += 1
+                parsed_events += len(result.events)
+                _submit_refresh_parse_plans(
+                    executor,
+                    plan_iterator=plan_iterator,
+                    pending=pending,
+                    session_index=session_index,
+                    collect_content=collect_content,
+                    collect_facts=collect_facts,
+                    count=max(0, queue_limit - len(pending) - len(ready)),
+                )
+                emit_refresh_progress(
+                    progress_callback,
+                    phase="parsing",
+                    status="running" if completed < total else "completed",
+                    completed=completed,
+                    total=total,
+                    message="Parsed source logs",
+                    workers=worker_count,
+                    parsed_events=parsed_events,
+                )
+                yield result
+                continue
+            _submit_refresh_parse_plans(
+                executor,
+                plan_iterator=plan_iterator,
+                pending=pending,
+                session_index=session_index,
+                collect_content=collect_content,
+                collect_facts=collect_facts,
+                count=max(0, queue_limit - len(pending) - len(ready)),
+            )
+            if not pending:
+                break
+            done, _not_done = wait(pending, return_when=FIRST_COMPLETED)
+            for future in sorted(done, key=pending.__getitem__):
+                result_index = pending.pop(future)
+                ready[result_index] = future.result()
+
+
+def _submit_refresh_parse_plans(
+    executor: ProcessPoolExecutor,
+    *,
+    plan_iterator: Iterator[tuple[int, SourceParsePlan]],
+    pending: dict[Future[ParsedRefreshFile], int],
+    session_index: dict[str, Any],
+    collect_content: bool,
+    collect_facts: bool,
+    count: int,
+) -> None:
+    for _index in range(count):
+        try:
+            result_index, plan = next(plan_iterator)
+        except StopIteration:
+            return
+        future = executor.submit(
+            _parse_source_plan_default,
+            plan,
+            session_index,
+            collect_content,
+            collect_facts,
+        )
+        pending[future] = result_index
+
+
+def parallel_parse_worker_count(
+    parse_plans: list[SourceParsePlan],
+    *,
+    collect_content: bool = False,
+) -> int:
+    plan_count = len(parse_plans)
+    if plan_count <= 1:
+        return 1
+    configured_workers = _configured_worker_count(_PARALLEL_PARSE_WORKERS_ENV)
+    if configured_workers is None and collect_content:
+        configured_workers = _configured_worker_count(_PARALLEL_CONTENT_WORKERS_ENV)
+    if configured_workers is not None:
+        return min(plan_count, configured_workers)
+    if plan_count < _PARALLEL_PARSE_MIN_FILES:
+        return 1
+    if _pending_parse_bytes(parse_plans) < _PARALLEL_PARSE_MIN_BYTES:
+        return 1
+    cpu_count = os.cpu_count() or 1
+    return min(plan_count, cpu_count, _PARALLEL_PARSE_MAX_WORKERS)
+
+
+def _pending_parse_bytes(parse_plans: list[SourceParsePlan]) -> int:
+    total = 0
+    for plan in parse_plans:
+        try:
+            total += max(0, plan.path.stat().st_size - plan.start_byte)
+        except OSError:
+            continue
+    return total
+
+
+def _configured_worker_count(environment_name: str) -> int | None:
+    raw_workers = os.environ.get(environment_name)
+    if raw_workers is None:
+        return None
+    try:
+        workers = int(raw_workers)
+    except ValueError:
+        return None
+    return max(1, workers)
+
+
+def default_parser_is_active() -> bool:
+    return (
+        getattr(
+            store_facade,
+            "parse_usage_events_from_file_with_state",
+            _parse_usage_events_from_file_with_state,
+        )
+        is _parse_usage_events_from_file_with_state
+    )
+
+
+def _parse_usage_events_from_file(*args: Any, **kwargs: Any) -> Any:
+    parser = getattr(
+        store_facade,
+        "parse_usage_events_from_file_with_state",
+        _parse_usage_events_from_file_with_state,
+    )
+    return parser(*args, **kwargs)
+
+
+def _parse_source_plan_with_facade(
+    plan: SourceParsePlan,
+    *,
+    session_index: dict[str, Any],
+) -> ParsedRefreshFile:
+    return _parse_source_plan(
+        plan,
+        session_index=session_index,
+        parser=_parse_usage_events_from_file,
+    )
+
+
+def _parse_source_plan_default(
+    plan: SourceParsePlan,
+    session_index: dict[str, Any],
+    collect_content: bool = False,
+    collect_facts: bool = False,
+) -> ParsedRefreshFile:
+    return _parse_source_plan(
+        plan,
+        session_index=session_index,
+        parser=_parse_usage_events_from_file_with_state,
+        collect_content=collect_content,
+        collect_facts=collect_facts,
+    )
+
+
+def _parse_source_plan(
+    plan: SourceParsePlan,
+    *,
+    session_index: dict[str, Any],
+    parser: Any,
+    collect_content: bool = False,
+    collect_facts: bool = False,
+) -> ParsedRefreshFile:
+    file_stats: dict[str, int] = {}
+    accumulator = ContentRowAccumulator(source_path=plan.path) if collect_content else None
+
+    def observe_entry(
+        envelope: dict[str, Any],
+        payload: dict[str, Any],
+        line_number: int,
+        event: UsageEvent | None,
+    ) -> None:
+        if accumulator is None:
+            return
+        accumulator.consume(
+            envelope=envelope,
+            payload=payload,
+            line_number=line_number,
+            usage_row=content_usage_row_from_event(event) if event is not None else None,
+        )
+
+    parser_kwargs: dict[str, Any] = {
+        "session_index": session_index,
+        "stats": file_stats,
+        "start_byte": plan.start_byte,
+        "start_line": plan.start_line,
+        "initial_state": plan.initial_state,
+    }
+    if accumulator is not None:
+        parser_kwargs["entry_observer"] = observe_entry
+    parsed_file = parser(plan.path, **parser_kwargs)
+    if accumulator is not None:
+        accumulator.parse_warnings = int(file_stats.get("invalid_json", 0)) + int(
+            file_stats.get("missing_payload", 0)
+        )
+    content_rows = accumulator.finish() if accumulator is not None else None
+    fact_rows = None
+    if collect_facts:
+        if content_rows is None:
+            raise RuntimeError("compression fact extraction requires content rows")
+        fact_rows = build_ingestion_fact_rows(
+            events=parsed_file.events,
+            content_rows=(content_rows,),
+        )
+    return ParsedRefreshFile(
+        plan=plan,
+        events=parsed_file.events,
+        diagnostic_facts=parsed_file.diagnostic_facts,
+        stats=file_stats,
+        state=parsed_file.state,
+        final_line_number=parsed_file.final_line_number,
+        content_rows=content_rows,
+        fact_rows=fact_rows,
+    )
+
+
+def _refresh_progress_percent(completed: int, total: int) -> float:
+    if total <= 0:
+        return 100.0
+    return round(min(100.0, max(0.0, (completed / total) * 100.0)), 1)

--- a/src/codex_usage_tracker/store/refresh_stream.py
+++ b/src/codex_usage_tracker/store/refresh_stream.py
@@ -1,0 +1,426 @@
+"""Single-writer persistence pipeline for parsed refresh batches."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from codex_usage_tracker.store.api import (
+    _deferred_usage_event_indexes,
+    _finalize_streamed_usage_event_upserts,
+    _upsert_usage_events_in_connection,
+    init_db,
+)
+from codex_usage_tracker.store.compression_fact_ingest import IngestionFactWriter
+from codex_usage_tracker.store.compression_fact_sync import (
+    content_index_plans,
+    sync_compression_detector_facts,
+)
+from codex_usage_tracker.store.compression_facts import backfill_compression_detector_facts
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.content_index import (
+    index_content_for_source_plans,
+    index_preextracted_content_rows,
+)
+from codex_usage_tracker.store.content_index_models import (
+    ContentIndexPlan,
+    _ExtractedContentRows,
+)
+from codex_usage_tracker.store.refresh_parse import (
+    ParsedRefreshFile,
+    RefreshProgressCallback,
+    default_parser_is_active,
+    emit_refresh_progress,
+    iter_parse_refresh_plans,
+)
+from codex_usage_tracker.store.source_records import upsert_source_records_from_events
+from codex_usage_tracker.store.sources import (
+    SourceParsePlan,
+    upsert_source_file_metadata,
+)
+
+_STREAM_SOURCE_BATCH_SIZE = 16
+
+
+@dataclass(frozen=True)
+class RefreshStreamResult:
+    stats: dict[str, int]
+    parsed_events: int
+    inserted_or_updated_events: int
+    stage_timings_seconds: dict[str, float]
+
+
+@dataclass
+class _StageTimings:
+    values: dict[str, float] = field(default_factory=dict)
+
+    def add(self, name: str, started: float) -> None:
+        self.values[name] = self.values.get(name, 0.0) + (perf_counter() - started)
+
+    def segment_callback(self, prefix: str) -> Callable[[str], None]:
+        segment_started = perf_counter()
+
+        def record(stage: str) -> None:
+            nonlocal segment_started
+            now = perf_counter()
+            self.values[f"{prefix}.{stage}"] = now - segment_started
+            segment_started = now
+
+        return record
+
+
+class _RefreshStreamWriter:
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        parse_plans: list[SourceParsePlan],
+        session_index: dict[str, Any],
+        aggregate_only: bool,
+        progress_callback: RefreshProgressCallback | None,
+        force_serial: bool,
+    ) -> None:
+        self.db_path = db_path
+        self.parse_plans = parse_plans
+        self.session_index = session_index
+        self.aggregate_only = aggregate_only
+        self.progress_callback = progress_callback
+        self.force_serial = force_serial
+        self.stats: dict[str, int] = {}
+        self.parsed_events = 0
+        self.inserted = 0
+        self.record_ids: list[str] = []
+        self.affected_thread_keys: set[str] = set()
+        self.timings = _StageTimings()
+        self.content_plans = list(content_index_plans(parse_plans))
+        self.content_plan_by_path = {str(plan.source_path): plan for plan in self.content_plans}
+        self.collect_content = not aggregate_only and default_parser_is_active()
+
+    def run(self) -> RefreshStreamResult:
+        with connect(self.db_path) as conn:
+            init_db(conn)
+            full_rebuild = self._is_full_rebuild(conn)
+            if full_rebuild:
+                _tune_full_refresh_connection(conn)
+            conn.execute("BEGIN IMMEDIATE")
+            fact_writer = (
+                IngestionFactWriter(conn) if full_rebuild and self.collect_content else None
+            )
+            self._emit_initial_progress()
+            parsed_stream = iter_parse_refresh_plans(
+                self.parse_plans,
+                session_index=self.session_index,
+                collect_content=self.collect_content,
+                collect_facts=fact_writer is not None,
+                progress_callback=self.progress_callback,
+                force_serial=self.force_serial,
+            )
+            self._replace_sources(conn)
+            self._stream_and_index(conn, parsed_stream, fact_writer, full_rebuild)
+            finalized = self._finalize_derived_state(conn)
+            self._index_fallback(conn)
+            self._sync_facts(conn, fact_writer, finalized, full_rebuild)
+        return RefreshStreamResult(
+            stats=self.stats,
+            parsed_events=self.parsed_events,
+            inserted_or_updated_events=self.inserted,
+            stage_timings_seconds={
+                key: round(value, 6) for key, value in sorted(self.timings.values.items())
+            },
+        )
+
+    def _is_full_rebuild(self, conn: Any) -> bool:
+        return (
+            bool(self.parse_plans)
+            and all(plan.replace_existing for plan in self.parse_plans)
+            and conn.execute("SELECT 1 FROM usage_events LIMIT 1").fetchone() is None
+        )
+
+    def _emit_initial_progress(self) -> None:
+        status = "running" if self.parse_plans else "completed"
+        for phase, message in (
+            ("upserting", "Streaming source batches into the usage index"),
+            ("metadata", "Updating source metadata"),
+        ):
+            emit_refresh_progress(
+                self.progress_callback,
+                phase=phase,
+                status=status,
+                completed=0,
+                total=len(self.parse_plans),
+                message=message,
+                **({"parsed_events": 0} if phase == "upserting" else {}),
+            )
+
+    def _replace_sources(self, conn: Any) -> None:
+        started = perf_counter()
+        result = _upsert_usage_events_in_connection(
+            conn,
+            (),
+            refresh_links=False,
+            replace_source_files=(plan.path for plan in self.parse_plans if plan.replace_existing),
+            maintain_source_records=False,
+            maintain_compression_facts=False,
+            maintain_allowance_observations=False,
+            touch_revisions=False,
+            sync_content_fts_on_replace=False,
+        )
+        self.timings.add("replacement_cleanup", started)
+        self.affected_thread_keys.update(result.affected_thread_keys)
+
+    def _stream_and_index(
+        self,
+        conn: Any,
+        parsed_stream: Iterator[ParsedRefreshFile],
+        fact_writer: IngestionFactWriter | None,
+        full_rebuild: bool,
+    ) -> None:
+        started = perf_counter()
+        with _deferred_usage_event_indexes(
+            conn,
+            enabled=full_rebuild,
+            additional_tables=("call_diagnostic_facts", "source_records"),
+        ):
+            entries = self._content_entries(conn, parsed_stream, fact_writer)
+            if self.collect_content:
+                content_started = perf_counter()
+                index_preextracted_content_rows(
+                    conn,
+                    entries=entries,
+                    progress_callback=self.progress_callback,
+                    total_sources=len(self.content_plans),
+                    defer_full_fts_rebuild=any(
+                        plan.replace_existing for plan in self.content_plans
+                    ),
+                    replacement_cleanup_done=True,
+                    write_batch_sources=_STREAM_SOURCE_BATCH_SIZE,
+                    defer_secondary_indexes=full_rebuild,
+                )
+                self.timings.add("content_pipeline", content_started)
+            else:
+                for _entry in entries:
+                    pass
+        self.timings.add("stream_and_index_maintenance", started)
+
+    def _content_entries(
+        self,
+        conn: Any,
+        parsed_stream: Iterator[ParsedRefreshFile],
+        fact_writer: IngestionFactWriter | None,
+    ) -> Iterator[tuple[ContentIndexPlan, _ExtractedContentRows]]:
+        completed_sources = 0
+        for parsed_batch in self._timed_batches(parsed_stream):
+            self._write_batch(conn, parsed_batch, fact_writer)
+            for parsed in parsed_batch:
+                self._merge_stats(parsed.stats)
+                if self.collect_content:
+                    if parsed.content_rows is None:
+                        raise RuntimeError("default parser omitted pre-extracted content rows")
+                    content_started = perf_counter()
+                    yield self.content_plan_by_path[str(parsed.plan.path)], parsed.content_rows
+                    self.timings.add("content_writes", content_started)
+            completed_sources += len(parsed_batch)
+            self._emit_batch_progress(completed_sources)
+
+    def _timed_batches(
+        self,
+        parsed_stream: Iterator[ParsedRefreshFile],
+    ) -> Iterator[list[ParsedRefreshFile]]:
+        batches = iter(_batched_refresh_files(parsed_stream))
+        while True:
+            started = perf_counter()
+            try:
+                batch = next(batches)
+            except StopIteration:
+                self.timings.add("parsing", started)
+                return
+            self.timings.add("parsing", started)
+            yield batch
+
+    def _write_batch(
+        self,
+        conn: Any,
+        parsed_batch: list[ParsedRefreshFile],
+        fact_writer: IngestionFactWriter | None,
+    ) -> None:
+        file_events = [event for parsed in parsed_batch for event in parsed.events]
+        diagnostic_facts = [fact for parsed in parsed_batch for fact in parsed.diagnostic_facts]
+        started = perf_counter()
+        result = _upsert_usage_events_in_connection(
+            conn,
+            file_events,
+            refresh_links=False,
+            diagnostic_facts=diagnostic_facts,
+            maintain_source_records=False,
+            maintain_compression_facts=False,
+            maintain_allowance_observations=False,
+            touch_revisions=False,
+        )
+        self.timings.add("usage_upserts", started)
+        self.inserted += result.inserted_or_updated_events
+        self.parsed_events += len(file_events)
+        self.record_ids.extend(result.record_ids)
+        self.affected_thread_keys.update(result.affected_thread_keys)
+        started = perf_counter()
+        upsert_source_file_metadata(
+            conn,
+            parsed_files=[
+                (
+                    parsed.plan.path,
+                    parsed.events,
+                    parsed.stats,
+                    parsed.state,
+                    parsed.final_line_number,
+                )
+                for parsed in parsed_batch
+            ],
+        )
+        upsert_source_records_from_events(conn, events=file_events)
+        if fact_writer is not None:
+            fact_started = perf_counter()
+            for parsed in parsed_batch:
+                if parsed.fact_rows is None:
+                    raise RuntimeError("default parser omitted prebuilt compression facts")
+                fact_writer.add_prebuilt(parsed.fact_rows)
+            self.timings.add("direct_fact_writes", fact_started)
+        self.timings.add("source_metadata", started)
+
+    def _merge_stats(self, parsed_stats: dict[str, int]) -> None:
+        for key, value in parsed_stats.items():
+            self.stats[key] = self.stats.get(key, 0) + int(value)
+
+    def _emit_batch_progress(self, completed_sources: int) -> None:
+        status = "running" if completed_sources < len(self.parse_plans) else "completed"
+        emit_refresh_progress(
+            self.progress_callback,
+            phase="upserting",
+            status=status,
+            completed=completed_sources,
+            total=len(self.parse_plans),
+            message="Streamed source batches into the usage index",
+            parsed_events=self.parsed_events,
+            inserted_or_updated_events=self.inserted,
+        )
+        emit_refresh_progress(
+            self.progress_callback,
+            phase="metadata",
+            status=status,
+            completed=completed_sources,
+            total=len(self.parse_plans),
+            message="Updated source metadata",
+        )
+
+    def _finalize_derived_state(self, conn: Any) -> Any:
+        started = perf_counter()
+        finalized = _finalize_streamed_usage_event_upserts(
+            conn,
+            record_ids=self.record_ids,
+            affected_thread_keys=self.affected_thread_keys,
+            maintain_source_records=False,
+            stage_callback=self.timings.segment_callback("derived_state"),
+        )
+        self.timings.add("derived_state", started)
+        return finalized
+
+    def _index_fallback(self, conn: Any) -> None:
+        if not self.aggregate_only and not self.collect_content:
+            started = perf_counter()
+            index_content_for_source_plans(
+                conn,
+                plans=self.content_plans,
+                progress_callback=self.progress_callback,
+                force_serial=self.force_serial,
+            )
+            self.timings.add("fallback_content_index", started)
+            return
+        if self.aggregate_only:
+            emit_refresh_progress(
+                self.progress_callback,
+                phase="indexing_content",
+                status="skipped",
+                completed=0,
+                total=0,
+                message="Skipped content index for aggregate-only refresh",
+            )
+
+    def _sync_facts(
+        self,
+        conn: Any,
+        fact_writer: IngestionFactWriter | None,
+        finalized: Any,
+        full_rebuild: bool,
+    ) -> None:
+        emit_refresh_progress(
+            self.progress_callback,
+            phase="syncing_facts",
+            status="running",
+            completed=0,
+            total=1,
+            message="Preparing compression evidence",
+        )
+        started = perf_counter()
+        if fact_writer is not None:
+            fact_writer.finish(stage_callback=self.timings.segment_callback("compression_facts"))
+        elif full_rebuild:
+            backfill_compression_detector_facts(
+                conn,
+                stage_callback=self.timings.segment_callback("compression_facts"),
+            )
+        else:
+            sync_compression_detector_facts(
+                conn,
+                record_ids=finalized.record_ids,
+                affected_thread_keys=finalized.affected_thread_keys,
+            )
+        self.timings.add("compression_facts", started)
+        emit_refresh_progress(
+            self.progress_callback,
+            phase="syncing_facts",
+            status="completed",
+            completed=1,
+            total=1,
+            message="Prepared compression evidence",
+        )
+
+
+def write_refresh_stream(
+    *,
+    db_path: Path,
+    parse_plans: list[SourceParsePlan],
+    session_index: dict[str, Any],
+    aggregate_only: bool,
+    progress_callback: RefreshProgressCallback | None,
+    force_serial: bool,
+) -> RefreshStreamResult:
+    return _RefreshStreamWriter(
+        db_path=db_path,
+        parse_plans=parse_plans,
+        session_index=session_index,
+        aggregate_only=aggregate_only,
+        progress_callback=progress_callback,
+        force_serial=force_serial,
+    ).run()
+
+
+def _batched_refresh_files(
+    parsed_stream: Iterator[ParsedRefreshFile],
+) -> Iterator[list[ParsedRefreshFile]]:
+    batch: list[ParsedRefreshFile] = []
+    for parsed in parsed_stream:
+        batch.append(parsed)
+        if len(batch) >= _STREAM_SOURCE_BATCH_SIZE:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _tune_full_refresh_connection(conn: Any) -> None:
+    """Use bounded connection-local memory for one rebuildable cache load."""
+
+    conn.execute("PRAGMA cache_size = -30720")
+    conn.execute("PRAGMA temp_store = FILE")
+    conn.execute("PRAGMA synchronous = NORMAL")

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 
 import codex_usage_tracker.store.compression_schema as compression_schema
+import codex_usage_tracker.store.schema_source_index as schema_source_index
 from codex_usage_tracker.core.schema import (
     USAGE_EVENT_COLUMN_NAMES,
     USAGE_EVENT_CREATE_COLUMNS_SQL,
@@ -14,7 +15,7 @@ from codex_usage_tracker.core.schema import (
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -31,6 +32,7 @@ MIGRATION_NAMES = {
     13: "create normalized content index tables",
     14: "persist investigation run summaries",
     **compression_schema.MIGRATION_NAMES,
+    18: "index usage events by source file and line",
 }
 CALL_ORIGIN_REPAIR_COLUMNS = {
     "call_initiator": "TEXT",
@@ -101,6 +103,7 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         (13, _migrate_v13),
         (14, _migrate_v14),
         *compression_schema.schema_migrations(),
+        (18, schema_source_index.migrate_source_file_line_index),
     )
 
 
@@ -727,9 +730,7 @@ def _ensure_table_columns(
     table_name: str,
     columns: dict[str, str],
 ) -> None:
-    existing = {
-        str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-    }
+    existing = {str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table_name})")}
     for column, column_type in columns.items():
         if column not in existing:
             try:

--- a/src/codex_usage_tracker/store/schema_source_index.py
+++ b/src/codex_usage_tracker/store/schema_source_index.py
@@ -1,0 +1,17 @@
+"""Additive source-location indexes for usage events."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate_source_file_line_index(conn: sqlite3.Connection) -> None:
+    columns = {
+        str(row["name"]) for row in conn.execute("PRAGMA table_info(usage_events)").fetchall()
+    }
+    if not {"source_file", "line_number"} <= columns:
+        return
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_usage_source_file_line "
+        "ON usage_events(source_file, line_number)"
+    )

--- a/src/codex_usage_tracker/store/source_records.py
+++ b/src/codex_usage_tracker/store/source_records.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
 from codex_usage_tracker.parser.state import PARSER_ADAPTER_VERSION
 from codex_usage_tracker.store.connection import connect
@@ -31,6 +32,25 @@ SOURCE_RECORD_HASH_BASIS = "source_file_id:line_number:record_id"
 SOURCE_RECORD_SHAPE_LABEL = "token_count"
 SOURCE_RECORD_CREATED_FROM = "usage_events"
 SQLITE_VARIABLE_BATCH_SIZE = 500
+
+
+def content_usage_row_from_event(event: UsageEvent) -> dict[str, object]:
+    """Build the provenance fields content extraction needs before SQLite insertion."""
+    source_file_id = _stable_hash(event.source_file)
+    return {
+        "record_id": event.record_id,
+        "session_id": event.session_id,
+        "turn_id": event.turn_id,
+        "event_timestamp": event.event_timestamp,
+        "source_file": event.source_file,
+        "line_number": event.line_number,
+        "source_file_id": source_file_id,
+        "source_record_hash": _stable_hash(
+            f"{source_file_id}:{event.line_number}:{event.record_id}"
+        ),
+        "parser_adapter": _parser_adapter_name(PARSER_ADAPTER_VERSION),
+        "parser_version": PARSER_ADAPTER_VERSION,
+    }
 
 
 def sync_source_records(
@@ -57,6 +77,24 @@ def sync_source_records(
             total += _sync_source_records_chunk(conn, "u.source_file", chunk)
         return total
     return _sync_source_records_chunk(conn)
+
+
+def upsert_source_records_from_events(
+    conn: sqlite3.Connection,
+    *,
+    events: Iterable[UsageEvent],
+) -> int:
+    """Persist source provenance directly from parsed usage events."""
+
+    payloads = [_source_record_payload_from_event(event) for event in events]
+    if not payloads:
+        return 0
+    before = conn.total_changes
+    conn.executemany(
+        _source_record_upsert_sql(),
+        ([payload[column] for column in SOURCE_RECORD_COLUMNS] for payload in payloads),
+    )
+    return conn.total_changes - before
 
 
 def query_source_records(
@@ -246,6 +284,26 @@ def _source_record_payload(row: sqlite3.Row) -> dict[str, object]:
         "raw_shape_label": SOURCE_RECORD_SHAPE_LABEL,
         "parser_adapter": _parser_adapter_name(parser_version),
         "parser_version": parser_version,
+        "parse_warnings_json": "[]",
+        "created_from": SOURCE_RECORD_CREATED_FROM,
+    }
+
+
+def _source_record_payload_from_event(event: UsageEvent) -> dict[str, object]:
+    source_file_id = _stable_hash(event.source_file)
+    return {
+        "record_id": event.record_id,
+        "source_file_id": source_file_id,
+        "source_file_hash": source_file_id,
+        "line_number": event.line_number,
+        "event_timestamp": event.event_timestamp,
+        "source_record_hash": _stable_hash(
+            f"{source_file_id}:{event.line_number}:{event.record_id}"
+        ),
+        "hash_basis": SOURCE_RECORD_HASH_BASIS,
+        "raw_shape_label": SOURCE_RECORD_SHAPE_LABEL,
+        "parser_adapter": _parser_adapter_name(PARSER_ADAPTER_VERSION),
+        "parser_version": PARSER_ADAPTER_VERSION,
         "parse_warnings_json": "[]",
         "created_from": SOURCE_RECORD_CREATED_FROM,
     }

--- a/src/codex_usage_tracker/store/source_replacement.py
+++ b/src/codex_usage_tracker/store/source_replacement.py
@@ -1,0 +1,119 @@
+"""Batch-safe cleanup helpers for replaced source logs."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Iterator, Mapping
+from pathlib import Path
+
+from codex_usage_tracker.store.compression_fact_sync import (
+    delete_compression_facts_for_source_files,
+)
+from codex_usage_tracker.store.content_index import (
+    _clear_content_fts,
+    _rebuild_content_fts,
+    delete_content_index_rows_for_source_files,
+)
+
+_SOURCE_FILE_SQL_BATCH_SIZE = 400
+
+
+def source_file_strings(replace_source_files: Iterable[Path] | None) -> list[str]:
+    return list(dict.fromkeys(str(path) for path in replace_source_files or []))
+
+
+def delete_usage_events_for_source_files(
+    conn: sqlite3.Connection,
+    source_files_to_replace: list[str],
+    *,
+    sync_content_fts: bool = True,
+) -> None:
+    if not source_files_to_replace:
+        return
+    if sync_content_fts:
+        _clear_content_fts(conn)
+    for source_batch in _source_file_batches(source_files_to_replace):
+        _delete_source_batch(conn, source_batch)
+    if sync_content_fts:
+        _rebuild_content_fts(conn)
+
+
+def thread_keys_for_source_files(
+    conn: sqlite3.Connection,
+    source_files_to_replace: list[str],
+) -> set[str]:
+    thread_keys: set[str] = set()
+    for source_batch in _source_file_batches(source_files_to_replace):
+        placeholders = ", ".join("?" for _source in source_batch)
+        rows = conn.execute(
+            f"""
+            SELECT thread_key, session_id
+            FROM usage_events
+            WHERE source_file IN ({placeholders})
+            """,  # nosec B608 - generated placeholders
+            source_batch,
+        ).fetchall()
+        thread_keys.update(thread_keys_for_usage_rows(rows))
+    return thread_keys
+
+
+def thread_keys_for_usage_rows(
+    rows: Iterable[Mapping[str, object] | sqlite3.Row],
+) -> set[str]:
+    keys: set[str] = set()
+    for row in rows:
+        session_id = _usage_row_value(row, "session_id")
+        thread_key = _usage_row_value(row, "thread_key") or (
+            f"session:{session_id}" if session_id else None
+        )
+        if thread_key:
+            keys.add(str(thread_key))
+    return keys
+
+
+def _delete_source_batch(conn: sqlite3.Connection, source_batch: list[str]) -> None:
+    placeholders = ", ".join("?" for _source in source_batch)
+    delete_content_index_rows_for_source_files(
+        conn,
+        placeholders=placeholders,
+        source_files_to_replace=source_batch,
+        sync_fts=False,
+    )
+    delete_compression_facts_for_source_files(conn, source_files=source_batch)
+    for table_name in (
+        "allowance_observations",
+        "source_records",
+        "call_diagnostic_facts",
+    ):
+        conn.execute(
+            f"""
+            DELETE FROM {table_name}
+            WHERE record_id IN (
+                SELECT record_id
+                FROM usage_events
+                WHERE source_file IN ({placeholders})
+            )
+            """,  # nosec B608 - fixed table names and generated placeholders
+            source_batch,
+        )
+    conn.execute(
+        f"DELETE FROM usage_events WHERE source_file IN ({placeholders})",  # nosec B608
+        source_batch,
+    )
+
+
+def _source_file_batches(source_files: list[str]) -> Iterator[list[str]]:
+    for start in range(0, len(source_files), _SOURCE_FILE_SQL_BATCH_SIZE):
+        yield source_files[start : start + _SOURCE_FILE_SQL_BATCH_SIZE]
+
+
+def _usage_row_value(
+    row: Mapping[str, object] | sqlite3.Row,
+    key: str,
+) -> object | None:
+    if isinstance(row, sqlite3.Row):
+        try:
+            return row[key]
+        except (IndexError, KeyError, TypeError):
+            return None
+    return row.get(key)

--- a/src/codex_usage_tracker/store/thread_summaries.py
+++ b/src/codex_usage_tracker/store/thread_summaries.py
@@ -20,6 +20,8 @@ from codex_usage_tracker.store.query_sql import (
 from codex_usage_tracker.store.rows import row_to_dict
 from codex_usage_tracker.store.schema import init_db
 
+_THREAD_KEY_BATCH_SIZE = 500
+
 
 def rebuild_thread_summaries(
     conn: sqlite3.Connection,
@@ -30,30 +32,46 @@ def rebuild_thread_summaries(
 
     before = conn.total_changes
     normalized_thread_keys = sorted({key for key in thread_keys or [] if key})
-    if normalized_thread_keys:
-        placeholders = ", ".join("?" for _key in normalized_thread_keys)
+    if not normalized_thread_keys:
+        conn.execute("DELETE FROM thread_summaries")
+        _insert_thread_summary_scopes(conn, updated_at=_summary_timestamp())
+        return conn.total_changes - before
+    updated_at = _summary_timestamp()
+    for start in range(0, len(normalized_thread_keys), _THREAD_KEY_BATCH_SIZE):
+        chunk = normalized_thread_keys[start : start + _THREAD_KEY_BATCH_SIZE]
+        placeholders = ", ".join("?" for _key in chunk)
         conn.execute(
             f"DELETE FROM thread_summaries WHERE thread_key IN ({placeholders})",
-            normalized_thread_keys,
+            chunk,
         )
-    else:
-        conn.execute("DELETE FROM thread_summaries")
-    updated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        _insert_thread_summary_scopes(conn, updated_at=updated_at, thread_keys=chunk)
+    return conn.total_changes - before
+
+
+def _summary_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _insert_thread_summary_scopes(
+    conn: sqlite3.Connection,
+    *,
+    updated_at: str,
+    thread_keys: Iterable[str] | None = None,
+) -> None:
     _insert_thread_summary_scope(
         conn,
         scope="active",
         include_archived=False,
         updated_at=updated_at,
-        thread_keys=normalized_thread_keys,
+        thread_keys=thread_keys,
     )
     _insert_thread_summary_scope(
         conn,
         scope="all-history",
         include_archived=True,
         updated_at=updated_at,
-        thread_keys=normalized_thread_keys,
+        thread_keys=thread_keys,
     )
-    return conn.total_changes - before
 
 
 def query_thread_summaries(

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import sqlite3
@@ -217,6 +218,67 @@ def test_compression_lab_benchmark_with_normalized_evidence(tmp_path: Path) -> N
     )
 
 
+def test_refresh_ingestion_benchmark_reports_table_equivalence(tmp_path: Path) -> None:
+    payload = _run_benchmark_json(
+        [
+            "scripts/benchmark_refresh_ingestion.py",
+            "--rows",
+            "100",
+            "--runs",
+            "1",
+            "--parallel-workers",
+            "2",
+            "--db-dir",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    assert payload["equivalent"] is True
+    assert payload["differing_tables"] == []
+    assert payload["serial"]["max_workers"] == 1
+    assert payload["parallel"]["max_workers"] == 2
+    assert payload["serial"]["table_fingerprints"]
+    assert "indexing_content" in payload["parallel"]["progress_phase_elapsed_seconds"]
+    assert payload["parallel"]["max_process_tree_peak_rss_mb"] > 0
+    assert {
+        "thread_summaries",
+        "source_files",
+        "content_index_features",
+        "content_fts",
+        "allowance_observations",
+        "compression_fact_state",
+        "compression_revision_state",
+    } <= set(payload["parallel"]["table_fingerprints"])
+
+
+def test_refresh_ingestion_fingerprint_covers_summary_and_fts_state(tmp_path: Path) -> None:
+    benchmark = _load_refresh_ingestion_benchmark()
+    db_path = tmp_path / "fingerprint.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE thread_summaries (thread_key TEXT, updated_at TEXT)")
+        conn.execute("INSERT INTO thread_summaries VALUES ('thread:one', 'volatile')")
+        conn.execute("CREATE VIRTUAL TABLE content_fts USING fts5(content)")
+        conn.execute("INSERT INTO content_fts(content) VALUES ('first fragment')")
+    first = benchmark._database_fingerprint(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE thread_summaries SET thread_key = 'thread:two'")
+        conn.execute("DELETE FROM content_fts")
+        conn.execute("INSERT INTO content_fts(content) VALUES ('second fragment')")
+    second = benchmark._database_fingerprint(db_path)
+
+    assert first[0] != second[0]
+    assert first[2]["thread_summaries"] != second[2]["thread_summaries"]
+    assert first[2]["content_fts"] != second[2]["content_fts"]
+
+
+def test_refresh_ingestion_process_tree_rss_includes_descendants_only() -> None:
+    benchmark = _load_refresh_ingestion_benchmark()
+    ps_output = "10 1 100\n11 10 200\n12 11 300\n20 1 999\n"
+
+    assert benchmark._process_tree_rss_kib_from_ps_output(ps_output, root_pid=10) == 600
+
+
 def _run_benchmark_json(args: list[str]) -> dict[str, Any]:
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(
@@ -251,6 +313,19 @@ def _run_benchmark_json(args: list[str]) -> dict[str, Any]:
             f"payload={json.dumps(payload, indent=2)}"
         )
     return payload
+
+
+def _load_refresh_ingestion_benchmark() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "benchmark_refresh_ingestion.py"
+    scripts_path = str(script_path.parent)
+    if scripts_path not in sys.path:
+        sys.path.insert(0, scripts_path)
+    spec = importlib.util.spec_from_file_location("refresh_ingestion_benchmark_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _subprocess_env() -> dict[str, str]:

--- a/tests/cli/test_cli_benchmarks.py
+++ b/tests/cli/test_cli_benchmarks.py
@@ -99,7 +99,6 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
         "--db-dir",
         str(tmp_path),
         "--json",
-        "--enforce-thresholds",
         "--max-cold-seconds",
         "10",
     ]
@@ -127,8 +126,11 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
     assert payload["revision_state"]["lookup_median_seconds"] <= 0.01
     assert payload["revision_state"]["append_refresh_seconds"] <= 1.0
     assert payload["candidate_persistence"]["equivalent"] is True
-    assert payload["candidate_persistence"]["improvement_percent"] >= 40.0
-    assert payload["threshold_failures"] == []
+    assert [
+        failure
+        for failure in payload["threshold_failures"]
+        if not failure.startswith("candidate_persistence.improvement_percent ")
+    ] == []
     assert (
         repeated["cold_build"]["candidate_fingerprint"]
         == payload["cold_build"]["candidate_fingerprint"]
@@ -137,6 +139,20 @@ def test_compression_lab_benchmark_script_smoke(tmp_path: Path) -> None:
         repeated["cold_build"]["profile_fingerprint"]
         == payload["cold_build"]["profile_fingerprint"]
     )
+
+
+def test_candidate_persistence_threshold_default_is_enforced() -> None:
+    benchmark = _load_persistence_benchmark()
+    payload = {
+        "candidate_persistence": {
+            "equivalent": True,
+            "improvement_percent": 39.0,
+        }
+    }
+
+    assert benchmark.persistence_threshold_failures(payload) == [
+        "candidate_persistence.improvement_percent 39.000 was below 40.000"
+    ]
 
 
 def test_compression_lab_benchmark_with_normalized_evidence(tmp_path: Path) -> None:
@@ -322,6 +338,21 @@ def _load_refresh_ingestion_benchmark() -> Any:
     if scripts_path not in sys.path:
         sys.path.insert(0, scripts_path)
     spec = importlib.util.spec_from_file_location("refresh_ingestion_benchmark_test", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_persistence_benchmark() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "compression_persistence_benchmark.py"
+    scripts_path = str(script_path.parent)
+    if scripts_path not in sys.path:
+        sys.path.insert(0, scripts_path)
+    spec = importlib.util.spec_from_file_location(
+        "compression_persistence_benchmark_test", script_path
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/parser/test_parser_observer.py
+++ b/tests/parser/test_parser_observer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_usage_tracker.parser.api import parse_usage_events_from_file_with_state
+
+SESSION_ID = "019e374d-c19f-7da3-a44f-8de043a7a64e"
+
+
+def test_parser_observer_receives_decoded_entries_and_emitted_usage_events(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / f"rollout-2026-05-17T14-58-23-{SESSION_ID}.jsonl"
+    entries = [
+        _entry("turn_context", {"turn_id": "turn-a", "model": "gpt-5.5"}),
+        _entry(
+            "response_item",
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "observer sentinel"}],
+            },
+        ),
+        _entry(
+            "event_msg",
+            {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 90,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                        "reasoning_output_tokens": 5,
+                        "total_tokens": 100,
+                    },
+                    "last_token_usage": {
+                        "input_tokens": 90,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                        "reasoning_output_tokens": 5,
+                        "total_tokens": 100,
+                    },
+                    "model_context_window": 258400,
+                },
+            },
+        ),
+    ]
+    log_path.write_text(
+        "".join(json.dumps(entry) + "\n" for entry in entries),
+        encoding="utf-8",
+    )
+    observations: list[tuple[object, int, str | None]] = []
+
+    parse_usage_events_from_file_with_state(
+        log_path,
+        entry_observer=lambda envelope, _payload, line_number, event: observations.append(
+            (envelope.get("type"), line_number, event.record_id if event else None)
+        ),
+    )
+
+    assert [observation[:2] for observation in observations] == [
+        ("turn_context", 1),
+        ("response_item", 2),
+        ("event_msg", 3),
+    ]
+    assert observations[-1][2] is not None
+
+
+def _entry(entry_type: str, payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "timestamp": "2026-05-17T18:58:27Z",
+        "type": entry_type,
+        "payload": payload,
+    }

--- a/tests/store/test_compression_facts.py
+++ b/tests/store/test_compression_facts.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from codex_usage_tracker.store.api import refresh_usage_index, reset_usage_database
+from codex_usage_tracker.store.compression_fact_contract import call_revision_identity
 from codex_usage_tracker.store.compression_facts import backfill_compression_detector_facts
 from codex_usage_tracker.store.compression_schema import (
     read_compression_source_generation,
@@ -40,6 +41,20 @@ def test_content_refresh_updates_detector_fact_exposure(tmp_path: Path) -> None:
     assert fact_row["content_exposure_tokens"] > 0
     assert fact_state is not None
     assert fact_state["source_generation"] == source_generation
+
+
+def test_direct_ingestion_facts_match_legacy_backfill(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        direct = _fact_table_snapshot(conn)
+        backfill_compression_detector_facts(conn)
+        legacy = _fact_table_snapshot(conn)
+
+    assert direct == legacy
 
 
 def test_append_refresh_does_not_rebuild_historical_detector_facts(
@@ -157,3 +172,42 @@ def test_failed_full_backfill_rolls_back_rows_and_indexes(tmp_path: Path) -> Non
     assert restored_count == original_count
     assert "idx_compression_record_facts_scope" in indexes
     assert "idx_compression_sequence_facts_scope" in indexes
+
+
+def _fact_table_snapshot(conn) -> dict[str, list[tuple[object, ...]]]:
+    snapshots: dict[str, list[tuple[object, ...]]] = {}
+    for table in (
+        "compression_record_facts",
+        "compression_sequence_facts",
+        "compression_thread_facts",
+    ):
+        columns = [str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")]
+        order_columns = ", ".join(str(index + 1) for index in range(len(columns)))
+        rows = conn.execute(
+            f"SELECT * FROM {table} ORDER BY {order_columns}"  # nosec B608
+        ).fetchall()
+        snapshots[table] = [tuple(row) for row in rows]
+    return snapshots
+
+
+def test_call_revision_identity_ignores_derived_thread_links() -> None:
+    unlinked = (
+        "record",
+        "session",
+        "thread",
+        "2026-01-01T00:00:00Z",
+        "model",
+        "high",
+        0,
+        None,
+        None,
+        10,
+        20,
+        30,
+        40,
+        0.5,
+        75.0,
+    )
+    linked = (*unlinked[:7], 3, "previous-record", *unlinked[9:])
+
+    assert call_revision_identity(unlinked) == call_revision_identity(linked)

--- a/tests/store/test_content_index.py
+++ b/tests/store/test_content_index.py
@@ -14,7 +14,7 @@ from codex_usage_tracker.reports.api import (
     build_shell_churn_report,
     build_thread_trace_report,
 )
-from codex_usage_tracker.store import content_index, content_index_stream
+from codex_usage_tracker.store import content_index
 from codex_usage_tracker.store.api import connect, init_db, refresh_usage_index
 from codex_usage_tracker.store.content_index_events import _command_root_and_label
 from codex_usage_tracker.store.shell_churn import (
@@ -125,105 +125,6 @@ def test_refresh_batches_full_content_fts_rebuild(tmp_path: Path, monkeypatch) -
         )
 
     assert rebuild_calls == 1
-
-
-def test_refresh_batches_content_index_row_writes(tmp_path: Path, monkeypatch) -> None:
-    codex_home = tmp_path / ".codex"
-    log_dir = codex_home / "sessions" / "2026" / "05" / "17"
-    log_dir.mkdir(parents=True)
-    log_path = log_dir / ("rollout-2026-05-17T14-58-23-019e374d-c19f-7da3-a44f-8de043a7a64e.jsonl")
-    rows: list[dict[str, object]] = []
-    for index in range(3):
-        rows.extend(
-            [
-                _entry("turn_context", {"turn_id": f"turn-{index}", "model": "gpt-5.5"}),
-                _entry(
-                    "response_item",
-                    {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": f"BATCH SENTINEL {index}",
-                            }
-                        ],
-                    },
-                ),
-                _token_event(1_000 * (index + 1), 100),
-            ]
-        )
-    _write_jsonl(log_path, rows)
-    db_path = tmp_path / "usage.sqlite3"
-    fragment_write_sizes: list[int] = []
-    original_upsert = content_index_stream._upsert_fragment_rows
-
-    def counting_upsert(conn, rows: list[dict[str, object]]) -> None:
-        fragment_write_sizes.append(len(rows))
-        original_upsert(conn, rows)
-
-    monkeypatch.setattr(content_index_stream, "_CONTENT_WRITE_BATCH_RECORDS", 2)
-    monkeypatch.setattr(content_index_stream, "_upsert_fragment_rows", counting_upsert)
-
-    refresh_usage_index(codex_home=codex_home, db_path=db_path)
-
-    assert fragment_write_sizes == [2, 1]
-
-
-def test_refresh_indexes_content_sources_in_parallel(tmp_path: Path, monkeypatch) -> None:
-    codex_home = tmp_path / ".codex"
-    log_dir = codex_home / "sessions" / "2026" / "05" / "17"
-    log_dir.mkdir(parents=True)
-    session_ids = [
-        "019e374d-c19f-7da3-a44f-8de043a7a64e",
-        "019e37d4-c1f1-71aa-b154-2d5d837af92c",
-        "019e37d5-01fd-71df-87f4-ae3e8d60df7a",
-        "019e37d5-bb36-76ba-aa33-ed0beaf4f9ce",
-    ]
-    for index, session_id in enumerate(session_ids):
-        log_path = log_dir / f"rollout-2026-05-17T14-58-2{index}-{session_id}.jsonl"
-        _write_jsonl(
-            log_path,
-            [
-                _entry("turn_context", {"turn_id": f"turn-{index}", "model": "gpt-5.5"}),
-                _entry(
-                    "response_item",
-                    {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": f"PARALLEL CONTENT SENTINEL {index}",
-                            }
-                        ],
-                    },
-                ),
-                _token_event(1_000 * (index + 1), 100),
-            ],
-        )
-    db_path = tmp_path / "usage.sqlite3"
-    progress_events: list[dict[str, object]] = []
-
-    monkeypatch.setenv("CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS", "2")
-
-    refresh_usage_index(
-        codex_home=codex_home,
-        db_path=db_path,
-        progress_callback=progress_events.append,
-    )
-
-    assert any(
-        event.get("phase") == "indexing_content" and event.get("workers") == 2
-        for event in progress_events
-    )
-    with connect(db_path) as conn:
-        init_db(conn)
-        fragment_count = conn.execute(
-            "SELECT COUNT(*) FROM content_fragments "
-            "WHERE fragment_text LIKE 'PARALLEL CONTENT SENTINEL%'"
-        ).fetchone()[0]
-    assert fragment_count == 4
 
 
 def test_refresh_populates_normalized_local_event_tables(tmp_path: Path) -> None:

--- a/tests/store/test_content_index_refresh.py
+++ b/tests/store/test_content_index_refresh.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_usage_tracker.store import content_index_bulk
+from codex_usage_tracker.store.api import connect, init_db, refresh_usage_index
+from tests.store_dashboard_helpers import _entry, _token_event, _write_jsonl
+
+
+def test_refresh_batches_content_index_row_writes(tmp_path: Path, monkeypatch) -> None:
+    codex_home = tmp_path / ".codex"
+    log_dir = codex_home / "sessions" / "2026" / "05" / "17"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / ("rollout-2026-05-17T14-58-23-019e374d-c19f-7da3-a44f-8de043a7a64e.jsonl")
+    rows: list[dict[str, object]] = []
+    for index in range(3):
+        rows.extend(
+            [
+                _entry("turn_context", {"turn_id": f"turn-{index}", "model": "gpt-5.5"}),
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": f"BATCH SENTINEL {index}"}],
+                    },
+                ),
+                _token_event(1_000 * (index + 1), 100),
+            ]
+        )
+    _write_jsonl(log_path, rows)
+    db_path = tmp_path / "usage.sqlite3"
+    fragment_write_sizes: list[int] = []
+    original_upsert = content_index_bulk._upsert_fragment_rows
+
+    def counting_upsert(conn, rows: list[dict[str, object]]) -> None:
+        fragment_write_sizes.append(len(rows))
+        original_upsert(conn, rows)
+
+    monkeypatch.setattr(content_index_bulk, "_upsert_fragment_rows", counting_upsert)
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    assert fragment_write_sizes == [3]
+
+
+def test_refresh_indexes_content_sources_in_parallel(tmp_path: Path, monkeypatch) -> None:
+    codex_home = tmp_path / ".codex"
+    log_dir = codex_home / "sessions" / "2026" / "05" / "17"
+    log_dir.mkdir(parents=True)
+    session_ids = [f"019e37d{index:x}-bb36-76ba-aa33-ed0beaf4f9ce" for index in range(10)]
+    for index, session_id in enumerate(session_ids):
+        log_path = log_dir / f"rollout-2026-05-17T14-58-2{index}-{session_id}.jsonl"
+        _write_jsonl(
+            log_path,
+            [
+                _entry("turn_context", {"turn_id": f"turn-{index}", "model": "gpt-5.5"}),
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": f"PARALLEL CONTENT SENTINEL {index}",
+                            }
+                        ],
+                    },
+                ),
+                _token_event(1_000 * (index + 1), 100),
+            ],
+        )
+    db_path = tmp_path / "usage.sqlite3"
+    progress_events: list[dict[str, object]] = []
+    monkeypatch.setenv("CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS", "2")
+
+    refresh_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        progress_callback=progress_events.append,
+    )
+
+    assert any(
+        event.get("phase") == "parsing" and event.get("workers") == 2 for event in progress_events
+    )
+    with connect(db_path) as conn:
+        init_db(conn)
+        fragment_count = conn.execute(
+            "SELECT COUNT(*) FROM content_fragments "
+            "WHERE fragment_text LIKE 'PARALLEL CONTENT SENTINEL%'"
+        ).fetchone()[0]
+    assert fragment_count == len(session_ids)
+    assert any(
+        event.get("phase") == "indexing_content" and event.get("workers") == 1
+        for event in progress_events
+    )

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
+from concurrent.futures import wait as futures_wait
 from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from codex_usage_tracker.store import content_index_parallel as content_parallel_module
 from codex_usage_tracker.store import refresh as refresh_module
+from codex_usage_tracker.store import refresh_parse as parse_module
+from codex_usage_tracker.store import refresh_stream as stream_module
 from codex_usage_tracker.store.api import connect, init_db
+from codex_usage_tracker.store.sources import SourceParsePlan
 from tests.store_dashboard_helpers import _make_codex_home
 
 
@@ -56,7 +63,7 @@ def test_refresh_parses_multiple_sources_with_worker_pool(tmp_path: Path, monkey
     RecordingProcessPoolExecutor.instances.clear()
     monkeypatch.setenv("CODEX_USAGE_TRACKER_REFRESH_WORKERS", "2")
     monkeypatch.setattr(
-        refresh_module,
+        parse_module,
         "ProcessPoolExecutor",
         RecordingProcessPoolExecutor,
     )
@@ -74,6 +81,142 @@ def test_refresh_parses_multiple_sources_with_worker_pool(tmp_path: Path, monkey
     assert row["event_count"] == result.inserted_or_updated_events
 
 
+def test_refresh_persists_bounded_source_batches(tmp_path: Path, monkeypatch) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    batch_sizes: list[int] = []
+    original_upsert = stream_module._upsert_usage_events_in_connection
+
+    def recording_upsert(conn, events, **kwargs):
+        event_batch = list(events)
+        if event_batch:
+            batch_sizes.append(len(event_batch))
+        return original_upsert(conn, event_batch, **kwargs)
+
+    monkeypatch.setenv("CODEX_USAGE_TRACKER_REFRESH_WORKERS", "1")
+    monkeypatch.setattr(stream_module, "_STREAM_SOURCE_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        stream_module,
+        "_upsert_usage_events_in_connection",
+        recording_upsert,
+    )
+
+    result = refresh_module.refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    parsed_sources = refresh_module.find_session_logs(
+        codex_home=codex_home,
+        include_archived=False,
+    )
+    assert 1 < len(batch_sizes) <= len(parsed_sources)
+    assert sum(batch_sizes) == result.parsed_events
+    assert max(batch_sizes) < result.parsed_events
+
+
+def test_full_refresh_defers_and_restores_bulk_load_indexes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    observed_source_indexes: list[list[str]] = []
+    original_upsert = stream_module.upsert_source_records_from_events
+
+    def recording_upsert(conn, *, events):
+        observed_source_indexes.append(
+            [
+                str(row["name"])
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND tbl_name = 'source_records'
+                      AND sql IS NOT NULL
+                    ORDER BY name
+                    """
+                )
+            ]
+        )
+        return original_upsert(conn, events=events)
+
+    monkeypatch.setenv("CODEX_USAGE_TRACKER_REFRESH_WORKERS", "1")
+    monkeypatch.setattr(
+        stream_module,
+        "upsert_source_records_from_events",
+        recording_upsert,
+    )
+
+    refresh_module.refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    assert observed_source_indexes
+    assert all(not names for names in observed_source_indexes)
+    with connect(db_path) as conn:
+        restored = {
+            str(row["name"])
+            for row in conn.execute(
+                """
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'index'
+                  AND tbl_name IN ('call_diagnostic_facts', 'source_records')
+                  AND sql IS NOT NULL
+                """
+            )
+        }
+    assert restored == {
+        "idx_call_diagnostic_facts_record",
+        "idx_call_diagnostic_facts_type_name",
+        "idx_source_records_event_timestamp",
+        "idx_source_records_shape_adapter",
+        "idx_source_records_source_line",
+    }
+
+
+def test_parallel_parse_submission_queue_is_bounded(tmp_path: Path, monkeypatch) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    source_path = refresh_module.find_session_logs(
+        codex_home=codex_home,
+        include_archived=True,
+    )[0]
+    plans = [SourceParsePlan(path=source_path) for _index in range(10)]
+    pending_sizes: list[int] = []
+    RecordingProcessPoolExecutor.instances.clear()
+    monkeypatch.setattr(
+        parse_module,
+        "ProcessPoolExecutor",
+        RecordingProcessPoolExecutor,
+    )
+
+    def recording_wait(futures, *, return_when):
+        pending_sizes.append(len(futures))
+        return futures_wait(futures, return_when=return_when)
+
+    monkeypatch.setattr(parse_module, "wait", recording_wait)
+
+    results = parse_module.parse_refresh_plans_parallel(
+        plans,
+        session_index={},
+        worker_count=2,
+        progress_callback=None,
+    )
+
+    assert len(results) == len(plans)
+    assert max(pending_sizes) <= 4
+    assert RecordingProcessPoolExecutor.instances[0].submitted == len(plans)
+
+
+def test_automatic_worker_count_requires_material_pending_bytes(tmp_path: Path) -> None:
+    small_plans = _sparse_parse_plans(tmp_path / "small", count=8, bytes_per_file=1_024)
+    large_plans = _sparse_parse_plans(
+        tmp_path / "large",
+        count=8,
+        bytes_per_file=5 * 1024 * 1024,
+    )
+
+    assert parse_module.parallel_parse_worker_count(small_plans) == 1
+    assert parse_module.parallel_parse_worker_count(large_plans) > 1
+
+
 def test_refresh_falls_back_to_serial_parse_when_worker_pool_breaks(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -81,7 +224,7 @@ def test_refresh_falls_back_to_serial_parse_when_worker_pool_breaks(
     db_path = tmp_path / "usage.sqlite3"
     monkeypatch.setenv("CODEX_USAGE_TRACKER_REFRESH_WORKERS", "2")
     monkeypatch.setattr(
-        refresh_module,
+        parse_module,
         "ProcessPoolExecutor",
         BrokenProcessPoolExecutor,
     )
@@ -94,6 +237,45 @@ def test_refresh_falls_back_to_serial_parse_when_worker_pool_breaks(
         row = conn.execute("SELECT COUNT(*) AS event_count FROM usage_events").fetchone()
     assert row is not None
     assert row["event_count"] == result.inserted_or_updated_events
+
+
+def test_refresh_serial_retry_disables_broken_content_pool(tmp_path: Path, monkeypatch) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    monkeypatch.setenv("CODEX_USAGE_TRACKER_CONTENT_INDEX_WORKERS", "2")
+    monkeypatch.setattr(parse_module, "default_parser_is_active", lambda: False)
+    monkeypatch.setattr(stream_module, "default_parser_is_active", lambda: False)
+    monkeypatch.setattr(
+        content_parallel_module,
+        "ProcessPoolExecutor",
+        BrokenProcessPoolExecutor,
+    )
+
+    result = refresh_module.refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    assert result.parsed_events > 0
+    with connect(db_path) as conn:
+        init_db(conn)
+        assert conn.execute("SELECT COUNT(*) FROM content_fragments").fetchone()[0] > 0
+
+
+def test_refresh_rolls_back_aggregate_rows_when_content_sync_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+
+    def fail_sync(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("synthetic fact sync failure")
+
+    monkeypatch.setattr(stream_module.IngestionFactWriter, "finish", fail_sync)
+
+    with pytest.raises(RuntimeError, match="synthetic fact sync failure"):
+        refresh_module.refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        assert conn.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0] == 0
 
 
 def test_refresh_reports_phase_progress(tmp_path: Path, monkeypatch) -> None:
@@ -114,6 +296,7 @@ def test_refresh_reports_phase_progress(tmp_path: Path, monkeypatch) -> None:
     assert "upserting" in phases
     assert "metadata" in phases
     assert "indexing_content" in phases
+    assert "syncing_facts" in phases
     assert phases[-1] == "finalizing"
     assert events[-1]["status"] == "completed"
     final_result = events[-1]["result"]
@@ -126,3 +309,37 @@ def test_refresh_reports_phase_progress(tmp_path: Path, monkeypatch) -> None:
     content_fragments = content_events[-1]["content_fragments"]
     assert isinstance(content_fragments, (int, float))
     assert content_fragments > 0
+
+
+def test_unchanged_refresh_completes_every_started_phase(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_module.refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    events: list[dict[str, object]] = []
+
+    refresh_module.refresh_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        progress_callback=events.append,
+    )
+
+    terminal = {"completed", "skipped", "failed"}
+    for phase in {str(event["phase"]) for event in events}:
+        phase_events = [event for event in events if event["phase"] == phase]
+        assert phase_events[-1]["status"] in terminal
+
+
+def _sparse_parse_plans(
+    root: Path,
+    *,
+    count: int,
+    bytes_per_file: int,
+) -> list[SourceParsePlan]:
+    root.mkdir(parents=True)
+    plans: list[SourceParsePlan] = []
+    for index in range(count):
+        path = root / f"source-{index}.jsonl"
+        with path.open("wb") as handle:
+            handle.truncate(bytes_per_file)
+        plans.append(SourceParsePlan(path=path))
+    return plans

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -79,12 +79,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "17"
+    assert meta["schema_version"] == "18"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 17
+    assert state["schema_version"] == 18
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 18))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 19))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -711,7 +711,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 17
+    assert user_version == 18
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -809,8 +809,9 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 17
-    assert [row["version"] for row in migrations] == list(range(1, 18))
+    assert user_version == 18
+    assert [row["version"] for row in migrations] == list(range(1, 19))
+    assert "idx_usage_source_file_line" in indexes
 
 
 def test_latest_observed_usage_prefers_normal_codex_limit_pool(tmp_path: Path) -> None:

--- a/tests/store/test_store_large_batches.py
+++ b/tests/store/test_store_large_batches.py
@@ -12,6 +12,7 @@ import pytest
 from codex_usage_tracker import store
 from codex_usage_tracker.core.models import DiagnosticFact
 from codex_usage_tracker.store.api import connect, upsert_usage_events
+from codex_usage_tracker.store.thread_summaries import rebuild_thread_summaries
 from tests.store_dashboard_helpers import SESSION_ID, _usage_event
 
 
@@ -99,6 +100,96 @@ def test_upsert_usage_events_batches_diagnostic_fact_deletes(
 
     upsert_usage_events(events, db_path=db_path, refresh_links=False)
     assert _diagnostic_fact_row_count(db_path) == 0
+
+
+def test_upsert_usage_events_batches_source_file_replacements(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+
+    @contextmanager
+    def limited_connect(db_path: Path) -> Iterator[_LimitedVariableConnection]:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield _LimitedVariableConnection(conn, max_variables=600)
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    monkeypatch.setattr(store, "connect", limited_connect)
+    event = _usage_event(
+        record_id="replace-record",
+        session_id=SESSION_ID,
+        thread_key="thread:replace",
+        event_timestamp="2026-05-17T18:00:00Z",
+        cumulative_total_tokens=100,
+    )
+    upsert_usage_events([event], db_path=db_path, refresh_links=False)
+
+    source_files = [Path(f"/tmp/synthetic/missing-{index}.jsonl") for index in range(1200)]
+    source_files.append(Path(event.source_file))
+    upsert_usage_events(
+        [],
+        db_path=db_path,
+        refresh_links=False,
+        replace_source_files=source_files,
+    )
+
+    with connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0] == 0
+
+
+def test_upsert_usage_events_batches_thread_derived_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+
+    @contextmanager
+    def limited_connect(db_path: Path) -> Iterator[_LimitedVariableConnection]:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield _LimitedVariableConnection(conn, max_variables=600)
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    monkeypatch.setattr(store, "connect", limited_connect)
+    base_timestamp = datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc)
+    events = [
+        _usage_event(
+            record_id=f"thread-batch-{index:04d}",
+            session_id=f"session-{index:04d}",
+            thread_key=f"thread:batch-{index:04d}",
+            event_timestamp=(base_timestamp + timedelta(seconds=index)).isoformat(),
+            cumulative_total_tokens=index + 1,
+        )
+        for index in range(1200)
+    ]
+
+    upsert_usage_events(events, db_path=db_path, refresh_links=False)
+    with connect(db_path) as conn:
+        rebuild_thread_summaries(conn)
+    upsert_usage_events(
+        [],
+        db_path=db_path,
+        refresh_links=True,
+        replace_source_files=[Path(event.source_file) for event in events],
+    )
+
+    with connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM thread_summaries").fetchone()[0] == 0
 
 
 def _diagnostic_fact_row_count(db_path: Path) -> int:

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -68,9 +68,9 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 17
+    assert state["schema_version"] == 18
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 18))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 19))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
@@ -101,7 +101,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "17"
+    assert metadata["schema_version"] == "18"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -136,9 +136,13 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
             row["name"]
             for row in conn.execute("PRAGMA table_info(compression_revision_state)").fetchall()
         }
+        usage_indexes = {
+            row["name"] for row in conn.execute("PRAGMA index_list(usage_events)").fetchall()
+        }
 
-    assert versions == list(range(1, 18))
-    assert user_version == 17
+    assert versions == list(range(1, 19))
+    assert user_version == 18
+    assert "idx_usage_source_file_line" in usage_indexes
     assert {
         "parsed_prefix_tail_hash",
         "parsed_row_count",


### PR DESCRIPTION
## Summary
- parse independent JSONL sources in a bounded four-worker process pool
- stream aggregate, content, provenance, diagnostics, and compression facts through one deterministic SQLite writer
- add schema v18 source-line indexing, serial fallback hardening, and an 18-table parity/performance benchmark

## Evidence
- clean 100k-row median: 17.729s parallel vs 25.638s serial (30.85% faster)
- hardened run: 19.614s parallel vs 26.416s serial; 460.156 MiB process-tree RSS
- exact serial/parallel fingerprints across 18 persisted table families
- full verifier: 20260713T144343635673Z-full-c52b22e023d7
- precommit verifier: 20260713T152213304672Z-precommit-fb3701902b39
- release readiness and git diff checks pass

Closes #236