### PR TITLE
refactor: wire recommendation-aware refresh

### DIFF
--- a/docs/architecture/decisions/0010-recommendation-engine-boundary.md
+++ b/docs/architecture/decisions/0010-recommendation-engine-boundary.md
@@ -1,0 +1,31 @@
+# ADR 0010: Recommendation Engine Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+Materialized recommendation facts must use the same scoring semantics as CLI,
+dashboard, and MCP reports. The store domain cannot depend on the reports
+domain because reports already depends on store queries. Copying the scorer
+into persistence would create two authorities that could drift.
+
+## Decision
+
+The pure scorer remains in `reports`. The higher-level
+`codex_usage_tracker.recommendation_engine` domain combines that scorer with
+pricing configuration and store persistence.
+
+The store refresh pipeline accepts a typed derived-fact callback and never
+imports recommendation policy. CLI and server refresh entry points supply the
+recommendation materializer, which runs inside the existing refresh
+transaction after normalized rows and links are finalized.
+
+## Consequences
+
+- Refresh and report paths share one scoring implementation.
+- Store persistence remains independent of pricing and report policy.
+- Recommendation engine changes require parity tests for reports and facts.
+- Raw store refresh remains available for store-level tests and migrations;
+  product refresh paths use the recommendation-aware entry point.

--- a/docs/dashboard-query-pipeline-refactor-roadmap.md
+++ b/docs/dashboard-query-pipeline-refactor-roadmap.md
@@ -58,8 +58,10 @@ reusable results.
 | Slice | Status | Tracking | Completion evidence |
 | --- | --- | --- | --- |
 | Loading and cancellation repair | Merged | #243 / #245 / `39fdcea` | Independent module cache/progress and real-data navigation QA |
-| PR 0: Measurement and route inventory | Ready for PR | #244 / #246 | Route inventory, benchmark artifact, and agent-perf run `20260713T231301Z-4a032512` |
-| PR 1: Recommendation facts | Pending | #244 | Branch, PR, migration/backfill tests |
+| PR 0: Measurement and route inventory | Merged | #244 / #246 / `1c4685b` | Route inventory, benchmark artifact, and agent-perf run `20260713T231301Z-4a032512` |
+| PR 1A: Derived-fact refresh hook | Merged | #244 / #247 / `a5681ba` | Transactional full/append callback coverage and 807-test CI matrix |
+| PR 1B: Recommendation fact materialization | Merged | #244 / #248 / `f1dfc22` | Schema v20, parity/incremental/backfill tests, and agent-perf run `20260713T234304Z-bade89ff` |
+| PR 1C: Product refresh wiring | Ready for PR | #244 | CLI/server wiring, architecture decision, and 38 focused refresh-path tests |
 | PR 2: Indexed recommendations API | Pending | #244 | Branch, PR, parity and latency results |
 | PR 3: Frontend module query registry | Pending | #244 | Branch, PR, lifecycle/browser tests |
 | PR 4: Heavy-route job migration | Pending | #244 | Branch, PR, async progress/cache tests |
@@ -240,9 +242,10 @@ inputs and outputs needed to reproduce current recommendation rows:
 - recommended action key;
 - fact and configuration versions.
 
-The exact table name and column set should be finalized in the schema PR after
-query-plan prototypes. The table must support indexed ordering by scope,
-recommendation score, recency, and record ID.
+PR 1 resolves this as dedicated `recommendation_facts` and
+`recommendation_fact_state` tables. Their indexes support ordering by scope,
+recommendation score, recency, and record ID without introducing a generalized
+derived-facts framework.
 
 ### Compatibility adapter
 

--- a/src/codex_usage_tracker/cli/commands_lifecycle.py
+++ b/src/codex_usage_tracker/cli/commands_lifecycle.py
@@ -19,12 +19,12 @@ from codex_usage_tracker.core.formatting import (
 )
 from codex_usage_tracker.diagnostics.api import run_doctor
 from codex_usage_tracker.pricing.api import update_pricing_from_openai_docs, write_pricing_template
-from codex_usage_tracker.reports.agentic_dogfood import build_agentic_dogfood_report
-from codex_usage_tracker.store.api import (
+from codex_usage_tracker.recommendation_engine.api import (
     rebuild_usage_index,
     refresh_usage_index,
-    reset_usage_database,
 )
+from codex_usage_tracker.reports.agentic_dogfood import build_agentic_dogfood_report
+from codex_usage_tracker.store.api import reset_usage_database
 
 
 def _run_setup(args: argparse.Namespace) -> int:

--- a/src/codex_usage_tracker/cli/dashboard.py
+++ b/src/codex_usage_tracker/cli/dashboard.py
@@ -11,9 +11,9 @@ from codex_usage_tracker.cli.output import print_json
 from codex_usage_tracker.core.api_payloads import path_payload, refresh_result_payload
 from codex_usage_tracker.core.i18n import normalize_language
 from codex_usage_tracker.dashboard.api import generate_dashboard
+from codex_usage_tracker.recommendation_engine.api import refresh_usage_index
 from codex_usage_tracker.server.api import serve_dashboard
 from codex_usage_tracker.server.utils import url_host
-from codex_usage_tracker.store.api import refresh_usage_index
 
 
 def run_dashboard(args: argparse.Namespace) -> int:

--- a/src/codex_usage_tracker/cli/mcp_server.py
+++ b/src/codex_usage_tracker/cli/mcp_server.py
@@ -152,6 +152,7 @@ from codex_usage_tracker.core.paths import (
 )
 from codex_usage_tracker.core.projects import apply_project_privacy_to_rows
 from codex_usage_tracker.diagnostics.api import run_doctor
+from codex_usage_tracker.recommendation_engine import api as recommendation_api
 from codex_usage_tracker.reports.agentic_dogfood import (
     DEFAULT_AGENTIC_DOGFOOD_DIR,
 )
@@ -173,7 +174,7 @@ def refresh_usage_index(
 ) -> dict[str, Any]:
     """Scan local Codex logs into SQLite usage and content indexes."""
 
-    result = store_api.refresh_usage_index(
+    result = recommendation_api.refresh_usage_index(
         codex_home=DEFAULT_CODEX_HOME,
         db_path=DEFAULT_DB_PATH,
         include_archived=include_archived,

--- a/src/codex_usage_tracker/cli/tach.domain.toml
+++ b/src/codex_usage_tracker/cli/tach.domain.toml
@@ -9,6 +9,7 @@ depends_on = [
     "//codex_usage_tracker.parser",
     "//codex_usage_tracker.pricing",
     "//codex_usage_tracker.reports",
+    "//codex_usage_tracker.recommendation_engine",
     "//codex_usage_tracker.server",
     "//codex_usage_tracker.store",
 ]

--- a/src/codex_usage_tracker/server/tach.domain.toml
+++ b/src/codex_usage_tracker/server/tach.domain.toml
@@ -7,5 +7,6 @@ depends_on = [
     "//codex_usage_tracker.diagnostics",
     "//codex_usage_tracker.pricing",
     "//codex_usage_tracker.reports",
+    "//codex_usage_tracker.recommendation_engine",
     "//codex_usage_tracker.store",
 ]

--- a/src/codex_usage_tracker/server/usage_refresh.py
+++ b/src/codex_usage_tracker/server/usage_refresh.py
@@ -14,6 +14,7 @@ from urllib.parse import parse_qs
 
 from codex_usage_tracker.core.i18n import normalize_language
 from codex_usage_tracker.dashboard.api import dashboard_payload
+from codex_usage_tracker.recommendation_engine.api import refresh_usage_index
 from codex_usage_tracker.server.utils import (
     elapsed_ms,
     first_query_value,
@@ -23,7 +24,6 @@ from codex_usage_tracker.server.utils import (
     truthy_query_value,
     utc_now,
 )
-from codex_usage_tracker.store.api import refresh_usage_index
 
 
 class UsageRefreshAuthError(PermissionError):


### PR DESCRIPTION
## Summary
- route CLI, dashboard, MCP refresh, and server refresh through the recommendation-aware orchestration boundary
- preserve raw store refresh for low-level tests and migrations
- document the dependency-inversion decision and update the roadmap ledger

## Validation
- 812 tests passed
- 38 focused CLI, MCP, server, and refresh-path tests passed
- Ruff, format, Tach, release readiness, and diff checks passed
- Agent Maintainer full verifier running

Closes part of #244.