### PR TITLE
refactor: route recommendations through indexed facts

### DIFF
--- a/docs/dashboard-query-pipeline-refactor-roadmap.md
+++ b/docs/dashboard-query-pipeline-refactor-roadmap.md
@@ -61,8 +61,9 @@ reusable results.
 | PR 0: Measurement and route inventory | Merged | #244 / #246 / `1c4685b` | Route inventory, benchmark artifact, and agent-perf run `20260713T231301Z-4a032512` |
 | PR 1A: Derived-fact refresh hook | Merged | #244 / #247 / `a5681ba` | Transactional full/append callback coverage and 807-test CI matrix |
 | PR 1B: Recommendation fact materialization | Merged | #244 / #248 / `f1dfc22` | Schema v20, parity/incremental/backfill tests, and agent-perf run `20260713T234304Z-bade89ff` |
-| PR 1C: Product refresh wiring | Ready for PR | #244 | CLI/server wiring, architecture decision, and 38 focused refresh-path tests |
-| PR 2: Indexed recommendations API | Pending | #244 | Branch, PR, parity and latency results |
+| PR 1C: Product refresh wiring | Merged | #244 / #249 / `3e569c6` | CLI/server wiring, architecture decision, and 38 focused refresh-path tests |
+| PR 2A: Indexed recommendations compatibility | In progress | #244 | Exact payload parity, freshness fallback, and public route/CLI/MCP wiring |
+| PR 2B: Bounded recommendation hydration | Pending | #244 | Agent-perf attribution plus 10k/100k/400k warm and cold latency results |
 | PR 3: Frontend module query registry | Pending | #244 | Branch, PR, lifecycle/browser tests |
 | PR 4: Heavy-route job migration | Pending | #244 | Branch, PR, async progress/cache tests |
 | PR 5: Query and cache hardening | Pending | #244 | Branch, PR, query plans and warm/cold budgets |

--- a/scripts/benchmark_dashboard_routes.py
+++ b/scripts/benchmark_dashboard_routes.py
@@ -21,12 +21,16 @@ from benchmark_synthetic_history import (  # noqa: E402
     _write_benchmark_config,
 )
 
+from codex_usage_tracker.recommendation_engine.materialization import (  # noqa: E402
+    backfill_recommendation_facts,
+)
 from codex_usage_tracker.server.recommendations import recommendations_payload  # noqa: E402
 from codex_usage_tracker.server.summary import summary_payload  # noqa: E402
 from codex_usage_tracker.store.api import (  # noqa: E402
     refresh_usage_event_links,
     upsert_usage_events,
 )
+from codex_usage_tracker.store.connection import connect  # noqa: E402
 
 DEFAULT_SIZES = (10_000, 100_000, 400_000)
 
@@ -88,6 +92,15 @@ def benchmark_fixture(
     refresh_usage_event_links(db_path=db_path)
     populate_seconds = round(time.perf_counter() - populate_started, 6)
 
+    materialize_started = time.perf_counter()
+    with connect(db_path) as conn:
+        materialized_rows = backfill_recommendation_facts(
+            conn,
+            pricing_path=config["pricing_path"],
+            allowance_path=config["allowance_path"],
+        )
+    materialize_seconds = round(time.perf_counter() - materialize_started, 6)
+
     route_actions: tuple[tuple[str, Callable[[], dict[str, object]]], ...] = (
         (
             "/api/summary",
@@ -114,6 +127,10 @@ def benchmark_fixture(
     return {
         "rows": rows,
         "populate_seconds": populate_seconds,
+        "recommendation_materialization": {
+            "rows": materialized_rows,
+            "seconds": materialize_seconds,
+        },
         "routes": [
             _benchmark_route(path, action, iterations=iterations) for path, action in route_actions
         ],

--- a/src/codex_usage_tracker/cli/commands_reports.py
+++ b/src/codex_usage_tracker/cli/commands_reports.py
@@ -14,12 +14,12 @@ from codex_usage_tracker.core.formatting import (
     format_session,
 )
 from codex_usage_tracker.core.projects import apply_project_privacy_to_rows
+from codex_usage_tracker.recommendation_engine.query import build_recommendations_report
 from codex_usage_tracker.reports.api import (
     build_action_brief_report,
     build_expensive_calls_report,
     build_pricing_coverage_report,
     build_query_report,
-    build_recommendations_report,
     build_source_coverage_report,
     build_summary_report,
 )

--- a/src/codex_usage_tracker/cli/mcp_discovery.py
+++ b/src/codex_usage_tracker/cli/mcp_discovery.py
@@ -11,13 +11,13 @@ from codex_usage_tracker.core.paths import (
     DEFAULT_PRICING_PATH,
     DEFAULT_PROJECTS_PATH,
 )
+from codex_usage_tracker.recommendation_engine.query import build_recommendations_report
 from codex_usage_tracker.reports.api import (
     build_content_search_report,
     build_large_low_output_report,
     build_pattern_scan_report,
     build_pricing_coverage_report,
     build_query_report,
-    build_recommendations_report,
     build_repeated_file_rediscovery_report,
     build_shell_churn_report,
     build_source_coverage_report,

--- a/src/codex_usage_tracker/recommendation_engine/query.py
+++ b/src/codex_usage_tracker/recommendation_engine/query.py
@@ -1,0 +1,250 @@
+"""Recommendation reports backed by materialized recommendation facts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.core.paths import DEFAULT_PROJECTS_PATH
+from codex_usage_tracker.core.projects import (
+    annotate_rows_with_project_identity,
+    apply_project_privacy_to_rows,
+    load_project_config,
+    validate_privacy_mode,
+)
+from codex_usage_tracker.core.threads import annotate_thread_attachments
+from codex_usage_tracker.pricing.allowance import (
+    annotate_rows_with_allowance,
+    load_allowance_config,
+)
+from codex_usage_tracker.pricing.api import annotate_rows_with_efficiency, load_pricing_config
+from codex_usage_tracker.recommendation_engine.fact_config import (
+    RECOMMENDATION_ALGORITHM_VERSION,
+    RECOMMENDATION_FACTS_VERSION,
+    load_recommendation_fact_config,
+    recommendation_generation_fingerprint,
+)
+from codex_usage_tracker.reports.filters import query_row_matches
+from codex_usage_tracker.reports.query import (
+    RecommendationsReport,
+)
+from codex_usage_tracker.reports.query import (
+    build_recommendations_report as build_legacy_recommendations_report,
+)
+from codex_usage_tracker.reports.recommendation_builder import (
+    recommendation_sort_key,
+    thread_recommendation_rows,
+)
+from codex_usage_tracker.store.compression_schema import read_compression_source_generation
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.recommendation_queries import query_recommendation_fact_page
+
+
+def build_recommendations_report(
+    *,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+    projects_path: Path = DEFAULT_PROJECTS_PATH,
+    since: str | None = None,
+    until: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    thread: str | None = None,
+    project: str | None = None,
+    include_archived: bool = False,
+    min_score: float | None = None,
+    limit: int = 20,
+    source_limit: int | None = None,
+    privacy_mode: str = "normal",
+) -> RecommendationsReport:
+    """Use current indexed facts, falling back to the legacy report safely."""
+
+    if source_limit is None and _recommendation_facts_are_current(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+    ):
+        return build_indexed_recommendations_report(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            projects_path=projects_path,
+            since=since,
+            until=until,
+            model=model,
+            effort=effort,
+            thread=thread,
+            project=project,
+            include_archived=include_archived,
+            min_score=min_score,
+            limit=limit,
+            source_limit=source_limit,
+            privacy_mode=privacy_mode,
+        )
+    return build_legacy_recommendations_report(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        projects_path=projects_path,
+        since=since,
+        until=until,
+        model=model,
+        effort=effort,
+        thread=thread,
+        project=project,
+        include_archived=include_archived,
+        min_score=min_score,
+        limit=limit,
+        source_limit=source_limit,
+        privacy_mode=privacy_mode,
+    )
+
+
+def build_indexed_recommendations_report(
+    *,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+    projects_path: Path = DEFAULT_PROJECTS_PATH,
+    since: str | None = None,
+    until: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    thread: str | None = None,
+    project: str | None = None,
+    include_archived: bool = False,
+    min_score: float | None = None,
+    limit: int = 20,
+    source_limit: int | None = None,
+    privacy_mode: str = "normal",
+) -> RecommendationsReport:
+    """Build the legacy report contract from indexed actionable facts."""
+
+    privacy_mode = validate_privacy_mode(privacy_mode)
+    page = query_recommendation_fact_page(
+        db_path=db_path,
+        since=since,
+        until=until,
+        model=model,
+        effort=effort,
+        thread=thread,
+        include_archived=include_archived,
+        min_score=min_score,
+        limit=0,
+    )
+    rows = annotate_thread_attachments(page.rows)
+    rows = annotate_rows_with_allowance(
+        annotate_rows_with_efficiency(rows, load_pricing_config(pricing_path)),
+        load_allowance_config(allowance_path),
+    )
+    rows = [_restore_materialized_recommendations(row) for row in rows]
+    rows = annotate_rows_with_project_identity(rows, load_project_config(projects_path))
+    scored_rows = [row for row in rows if _matches_project(row, project)]
+    scored_rows.sort(key=recommendation_sort_key)
+    normalized_limit = None if limit <= 0 else limit
+    limited_rows = scored_rows if normalized_limit is None else scored_rows[:normalized_limit]
+    private_rows = apply_project_privacy_to_rows(limited_rows, privacy_mode=privacy_mode)
+    return RecommendationsReport(
+        {
+            "schema": "codex-usage-tracker-recommendations-v1",
+            "filters": {
+                "since": since,
+                "until": until,
+                "model": model,
+                "effort": effort,
+                "thread": thread,
+                "project": project,
+                "include_archived": include_archived,
+                "min_score": min_score,
+                "limit": normalized_limit,
+                "source_limit": source_limit,
+                "privacy_mode": privacy_mode,
+            },
+            "row_count": len(private_rows),
+            "total_matched_rows": len(scored_rows),
+            "truncated": normalized_limit is not None and len(scored_rows) > normalized_limit,
+            "threads": thread_recommendation_rows(
+                scored_rows,
+                limit=normalized_limit or 20,
+            ),
+            "rows": private_rows,
+        }
+    )
+
+
+def _restore_materialized_recommendations(row: dict[str, Any]) -> dict[str, Any]:
+    copy = dict(row)
+    recommendations = json.loads(str(copy.pop("fact_recommendations_json")))
+    copy.pop("fact_primary_recommendation_key", None)
+    copy.pop("fact_secondary_recommendation_keys_json", None)
+    copy["recommendation_score"] = float(copy.pop("fact_recommendation_score"))
+    copy["action_recommendations"] = recommendations
+    copy["primary_recommendation"] = recommendations[0] if recommendations else None
+    copy["secondary_recommendations"] = recommendations[1:]
+    copy["primary_signal"] = recommendations[0]["key"] if recommendations else None
+    copy["secondary_signals"] = [item["key"] for item in recommendations[1:]]
+    copy["recommended_action"] = (
+        recommendations[0]["action"]
+        if recommendations
+        else "No aggregate action is flagged; continue monitoring usage patterns."
+    )
+    copy["recommended_action_key"] = copy.pop("fact_recommended_action_key")
+    copy["flag_explanations"] = [item["why"] for item in recommendations]
+    copy["flag_explanation_keys"] = [item["why_key"] for item in recommendations]
+    return copy
+
+
+def _matches_project(row: dict[str, Any], project: str | None) -> bool:
+    return query_row_matches(
+        row,
+        until=None,
+        model=None,
+        effort=None,
+        thread=None,
+        project=project,
+        pricing_status=None,
+        credit_confidence=None,
+        min_tokens=None,
+        min_credits=None,
+    )
+
+
+def _recommendation_facts_are_current(
+    *,
+    db_path: Path,
+    pricing_path: Path,
+    allowance_path: Path,
+) -> bool:
+    config = load_recommendation_fact_config(
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+    )
+    try:
+        with connect(db_path) as conn:
+            state = conn.execute(
+                "SELECT * FROM recommendation_fact_state WHERE singleton = 1"
+            ).fetchone()
+            if state is None:
+                return False
+            source_generation = read_compression_source_generation(conn)
+            expected_generation = recommendation_generation_fingerprint(
+                source_generation=source_generation,
+                config_fingerprint=config.fingerprint,
+            )
+            fact_count = int(
+                conn.execute("SELECT COUNT(*) FROM recommendation_facts").fetchone()[0]
+            )
+            usage_count = int(conn.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0])
+    except sqlite3.Error:
+        return False
+    return (
+        int(state["facts_version"]) == RECOMMENDATION_FACTS_VERSION
+        and int(state["algorithm_version"]) == RECOMMENDATION_ALGORITHM_VERSION
+        and int(state["source_generation"]) == source_generation
+        and str(state["generation_fingerprint"]) == expected_generation
+        and str(state["config_fingerprint"]) == config.fingerprint
+        and int(state["record_count"]) == fact_count == usage_count
+    )

--- a/src/codex_usage_tracker/server/recommendations.py
+++ b/src/codex_usage_tracker/server/recommendations.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 from pathlib import Path
 from urllib.parse import parse_qs
 
-from codex_usage_tracker.reports.api import build_recommendations_report
+from codex_usage_tracker.recommendation_engine.query import build_recommendations_report
 from codex_usage_tracker.server.utils import (
     first_query_value,
     parse_optional_float,

--- a/src/codex_usage_tracker/store/recommendation_queries.py
+++ b/src/codex_usage_tracker/store/recommendation_queries.py
@@ -1,0 +1,105 @@
+"""Indexed read services for materialized recommendation facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.query_sql import normalize_limit, usage_where_clause
+from codex_usage_tracker.store.rows import usage_row_to_dict
+from codex_usage_tracker.store.usage_timing import (
+    USAGE_TIMING_JOIN_SQL,
+    USAGE_TIMING_SELECT_SQL,
+    usage_parent_select_sql,
+)
+
+
+@dataclass(frozen=True)
+class RecommendationFactPage:
+    """Ordered recommendation rows plus the count before response limiting."""
+
+    rows: list[dict[str, Any]]
+    total_count: int
+
+
+def query_recommendation_fact_page(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_score: float | None = None,
+    limit: int | None = 20,
+) -> RecommendationFactPage:
+    """Return actionable facts in the legacy recommendation order."""
+
+    where_clause, params = usage_where_clause(
+        since=since,
+        until=until,
+        model=model,
+        effort=effort,
+        thread=thread,
+        table_alias="usage_events",
+        include_archived=include_archived,
+    )
+    where_clause = _extend_fact_filters(where_clause, params, min_score=min_score)
+    normalized_limit = normalize_limit(limit)
+    limit_clause = "" if normalized_limit is None else " LIMIT ?"
+    row_params = [*params] if normalized_limit is None else [*params, normalized_limit]
+    from_clause = "recommendation_facts rf JOIN usage_events USING (record_id)"
+
+    with connect(db_path) as conn:
+        total_count = int(
+            conn.execute(
+                f"SELECT COUNT(*) FROM {from_clause} {where_clause}",
+                params,
+            ).fetchone()[0]
+        )
+        rows = conn.execute(
+            f"""
+            SELECT
+                usage_events.*,
+                {USAGE_TIMING_SELECT_SQL},
+                {usage_parent_select_sql(include_archived=include_archived)},
+                rf.recommendation_score AS fact_recommendation_score,
+                rf.primary_recommendation_key AS fact_primary_recommendation_key,
+                rf.secondary_recommendation_keys_json
+                    AS fact_secondary_recommendation_keys_json,
+                rf.recommended_action_key AS fact_recommended_action_key,
+                rf.recommendations_json AS fact_recommendations_json
+            FROM {from_clause}
+            {USAGE_TIMING_JOIN_SQL}
+            {where_clause}
+            ORDER BY
+                rf.recommendation_score DESC,
+                rf.total_tokens DESC,
+                rf.event_timestamp ASC,
+                rf.record_id ASC
+            {limit_clause}
+            """,
+            row_params,
+        ).fetchall()
+    return RecommendationFactPage(
+        rows=[usage_row_to_dict(row) for row in rows],
+        total_count=total_count,
+    )
+
+
+def _extend_fact_filters(
+    where_clause: str,
+    params: list[Any],
+    *,
+    min_score: float | None,
+) -> str:
+    clauses = ["json_array_length(rf.recommendations_json) > 0"]
+    if min_score is not None:
+        clauses.append("rf.recommendation_score >= ?")
+        params.append(min_score)
+    separator = " AND " if where_clause else " WHERE "
+    return f"{where_clause}{separator}{' AND '.join(clauses)}"

--- a/src/codex_usage_tracker/store/recommendation_queries.py
+++ b/src/codex_usage_tracker/store/recommendation_queries.py
@@ -53,38 +53,32 @@ def query_recommendation_fact_page(
     limit_clause = "" if normalized_limit is None else " LIMIT ?"
     row_params = [*params] if normalized_limit is None else [*params, normalized_limit]
     from_clause = "recommendation_facts rf JOIN usage_events USING (record_id)"
+    count_query = f"SELECT COUNT(*) FROM {from_clause} {where_clause}"  # nosec B608 - internal SQL templates; values remain bound
+    row_query = f"""
+        SELECT
+            usage_events.*,
+            {USAGE_TIMING_SELECT_SQL},
+            {usage_parent_select_sql(include_archived=include_archived)},
+            rf.recommendation_score AS fact_recommendation_score,
+            rf.primary_recommendation_key AS fact_primary_recommendation_key,
+            rf.secondary_recommendation_keys_json
+                AS fact_secondary_recommendation_keys_json,
+            rf.recommended_action_key AS fact_recommended_action_key,
+            rf.recommendations_json AS fact_recommendations_json
+        FROM {from_clause}
+        {USAGE_TIMING_JOIN_SQL}
+        {where_clause}
+        ORDER BY
+            rf.recommendation_score DESC,
+            rf.total_tokens DESC,
+            rf.event_timestamp ASC,
+            rf.record_id ASC
+        {limit_clause}
+    """  # nosec B608 - clauses are internal templates and values remain bound
 
     with connect(db_path) as conn:
-        total_count = int(
-            conn.execute(
-                f"SELECT COUNT(*) FROM {from_clause} {where_clause}",
-                params,
-            ).fetchone()[0]
-        )
-        rows = conn.execute(
-            f"""
-            SELECT
-                usage_events.*,
-                {USAGE_TIMING_SELECT_SQL},
-                {usage_parent_select_sql(include_archived=include_archived)},
-                rf.recommendation_score AS fact_recommendation_score,
-                rf.primary_recommendation_key AS fact_primary_recommendation_key,
-                rf.secondary_recommendation_keys_json
-                    AS fact_secondary_recommendation_keys_json,
-                rf.recommended_action_key AS fact_recommended_action_key,
-                rf.recommendations_json AS fact_recommendations_json
-            FROM {from_clause}
-            {USAGE_TIMING_JOIN_SQL}
-            {where_clause}
-            ORDER BY
-                rf.recommendation_score DESC,
-                rf.total_tokens DESC,
-                rf.event_timestamp ASC,
-                rf.record_id ASC
-            {limit_clause}
-            """,
-            row_params,
-        ).fetchall()
+        total_count = int(conn.execute(count_query, params).fetchone()[0])
+        rows = conn.execute(row_query, row_params).fetchall()
     return RecommendationFactPage(
         rows=[usage_row_to_dict(row) for row in rows],
         total_count=total_count,

--- a/tests/reports/test_indexed_recommendations.py
+++ b/tests/reports/test_indexed_recommendations.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.recommendation_engine import query as recommendation_query
+from codex_usage_tracker.recommendation_engine.materialization import (
+    backfill_recommendation_facts,
+)
+from codex_usage_tracker.recommendation_engine.query import (
+    build_indexed_recommendations_report,
+)
+from codex_usage_tracker.recommendation_engine.query import (
+    build_recommendations_report as build_engine_recommendations_report,
+)
+from codex_usage_tracker.reports.query import build_recommendations_report
+from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.connection import connect
+from tests.store_dashboard_helpers import _usage_event, _write_pricing
+
+
+def _materialize_actionable_event(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    allowance_path = tmp_path / "allowance.json"
+    projects_path = tmp_path / "projects.json"
+    event = replace(
+        _usage_event(
+            record_id="indexed",
+            session_id="session-indexed",
+            thread_key="thread:indexed",
+            event_timestamp="2026-07-13T12:00:00Z",
+            cumulative_total_tokens=900_000,
+        ),
+        input_tokens=250_000,
+        cached_input_tokens=1_000,
+        total_tokens=250_050,
+    )
+    upsert_usage_events([event], db_path=db_path)
+    with connect(db_path) as conn:
+        backfill_recommendation_facts(
+            conn,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+        )
+    return db_path, pricing_path, allowance_path, projects_path
+
+
+def test_indexed_recommendations_match_legacy_payload(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    allowance_path = tmp_path / "allowance.json"
+    projects_path = tmp_path / "projects.json"
+    events = [
+        replace(
+            _usage_event(
+                record_id="high-context",
+                session_id="session-a",
+                thread_key="thread:alpha",
+                event_timestamp="2026-07-13T12:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            model_context_window=1_000,
+            input_tokens=950,
+            cached_input_tokens=100,
+            total_tokens=975,
+        ),
+        replace(
+            _usage_event(
+                record_id="large-call",
+                session_id="session-b",
+                thread_key="thread:beta",
+                event_timestamp="2026-07-13T13:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            input_tokens=250_000,
+            cached_input_tokens=1_000,
+            output_tokens=50,
+            reasoning_output_tokens=40_000,
+            total_tokens=250_050,
+        ),
+    ]
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        backfill_recommendation_facts(
+            conn,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+        )
+
+    arguments = {
+        "db_path": db_path,
+        "pricing_path": pricing_path,
+        "allowance_path": allowance_path,
+        "projects_path": projects_path,
+        "limit": 1,
+    }
+    legacy = build_recommendations_report(**arguments)
+    indexed = build_indexed_recommendations_report(**arguments)
+
+    assert indexed.payload == legacy.payload
+
+
+def test_recommendations_fall_back_when_materialized_facts_are_missing(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    pricing_path = _write_pricing(tmp_path / "pricing.json")
+    allowance_path = tmp_path / "allowance.json"
+    projects_path = tmp_path / "projects.json"
+    event = replace(
+        _usage_event(
+            record_id="legacy-only",
+            session_id="session-legacy",
+            thread_key="thread:legacy",
+            event_timestamp="2026-07-13T12:00:00Z",
+            cumulative_total_tokens=900_000,
+        ),
+        input_tokens=250_000,
+        cached_input_tokens=1_000,
+        total_tokens=250_050,
+    )
+    upsert_usage_events([event], db_path=db_path)
+    arguments = {
+        "db_path": db_path,
+        "pricing_path": pricing_path,
+        "allowance_path": allowance_path,
+        "projects_path": projects_path,
+    }
+
+    expected = build_recommendations_report(**arguments)
+    actual = build_engine_recommendations_report(**arguments)
+
+    assert expected.payload["row_count"] > 0
+    assert actual.payload == expected.payload
+
+
+def test_recommendations_use_current_materialized_facts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path, pricing_path, allowance_path, projects_path = _materialize_actionable_event(tmp_path)
+
+    def fail_legacy(**_kwargs: object) -> object:
+        raise AssertionError("current materialized facts should avoid the legacy path")
+
+    monkeypatch.setattr(
+        recommendation_query,
+        "build_legacy_recommendations_report",
+        fail_legacy,
+    )
+
+    report = build_engine_recommendations_report(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        projects_path=projects_path,
+    )
+
+    assert report.payload["row_count"] == 1
+
+
+def test_recommendations_fall_back_when_config_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path, pricing_path, allowance_path, projects_path = _materialize_actionable_event(tmp_path)
+    pricing = json.loads(pricing_path.read_text(encoding="utf-8"))
+    pricing["models"]["gpt-5.5"]["input_per_million"] = 3.0
+    pricing_path.write_text(json.dumps(pricing), encoding="utf-8")
+
+    def fail_indexed(**_kwargs: object) -> object:
+        raise AssertionError("stale materialized facts must not be queried")
+
+    monkeypatch.setattr(
+        recommendation_query,
+        "build_indexed_recommendations_report",
+        fail_indexed,
+    )
+
+    report = build_engine_recommendations_report(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        projects_path=projects_path,
+    )
+
+    assert report.payload["row_count"] == 1
+
+
+def test_recommendations_preserve_source_limit_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path, pricing_path, allowance_path, projects_path = _materialize_actionable_event(tmp_path)
+
+    def fail_indexed(**_kwargs: object) -> object:
+        raise AssertionError("source-limited reports require legacy row selection")
+
+    monkeypatch.setattr(
+        recommendation_query,
+        "build_indexed_recommendations_report",
+        fail_indexed,
+    )
+
+    report = build_engine_recommendations_report(
+        db_path=db_path,
+        pricing_path=pricing_path,
+        allowance_path=allowance_path,
+        projects_path=projects_path,
+        source_limit=1,
+    )
+
+    assert report.payload["filters"]["source_limit"] == 1

--- a/tests/server/test_server_recommendations.py
+++ b/tests/server/test_server_recommendations.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from codex_usage_tracker.recommendation_engine import query as recommendation_query
 from codex_usage_tracker.server import recommendations as server_recommendations
 
 
@@ -30,6 +31,13 @@ class _RouteSenders:
 
     def send_json(self, status: HTTPStatus, payload: dict[str, object]) -> None:
         self.json_payloads.append((status, payload))
+
+
+def test_server_uses_recommendation_query_orchestrator() -> None:
+    assert (
+        server_recommendations.build_recommendations_report
+        is recommendation_query.build_recommendations_report
+    )
 
 
 def test_handle_recommendations_request_sends_payload(

--- a/tests/store/test_recommendation_queries.py
+++ b/tests/store/test_recommendation_queries.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from codex_usage_tracker.recommendation_engine.materialization import (
+    sync_recommendation_facts,
+)
+from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.recommendation_queries import (
+    query_recommendation_fact_page,
+)
+from tests.store_dashboard_helpers import _usage_event
+
+
+def test_recommendation_fact_page_orders_and_counts_before_limiting(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    events = [
+        replace(
+            _usage_event(
+                record_id="lower-score",
+                session_id="session-lower",
+                thread_key="thread:lower",
+                event_timestamp="2026-07-13T12:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            total_tokens=900,
+        ),
+        replace(
+            _usage_event(
+                record_id="higher-score",
+                session_id="session-higher",
+                thread_key="thread:higher",
+                event_timestamp="2026-07-13T13:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            total_tokens=100,
+        ),
+    ]
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id for event in events])
+        conn.execute(
+            "UPDATE recommendation_facts SET recommendation_score = 10 WHERE record_id = ?",
+            ("lower-score",),
+        )
+        conn.execute(
+            "UPDATE recommendation_facts SET recommendation_score = 20 WHERE record_id = ?",
+            ("higher-score",),
+        )
+
+    page = query_recommendation_fact_page(db_path=db_path, limit=1)
+
+    assert page.total_count == 2
+    assert [row["record_id"] for row in page.rows] == ["higher-score"]
+    assert page.rows[0]["fact_recommendation_score"] == 20


### PR DESCRIPTION
## Summary
- add an indexed recommendation query service over materialized recommendation facts
- preserve the existing v1 recommendation payload, filters, ordering, privacy, and source-limit behavior
- fall back safely when facts are missing, stale, or built from different pricing/allowance configuration
- route server, CLI, and MCP discovery through the compatibility orchestrator
- prepare deterministic dashboard route benchmarks with explicit fact materialization timing

## Validation
- `819 passed in 44.07s`
- `ruff check` and format checks
- `tach check`
- targeted Mypy for recommendation engine and store
- `python scripts/check_release.py`
- `git diff --check`

## Performance scope
This is PR2A of the roadmap. It lands compatibility and freshness boundaries under the 800-line ratchet. PR2B follows with bounded hydration/thread-level aggregation; agent-perf run `20260714T011721Z-58ac3b4a` confirmed the remaining full-history cost is the per-request thread aggregate.