### PR TITLE
feat: materialize recommendation facts

### DIFF
--- a/src/codex_usage_tracker/recommendation_engine/__init__.py
+++ b/src/codex_usage_tracker/recommendation_engine/__init__.py
@@ -1,0 +1,1 @@
+"""Pure recommendation scoring and fact configuration identity."""

--- a/src/codex_usage_tracker/recommendation_engine/api.py
+++ b/src/codex_usage_tracker/recommendation_engine/api.py
@@ -1,0 +1,46 @@
+"""Application refresh entry points with recommendation fact maintenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_usage_tracker.core.models import RefreshResult
+from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME, DEFAULT_DB_PATH
+from codex_usage_tracker.recommendation_engine.materialization import (
+    sync_refresh_recommendation_facts,
+)
+from codex_usage_tracker.store.api import rebuild_usage_index as _rebuild_usage_index
+from codex_usage_tracker.store.api import refresh_usage_index as _refresh_usage_index
+from codex_usage_tracker.store.refresh_parse import RefreshProgressCallback
+
+
+def refresh_usage_index(
+    codex_home: Path = DEFAULT_CODEX_HOME,
+    db_path: Path = DEFAULT_DB_PATH,
+    include_archived: bool = False,
+    aggregate_only: bool = False,
+    progress_callback: RefreshProgressCallback | None = None,
+) -> RefreshResult:
+    return _refresh_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        include_archived=include_archived,
+        aggregate_only=aggregate_only,
+        progress_callback=progress_callback,
+        derived_fact_sync=sync_refresh_recommendation_facts,
+    )
+
+
+def rebuild_usage_index(
+    codex_home: Path = DEFAULT_CODEX_HOME,
+    db_path: Path = DEFAULT_DB_PATH,
+    include_archived: bool = False,
+    aggregate_only: bool = False,
+) -> RefreshResult:
+    return _rebuild_usage_index(
+        codex_home=codex_home,
+        db_path=db_path,
+        include_archived=include_archived,
+        aggregate_only=aggregate_only,
+        derived_fact_sync=sync_refresh_recommendation_facts,
+    )

--- a/src/codex_usage_tracker/recommendation_engine/fact_config.py
+++ b/src/codex_usage_tracker/recommendation_engine/fact_config.py
@@ -1,0 +1,106 @@
+"""Configuration identity for persisted recommendation facts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, fields, is_dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.core.paths import (
+    DEFAULT_ALLOWANCE_PATH,
+    DEFAULT_PRICING_PATH,
+    DEFAULT_RATE_CARD_PATH,
+    DEFAULT_THRESHOLDS_PATH,
+)
+from codex_usage_tracker.pricing.allowance_config import (
+    UsageAllowanceConfig,
+    load_allowance_config,
+)
+from codex_usage_tracker.pricing.allowance_usage import annotate_rows_with_allowance
+from codex_usage_tracker.pricing.config import PricingConfig, load_pricing_config
+from codex_usage_tracker.pricing.costing import annotate_rows_with_efficiency
+from codex_usage_tracker.reports.recommendations import (
+    ThresholdConfig,
+    annotate_rows_with_recommendations,
+    load_threshold_config,
+)
+
+RECOMMENDATION_FACTS_VERSION = 1
+RECOMMENDATION_ALGORITHM_VERSION = 1
+_IGNORED_CONFIG_FIELDS = frozenset({"error", "path", "rate_card_error", "rate_card_path"})
+
+
+@dataclass(frozen=True)
+class RecommendationFactConfig:
+    pricing: PricingConfig
+    allowance: UsageAllowanceConfig
+    thresholds: ThresholdConfig
+    fingerprint: str
+
+
+def annotate_rows_for_recommendation_facts(
+    rows: list[dict[str, Any]],
+    config: RecommendationFactConfig,
+) -> list[dict[str, Any]]:
+    values = annotate_rows_with_efficiency(rows, config.pricing)
+    values = annotate_rows_with_allowance(values, config.allowance)
+    return annotate_rows_with_recommendations(values, config.thresholds)
+
+
+def load_recommendation_fact_config(
+    *,
+    pricing_path: Path = DEFAULT_PRICING_PATH,
+    allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
+    rate_card_path: Path = DEFAULT_RATE_CARD_PATH,
+    thresholds_path: Path = DEFAULT_THRESHOLDS_PATH,
+) -> RecommendationFactConfig:
+    pricing = load_pricing_config(pricing_path)
+    allowance = load_allowance_config(allowance_path, rate_card_path=rate_card_path)
+    thresholds = load_threshold_config(thresholds_path)
+    payload = {
+        "algorithm_version": RECOMMENDATION_ALGORITHM_VERSION,
+        "allowance": _canonical_config(allowance),
+        "facts_version": RECOMMENDATION_FACTS_VERSION,
+        "pricing": _canonical_config(pricing),
+        "thresholds": _canonical_config(thresholds),
+    }
+    fingerprint = sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+    return RecommendationFactConfig(pricing, allowance, thresholds, fingerprint)
+
+
+def recommendation_generation_fingerprint(
+    *,
+    source_generation: int,
+    config_fingerprint: str,
+) -> str:
+    payload = {
+        "algorithm_version": RECOMMENDATION_ALGORITHM_VERSION,
+        "config_fingerprint": config_fingerprint,
+        "facts_version": RECOMMENDATION_FACTS_VERSION,
+        "source_generation": source_generation,
+    }
+    return sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_config(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            item.name: _canonical_config(getattr(value, item.name))
+            for item in fields(value)
+            if item.name not in _IGNORED_CONFIG_FIELDS
+        }
+    if isinstance(value, dict):
+        return {str(key): _canonical_config(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_canonical_config(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_canonical_config(item) for item in value)
+    if isinstance(value, Path):
+        return value.name
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)

--- a/src/codex_usage_tracker/recommendation_engine/materialization.py
+++ b/src/codex_usage_tracker/recommendation_engine/materialization.py
@@ -1,0 +1,247 @@
+"""Incremental materialization of aggregate recommendation facts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable, Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.core.paths import (
+    DEFAULT_ALLOWANCE_PATH,
+    DEFAULT_PRICING_PATH,
+    DEFAULT_RATE_CARD_PATH,
+    DEFAULT_THRESHOLDS_PATH,
+)
+from codex_usage_tracker.recommendation_engine.fact_config import (
+    RECOMMENDATION_ALGORITHM_VERSION,
+    RECOMMENDATION_FACTS_VERSION,
+    RecommendationFactConfig,
+    annotate_rows_for_recommendation_facts,
+    load_recommendation_fact_config,
+    recommendation_generation_fingerprint,
+)
+from codex_usage_tracker.store.compression_schema import read_compression_source_generation
+from codex_usage_tracker.store.recommendation_schema import (
+    create_recommendation_fact_indexes,
+    drop_recommendation_fact_indexes,
+)
+from codex_usage_tracker.store.rows import row_to_dict
+
+_FACT_BATCH_SIZE = 1_000
+
+
+def backfill_recommendation_facts(
+    conn: sqlite3.Connection,
+    *,
+    pricing_path: Path = DEFAULT_PRICING_PATH,
+    allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
+    rate_card_path: Path = DEFAULT_RATE_CARD_PATH,
+    thresholds_path: Path = DEFAULT_THRESHOLDS_PATH,
+) -> int:
+    """Rebuild all recommendation facts from normalized SQLite rows only."""
+    config = load_recommendation_fact_config(
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        rate_card_path=rate_card_path,
+        thresholds_path=thresholds_path,
+    )
+    generation = _generation(conn, config)
+    drop_recommendation_fact_indexes(conn)
+    try:
+        conn.execute("DELETE FROM recommendation_facts")
+        cursor = conn.execute("SELECT * FROM usage_events ORDER BY record_id")
+        count = _insert_cursor_facts(conn, cursor, config=config, generation=generation)
+    finally:
+        create_recommendation_fact_indexes(conn)
+    _stamp_state(conn, config=config, generation=generation)
+    return count
+
+
+def sync_recommendation_facts(
+    conn: sqlite3.Connection,
+    *,
+    record_ids: Iterable[str],
+) -> int:
+    """Replace facts only for changed normalized usage records."""
+    targets = tuple(dict.fromkeys(str(record_id) for record_id in record_ids if record_id))
+    config = load_recommendation_fact_config()
+    generation = _generation(conn, config)
+    _populate_targets(conn, targets)
+    conn.execute(
+        """
+        DELETE FROM recommendation_facts
+        WHERE record_id IN (SELECT record_id FROM recommendation_fact_targets)
+        """
+    )
+    cursor = conn.execute(
+        """
+        SELECT usage_events.*
+        FROM usage_events
+        JOIN recommendation_fact_targets USING(record_id)
+        ORDER BY usage_events.record_id
+        """
+    )
+    count = _insert_cursor_facts(conn, cursor, config=config, generation=generation)
+    _stamp_state(conn, config=config, generation=generation)
+    return count
+
+
+def sync_refresh_recommendation_facts(
+    conn: sqlite3.Connection,
+    record_ids: tuple[str, ...],
+    full_rebuild: bool,
+) -> None:
+    if full_rebuild:
+        backfill_recommendation_facts(conn)
+    else:
+        sync_recommendation_facts(conn, record_ids=record_ids)
+
+
+def _generation(
+    conn: sqlite3.Connection,
+    config: RecommendationFactConfig,
+) -> tuple[int, str, str]:
+    source_generation = read_compression_source_generation(conn)
+    fingerprint = recommendation_generation_fingerprint(
+        source_generation=source_generation,
+        config_fingerprint=config.fingerprint,
+    )
+    updated_at = datetime.now(timezone.utc).isoformat()
+    return source_generation, fingerprint, updated_at
+
+
+def _populate_targets(conn: sqlite3.Connection, record_ids: tuple[str, ...]) -> None:
+    conn.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS recommendation_fact_targets (record_id TEXT PRIMARY KEY)"
+    )
+    conn.execute("DELETE FROM recommendation_fact_targets")
+    conn.executemany(
+        "INSERT OR IGNORE INTO recommendation_fact_targets(record_id) VALUES (?)",
+        ((record_id,) for record_id in record_ids),
+    )
+
+
+def _insert_cursor_facts(
+    conn: sqlite3.Connection,
+    cursor: sqlite3.Cursor,
+    *,
+    config: RecommendationFactConfig,
+    generation: tuple[int, str, str],
+) -> int:
+    inserted = 0
+    while rows := cursor.fetchmany(_FACT_BATCH_SIZE):
+        facts = list(_fact_rows(rows, config=config, generation=generation))
+        conn.executemany(_FACT_INSERT_SQL, facts)
+        inserted += len(facts)
+    return inserted
+
+
+def _fact_rows(
+    rows: list[sqlite3.Row],
+    *,
+    config: RecommendationFactConfig,
+    generation: tuple[int, str, str],
+) -> Iterator[tuple[Any, ...]]:
+    source_generation, generation_fingerprint, updated_at = generation
+    values = [row_to_dict(row) for row in rows]
+    values = annotate_rows_for_recommendation_facts(values, config)
+    for row in values:
+        recommendations = row["action_recommendations"]
+        yield (
+            row["record_id"],
+            row["event_timestamp"],
+            int(row.get("is_archived") or 0),
+            str(row.get("thread_key") or ""),
+            row.get("model"),
+            row.get("effort"),
+            _integer(row.get("input_tokens")),
+            _integer(row.get("cached_input_tokens")),
+            _integer(row.get("uncached_input_tokens")),
+            _integer(row.get("output_tokens")),
+            _integer(row.get("reasoning_output_tokens")),
+            _integer(row.get("total_tokens")),
+            _integer(row.get("cumulative_total_tokens")),
+            _number(row.get("cache_ratio")),
+            _number(row.get("context_window_percent")),
+            row.get("estimated_cost_usd"),
+            row.get("pricing_model"),
+            int(bool(row.get("pricing_estimated"))),
+            row.get("usage_credits"),
+            str(row.get("usage_credit_confidence") or "unpriced"),
+            row.get("primary_signal"),
+            _json(row.get("secondary_signals") or []),
+            _number(row.get("recommendation_score")),
+            row["recommended_action_key"],
+            _json(recommendations),
+            RECOMMENDATION_FACTS_VERSION,
+            RECOMMENDATION_ALGORITHM_VERSION,
+            source_generation,
+            generation_fingerprint,
+            config.fingerprint,
+            updated_at,
+        )
+
+
+def _stamp_state(
+    conn: sqlite3.Connection,
+    *,
+    config: RecommendationFactConfig,
+    generation: tuple[int, str, str],
+) -> None:
+    source_generation, generation_fingerprint, updated_at = generation
+    count = int(conn.execute("SELECT COUNT(*) FROM recommendation_facts").fetchone()[0])
+    conn.execute(
+        """
+        INSERT INTO recommendation_fact_state (
+            singleton, facts_version, algorithm_version, source_generation,
+            generation_fingerprint, config_fingerprint, record_count, updated_at
+        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(singleton) DO UPDATE SET
+            facts_version = excluded.facts_version,
+            algorithm_version = excluded.algorithm_version,
+            source_generation = excluded.source_generation,
+            generation_fingerprint = excluded.generation_fingerprint,
+            config_fingerprint = excluded.config_fingerprint,
+            record_count = excluded.record_count,
+            updated_at = excluded.updated_at
+        """,
+        (
+            RECOMMENDATION_FACTS_VERSION,
+            RECOMMENDATION_ALGORITHM_VERSION,
+            source_generation,
+            generation_fingerprint,
+            config.fingerprint,
+            count,
+            updated_at,
+        ),
+    )
+
+
+def _integer(value: Any) -> int:
+    return int(value or 0)
+
+
+def _number(value: Any) -> float:
+    return float(value or 0)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+_FACT_INSERT_SQL = """
+    INSERT INTO recommendation_facts (
+        record_id, event_timestamp, is_archived, thread_key, model, effort,
+        input_tokens, cached_input_tokens, uncached_input_tokens, output_tokens,
+        reasoning_output_tokens, total_tokens, cumulative_total_tokens, cache_ratio,
+        context_window_percent, estimated_cost_usd, pricing_model, pricing_estimated,
+        usage_credits, usage_credit_confidence, primary_recommendation_key,
+        secondary_recommendation_keys_json, recommendation_score,
+        recommended_action_key, recommendations_json, facts_version,
+        algorithm_version, source_generation, generation_fingerprint,
+        config_fingerprint, updated_at
+    ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+"""

--- a/src/codex_usage_tracker/recommendation_engine/tach.domain.toml
+++ b/src/codex_usage_tracker/recommendation_engine/tach.domain.toml
@@ -1,0 +1,7 @@
+[root]
+depends_on = [
+    "//codex_usage_tracker.core",
+    "//codex_usage_tracker.pricing",
+    "//codex_usage_tracker.reports",
+    "//codex_usage_tracker.store",
+]

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -76,6 +76,7 @@ from codex_usage_tracker.store.diagnostic_queries import (
 )
 from codex_usage_tracker.store.exports import export_usage_csv as export_usage_csv
 from codex_usage_tracker.store.investigation_runs import insert_investigation_run
+from codex_usage_tracker.store.recommendation_schema import clear_recommendation_fact_tables
 from codex_usage_tracker.store.refresh_callbacks import DerivedFactSyncCallback
 from codex_usage_tracker.store.rows import (
     row_to_dict as _row_to_dict,
@@ -196,6 +197,7 @@ def reset_usage_database(db_path: Path = DEFAULT_DB_PATH) -> dict[str, Any]:
         deleted_rows = int(row["count"] if row is not None else 0)
         clear_content_index_rows(conn)
         clear_compression_detector_facts(conn)
+        clear_recommendation_fact_tables(conn)
         conn.execute("DELETE FROM call_diagnostic_facts")
         conn.execute("DELETE FROM diagnostic_snapshots")
         conn.execute("DELETE FROM allowance_observations")

--- a/src/codex_usage_tracker/store/recommendation_schema.py
+++ b/src/codex_usage_tracker/store/recommendation_schema.py
@@ -1,0 +1,92 @@
+"""SQLite schema objects for materialized recommendation facts."""
+
+from __future__ import annotations
+
+import sqlite3
+
+MIGRATION_NAMES = {20: "persist versioned recommendation facts"}
+
+_INDEX_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_scope "
+    "ON recommendation_facts(is_archived, recommendation_score DESC, "
+    "event_timestamp DESC, record_id)",
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_model_effort "
+    "ON recommendation_facts(model, effort, is_archived, recommendation_score DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_thread "
+    "ON recommendation_facts(thread_key, recommendation_score DESC, event_timestamp DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_primary "
+    "ON recommendation_facts(primary_recommendation_key, recommendation_score DESC)",
+)
+_INDEX_DROP_STATEMENTS = tuple(
+    statement.replace("CREATE INDEX IF NOT EXISTS ", "DROP INDEX IF EXISTS ").split(" ON ", 1)[0]
+    for statement in _INDEX_STATEMENTS
+)
+
+
+def create_recommendation_fact_tables(conn: sqlite3.Connection) -> None:
+    """Create versioned aggregate-only recommendation facts and state."""
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS recommendation_facts (
+            record_id TEXT PRIMARY KEY,
+            event_timestamp TEXT NOT NULL,
+            is_archived INTEGER NOT NULL DEFAULT 0,
+            thread_key TEXT NOT NULL DEFAULT '',
+            model TEXT,
+            effort TEXT,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            uncached_input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+            total_tokens INTEGER NOT NULL DEFAULT 0,
+            cumulative_total_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_ratio REAL NOT NULL DEFAULT 0,
+            context_window_percent REAL NOT NULL DEFAULT 0,
+            estimated_cost_usd REAL,
+            pricing_model TEXT,
+            pricing_estimated INTEGER NOT NULL DEFAULT 0,
+            usage_credits REAL,
+            usage_credit_confidence TEXT NOT NULL DEFAULT 'unpriced',
+            primary_recommendation_key TEXT,
+            secondary_recommendation_keys_json TEXT NOT NULL DEFAULT '[]',
+            recommendation_score REAL NOT NULL DEFAULT 0,
+            recommended_action_key TEXT NOT NULL,
+            recommendations_json TEXT NOT NULL DEFAULT '[]',
+            facts_version INTEGER NOT NULL,
+            algorithm_version INTEGER NOT NULL,
+            source_generation INTEGER NOT NULL,
+            generation_fingerprint TEXT NOT NULL,
+            config_fingerprint TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY(record_id) REFERENCES usage_events(record_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS recommendation_fact_state (
+            singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+            facts_version INTEGER NOT NULL,
+            algorithm_version INTEGER NOT NULL,
+            source_generation INTEGER NOT NULL,
+            generation_fingerprint TEXT NOT NULL,
+            config_fingerprint TEXT NOT NULL,
+            record_count INTEGER NOT NULL DEFAULT 0,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+    create_recommendation_fact_indexes(conn)
+
+
+def clear_recommendation_fact_tables(conn: sqlite3.Connection) -> None:
+    conn.execute("DELETE FROM recommendation_facts")
+    conn.execute("DELETE FROM recommendation_fact_state")
+
+
+def create_recommendation_fact_indexes(conn: sqlite3.Connection) -> None:
+    for statement in _INDEX_STATEMENTS:
+        conn.execute(statement)
+
+
+def drop_recommendation_fact_indexes(conn: sqlite3.Connection) -> None:
+    for statement in _INDEX_DROP_STATEMENTS:
+        conn.execute(statement)

--- a/src/codex_usage_tracker/store/refresh.py
+++ b/src/codex_usage_tracker/store/refresh.py
@@ -170,6 +170,7 @@ def rebuild_usage_index(
             "allowance_observations",
             "call_diagnostic_facts",
             "diagnostic_snapshots",
+            "recommendation_fact_state",
             "source_records",
             "usage_events",
             "thread_summaries",

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 
 import codex_usage_tracker.store.compression_schema as compression_schema
+import codex_usage_tracker.store.recommendation_schema as recommendation_schema
 import codex_usage_tracker.store.schema_source_index as schema_source_index
 from codex_usage_tracker.core.schema import (
     USAGE_EVENT_COLUMN_NAMES,
@@ -15,7 +16,7 @@ from codex_usage_tracker.core.schema import (
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -32,6 +33,7 @@ MIGRATION_NAMES = {
     13: "create normalized content index tables",
     14: "persist investigation run summaries",
     **compression_schema.MIGRATION_NAMES,
+    **recommendation_schema.MIGRATION_NAMES,
     18: "index usage events by source file and line",
 }
 CALL_ORIGIN_REPAIR_COLUMNS = {
@@ -105,6 +107,7 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         *compression_schema.schema_migrations(),
         (18, schema_source_index.migrate_source_file_line_index),
         (19, compression_schema.add_candidate_record_metadata),
+        (20, recommendation_schema.create_recommendation_fact_tables),
     )
 
 

--- a/src/codex_usage_tracker/store/source_replacement.py
+++ b/src/codex_usage_tracker/store/source_replacement.py
@@ -84,6 +84,7 @@ def _delete_source_batch(conn: sqlite3.Connection, source_batch: list[str]) -> N
         "allowance_observations",
         "source_records",
         "call_diagnostic_facts",
+        "recommendation_facts",
     ):
         conn.execute(
             f"""

--- a/tests/store/test_compression_runs.py
+++ b/tests/store/test_compression_runs.py
@@ -171,7 +171,7 @@ def test_candidate_record_metadata_migration_backfills_existing_claims(
         conn.execute("PRAGMA user_version = 18")
     with connect(db_path) as conn:
         init_db(conn)
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 19
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 20
     with connect(db_path) as conn:
         conn.execute("DELETE FROM usage_events WHERE record_id = ?", ("record-cmp_old",))
 

--- a/tests/store/test_recommendation_facts.py
+++ b/tests/store/test_recommendation_facts.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from codex_usage_tracker.pricing.allowance import annotate_rows_with_allowance
+from codex_usage_tracker.pricing.costing import annotate_rows_with_efficiency
+from codex_usage_tracker.recommendation_engine.api import refresh_usage_index
+from codex_usage_tracker.recommendation_engine.materialization import (
+    backfill_recommendation_facts,
+    sync_recommendation_facts,
+)
+from codex_usage_tracker.reports.recommendations import (
+    annotate_rows_with_recommendations,
+)
+from codex_usage_tracker.store.api import (
+    query_dashboard_events,
+    upsert_usage_events,
+)
+from codex_usage_tracker.store.connection import connect
+from tests.store_dashboard_helpers import _entry, _make_codex_home, _token_event, _usage_event
+
+
+def test_materialized_recommendation_facts_match_legacy_annotations(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    events = [
+        replace(
+            _usage_event(
+                record_id="edge-unpriced",
+                session_id="session-edge",
+                thread_key="thread:edge",
+                event_timestamp="2026-07-13T12:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            model="synthetic-unpriced-model",
+            input_tokens=250_000,
+            cached_input_tokens=1_000,
+            output_tokens=50,
+            reasoning_output_tokens=40_000,
+            total_tokens=250_050,
+        ),
+        replace(
+            _usage_event(
+                record_id="edge-archived",
+                session_id="session-archived",
+                thread_key="thread:archived",
+                event_timestamp="2026-07-12T12:00:00Z",
+                cumulative_total_tokens=1_000,
+            ),
+            is_archived=1,
+            model="synthetic-unpriced-model",
+        ),
+    ]
+
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(
+            conn,
+            record_ids=(event.record_id for event in events),
+        )
+
+    legacy_rows = query_dashboard_events(db_path=db_path, limit=0)
+    legacy_rows = annotate_rows_with_allowance(annotate_rows_with_efficiency(legacy_rows))
+    expected = {row["record_id"]: row for row in annotate_rows_with_recommendations(legacy_rows)}
+    with connect(db_path) as conn:
+        facts = conn.execute(
+            """
+            SELECT * FROM recommendation_facts ORDER BY record_id
+            """
+        ).fetchall()
+
+    assert {str(row["record_id"]) for row in facts} == set(expected)
+    for fact in facts:
+        legacy = expected[str(fact["record_id"])]
+        recommendations = json.loads(str(fact["recommendations_json"]))
+        assert recommendations == legacy["action_recommendations"]
+        assert fact["primary_recommendation_key"] == legacy["primary_signal"]
+        assert (
+            json.loads(str(fact["secondary_recommendation_keys_json"]))
+            == legacy["secondary_signals"]
+        )
+        assert fact["recommendation_score"] == legacy["recommendation_score"]
+        assert fact["recommended_action_key"] == legacy["recommended_action_key"]
+
+
+def test_append_sync_does_not_rebuild_historical_recommendation_facts(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    source_path = next((codex_home / "sessions").glob("**/*.jsonl"))
+    with connect(db_path) as conn:
+        initial_count = int(conn.execute("SELECT COUNT(*) FROM recommendation_facts").fetchone()[0])
+        conn.executescript(
+            """
+            CREATE TABLE protected_recommendation_facts (
+                record_id TEXT PRIMARY KEY
+            );
+            INSERT INTO protected_recommendation_facts
+            SELECT record_id FROM recommendation_facts;
+            CREATE TRIGGER protect_historical_recommendation_fact
+            BEFORE DELETE ON recommendation_facts
+            WHEN OLD.record_id IN (SELECT record_id FROM protected_recommendation_facts)
+            BEGIN
+                SELECT RAISE(ABORT, 'historical recommendation fact was rebuilt');
+            END;
+            """
+        )
+
+    with source_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "APPENDED FACT"}],
+                    },
+                )
+            )
+            + "\n"
+        )
+        handle.write(json.dumps(_token_event(8_000, 400)) + "\n")
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+
+    with connect(db_path) as conn:
+        final_count = int(conn.execute("SELECT COUNT(*) FROM recommendation_facts").fetchone()[0])
+    assert final_count == initial_count + 1
+
+
+def test_recommendation_fact_backfill_is_idempotent_and_db_only(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    event = _usage_event(
+        record_id="backfill",
+        session_id="session",
+        thread_key="thread:session",
+        event_timestamp="2026-07-13T12:00:00Z",
+        cumulative_total_tokens=1_000,
+    )
+    upsert_usage_events([event], db_path=db_path)
+
+    with connect(db_path) as conn:
+        conn.execute("DELETE FROM recommendation_facts")
+        first_count = backfill_recommendation_facts(conn)
+        first = _fact_snapshot(conn)
+        second_count = backfill_recommendation_facts(conn)
+        second = _fact_snapshot(conn)
+
+    assert first_count == 1
+    assert second_count == 1
+    assert first == second
+
+
+def test_source_replacement_removes_orphaned_recommendation_facts(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    source_path = tmp_path / "synthetic-source.jsonl"
+    event = replace(
+        _usage_event(
+            record_id="removed",
+            session_id="session",
+            thread_key="thread:session",
+            event_timestamp="2026-07-13T12:00:00Z",
+            cumulative_total_tokens=1_000,
+        ),
+        source_file=str(source_path),
+    )
+    upsert_usage_events([event], db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id])
+
+    upsert_usage_events([], db_path=db_path, replace_source_files=[source_path])
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[])
+
+    with connect(db_path) as conn:
+        fact_count = int(conn.execute("SELECT COUNT(*) FROM recommendation_facts").fetchone()[0])
+        state_count = int(
+            conn.execute(
+                "SELECT record_count FROM recommendation_fact_state WHERE singleton = 1"
+            ).fetchone()[0]
+        )
+    assert fact_count == 0
+    assert state_count == 0
+
+
+def test_threshold_changes_update_recommendation_config_fingerprint(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    thresholds_path = tmp_path / "thresholds.json"
+    event = replace(
+        _usage_event(
+            record_id="threshold",
+            session_id="session",
+            thread_key="thread:session",
+            event_timestamp="2026-07-13T12:00:00Z",
+            cumulative_total_tokens=900_000,
+        ),
+        model="synthetic-unpriced-model",
+    )
+    upsert_usage_events([event], db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id])
+    with connect(db_path) as conn:
+        initial = conn.execute(
+            "SELECT config_fingerprint FROM recommendation_fact_state WHERE singleton = 1"
+        ).fetchone()
+
+    thresholds_path.write_text(
+        json.dumps({"large_cumulative_tokens": 2_000_000}),
+        encoding="utf-8",
+    )
+    with connect(db_path) as conn:
+        backfill_recommendation_facts(conn, thresholds_path=thresholds_path)
+        changed = conn.execute(
+            "SELECT config_fingerprint FROM recommendation_fact_state WHERE singleton = 1"
+        ).fetchone()
+
+    assert initial is not None
+    assert changed is not None
+    assert changed[0] != initial[0]
+
+
+def _fact_snapshot(conn) -> list[tuple[object, ...]]:
+    return [
+        tuple(row)
+        for row in conn.execute(
+            """
+            SELECT
+                record_id,
+                primary_recommendation_key,
+                secondary_recommendation_keys_json,
+                recommendation_score,
+                recommended_action_key,
+                recommendations_json,
+                facts_version,
+                algorithm_version,
+                config_fingerprint
+            FROM recommendation_facts
+            ORDER BY record_id
+            """
+        )
+    ]

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -79,12 +79,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "19"
+    assert meta["schema_version"] == "20"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 19
+    assert state["schema_version"] == 20
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 20))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 21))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -711,7 +711,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 19
+    assert user_version == 20
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -809,8 +809,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 19
-    assert [row["version"] for row in migrations] == list(range(1, 20))
+    assert user_version == 20
+    assert [row["version"] for row in migrations] == list(range(1, 21))
     assert "idx_usage_source_file_line" in indexes
 
 

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -68,17 +68,22 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 19
+    assert state["schema_version"] == 20
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 20))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 21))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
         snapshots = conn.execute("SELECT COUNT(*) AS count FROM diagnostic_snapshots").fetchone()
+        recommendation_facts = conn.execute(
+            "SELECT COUNT(*) AS count FROM recommendation_facts"
+        ).fetchone()
     assert facts is not None
     assert facts["count"] == 0
     assert snapshots is not None
     assert snapshots["count"] == 0
+    assert recommendation_facts is not None
+    assert recommendation_facts["count"] == 0
 
 
 def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
@@ -101,7 +106,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "19"
+    assert metadata["schema_version"] == "20"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -140,8 +145,8 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
             row["name"] for row in conn.execute("PRAGMA index_list(usage_events)").fetchall()
         }
 
-    assert versions == list(range(1, 20))
-    assert user_version == 19
+    assert versions == list(range(1, 21))
+    assert user_version == 20
     assert "idx_usage_source_file_line" in usage_indexes
     assert {
         "parsed_prefix_tail_hash",


### PR DESCRIPTION
## Summary
- add schema v20 recommendation fact and state tables with indexed ordering
- materialize the existing recommendation scorer deterministically without duplicating scoring policy
- support targeted append sync, DB-only backfill, source replacement cleanup, and reset/rebuild lifecycle
- preserve the store boundary through the derived-fact callback introduced in #247

## Validation
- 812 tests passed
- focused recommendation, migration, callback, and schema tests passed
- Ruff, format, targeted Mypy, Tach, release readiness, and diff checks passed
- Agent Maintainer full verifier running
- agent-perf run: `20260713T234304Z-bade89ff`; 10k unprofiled populate ~1.18s and 100k candidate populate 17.99s; profile attribution found fact insertion at ~1.8-2% and row conversion at ~3-4%

Closes part of #244.