### PR TITLE
feat: add overlap-aware compression simulator

### DIFF
--- a/.agent-maintainer/change-plans/compression-overlap-simulator.md
+++ b/.agent-maintainer/change-plans/compression-overlap-simulator.md
@@ -1,0 +1,88 @@
++++
+id = "compression-overlap-simulator"
+kind = "cohesive-migration"
+status = "complete"
+base_ref = "origin/main"
+expires = 2026-07-27
+allowed_paths = [
+  ".agent-maintainer/change-plans/compression-overlap-simulator.md",
+  "docs/compression-lab-roadmap.md",
+  "docs/mcp.md",
+  "docs/cli-json-schemas.md",
+  "src/codex_usage_tracker/compression/attribution.py",
+  "src/codex_usage_tracker/compression/payloads.py",
+  "src/codex_usage_tracker/compression/simulator.py",
+  "src/codex_usage_tracker/compression/simulation_api.py",
+  "src/codex_usage_tracker/compression/simulation_payloads.py",
+  "src/codex_usage_tracker/store/compression_capacities.py",
+  "src/codex_usage_tracker/cli/mcp_compression.py",
+  "tests/compression/test_simulator.py",
+  "tests/cli/test_mcp_simulation.py",
+  "tests/cli/test_mcp_integration.py",
+  "tests/cli/test_cli_release.py",
+]
+forbidden_paths = ["src/codex_usage_tracker/store/schema.py", "config/prod/**", ".env", ".env.*"]
+max_changed_files = 15
+max_changed_lines = 1800
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+# Cohesive Change Plan: compression-overlap-simulator
+
+## Why this change intentionally large
+
+PR 4 adds one read-only what-if workflow across the pure overlap allocator,
+typed candidate hydration, compact payload construction, shared API validation,
+MCP registration, contract tests, and user documentation. Those layers must
+agree on deterministic selection ordering, capacity bounds, stale-run behavior,
+privacy flags, and serialized-size limits.
+
+## Why this should not be split smaller
+
+The simulator is unsafe to expose without capacity and determinism tests, while
+the pure calculation has no user-facing value until the API and MCP adapter can
+validate persisted run/candidate identity. The implementation remains one
+reviewable vertical slice; skill routing and dogfood workflows stay in PR 5.
+
+## What allowed to change
+
+- Hydrate persisted candidates into existing typed compression contracts.
+- Recalculate overlap allocation for an explicit bounded candidate selection.
+- Add compact portfolio, calculation-trace, and verification-plan payloads.
+- Add `usage_compression_simulate` and structured selection/staleness errors.
+- Add focused determinism, capacity, privacy, payload-budget, and MCP tests.
+- Update Compression Lab roadmap and public MCP/schema documentation.
+
+## What must not change
+
+- Compression persistence tables, migrations, refresh/index behavior, or jobs.
+  PR 4 may read existing detector-ready record capacities through one bounded
+  query module; it must not write or reinterpret those facts.
+- Detector ranking, estimates, default candidate identities, or cached profiles.
+- Existing MCP tool names, behavior, or stable payload contracts.
+- Default raw-content privacy behavior; simulation remains aggregate-only.
+- Dashboard, parser, pricing, allowance, release metadata, or plugin routing.
+
+## Verification plan
+
+- Start with failing pure tests for order independence, shared/disjoint capacity,
+  subset reallocation, and deterministic trace ordering.
+- Add API/MCP tests for empty, duplicate, over-limit, unknown, foreign,
+  incomplete, and stale selections plus the serialized payload ceiling.
+- Run focused compression/MCP tests, Ruff, Pyright, Tach, Xenon, Bandit,
+  Markdown lint, release checks, the full Python suite, and the full Agent
+  Maintainer verifier.
+- Run one independent correctness/privacy review before publication.
+
+## Rollback plan
+
+Revert the PR 4 squash commit. PR 3 run, candidate, payload, and MCP contracts
+remain unchanged because simulation is derived and does not persist state.
+
+## Follow-up ratchet work
+
+PR 5 may route skills and dogfood workflows to the simulator only after this
+contract passes local and GitHub CI. Keep each new simulator module below the
+repository source-size and complexity limits.

--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -351,6 +351,7 @@ usage_compression_status(run_id="compression_...")
 usage_compression_profile(run_id="compression_...")
 usage_compression_candidates(run_id="compression_...", limit=20, offset=0)
 usage_compression_candidate_detail(candidate_id="cmp_...", evidence_mode="handles")
+usage_compression_simulate(run_id="compression_...", candidate_ids=["cmp_..."])
 ```
 
 Schema: `codex-usage-tracker-compression-api-v1`
@@ -382,6 +383,24 @@ Candidate detail supports these disclosure levels:
 The serialized targets are 4 KiB for status, 8 KiB for profile, 16 KiB for a
 candidate page, and 24 KiB for candidate detail. Excerpts are additionally capped
 at 50 rows and 2,000 characters per excerpt even when larger values are supplied.
+
+Simulation accepts 1 to 50 unique candidate IDs from one completed run. It
+loads unique record/component capacity from persisted detector-ready facts,
+reapplies the same deterministic overlap allocator, and returns:
+
+- selected-candidate gross and overlap-adjusted low/likely/high totals;
+- unique eligible capacity and overlap-group counts;
+- per-candidate persisted versus simulated adjusted estimates;
+- a bounded record/component calculation trace; and
+- bounded intervention and verification rows.
+
+Simulation is aggregate-only and targets 16 KiB. Trace, verification, and then
+per-candidate rows are truncated before portfolio totals. Empty, duplicate,
+over-limit, unknown, or foreign-run selections return
+`invalid_candidate_selection`. A stale run returns `compression_run_stale` and
+`usage_compression_start` arguments that preserve its original scope and detector
+set while adding `refresh=true`; it does not return a potentially ambiguous
+historical portfolio.
 
 ```json
 {

--- a/docs/compression-lab-roadmap.md
+++ b/docs/compression-lab-roadmap.md
@@ -95,7 +95,11 @@ Exit gates:
 
 ### PR 4: Overlap-Aware Simulator
 
-Status: pending
+Status: complete
+
+Issue: [#240](https://github.com/douglasmonsky/codex-usage-tracker/issues/240)
+
+Branch: `feature/240-compression-simulator`
 
 Deliverables:
 
@@ -485,45 +489,50 @@ whole-pipeline timing or equivalence claim.
   selections use collision-free candidate IDs; candidate count and page rows
   share one SQLite snapshot; and error envelopes preserve known run identity.
   The full Agent Maintainer profile passed as
-  `20260713T175803017442Z-full-24f9a9b32803`; PR publication remains.
+  `20260713T175803017442Z-full-24f9a9b32803`. PR #239 merged at `792fe36` and
+  issue #238 is closed.
+- 2026-07-13: PR 4 issue #240 started from `792fe36`. The read-only simulator
+  hydrates up to 50 persisted candidates, loads exact record/component capacity
+  from detector-ready facts, reapplies the existing deterministic allocator,
+  and returns compact portfolio totals, bounded calculation groups, and
+  verification plans through `usage_compression_simulate`. Focused pure/API/MCP
+  and lifecycle tests pass.
+- 2026-07-13: Independent PR 4 review found that selected-claim maxima could
+  undercount records containing multiple disjoint tool outputs. The simulator
+  now reads exact detector-ready capacities, rejects stale or missing-capacity
+  runs with equivalent-scope refresh arguments, and forces aggregate-only
+  privacy flags. Eight hundred tests and full Agent Maintainer run
+  `20260713T191209272669Z-full-0eb1ed1f3ae5` pass; PR publication remains.
 
 ## Current Restart Checkpoint
 
 Worktree: `/Users/Monsky/Documents/Codex/2026-07-11/r11-compression-detectors`
 
-Branch: `feature/238-compression-mcp-progress-cache`, tracking `origin/main` at
-`aa7e4e322473b2be2c4e6f78f8cbb71b704c82f2`.
+Branch: `feature/240-compression-simulator`, tracking `origin/main` at
+`792fe360e68626e1daf7594c790f0d02fb0c6ef4`.
 
 Pause checkpoint (2026-07-13):
 
-- CP6 merged through PR #237 at `88b89b8`; its issue #236 is closed. The
-  performance evidence below remains authoritative.
+- PR 3 merged through PR #239 at `792fe36`; issue #238 is closed. CP1-CP6 and
+  PR 3 evidence below remains authoritative.
 - Preserve the pre-existing untracked `.idea/` directory and local `uv.lock`.
-  Do not stage, remove, or modify them for PR 3.
-- PR 3 implementation and local verification are complete but not yet committed
+  Do not stage, remove, or modify them for PR 4.
+- PR 4 implementation and local verification are complete but not yet committed
   or published.
-  The worktree contains the async registry, shared API/payload layer, five MCP
-  tools, SQL-backed candidate filters, bounded content excerpts, schema v19,
-  contract docs, and focused tests. Keep these edits together with the existing
-  roadmap checkpoint commit `cb4e593`.
+  It adds one pure simulator, one validated API, one compact payload module, and
+  one MCP adapter without adding persistence, migrations, jobs, or detectors.
 - Serena semantic recovery was exhausted for this task after two bounded doctor
   probes and broker/history inspection. Use native `rg`, type checks, tests, and
   inspections for the rest of this task rather than retrying Serena.
-- An independent review found and the branch now repairs three correctness
-  risks: detector-subset candidate-ID collisions, mixed pagination snapshots,
-  and incomplete-run errors that lost known run identity. Candidate claim rows
-  now persist immutable model/thread/time metadata, migration 19 backfills old
-  claims, one SQLite read transaction covers count plus page rows, and an
-  oversized first row cannot produce a non-advancing cursor.
-- Focused lifecycle, deduplication, restart, migration, paging, privacy,
-  payload-budget, and error-envelope tests pass. The full Python suite reports
-  782 passing tests; Ruff, Pyright, Tach, Bandit, Markdown lint, release checks,
-  and the full Agent Maintainer profile pass. The remaining PR 3 work is the
-  focused commit, PR publication, GitHub CI, and merge.
-- PR 3 is only complete after immediate cold start, sub-500 ms representative
-  warm profile/list queries, compact default payloads without raw fragments, and
-  handles/summaries/bounded-excerpts detail modes are proven. Open and merge a
-  focused PR closing #238, then continue PR 4 and PR 5 as separate roadmap PRs.
+- Pure tests prove byte-stable ordering, shared-capacity capping, disjoint
+  preservation, subset reallocation, and lexical trace ordering. API/MCP tests
+  cover empty, duplicate, over-limit, unknown, foreign, incomplete, stale,
+  missing-capacity, multi-tool-output capacity, privacy, lifecycle routing, and
+  payload-budget behavior. Forty-four focused tests pass.
+- The full Python suite reports 800 passing tests. Ruff, Pyright, Tach, Xenon,
+  Bandit, Markdown lint, release checks, and the full Agent Maintainer profile
+  pass. The remaining PR 4 work is final diff/privacy review, focused commit,
+  PR publication, GitHub CI, and merge. Then continue PR 5 separately.
 
 Validated behavior at this checkpoint:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -127,6 +127,7 @@ the highest-token thread summaries instead.
 - `usage_compression_profile`
 - `usage_compression_candidates`
 - `usage_compression_candidate_detail`
+- `usage_compression_simulate`
 - `usage_recommendations`
 - `session_usage`
 - `usage_call_context`
@@ -193,6 +194,7 @@ usage_compression_status(run_id="compression_...")
 usage_compression_profile(run_id="compression_...")
 usage_compression_candidates(run_id="compression_...", limit=20)
 usage_compression_candidate_detail(candidate_id="cmp_...", evidence_mode="handles")
+usage_compression_simulate(run_id="compression_...", candidate_ids=["cmp_..."])
 ```
 
 - `usage_compression_start(...)` returns immediately. It reuses an exact
@@ -215,13 +217,20 @@ usage_compression_candidate_detail(candidate_id="cmp_...", evidence_mode="handle
   handles. `evidence_mode="summaries"` returns bounded claim summaries.
   `evidence_mode="excerpts"` is the explicit opt-in that may return raw local
   indexed text; `evidence_limit` and `max_excerpt_chars` remain bounded.
+- `usage_compression_simulate(...)` recalculates overlap allocation for up to 50
+  explicitly selected candidates. It returns deterministic portfolio totals, a
+  bounded record/component calculation trace, and verification plans without
+  persisting state or returning indexed content. Unknown or foreign candidates
+  fail as one structured selection error. Stale runs return a structured error
+  with refresh arguments that preserve the original scope and detector set.
 
-All five tools use `codex-usage-tracker-compression-api-v1`. Common fields disclose run,
+All six tools use `codex-usage-tracker-compression-api-v1`. Common fields disclose run,
 scope, versions, coverage, cache/timing state, warnings/caveats, pagination,
 recommended next-tool arguments, `content_mode`, `includes_indexed_content`, and
 `includes_raw_fragments`. Default status, profile, candidate-page, and detail
 targets are 4 KiB, 8 KiB, 16 KiB, and 24 KiB respectively. Candidate pages never
-embed claims or excerpts.
+embed claims or excerpts. Simulation responses target 16 KiB and trim trace or
+verification rows before portfolio totals.
 
 ## Local Content And Raw Context
 

--- a/src/codex_usage_tracker/cli/mcp_compression.py
+++ b/src/codex_usage_tracker/cli/mcp_compression.py
@@ -14,6 +14,8 @@ from codex_usage_tracker.compression.api import (
 )
 from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.compression.payloads import CANDIDATE_PAGE_BUDGET_BYTES
+from codex_usage_tracker.compression.simulation_api import compression_simulate
+from codex_usage_tracker.compression.simulation_payloads import SIMULATION_BUDGET_BYTES
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
 
 
@@ -111,6 +113,20 @@ def usage_compression_candidate_detail(
         evidence_mode=evidence_mode,
         evidence_limit=evidence_limit,
         max_excerpt_chars=max_excerpt_chars,
+    )
+
+
+@mcp.tool()
+def usage_compression_simulate(
+    run_id: str,
+    candidate_ids: list[str],
+) -> dict[str, Any]:
+    """Recalculate a bounded selected-candidate portfolio without double counting."""
+    return compression_simulate(
+        DEFAULT_DB_PATH,
+        run_id=run_id,
+        candidate_ids=candidate_ids,
+        max_payload_bytes=SIMULATION_BUDGET_BYTES,
     )
 
 

--- a/src/codex_usage_tracker/compression/attribution.py
+++ b/src/codex_usage_tracker/compression/attribution.py
@@ -148,7 +148,7 @@ def _apply_group_allocation(
     adjusted: dict[str, list[int]],
     overlaps: dict[str, set[str]],
 ) -> None:
-    allocations = _allocate_claim_ranges(claims, capacity)
+    allocations = allocate_claim_ranges(claims, capacity)
     active_ids = sorted(candidate_id for candidate_id, estimate in claims if estimate.high > 0)
     _record_overlaps(active_ids, overlaps)
     for candidate_id, estimate in allocations.items():
@@ -168,10 +168,11 @@ def _add_estimate(total: list[int], estimate: EstimateRange) -> None:
     total[2] += estimate.high
 
 
-def _allocate_claim_ranges(
+def allocate_claim_ranges(
     claims: list[tuple[str, EstimateRange]],
     capacity: int,
 ) -> dict[str, EstimateRange]:
+    """Allocate one record/component claim group within a fixed capacity."""
     current = {candidate_id: 0 for candidate_id, _estimate in claims}
     bounds: list[dict[str, int]] = []
     for attribute in ("low", "likely", "high"):

--- a/src/codex_usage_tracker/compression/payloads.py
+++ b/src/codex_usage_tracker/compression/payloads.py
@@ -23,7 +23,7 @@ _DEFAULT_CAVEATS = [
 
 
 def compression_status_payload(run: Mapping[str, Any]) -> dict[str, Any]:
-    payload = _envelope(run, kind="status")
+    payload = compression_envelope(run, kind="status")
     payload.update(
         {
             "progress": _status_progress(run),
@@ -36,7 +36,7 @@ def compression_status_payload(run: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def compression_profile_payload(run: Mapping[str, Any]) -> dict[str, Any]:
-    payload = _envelope(run, kind="profile")
+    payload = compression_envelope(run, kind="profile")
     profile = dict(run.get("public_profile") or {})
     payload["profile"] = profile
     canonical_run_id = str(profile.get("run_id") or run.get("run_id") or "")
@@ -55,7 +55,7 @@ def compression_candidate_page_payload(
     *,
     max_bytes: int | None,
 ) -> dict[str, Any]:
-    payload = _envelope(run, kind="candidate_page")
+    payload = compression_envelope(run, kind="candidate_page")
     source_rows = [dict(row) for row in page.get("rows") or []]
     source_count = len(source_rows)
     payload["candidates"] = [dict(row) for row in source_rows]
@@ -77,7 +77,7 @@ def compression_candidate_detail_payload(
     evidence: Sequence[Mapping[str, Any]],
     max_bytes: int = CANDIDATE_DETAIL_BUDGET_BYTES,
 ) -> dict[str, Any]:
-    payload = _envelope(run, kind="candidate_detail")
+    payload = compression_envelope(run, kind="candidate_detail")
     compact_candidate = {
         key: value for key, value in candidate.items() if key not in {"claims", "evidence_handles"}
     }
@@ -226,9 +226,10 @@ def compression_error_payload(
     next_tool: str,
     next_arguments: Mapping[str, Any] | None = None,
     run: Mapping[str, Any] | None = None,
+    details: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     if run is not None:
-        payload = _envelope(run, kind=kind)
+        payload = compression_envelope(run, kind=kind)
         payload["status"] = "error"
     else:
         payload = {
@@ -255,12 +256,13 @@ def compression_error_payload(
             "caveats": list(_DEFAULT_CAVEATS),
             "payload_truncated": False,
         }
-    payload["error"] = {"code": code, "message": message}
+    payload["error"] = {"code": code, "message": message, **dict(details or {})}
     payload["next"] = {"tool": next_tool, "arguments": dict(next_arguments or {})}
     return payload
 
 
-def _envelope(run: Mapping[str, Any], *, kind: str) -> dict[str, Any]:
+def compression_envelope(run: Mapping[str, Any], *, kind: str) -> dict[str, Any]:
+    """Build the stable common envelope shared by Compression Lab responses."""
     public_profile = _public_profile(run)
     raw_mappings, compact_mappings = _envelope_mappings(run, public_profile)
     payload = {

--- a/src/codex_usage_tracker/compression/simulation_api.py
+++ b/src/codex_usage_tracker/compression/simulation_api.py
@@ -1,0 +1,225 @@
+"""Validated application API for overlap-aware compression simulations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.compression.detector_registry import DETECTOR_SET_VERSION
+from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.payloads import compression_error_payload
+from codex_usage_tracker.compression.request import prepare_compression_request
+from codex_usage_tracker.compression.simulation_payloads import (
+    SIMULATION_BUDGET_BYTES,
+    compression_simulation_payload,
+)
+from codex_usage_tracker.compression.simulator import simulate_candidate_portfolio
+from codex_usage_tracker.store.compression_candidates import get_compression_candidate
+from codex_usage_tracker.store.compression_capacities import (
+    load_record_component_capacities,
+)
+from codex_usage_tracker.store.compression_runs import get_compression_run
+
+MAX_SIMULATION_CANDIDATES = 50
+_COMPLETED_STATUSES = frozenset({"completed", "completed_with_warnings"})
+
+
+def compression_simulate(
+    db_path: Path,
+    *,
+    run_id: str,
+    candidate_ids: Sequence[str],
+    max_payload_bytes: int = SIMULATION_BUDGET_BYTES,
+) -> dict[str, Any]:
+    """Validate and simulate one explicit persisted candidate portfolio."""
+    run = get_compression_run(db_path, run_id=run_id)
+    if run is None:
+        return _missing_run(run_id)
+    if run["status"] not in _COMPLETED_STATUSES:
+        return compression_error_payload(
+            kind="simulation",
+            code="compression_run_not_complete",
+            message="Simulation is available after the compression run completes.",
+            next_tool="usage_compression_status",
+            next_arguments={"run_id": run_id},
+            run=run,
+        )
+    selected, error = _validate_selection(candidate_ids)
+    if error is not None:
+        return _selection_error(run, run_id, **error)
+    records, unknown_ids, foreign_ids = _load_candidates(db_path, run_id, selected)
+    if unknown_ids or foreign_ids:
+        return _selection_error(
+            run,
+            run_id,
+            reason="unknown_or_foreign",
+            unknown_candidate_ids=unknown_ids,
+            foreign_candidate_ids=foreign_ids,
+        )
+    stale, refresh_arguments = _stale_state(db_path, run)
+    if stale:
+        return compression_error_payload(
+            kind="simulation",
+            code="compression_run_stale",
+            message="Refresh the same compression scope before simulating candidates.",
+            next_tool="usage_compression_start",
+            next_arguments=refresh_arguments,
+            run=run,
+        )
+    capacities = load_record_component_capacities(db_path, _record_ids(records))
+    try:
+        result = simulate_candidate_portfolio(records, capacities)
+    except ValueError:
+        return compression_error_payload(
+            kind="simulation",
+            code="compression_capacity_unavailable",
+            message="Detector-ready capacity is incomplete; refresh analysis and retry.",
+            next_tool="usage_compression_start",
+            next_arguments=refresh_arguments,
+            run=run,
+        )
+    return compression_simulation_payload(
+        run,
+        result,
+        max_bytes=max_payload_bytes,
+    )
+
+
+def _validate_selection(
+    candidate_ids: Sequence[str],
+) -> tuple[tuple[str, ...], dict[str, Any] | None]:
+    selected = tuple(str(candidate_id) for candidate_id in candidate_ids)
+    if not selected:
+        return selected, {"reason": "empty"}
+    if len(selected) > MAX_SIMULATION_CANDIDATES:
+        return selected, {
+            "reason": "over_limit",
+            "maximum_candidate_count": MAX_SIMULATION_CANDIDATES,
+        }
+    if len(set(selected)) != len(selected):
+        return selected, {"reason": "duplicate"}
+    if any(not candidate_id for candidate_id in selected):
+        return selected, {"reason": "empty_id"}
+    return tuple(sorted(selected)), None
+
+
+def _load_candidates(
+    db_path: Path,
+    run_id: str,
+    candidate_ids: Sequence[str],
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    records: list[dict[str, Any]] = []
+    unknown: list[str] = []
+    foreign: list[str] = []
+    for candidate_id in candidate_ids:
+        candidate = get_compression_candidate(db_path, candidate_id=candidate_id)
+        if candidate is None:
+            unknown.append(candidate_id)
+        elif str(candidate.get("run_id") or "") != run_id:
+            foreign.append(candidate_id)
+        else:
+            records.append(candidate)
+    return records, unknown[:16], foreign[:16]
+
+
+def _selection_error(
+    run: Mapping[str, Any],
+    run_id: str,
+    *,
+    reason: str,
+    **details: Any,
+) -> dict[str, Any]:
+    return compression_error_payload(
+        kind="simulation",
+        code="invalid_candidate_selection",
+        message="Select unique candidates from one completed compression run.",
+        next_tool="usage_compression_candidates",
+        next_arguments={"run_id": run_id},
+        run=run,
+        details={"reason": reason, **details},
+    )
+
+
+def _missing_run(run_id: str) -> dict[str, Any]:
+    return compression_error_payload(
+        kind="simulation",
+        code="compression_run_not_found",
+        message="No persisted compression run matched that ID.",
+        next_tool="usage_compression_start",
+        next_arguments={},
+        details={"requested_run_id": run_id},
+    )
+
+
+def _stale_state(
+    db_path: Path,
+    run: Mapping[str, Any],
+) -> tuple[bool, dict[str, Any]]:
+    known, families = _run_detector_families(run)
+    refresh_arguments = _refresh_arguments(run, families)
+    if not known:
+        return True, refresh_arguments
+    try:
+        current = prepare_compression_request(
+            db_path,
+            _run_scope(run),
+            detector_families=families,
+        )
+    except ValueError:
+        return True, refresh_arguments
+    return current.revision_key != str(run.get("revision_key") or ""), refresh_arguments
+
+
+def _run_detector_families(
+    run: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...] | None]:
+    version = str(run.get("detector_set_version") or "")
+    if version == DETECTOR_SET_VERSION:
+        return True, None
+    prefix = f"{DETECTOR_SET_VERSION}:"
+    if not version.startswith(prefix):
+        return False, None
+    families = tuple(family for family in version[len(prefix) :].split(",") if family)
+    return True, families
+
+
+def _run_scope(run: Mapping[str, Any]) -> CompressionScope:
+    scope = run.get("scope")
+    values = dict(scope) if isinstance(scope, Mapping) else {}
+    return CompressionScope(
+        since=_optional_text(values.get("since")),
+        until=_optional_text(values.get("until")),
+        thread=_optional_text(values.get("thread")),
+        include_archived=bool(values.get("include_archived")),
+        model=_optional_text(values.get("model")),
+        effort=_optional_text(values.get("effort")),
+    )
+
+
+def _refresh_arguments(
+    run: Mapping[str, Any],
+    families: tuple[str, ...] | None,
+) -> dict[str, Any]:
+    scope = _run_scope(run)
+    arguments = {"refresh": True, **scope.as_dict()}
+    if families is not None:
+        arguments["detector_families"] = list(families)
+    return arguments
+
+
+def _record_ids(records: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(claim.get("record_id") or "")
+                for record in records
+                for claim in record.get("claims") or []
+                if isinstance(claim, Mapping) and claim.get("record_id")
+            }
+        )
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/src/codex_usage_tracker/compression/simulation_payloads.py
+++ b/src/codex_usage_tracker/compression/simulation_payloads.py
@@ -1,0 +1,103 @@
+"""Compact public payload for overlap-aware Compression Lab simulations."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from codex_usage_tracker.compression.payloads import compression_envelope
+from codex_usage_tracker.compression.simulator import SimulationResult
+
+SIMULATION_BUDGET_BYTES = 16 * 1024
+
+
+def compression_simulation_payload(
+    run: Mapping[str, Any],
+    result: SimulationResult,
+    *,
+    max_bytes: int = SIMULATION_BUDGET_BYTES,
+) -> dict[str, Any]:
+    """Build a bounded simulation payload while preserving portfolio totals."""
+    result_payload = result.as_dict()
+    groups = list(result_payload.pop("groups"))
+    verification_plan = list(result_payload.pop("verification_plan"))
+    payload = compression_envelope(run, kind="simulation")
+    payload.update(
+        {
+            "stale": False,
+            "content_mode": "aggregate",
+            "includes_indexed_content": False,
+            "includes_raw_fragments": False,
+            "simulation": result_payload,
+            "calculation_trace": _trace_page(groups),
+            "verification_plan": _page(verification_plan),
+            "next": _simulation_next(result.selected_candidate_ids),
+        }
+    )
+    _trim_simulation_payload(payload, max_bytes)
+    return payload
+
+
+def _trim_simulation_payload(payload: dict[str, Any], max_bytes: int) -> None:
+    for key in ("calculation_trace", "verification_plan"):
+        page = payload[key]
+        rows = page["rows"]
+        while rows and _json_size(payload) > max_bytes:
+            rows.pop()
+        _finalize_page(page)
+    candidates = payload["simulation"]["candidates"]
+    requested = len(candidates)
+    payload["simulation"]["candidate_results"] = {
+        "requested": requested,
+        "returned": requested,
+        "truncated": False,
+    }
+    while candidates and _json_size(payload) > max_bytes:
+        candidates.pop()
+    payload["simulation"]["candidate_results"].update(
+        returned=len(candidates),
+        truncated=len(candidates) < requested,
+    )
+    payload["payload_truncated"] = bool(
+        payload.get("payload_truncated")
+        or payload["calculation_trace"]["truncated"]
+        or payload["verification_plan"]["truncated"]
+        or len(candidates) < requested
+    )
+
+
+def _page(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "total": len(rows),
+        "returned": len(rows),
+        "truncated": False,
+        "rows": rows,
+    }
+
+
+def _trace_page(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "total_groups": len(rows),
+        "returned_groups": len(rows),
+        "truncated": False,
+        "rows": rows,
+    }
+
+
+def _finalize_page(page: dict[str, Any]) -> None:
+    if "total_groups" in page:
+        page["returned_groups"] = len(page["rows"])
+        page["truncated"] = page["returned_groups"] < page["total_groups"]
+        return
+    page["returned"] = len(page["rows"])
+    page["truncated"] = page["returned"] < page["total"]
+
+
+def _simulation_next(candidate_ids: tuple[str, ...]) -> dict[str, Any]:
+    arguments = {"candidate_id": candidate_ids[0]} if candidate_ids else {}
+    return {"tool": "usage_compression_candidate_detail", "arguments": arguments}
+
+
+def _json_size(payload: Mapping[str, Any]) -> int:
+    return len(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8"))

--- a/src/codex_usage_tracker/compression/simulator.py
+++ b/src/codex_usage_tracker/compression/simulator.py
@@ -1,0 +1,266 @@
+"""Pure overlap-aware what-if simulation for persisted compression candidates."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from codex_usage_tracker.compression.attribution import (
+    CapacityLedger,
+    allocate_claim_ranges,
+    allocate_overlaps,
+    portfolio_estimate,
+)
+from codex_usage_tracker.compression.models import (
+    CandidateDraft,
+    ComponentClaim,
+    ComponentExposure,
+    ComponentName,
+    CompressionCandidate,
+    EstimateRange,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationResult:
+    """Deterministic selected-candidate portfolio and calculation trace."""
+
+    selected_candidate_ids: tuple[str, ...]
+    gross_estimate: EstimateRange
+    overlap_adjusted_estimate: EstimateRange
+    unique_eligible_capacity_tokens: int
+    overlap_group_count: int
+    candidates: tuple[dict[str, Any], ...]
+    groups: tuple[dict[str, Any], ...]
+    verification_plan: tuple[dict[str, Any], ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "selected_candidate_ids": list(self.selected_candidate_ids),
+            "candidate_count": len(self.selected_candidate_ids),
+            "gross_estimate": self.gross_estimate.as_dict(),
+            "overlap_adjusted_estimate": self.overlap_adjusted_estimate.as_dict(),
+            "unique_eligible_capacity_tokens": self.unique_eligible_capacity_tokens,
+            "overlap_group_count": self.overlap_group_count,
+            "candidates": [dict(row) for row in self.candidates],
+            "groups": [dict(row) for row in self.groups],
+            "verification_plan": [dict(row) for row in self.verification_plan],
+        }
+
+
+def simulate_candidate_portfolio(
+    candidate_records: Sequence[Mapping[str, Any]],
+    capacities: Mapping[tuple[str, str], int],
+) -> SimulationResult:
+    """Reallocate selected persisted candidates without double-counting capacity."""
+    ordered_records = sorted(candidate_records, key=_candidate_id)
+    drafts = tuple(_candidate_draft(record) for record in ordered_records)
+    ledger = _capacity_ledger(drafts, capacities)
+    allocated = tuple(allocate_overlaps(drafts, ledger))
+    groups = _trace_groups(drafts, ledger)
+    return SimulationResult(
+        selected_candidate_ids=tuple(candidate.candidate_id for candidate in allocated),
+        gross_estimate=_sum_ranges(draft.gross_estimate for draft in drafts),
+        overlap_adjusted_estimate=portfolio_estimate(allocated),
+        unique_eligible_capacity_tokens=sum(ledger.capacities.values()),
+        overlap_group_count=sum(1 for group in groups if len(group["claims"]) > 1),
+        candidates=_candidate_results(ordered_records, allocated),
+        groups=groups,
+        verification_plan=_verification_plan(ordered_records),
+    )
+
+
+def _candidate_draft(record: Mapping[str, Any]) -> CandidateDraft:
+    claims = tuple(_claim(row) for row in _mapping_rows(record.get("claims")))
+    confidence = _mapping(record.get("confidence"))
+    estimator = _mapping(record.get("estimator"))
+    return CandidateDraft(
+        candidate_id=_candidate_id(record),
+        family=_text(record, "family"),
+        pattern=_text(record, "pattern"),
+        pattern_key=_text(record, "pattern_key"),
+        detector_version=_text(record, "detector_version"),
+        estimator_version=_text(estimator, "version"),
+        record_ids=tuple(sorted({claim.record_id for claim in claims})),
+        thread_keys=_text_values(record.get("thread_keys")),
+        observation_count=_integer(record.get("observation_count")),
+        observed_exposure=_component_exposure(record.get("observed_exposure")),
+        claims=claims,
+        gross_estimate=_estimate(record.get("gross_estimate")),
+        confidence_grade=_text(confidence, "grade", default="unknown"),
+        confidence_score=_float(confidence.get("score")),
+        confidence_reasons=_text_values(confidence.get("reasons")),
+        estimator_tier=_text(estimator, "tier", default="unknown"),
+        estimator_name=_text(estimator, "name", default="unknown"),
+        estimator_assumptions=_text_values(estimator.get("assumptions")),
+        evidence_handles=tuple(_mapping_rows(record.get("evidence_handles"))),
+        intervention=_mapping(record.get("intervention")),
+        verification=_mapping(record.get("verification")),
+        first_seen=_optional_text(record.get("first_seen")),
+        last_seen=_optional_text(record.get("last_seen")),
+        data_quality_warnings=_text_values(record.get("data_quality_warnings")),
+    )
+
+
+def _capacity_ledger(
+    drafts: Sequence[CandidateDraft],
+    capacities: Mapping[tuple[str, str], int],
+) -> CapacityLedger:
+    selected_keys: set[tuple[str, ComponentName]] = {
+        (claim.record_id, claim.component) for draft in drafts for claim in draft.claims
+    }
+    ledger_capacities: dict[tuple[str, ComponentName], int] = {}
+    for key in sorted(selected_keys):
+        if key in capacities:
+            ledger_capacities[key] = max(0, int(capacities[key]))
+    return CapacityLedger(ledger_capacities)
+
+
+def _trace_groups(
+    drafts: Sequence[CandidateDraft],
+    ledger: CapacityLedger,
+) -> tuple[dict[str, Any], ...]:
+    grouped: dict[
+        tuple[str, ComponentName],
+        list[tuple[str, EstimateRange]],
+    ] = defaultdict(list)
+    for draft in drafts:
+        for claim in draft.claims:
+            grouped[(claim.record_id, claim.component)].append((draft.candidate_id, claim.estimate))
+    return tuple(
+        _trace_group(key, sorted(claims), ledger.capacity(*key))
+        for key, claims in sorted(grouped.items())
+    )
+
+
+def _trace_group(
+    key: tuple[str, ComponentName],
+    claims: list[tuple[str, EstimateRange]],
+    capacity: int,
+) -> dict[str, Any]:
+    allocations = allocate_claim_ranges(claims, capacity)
+    return {
+        "record_id": key[0],
+        "component": key[1],
+        "capacity_tokens": capacity,
+        "claims": [
+            {
+                "candidate_id": candidate_id,
+                "gross_estimate": estimate.as_dict(),
+                "adjusted_estimate": allocations[candidate_id].as_dict(),
+            }
+            for candidate_id, estimate in claims
+        ],
+    }
+
+
+def _candidate_results(
+    records: Sequence[Mapping[str, Any]],
+    candidates: Sequence[CompressionCandidate],
+) -> tuple[dict[str, Any], ...]:
+    records_by_id = {_candidate_id(record): record for record in records}
+    return tuple(
+        {
+            "candidate_id": candidate.candidate_id,
+            "family": candidate.draft.family,
+            "gross_estimate": candidate.draft.gross_estimate.as_dict(),
+            "persisted_adjusted_estimate": _estimate(
+                records_by_id[candidate.candidate_id].get("adjusted_estimate")
+            ).as_dict(),
+            "simulated_adjusted_estimate": candidate.adjusted_estimate.as_dict(),
+            "overlapping_candidate_ids": list(candidate.overlapping_candidate_ids),
+        }
+        for candidate in candidates
+    )
+
+
+def _verification_plan(
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    return tuple(
+        {
+            "candidate_id": _candidate_id(record),
+            "intervention": _mapping(record.get("intervention")),
+            "verification": _mapping(record.get("verification")),
+        }
+        for record in records
+    )
+
+
+def _claim(row: Mapping[str, Any]) -> ComponentClaim:
+    component = cast(ComponentName, _text(row, "component"))
+    return ComponentClaim(
+        record_id=_text(row, "record_id"),
+        component=component,
+        exposure_tokens=_integer(row.get("exposure_tokens")),
+        estimate=_estimate(row.get("estimate")),
+    )
+
+
+def _component_exposure(value: Any) -> ComponentExposure:
+    exposure = _mapping(value)
+    return ComponentExposure(
+        cached_input=_integer(exposure.get("cached_input")),
+        uncached_input=_integer(exposure.get("uncached_input")),
+        output=_integer(exposure.get("output")),
+        reasoning_output=_integer(exposure.get("reasoning_output")),
+        content_fragment=_integer(exposure.get("content_fragment")),
+        tool_output=_integer(exposure.get("tool_output")),
+    )
+
+
+def _sum_ranges(estimates: Iterable[EstimateRange]) -> EstimateRange:
+    rows = tuple(estimates)
+    return EstimateRange(
+        low=sum(estimate.low for estimate in rows),
+        likely=sum(estimate.likely for estimate in rows),
+        high=sum(estimate.high for estimate in rows),
+    )
+
+
+def _estimate(value: Any) -> EstimateRange:
+    estimate = _mapping(value)
+    return EstimateRange(
+        low=_integer(estimate.get("low")),
+        likely=_integer(estimate.get("likely")),
+        high=_integer(estimate.get("high")),
+    )
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _mapping_rows(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [dict(row) for row in value if isinstance(row, Mapping)]
+
+
+def _candidate_id(record: Mapping[str, Any]) -> str:
+    return _text(record, "candidate_id")
+
+
+def _text(value: Mapping[str, Any], key: str, *, default: str = "") -> str:
+    item = value.get(key)
+    return default if item is None else str(item)
+
+
+def _text_values(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(sorted(str(item) for item in value))
+
+
+def _integer(value: Any) -> int:
+    return int(value) if value is not None else 0
+
+
+def _float(value: Any) -> float:
+    return float(value) if value is not None else 0.0
+
+
+def _optional_text(value: Any) -> str | None:
+    return None if value is None else str(value)

--- a/src/codex_usage_tracker/store/compression_capacities.py
+++ b/src/codex_usage_tracker/store/compression_capacities.py
@@ -1,0 +1,54 @@
+"""Bounded reads of detector-ready record/component token capacities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+
+_COMPONENT_COLUMNS = {
+    "cached_input": "cached_input_tokens",
+    "uncached_input": "uncached_input_tokens",
+    "output": "output_tokens",
+    "reasoning_output": "reasoning_output_tokens",
+    "content_fragment": "content_exposure_tokens",
+    "tool_output": "tool_output_exposure_tokens",
+}
+
+
+def load_record_component_capacities(
+    db_path: Path,
+    record_ids: Iterable[str],
+) -> dict[tuple[str, str], int]:
+    """Return exact persisted capacities for selected record IDs."""
+    normalized = sorted({str(record_id) for record_id in record_ids if record_id})
+    capacities: dict[tuple[str, str], int] = {}
+    with connect(db_path) as conn:
+        init_db(conn)
+        for offset in range(0, len(normalized), 500):
+            batch = normalized[offset : offset + 500]
+            placeholders = ",".join("?" for _value in batch)
+            query = "\n".join(
+                (
+                    "SELECT record_id,",
+                    ", ".join(_COMPONENT_COLUMNS.values()),
+                    "FROM compression_record_facts",
+                    "WHERE record_id IN (",
+                    placeholders,
+                    ")",
+                )
+            )
+            rows = conn.execute(query, batch).fetchall()
+            for row in rows:
+                capacities.update(_row_capacities(row))
+    return capacities
+
+
+def _row_capacities(row) -> dict[tuple[str, str], int]:
+    record_id = str(row["record_id"])
+    return {
+        (record_id, component): max(0, int(row[column] or 0))
+        for component, column in _COMPONENT_COLUMNS.items()
+    }

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -87,6 +87,7 @@ MCP_TOOL_NAMES = {
     "usage_compression_profile",
     "usage_compression_candidates",
     "usage_compression_candidate_detail",
+    "usage_compression_simulate",
     "usage_recommendations",
     "session_usage",
     "usage_call_context",

--- a/tests/cli/test_mcp_simulation.py
+++ b/tests/cli/test_mcp_simulation.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.cli import mcp_compression
+from codex_usage_tracker.compression.models import CompressionScope
+from codex_usage_tracker.compression.request import prepare_compression_request
+from codex_usage_tracker.compression.simulation_api import compression_simulate
+from codex_usage_tracker.compression.simulation_payloads import SIMULATION_BUDGET_BYTES
+from codex_usage_tracker.store.compression_candidates import replace_compression_candidates
+from codex_usage_tracker.store.compression_revisions import touch_compression_revisions
+from codex_usage_tracker.store.compression_runs import (
+    create_compression_run,
+    update_compression_run,
+)
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.schema import init_db
+from tests.store.test_compression_runs import candidate
+
+
+def test_simulation_api_returns_compact_content_free_portfolio(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, candidate_count=3)
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert payload["kind"] == "simulation"
+    assert payload["run_id"] == run_id
+    assert payload["simulation"]["selected_candidate_ids"] == sorted(candidate_ids)
+    assert payload["simulation"]["candidate_count"] == 3
+    assert payload["calculation_trace"]["total_groups"] == 3
+    assert payload["includes_indexed_content"] is False
+    assert payload["includes_raw_fragments"] is False
+    assert "excerpt" not in json.dumps(payload)
+    assert len(json.dumps(payload, separators=(",", ":")).encode()) <= SIMULATION_BUDGET_BYTES
+
+
+def test_simulation_overrides_indexed_run_privacy_flags(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, candidate_count=1, content_indexed=True)
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert payload["content_mode"] == "aggregate"
+    assert payload["includes_indexed_content"] is False
+    assert payload["includes_raw_fragments"] is False
+
+
+def test_api_uses_full_record_capacity_for_disjoint_tool_outputs(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_tool_output_run(db_path)
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert (
+        payload["simulation"]["overlap_adjusted_estimate"]
+        == payload["simulation"]["gross_estimate"]
+    )
+    assert payload["calculation_trace"]["rows"][0]["capacity_tokens"] == 200
+
+
+def test_missing_record_capacity_returns_refresh_error(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, candidate_count=1)
+    with connect(db_path) as conn:
+        conn.execute("DELETE FROM compression_record_facts")
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert payload["error"]["code"] == "compression_capacity_unavailable"
+    assert payload["next"]["tool"] == "usage_compression_start"
+
+
+def test_mcp_simulation_enforces_budget_and_preserves_totals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, candidate_count=50)
+    monkeypatch.setattr(mcp_compression, "DEFAULT_DB_PATH", db_path)
+
+    payload = mcp_compression.usage_compression_simulate(
+        run_id=run_id,
+        candidate_ids=list(reversed(candidate_ids)),
+    )
+
+    assert payload["simulation"]["candidate_count"] == 50
+    assert payload["simulation"]["gross_estimate"]["high"] > 0
+    assert payload["calculation_trace"]["truncated"] is True
+    assert len(json.dumps(payload, separators=(",", ":")).encode()) <= SIMULATION_BUDGET_BYTES
+
+
+@pytest.mark.parametrize(
+    ("candidate_ids", "reason"),
+    [
+        ([], "empty"),
+        (["cmp_000", "cmp_000"], "duplicate"),
+        ([f"candidate-{index}" for index in range(51)], "over_limit"),
+    ],
+)
+def test_invalid_candidate_selections_return_structured_errors(
+    tmp_path: Path,
+    candidate_ids: list[str],
+    reason: str,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, _available = _seed_run(db_path, candidate_count=2)
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert payload["run_id"] == run_id
+    assert payload["error"]["code"] == "invalid_candidate_selection"
+    assert payload["error"]["reason"] == reason
+    assert payload["next"] == {
+        "tool": "usage_compression_candidates",
+        "arguments": {"run_id": run_id},
+    }
+
+
+def test_unknown_and_foreign_candidates_are_not_silently_dropped(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, run_id="run-one", candidate_count=1)
+    _foreign_run, foreign_ids = _seed_run(
+        db_path,
+        run_id="run-two",
+        candidate_count=1,
+        candidate_prefix="foreign",
+    )
+
+    payload = compression_simulate(
+        db_path,
+        run_id=run_id,
+        candidate_ids=[candidate_ids[0], foreign_ids[0], "missing-candidate"],
+    )
+
+    assert payload["error"]["code"] == "invalid_candidate_selection"
+    assert payload["error"]["unknown_candidate_ids"] == ["missing-candidate"]
+    assert payload["error"]["foreign_candidate_ids"] == [foreign_ids[0]]
+
+
+def test_incomplete_run_returns_status_poll_guidance(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    prepared = prepare_compression_request(db_path, CompressionScope())
+    create_compression_run(
+        db_path,
+        run_id="run-pending",
+        source_revision="",
+        scope={"include_archived": False},
+        **prepared.cache_lookup(),
+    )
+
+    payload = compression_simulate(
+        db_path,
+        run_id="run-pending",
+        candidate_ids=["candidate-1"],
+    )
+
+    assert payload["error"]["code"] == "compression_run_not_complete"
+    assert payload["next"]["tool"] == "usage_compression_status"
+
+
+def test_stale_run_returns_equivalent_scope_refresh_guidance(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    scope = CompressionScope(
+        since="2026-07-01T00:00:00+00:00",
+        until="2026-07-02T00:00:00+00:00",
+        thread="thread:selected",
+        model="gpt-5.5",
+    )
+    run_id, candidate_ids = _seed_run(
+        db_path,
+        candidate_count=1,
+        scope=scope,
+        detector_families=("stale_context",),
+    )
+    with connect(db_path) as conn:
+        init_db(conn)
+        touch_compression_revisions(conn, ("calls",))
+
+    payload = compression_simulate(db_path, run_id=run_id, candidate_ids=candidate_ids)
+
+    assert payload["error"]["code"] == "compression_run_stale"
+    assert payload["next"]["tool"] == "usage_compression_start"
+    arguments = payload["next"]["arguments"]
+    assert arguments["refresh"] is True
+    assert arguments["since"] == scope.since
+    assert arguments["until"] == scope.until
+    assert arguments["thread"] == scope.thread
+    assert arguments["model"] == scope.model
+    assert arguments["detector_families"] == ["stale_context"]
+
+
+def test_existing_mcp_lifecycle_can_route_into_simulation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    run_id, candidate_ids = _seed_run(db_path, candidate_count=1)
+    monkeypatch.setattr(mcp_compression, "DEFAULT_DB_PATH", db_path)
+
+    started = mcp_compression.usage_compression_start()
+    status = mcp_compression.usage_compression_status(started["run_id"])
+    profile = mcp_compression.usage_compression_profile(run_id=run_id)
+    candidates = mcp_compression.usage_compression_candidates(run_id=run_id, limit=10)
+    simulation = mcp_compression.usage_compression_simulate(
+        run_id=run_id,
+        candidate_ids=candidate_ids,
+    )
+
+    assert started["run_id"] == run_id
+    assert status["status"] == "completed"
+    assert profile["profile"]["candidate_count"] == 1
+    assert candidates["pagination"]["total"] == 1
+    assert simulation["schema"] == "codex-usage-tracker-compression-api-v1"
+    assert simulation["includes_raw_fragments"] is False
+
+
+def _seed_run(
+    db_path: Path,
+    *,
+    run_id: str = "run-completed",
+    candidate_count: int,
+    candidate_prefix: str = "cmp",
+    scope: CompressionScope | None = None,
+    detector_families: tuple[str, ...] | None = None,
+    content_indexed: bool = False,
+) -> tuple[str, list[str]]:
+    normalized_scope = scope or CompressionScope()
+    prepared = prepare_compression_request(
+        db_path,
+        normalized_scope,
+        detector_families=detector_families,
+    )
+    create_compression_run(
+        db_path,
+        run_id=run_id,
+        source_revision="source-revision",
+        source_generation=prepared.source_generation,
+        scope=normalized_scope.as_dict(),
+        **prepared.cache_lookup(),
+    )
+    candidate_ids = [f"{candidate_prefix}_{index:03d}" for index in range(candidate_count)]
+    rows = [
+        candidate(candidate_id, likely=max(10, 90 - index)).as_dict()
+        for index, candidate_id in enumerate(candidate_ids)
+    ]
+    _seed_record_capacities(db_path, candidate_ids)
+    replace_compression_candidates(db_path, run_id=run_id, candidates=rows)
+    update_compression_run(
+        db_path,
+        run_id=run_id,
+        status="completed",
+        progress_percent=100,
+        stage="complete",
+        public_profile={
+            "schema": "codex-usage-compression-profile-v1",
+            "run_id": run_id,
+            "status": "completed",
+            "candidate_count": candidate_count,
+            "coverage": {"call_count": candidate_count},
+            "cache": {"mode": "cold", "reused": False},
+            "warnings": [],
+            "caveats": [],
+            "content_mode": "indexed" if content_indexed else "aggregate",
+            "includes_indexed_content": content_indexed,
+        },
+    )
+    return run_id, candidate_ids
+
+
+def _seed_record_capacities(db_path: Path, candidate_ids: list[str]) -> None:
+    with connect(db_path) as conn:
+        init_db(conn)
+        for candidate_id in candidate_ids:
+            record_id = f"record-{candidate_id}"
+            _seed_record_capacity(conn, record_id, uncached_input=100)
+
+
+def _seed_tool_output_run(db_path: Path) -> tuple[str, list[str]]:
+    run_id = "run-tool-output"
+    prepared = prepare_compression_request(db_path, CompressionScope())
+    create_compression_run(
+        db_path,
+        run_id=run_id,
+        source_revision="source-revision",
+        source_generation=prepared.source_generation,
+        scope=CompressionScope().as_dict(),
+        **prepared.cache_lookup(),
+    )
+    candidate_ids = ["tool-a", "tool-b"]
+    rows = [_tool_output_candidate(candidate_id) for candidate_id in candidate_ids]
+    with connect(db_path) as conn:
+        init_db(conn)
+        _seed_record_capacity(conn, "record-shared", tool_output=200)
+    replace_compression_candidates(db_path, run_id=run_id, candidates=rows)
+    update_compression_run(
+        db_path,
+        run_id=run_id,
+        status="completed",
+        progress_percent=100,
+        stage="complete",
+        public_profile={
+            "run_id": run_id,
+            "status": "completed",
+            "candidate_count": 2,
+            "coverage": {"call_count": 1},
+        },
+    )
+    return run_id, candidate_ids
+
+
+def _tool_output_candidate(candidate_id: str) -> dict:
+    row = candidate(candidate_id, likely=60).as_dict()
+    row["record_ids"] = ["record-shared"]
+    row["observed_exposure"] = {"tool_output": 100}
+    row["claims"][0].update(
+        record_id="record-shared",
+        component="tool_output",
+        exposure_tokens=100,
+    )
+    row["evidence_handles"] = [{"record_id": "record-shared"}]
+    return row
+
+
+def _seed_record_capacity(
+    conn,
+    record_id: str,
+    *,
+    uncached_input: int = 0,
+    tool_output: int = 0,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO usage_events (
+            record_id, session_id, event_timestamp, source_file, line_number,
+            input_tokens, cached_input_tokens, output_tokens,
+            reasoning_output_tokens, total_tokens, cumulative_input_tokens,
+            cumulative_cached_input_tokens, cumulative_output_tokens,
+            cumulative_reasoning_output_tokens, cumulative_total_tokens,
+            uncached_input_tokens, cache_ratio, reasoning_output_ratio,
+            context_window_percent
+        ) VALUES (?, ?, ?, ?, 1, ?, 0, 0, 0, ?, ?, 0, 0, 0, ?, ?, 0, 0, 0)
+        """,
+        (
+            record_id,
+            f"session-{record_id}",
+            "2026-07-01T00:00:00+00:00",
+            f"/synthetic/{record_id}.jsonl",
+            uncached_input,
+            uncached_input,
+            uncached_input,
+            uncached_input,
+            uncached_input,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO compression_record_facts (
+            record_id, source_file, session_id, thread_key, event_timestamp,
+            uncached_input_tokens, tool_output_exposure_tokens, facts_version,
+            updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+        """,
+        (
+            record_id,
+            f"/synthetic/{record_id}.jsonl",
+            f"session-{record_id}",
+            "thread-1",
+            "2026-07-01T00:00:00+00:00",
+            uncached_input,
+            tool_output,
+            "2026-07-01T00:00:00+00:00",
+        ),
+    )

--- a/tests/compression/test_simulator.py
+++ b/tests/compression/test_simulator.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from codex_usage_tracker.compression.models import (
+    CandidateDraft,
+    ComponentClaim,
+    ComponentExposure,
+    ComponentName,
+    CompressionCandidate,
+    EstimateRange,
+)
+from codex_usage_tracker.compression.simulator import simulate_candidate_portfolio
+
+
+def test_simulation_is_deterministic_for_candidate_order() -> None:
+    first = _candidate("candidate-b", record_id="record-1", component="uncached_input")
+    second = _candidate("candidate-a", record_id="record-1", component="uncached_input")
+
+    capacities = _capacities(first, second)
+    left = simulate_candidate_portfolio([first, second], capacities).as_dict()
+    right = simulate_candidate_portfolio([second, first], capacities).as_dict()
+
+    assert json.dumps(left, sort_keys=True) == json.dumps(right, sort_keys=True)
+    assert left["selected_candidate_ids"] == ["candidate-a", "candidate-b"]
+
+
+def test_shared_claims_never_exceed_unique_component_capacity() -> None:
+    candidates = [
+        _candidate("candidate-a", record_id="record-1", component="uncached_input"),
+        _candidate("candidate-b", record_id="record-1", component="uncached_input"),
+    ]
+    result = simulate_candidate_portfolio(candidates, _capacities(*candidates)).as_dict()
+
+    assert result["gross_estimate"] == {"low": 80, "likely": 120, "high": 160}
+    assert result["overlap_adjusted_estimate"] == {"low": 80, "likely": 100, "high": 100}
+    assert result["unique_eligible_capacity_tokens"] == 100
+    assert result["overlap_group_count"] == 1
+    assert result["groups"][0]["capacity_tokens"] == 100
+    assert sum(claim["adjusted_estimate"]["high"] for claim in result["groups"][0]["claims"]) == 100
+
+
+def test_disjoint_claims_retain_gross_estimates() -> None:
+    candidates = [
+        _candidate("candidate-a", record_id="record-1", component="uncached_input"),
+        _candidate("candidate-b", record_id="record-2", component="uncached_input"),
+    ]
+    result = simulate_candidate_portfolio(candidates, _capacities(*candidates)).as_dict()
+
+    assert result["overlap_adjusted_estimate"] == result["gross_estimate"]
+    assert result["unique_eligible_capacity_tokens"] == 200
+    assert result["overlap_group_count"] == 0
+
+
+def test_subset_simulation_reclaims_capacity_from_unselected_candidates() -> None:
+    selected = _candidate(
+        "candidate-a",
+        record_id="record-1",
+        component="uncached_input",
+        persisted_adjusted=EstimateRange(low=10, likely=20, high=30),
+    )
+
+    result = simulate_candidate_portfolio([selected], _capacities(selected)).as_dict()
+
+    assert result["candidates"][0]["persisted_adjusted_estimate"] == {
+        "low": 10,
+        "likely": 20,
+        "high": 30,
+    }
+    assert result["candidates"][0]["simulated_adjusted_estimate"] == {
+        "low": 40,
+        "likely": 60,
+        "high": 80,
+    }
+
+
+def test_trace_groups_and_claims_are_lexically_sorted() -> None:
+    candidates = [
+        _candidate("candidate-z", record_id="record-z", component="output"),
+        _candidate("candidate-b", record_id="record-a", component="cached_input"),
+        _candidate("candidate-a", record_id="record-a", component="cached_input"),
+    ]
+    result = simulate_candidate_portfolio(candidates, _capacities(*candidates)).as_dict()
+
+    assert [(group["record_id"], group["component"]) for group in result["groups"]] == [
+        ("record-a", "cached_input"),
+        ("record-z", "output"),
+    ]
+    assert [claim["candidate_id"] for claim in result["groups"][0]["claims"]] == [
+        "candidate-a",
+        "candidate-b",
+    ]
+
+
+def test_full_record_capacity_preserves_disjoint_tool_outputs_on_one_record() -> None:
+    candidates = [
+        _candidate("tool-a", record_id="record-1", component="tool_output"),
+        _candidate("tool-b", record_id="record-1", component="tool_output"),
+    ]
+
+    result = simulate_candidate_portfolio(
+        candidates,
+        {("record-1", "tool_output"): 200},
+    ).as_dict()
+
+    assert result["overlap_adjusted_estimate"] == result["gross_estimate"]
+    assert result["groups"][0]["capacity_tokens"] == 200
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    record_id: str,
+    component: ComponentName,
+    persisted_adjusted: EstimateRange | None = None,
+) -> dict[str, object]:
+    estimate = EstimateRange(low=40, likely=60, high=80)
+    claim = ComponentClaim(
+        record_id=record_id,
+        component=component,
+        exposure_tokens=100,
+        estimate=estimate,
+    )
+    exposure = _exposure(component)
+    draft = CandidateDraft(
+        candidate_id=candidate_id,
+        family="stale_context",
+        pattern="Synthetic compression opportunity",
+        pattern_key=f"pattern:{candidate_id}",
+        detector_version="stale-v1",
+        estimator_version="estimator-v1",
+        record_ids=(record_id,),
+        thread_keys=("thread-1",),
+        observation_count=1,
+        observed_exposure=exposure,
+        claims=(claim,),
+        gross_estimate=estimate,
+        confidence_grade="medium",
+        confidence_score=0.7,
+        confidence_reasons=("synthetic evidence",),
+        estimator_tier="fallback",
+        estimator_name="synthetic-estimator",
+        estimator_assumptions=("test assumption",),
+        evidence_handles=({"record_id": record_id},),
+        intervention={"family": "fresh_handoff"},
+        verification={"tool": "usage_compression_profile"},
+    )
+    candidate = CompressionCandidate(
+        draft=draft,
+        adjusted_estimate=persisted_adjusted or estimate,
+    )
+    return candidate.as_dict()
+
+
+def _exposure(component: ComponentName) -> ComponentExposure:
+    return ComponentExposure(
+        cached_input=100 if component == "cached_input" else 0,
+        uncached_input=100 if component == "uncached_input" else 0,
+        output=100 if component == "output" else 0,
+        reasoning_output=100 if component == "reasoning_output" else 0,
+        content_fragment=100 if component == "content_fragment" else 0,
+        tool_output=100 if component == "tool_output" else 0,
+    )
+
+
+def _capacities(*records: dict[str, object]) -> dict[tuple[str, str], int]:
+    capacities: dict[tuple[str, str], int] = {}
+    for record in records:
+        claims = record.get("claims")
+        if not isinstance(claims, list):
+            continue
+        for claim in claims:
+            if not isinstance(claim, Mapping):
+                continue
+            key = (str(claim.get("record_id")), str(claim.get("component")))
+            exposure = int(str(claim.get("exposure_tokens") or 0))
+            capacities[key] = max(capacities.get(key, 0), exposure)
+    return capacities


### PR DESCRIPTION
## Summary

- add usage_compression_simulate for deterministic selected-candidate what-if portfolios
- reuse the existing overlap allocator with exact detector-ready record/component capacities
- return bounded calculation traces, per-candidate adjusted estimates, and verification plans within 16 KiB
- reject invalid, foreign, incomplete, stale, or missing-capacity selections with actionable structured errors
- preserve aggregate-only privacy flags and all existing Compression Lab contracts

## Validation

- 800 Python tests passed
- full Agent Maintainer: 20260713T191209272669Z-full-0eb1ed1f3ae5
- precommit Agent Maintainer: 20260713T191643010755Z-precommit-9b8d93f35f30
- Pyright, Ruff, Tach, Xenon, Bandit, Markdown lint, release checks, and diff checks passed
- independent review findings on tool-output capacity, privacy flags, stale scope, and lifecycle coverage were resolved

Closes #240