### PR TITLE
refactor: add derived fact refresh hook

### DIFF
--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -76,6 +76,7 @@ from codex_usage_tracker.store.diagnostic_queries import (
 )
 from codex_usage_tracker.store.exports import export_usage_csv as export_usage_csv
 from codex_usage_tracker.store.investigation_runs import insert_investigation_run
+from codex_usage_tracker.store.refresh_callbacks import DerivedFactSyncCallback
 from codex_usage_tracker.store.rows import (
     row_to_dict as _row_to_dict,
 )
@@ -146,6 +147,7 @@ def refresh_usage_index(
     include_archived: bool = False,
     aggregate_only: bool = False,
     progress_callback: RefreshProgressCallback | None = None,
+    derived_fact_sync: DerivedFactSyncCallback | None = None,
 ) -> RefreshResult:
     """Scan Codex logs and upsert aggregate usage events."""
 
@@ -159,6 +161,7 @@ def refresh_usage_index(
         include_archived=include_archived,
         aggregate_only=aggregate_only,
         progress_callback=progress_callback,
+        derived_fact_sync=derived_fact_sync,
     )
 
 
@@ -167,6 +170,7 @@ def rebuild_usage_index(
     db_path: Path = DEFAULT_DB_PATH,
     include_archived: bool = False,
     aggregate_only: bool = False,
+    derived_fact_sync: DerivedFactSyncCallback | None = None,
 ) -> RefreshResult:
     """Drop and rebuild the usage index from all selected Codex logs."""
 
@@ -179,6 +183,7 @@ def rebuild_usage_index(
         db_path=db_path,
         include_archived=include_archived,
         aggregate_only=aggregate_only,
+        derived_fact_sync=derived_fact_sync,
     )
 
 

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -15,6 +15,7 @@ from codex_usage_tracker.store.api import (
     record_refresh_metadata,
 )
 from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.refresh_callbacks import DerivedFactSyncCallback
 from codex_usage_tracker.store.refresh_parse import (
     RefreshProgressCallback,
     emit_refresh_progress,
@@ -29,6 +30,7 @@ def refresh_usage_index(
     include_archived: bool = False,
     aggregate_only: bool = False,
     progress_callback: RefreshProgressCallback | None = None,
+    derived_fact_sync: DerivedFactSyncCallback | None = None,
 ) -> RefreshResult:
     """Scan Codex logs and upsert aggregate usage events."""
 
@@ -64,6 +66,7 @@ def refresh_usage_index(
             aggregate_only=aggregate_only,
             progress_callback=progress_callback,
             force_serial=False,
+            derived_fact_sync=derived_fact_sync,
         )
     except BrokenProcessPool:
         emit_refresh_progress(
@@ -82,6 +85,7 @@ def refresh_usage_index(
             aggregate_only=aggregate_only,
             progress_callback=progress_callback,
             force_serial=True,
+            derived_fact_sync=derived_fact_sync,
         )
     emit_refresh_progress(
         progress_callback,
@@ -155,6 +159,7 @@ def rebuild_usage_index(
     db_path: Path = DEFAULT_DB_PATH,
     include_archived: bool = False,
     aggregate_only: bool = False,
+    derived_fact_sync: DerivedFactSyncCallback | None = None,
 ) -> RefreshResult:
     """Clear aggregate rows and rescan local Codex logs."""
 
@@ -177,4 +182,5 @@ def rebuild_usage_index(
         db_path=db_path,
         include_archived=include_archived,
         aggregate_only=aggregate_only,
+        derived_fact_sync=derived_fact_sync,
     )

--- a/src/codex_usage_tracker/store/refresh_callbacks.py
+++ b/src/codex_usage_tracker/store/refresh_callbacks.py
@@ -1,0 +1,8 @@
+"""Dependency-inversion callbacks for derived refresh stages."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+
+DerivedFactSyncCallback = Callable[[sqlite3.Connection, tuple[str, ...], bool], None]

--- a/src/codex_usage_tracker/store/refresh_stream.py
+++ b/src/codex_usage_tracker/store/refresh_stream.py
@@ -29,6 +29,7 @@ from codex_usage_tracker.store.content_index_models import (
     ContentIndexPlan,
     _ExtractedContentRows,
 )
+from codex_usage_tracker.store.refresh_callbacks import DerivedFactSyncCallback
 from codex_usage_tracker.store.refresh_parse import (
     ParsedRefreshFile,
     RefreshProgressCallback,
@@ -82,6 +83,7 @@ class _RefreshStreamWriter:
         aggregate_only: bool,
         progress_callback: RefreshProgressCallback | None,
         force_serial: bool,
+        derived_fact_sync: DerivedFactSyncCallback | None,
     ) -> None:
         self.db_path = db_path
         self.parse_plans = parse_plans
@@ -89,6 +91,7 @@ class _RefreshStreamWriter:
         self.aggregate_only = aggregate_only
         self.progress_callback = progress_callback
         self.force_serial = force_serial
+        self.derived_fact_sync = derived_fact_sync
         self.stats: dict[str, int] = {}
         self.parsed_events = 0
         self.inserted = 0
@@ -376,6 +379,10 @@ class _RefreshStreamWriter:
                 affected_thread_keys=finalized.affected_thread_keys,
             )
         self.timings.add("compression_facts", started)
+        if self.derived_fact_sync is not None:
+            recommendation_started = perf_counter()
+            self.derived_fact_sync(conn, finalized.record_ids, full_rebuild)
+            self.timings.add("recommendation_facts", recommendation_started)
         emit_refresh_progress(
             self.progress_callback,
             phase="syncing_facts",
@@ -394,6 +401,7 @@ def write_refresh_stream(
     aggregate_only: bool,
     progress_callback: RefreshProgressCallback | None,
     force_serial: bool,
+    derived_fact_sync: DerivedFactSyncCallback | None = None,
 ) -> RefreshStreamResult:
     return _RefreshStreamWriter(
         db_path=db_path,
@@ -402,6 +410,7 @@ def write_refresh_stream(
         aggregate_only=aggregate_only,
         progress_callback=progress_callback,
         force_serial=force_serial,
+        derived_fact_sync=derived_fact_sync,
     ).run()
 
 

--- a/tests/store/test_refresh_callbacks.py
+++ b/tests/store/test_refresh_callbacks.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_usage_tracker.store.api import refresh_usage_index
+from tests.store_dashboard_helpers import _entry, _make_codex_home, _token_event
+
+
+def test_refresh_derived_fact_callback_receives_full_and_append_targets(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    calls: list[tuple[tuple[str, ...], bool, bool]] = []
+
+    def sync(conn, record_ids: tuple[str, ...], full_rebuild: bool) -> None:
+        calls.append((record_ids, full_rebuild, conn.in_transaction))
+
+    refresh_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        derived_fact_sync=sync,
+    )
+    source_path = next((codex_home / "sessions").glob("**/*.jsonl"))
+    with source_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "APPENDED"}],
+                    },
+                )
+            )
+            + "\n"
+        )
+        handle.write(json.dumps(_token_event(8_000, 400)) + "\n")
+    refresh_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        derived_fact_sync=sync,
+    )
+
+    assert len(calls) == 2
+    assert calls[0][1:] == (True, True)
+    assert calls[1][1:] == (False, True)
+    assert len(calls[0][0]) > 0
+    assert len(calls[1][0]) == 1


### PR DESCRIPTION
## Summary
- add a typed derived-fact callback to index refresh and rebuild flows
- execute derived fact updates inside the existing write transaction
- prove full rebuild and one-record append targeting without coupling the store to recommendation policy

## Validation
- 807 tests passed
- Ruff, format, mypy, Tach, release check, and git diff check passed
- Agent Maintainer full verifier running

Closes part of #244.