### PR TITLE
perf: materialize recommendation thread summaries

### DIFF
--- a/docs/dashboard-query-pipeline-refactor-roadmap.md
+++ b/docs/dashboard-query-pipeline-refactor-roadmap.md
@@ -62,8 +62,8 @@ reusable results.
 | PR 1A: Derived-fact refresh hook | Merged | #244 / #247 / `a5681ba` | Transactional full/append callback coverage and 807-test CI matrix |
 | PR 1B: Recommendation fact materialization | Merged | #244 / #248 / `f1dfc22` | Schema v20, parity/incremental/backfill tests, and agent-perf run `20260713T234304Z-bade89ff` |
 | PR 1C: Product refresh wiring | Merged | #244 / #249 / `3e569c6` | CLI/server wiring, architecture decision, and 38 focused refresh-path tests |
-| PR 2A: Indexed recommendations compatibility | In progress | #244 | Exact payload parity, freshness fallback, and public route/CLI/MCP wiring |
-| PR 2B: Bounded recommendation hydration | Pending | #244 | Agent-perf attribution plus 10k/100k/400k warm and cold latency results |
+| PR 2A: Indexed recommendations compatibility | Merged | #244 / #250 / `378a2d1` | Exact payload parity, freshness fallback, and public route/CLI/MCP wiring |
+| PR 2B: Bounded recommendation hydration | In progress | #244 | 400k legacy 29.96 s; indexed median 135 ms / p95 151 ms; baseline agent-perf `20260714T011721Z-58ac3b4a` |
 | PR 3: Frontend module query registry | Pending | #244 | Branch, PR, lifecycle/browser tests |
 | PR 4: Heavy-route job migration | Pending | #244 | Branch, PR, async progress/cache tests |
 | PR 5: Query and cache hardening | Pending | #244 | Branch, PR, query plans and warm/cold budgets |
@@ -85,6 +85,11 @@ The initial real-data trace used a local all-history scope with 404,176 calls:
 
 These values are diagnostic baselines, not universal benchmarks. Automated
 performance gates will use synthetic databases with stable sizes and shapes.
+
+PR 2B's synthetic 400,000-row comparison reduced the same recommendation
+request from 29.96 seconds on the legacy fallback to a 134.6 ms median and
+151.1 ms p95 over 20 indexed runs. The request now reads materialized thread
+rollups, hydrates only the top 20 rows, and keeps ranking index-backed.
 
 ## Architectural Principles
 

--- a/src/codex_usage_tracker/recommendation_engine/fact_config.py
+++ b/src/codex_usage_tracker/recommendation_engine/fact_config.py
@@ -86,11 +86,7 @@ def recommendation_generation_fingerprint(
 
 def _canonical_config(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
-        return {
-            item.name: _canonical_config(getattr(value, item.name))
-            for item in fields(value)
-            if item.name not in _IGNORED_CONFIG_FIELDS
-        }
+        return _canonical_dataclass(value)
     if isinstance(value, dict):
         return {str(key): _canonical_config(item) for key, item in sorted(value.items())}
     if isinstance(value, (list, tuple)):
@@ -100,6 +96,14 @@ def _canonical_config(value: Any) -> Any:
     if isinstance(value, Path):
         return value.name
     return value
+
+
+def _canonical_dataclass(value: Any) -> dict[str, Any]:
+    return {
+        item.name: _canonical_config(getattr(value, item.name))
+        for item in fields(value)
+        if item.name not in _IGNORED_CONFIG_FIELDS
+    }
 
 
 def _canonical_json(value: Any) -> str:

--- a/src/codex_usage_tracker/recommendation_engine/materialization.py
+++ b/src/codex_usage_tracker/recommendation_engine/materialization.py
@@ -23,6 +23,9 @@ from codex_usage_tracker.recommendation_engine.fact_config import (
     load_recommendation_fact_config,
     recommendation_generation_fingerprint,
 )
+from codex_usage_tracker.recommendation_engine.summary_materialization import (
+    sync_thread_recommendation_summaries,
+)
 from codex_usage_tracker.store.compression_schema import read_compression_source_generation
 from codex_usage_tracker.store.recommendation_schema import (
     create_recommendation_fact_indexes,
@@ -57,6 +60,7 @@ def backfill_recommendation_facts(
     finally:
         create_recommendation_fact_indexes(conn)
     _stamp_state(conn, config=config, generation=generation)
+    sync_thread_recommendation_summaries(conn)
     return count
 
 
@@ -64,12 +68,27 @@ def sync_recommendation_facts(
     conn: sqlite3.Connection,
     *,
     record_ids: Iterable[str],
+    thread_keys: Iterable[str] | None = None,
 ) -> int:
     """Replace facts only for changed normalized usage records."""
     targets = tuple(dict.fromkeys(str(record_id) for record_id in record_ids if record_id))
     config = load_recommendation_fact_config()
     generation = _generation(conn, config)
     _populate_targets(conn, targets)
+    affected_thread_keys = {
+        str(row[0])
+        for row in conn.execute(
+            """
+            SELECT thread_key FROM recommendation_facts
+            WHERE record_id IN (SELECT record_id FROM recommendation_fact_targets)
+            UNION
+            SELECT thread_key FROM usage_events
+            WHERE record_id IN (SELECT record_id FROM recommendation_fact_targets)
+            """
+        ).fetchall()
+        if row[0]
+    }
+    affected_thread_keys.update(str(key) for key in thread_keys or () if key)
     conn.execute(
         """
         DELETE FROM recommendation_facts
@@ -86,18 +105,24 @@ def sync_recommendation_facts(
     )
     count = _insert_cursor_facts(conn, cursor, config=config, generation=generation)
     _stamp_state(conn, config=config, generation=generation)
+    sync_thread_recommendation_summaries(conn, thread_keys=affected_thread_keys)
     return count
 
 
 def sync_refresh_recommendation_facts(
     conn: sqlite3.Connection,
     record_ids: tuple[str, ...],
+    thread_keys: frozenset[str],
     full_rebuild: bool,
 ) -> None:
     if full_rebuild:
         backfill_recommendation_facts(conn)
     else:
-        sync_recommendation_facts(conn, record_ids=record_ids)
+        sync_recommendation_facts(
+            conn,
+            record_ids=record_ids,
+            thread_keys=thread_keys,
+        )
 
 
 def _generation(

--- a/src/codex_usage_tracker/recommendation_engine/query.py
+++ b/src/codex_usage_tracker/recommendation_engine/query.py
@@ -39,7 +39,10 @@ from codex_usage_tracker.reports.recommendation_builder import (
 )
 from codex_usage_tracker.store.compression_schema import read_compression_source_generation
 from codex_usage_tracker.store.connection import connect
-from codex_usage_tracker.store.recommendation_queries import query_recommendation_fact_page
+from codex_usage_tracker.store.recommendation_queries import (
+    query_recommendation_fact_page,
+    query_recommendation_thread_summaries,
+)
 
 
 def build_recommendations_report(
@@ -124,6 +127,22 @@ def build_indexed_recommendations_report(
     """Build the legacy report contract from indexed actionable facts."""
 
     privacy_mode = validate_privacy_mode(privacy_mode)
+    normalized_limit = _normalize_report_limit(limit)
+    thread_summaries = (
+        query_recommendation_thread_summaries(
+            db_path=db_path,
+            since=since,
+            until=until,
+            model=model,
+            effort=effort,
+            thread=thread,
+            include_archived=include_archived,
+            min_score=min_score,
+            limit=normalized_limit,
+        )
+        if project is None and normalized_limit is not None
+        else None
+    )
     page = query_recommendation_fact_page(
         db_path=db_path,
         since=since,
@@ -133,7 +152,7 @@ def build_indexed_recommendations_report(
         thread=thread,
         include_archived=include_archived,
         min_score=min_score,
-        limit=0,
+        limit=normalized_limit if thread_summaries is not None else 0,
     )
     rows = annotate_thread_attachments(page.rows)
     rows = annotate_rows_with_allowance(
@@ -144,8 +163,8 @@ def build_indexed_recommendations_report(
     rows = annotate_rows_with_project_identity(rows, load_project_config(projects_path))
     scored_rows = [row for row in rows if _matches_project(row, project)]
     scored_rows.sort(key=recommendation_sort_key)
-    normalized_limit = None if limit <= 0 else limit
-    limited_rows = scored_rows if normalized_limit is None else scored_rows[:normalized_limit]
+    limited_rows = scored_rows[:normalized_limit]
+    total_matched_rows = page.total_count if thread_summaries is not None else len(scored_rows)
     private_rows = apply_project_privacy_to_rows(limited_rows, privacy_mode=privacy_mode)
     return RecommendationsReport(
         {
@@ -164,15 +183,28 @@ def build_indexed_recommendations_report(
                 "privacy_mode": privacy_mode,
             },
             "row_count": len(private_rows),
-            "total_matched_rows": len(scored_rows),
-            "truncated": normalized_limit is not None and len(scored_rows) > normalized_limit,
-            "threads": thread_recommendation_rows(
-                scored_rows,
-                limit=normalized_limit or 20,
+            "total_matched_rows": total_matched_rows,
+            "truncated": normalized_limit is not None and total_matched_rows > normalized_limit,
+            "threads": _recommendation_thread_payload(
+                thread_summaries, scored_rows, normalized_limit
             ),
             "rows": private_rows,
         }
     )
+
+
+def _recommendation_thread_payload(
+    summaries: list[dict[str, Any]] | None,
+    rows: list[dict[str, Any]],
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    if summaries is not None:
+        return summaries
+    return thread_recommendation_rows(rows, limit=limit or 20)
+
+
+def _normalize_report_limit(limit: int) -> int | None:
+    return None if limit <= 0 else limit
 
 
 def _restore_materialized_recommendations(row: dict[str, Any]) -> dict[str, Any]:

--- a/src/codex_usage_tracker/recommendation_engine/summary_materialization.py
+++ b/src/codex_usage_tracker/recommendation_engine/summary_materialization.py
@@ -1,0 +1,263 @@
+"""Incremental materialization for exact recommendation thread summaries."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable
+from typing import Any
+
+_THREAD_KEY_BATCH_SIZE = 400
+_RESET_SQL = """
+    UPDATE thread_summaries
+    SET recommendation_score = 0,
+        recommendation_total_tokens = 0,
+        recommendation_summary_json = NULL,
+        max_recommendation_score = 0,
+        primary_recommendation = NULL
+"""
+
+
+def sync_thread_recommendation_summaries(
+    conn: sqlite3.Connection,
+    *,
+    thread_keys: Iterable[str] | None = None,
+) -> int:
+    """Refresh exact recommendation rollups for all or selected threads."""
+    normalized = tuple(sorted({str(key) for key in thread_keys or () if key}))
+    selected = normalized if thread_keys is not None and _summaries_are_complete(conn) else None
+    before = conn.total_changes
+    _reset_summaries(conn, selected)
+    for chunk in _thread_key_chunks(selected):
+        rows = _aggregate_summaries(conn, chunk)
+        signals = _aggregate_signals(conn, chunk)
+        _persist_summaries(conn, rows, signals)
+    _update_completeness(conn, selected)
+    return conn.total_changes - before
+
+
+def _reset_summaries(
+    conn: sqlite3.Connection,
+    thread_keys: tuple[str, ...] | None,
+) -> None:
+    if thread_keys is None:
+        conn.execute(_RESET_SQL)
+        return
+    if not thread_keys:
+        return
+    placeholders = ", ".join("?" for _ in thread_keys)
+    conn.execute(
+        f"{_RESET_SQL} WHERE thread_key IN ({placeholders})",  # nosec B608
+        thread_keys,
+    )
+
+
+def _thread_key_chunks(
+    thread_keys: tuple[str, ...] | None,
+) -> Iterable[tuple[str, ...] | None]:
+    if thread_keys is None:
+        yield None
+        return
+    for start in range(0, len(thread_keys), _THREAD_KEY_BATCH_SIZE):
+        yield thread_keys[start : start + _THREAD_KEY_BATCH_SIZE]
+
+
+def _aggregate_summaries(
+    conn: sqlite3.Connection,
+    thread_keys: tuple[str, ...] | None,
+) -> list[sqlite3.Row]:
+    filter_sql, params = _thread_filter("rf.thread_key", thread_keys)
+    return conn.execute(
+        f"""
+        WITH scopes(scope, include_archived) AS (
+            VALUES ('active', 0), ('all-history', 1)
+        ),
+        scoped AS (
+            SELECT s.scope, rf.thread_key, rf.record_id, rf.event_timestamp,
+                rf.total_tokens, rf.estimated_cost_usd, rf.usage_credits,
+                rf.recommendation_score, rf.recommendations_json,
+                rf.primary_recommendation_key, usage_events.session_id
+            FROM recommendation_facts AS rf
+            JOIN usage_events USING(record_id)
+            JOIN scopes AS s ON s.include_archived = 1 OR rf.is_archived = 0
+            WHERE json_array_length(rf.recommendations_json) > 0
+            {filter_sql}
+        ),
+        ranked AS (
+            SELECT scoped.*,
+                row_number() OVER (
+                    PARTITION BY scope, thread_key
+                    ORDER BY recommendation_score DESC, total_tokens DESC,
+                        event_timestamp ASC, record_id ASC
+                ) AS recommendation_rank
+            FROM scoped
+        ),
+        aggregate_rows AS (
+            SELECT scope, thread_key,
+                count(*) AS call_count,
+                count(DISTINCT session_id) AS session_count,
+                sum(total_tokens) AS total_tokens,
+                sum(coalesce(estimated_cost_usd, 0)) AS estimated_cost_usd,
+                sum(coalesce(usage_credits, 0)) AS usage_credits,
+                sum(recommendation_score) AS recommendation_score,
+                max(recommendation_score) AS max_recommendation_score,
+                max(event_timestamp) AS latest_event
+            FROM scoped
+            GROUP BY scope, thread_key
+        )
+        SELECT aggregate_rows.*, ranked.recommendations_json,
+            ranked.primary_recommendation_key
+        FROM aggregate_rows
+        JOIN ranked USING(scope, thread_key)
+        WHERE ranked.recommendation_rank = 1
+        """,  # nosec B608 - only generated placeholders; values remain bound
+        params,
+    ).fetchall()
+
+
+def _aggregate_signals(
+    conn: sqlite3.Connection,
+    thread_keys: tuple[str, ...] | None,
+) -> dict[tuple[str, str], set[str]]:
+    filter_sql, params = _thread_filter("rf.thread_key", thread_keys)
+    rows = conn.execute(
+        f"""
+        WITH scopes(scope, include_archived) AS (
+            VALUES ('active', 0), ('all-history', 1)
+        ),
+        scoped AS (
+            SELECT s.scope, rf.thread_key, rf.primary_recommendation_key,
+                rf.secondary_recommendation_keys_json
+            FROM recommendation_facts AS rf
+            JOIN scopes AS s ON s.include_archived = 1 OR rf.is_archived = 0
+            WHERE json_array_length(rf.recommendations_json) > 0
+            {filter_sql}
+        ),
+        signals AS (
+            SELECT scope, thread_key, primary_recommendation_key AS signal FROM scoped
+            UNION
+            SELECT scope, thread_key, json_each.value AS signal
+            FROM scoped, json_each(scoped.secondary_recommendation_keys_json)
+        )
+        SELECT scope, thread_key, signal
+        FROM signals
+        WHERE signal IS NOT NULL AND signal != ''
+        """,  # nosec B608 - only generated placeholders; values remain bound
+        params,
+    ).fetchall()
+    result: dict[tuple[str, str], set[str]] = {}
+    for row in rows:
+        result.setdefault((str(row["scope"]), str(row["thread_key"])), set()).add(
+            str(row["signal"])
+        )
+    return result
+
+
+def _persist_summaries(
+    conn: sqlite3.Connection,
+    rows: list[sqlite3.Row],
+    signals: dict[tuple[str, str], set[str]],
+) -> None:
+    updates = []
+    for row in rows:
+        key = (str(row["scope"]), str(row["thread_key"]))
+        recommendations = json.loads(str(row["recommendations_json"]))
+        primary = recommendations[0] if recommendations else None
+        primary_key = primary.get("key") if isinstance(primary, dict) else None
+        summary: dict[str, Any] = {
+            "thread": _thread_label(key[1]),
+            "call_count": int(row["call_count"]),
+            "session_count": int(row["session_count"]),
+            "total_tokens": int(row["total_tokens"]),
+            "estimated_cost_usd": round(float(row["estimated_cost_usd"]), 6),
+            "usage_credits": round(float(row["usage_credits"]), 6),
+            "recommendation_score": round(float(row["recommendation_score"]), 2),
+            "max_recommendation_score": round(float(row["max_recommendation_score"]), 2),
+            "primary_recommendation": primary,
+            "secondary_signals": sorted(
+                signal for signal in signals.get(key, set()) if signal != primary_key
+            ),
+            "latest_event": row["latest_event"],
+        }
+        updates.append(
+            (
+                summary["recommendation_score"],
+                summary["total_tokens"],
+                json.dumps(summary, separators=(",", ":"), sort_keys=True),
+                summary["max_recommendation_score"],
+                primary_key,
+                key[1],
+                key[0],
+            )
+        )
+    conn.executemany(
+        """
+        UPDATE thread_summaries
+        SET recommendation_score = ?, recommendation_total_tokens = ?,
+            recommendation_summary_json = ?, max_recommendation_score = ?,
+            primary_recommendation = ?
+        WHERE thread_key = ? AND is_archived_scope = ?
+        """,
+        updates,
+    )
+
+
+def _update_completeness(
+    conn: sqlite3.Connection,
+    thread_keys: tuple[str, ...] | None,
+) -> None:
+    current_row = conn.execute(
+        "SELECT thread_summaries_complete FROM recommendation_fact_state WHERE singleton = 1"
+    ).fetchone()
+    current = bool(current_row and current_row[0])
+    check_keys = thread_keys if current and thread_keys is not None else None
+    filter_sql, params = _thread_filter("rf.thread_key", check_keys)
+    noncanonical = conn.execute(
+        f"""
+        SELECT 1
+        FROM recommendation_facts AS rf
+        JOIN usage_events USING(record_id)
+        WHERE json_array_length(rf.recommendations_json) > 0
+            AND (
+                nullif(usage_events.thread_name, '') IS NULL
+                OR rf.thread_key != 'thread:' || usage_events.thread_name
+            )
+        {filter_sql}
+        LIMIT 1
+        """,  # nosec B608 - only generated placeholders; values remain bound
+        params,
+    ).fetchone()
+    complete = noncanonical is None if check_keys is None else current and noncanonical is None
+    conn.execute(
+        """
+        UPDATE recommendation_fact_state
+        SET thread_summaries_complete = ?
+        WHERE singleton = 1
+        """,
+        (int(complete),),
+    )
+
+
+def _thread_filter(
+    column: str,
+    thread_keys: tuple[str, ...] | None,
+) -> tuple[str, list[str]]:
+    if thread_keys is None:
+        return "", []
+    if not thread_keys:
+        return "AND 0", []
+    placeholders = ", ".join("?" for _ in thread_keys)
+    return f"AND {column} IN ({placeholders})", list(thread_keys)
+
+
+def _summaries_are_complete(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT thread_summaries_complete FROM recommendation_fact_state WHERE singleton = 1"
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def _thread_label(thread_key: str) -> str:
+    if thread_key.startswith("thread:"):
+        return thread_key.removeprefix("thread:")
+    return thread_key.removeprefix("session:")

--- a/src/codex_usage_tracker/store/recommendation_queries.py
+++ b/src/codex_usage_tracker/store/recommendation_queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -48,7 +49,12 @@ def query_recommendation_fact_page(
         table_alias="usage_events",
         include_archived=include_archived,
     )
-    where_clause = _extend_fact_filters(where_clause, params, min_score=min_score)
+    where_clause = _extend_fact_filters(
+        where_clause,
+        params,
+        include_archived=include_archived,
+        min_score=min_score,
+    )
     normalized_limit = normalize_limit(limit)
     limit_clause = "" if normalized_limit is None else " LIMIT ?"
     row_params = [*params] if normalized_limit is None else [*params, normalized_limit]
@@ -85,13 +91,62 @@ def query_recommendation_fact_page(
     )
 
 
+def query_recommendation_thread_summaries(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+    thread: str | None = None,
+    include_archived: bool = False,
+    min_score: float | None = None,
+    limit: int | None = 20,
+) -> list[dict[str, Any]] | None:
+    """Read exact materialized summaries for the unfiltered common path."""
+
+    if any(value is not None for value in (since, until, model, effort, thread, min_score)):
+        return None
+    normalized_limit = normalize_limit(limit)
+    limit_clause = "" if normalized_limit is None else " LIMIT ?"
+    params = [] if normalized_limit is None else [normalized_limit]
+    with connect(db_path) as conn:
+        state = conn.execute(
+            """
+            SELECT thread_summaries_complete
+            FROM recommendation_fact_state
+            WHERE singleton = 1
+            """
+        ).fetchone()
+        if state is None or not bool(state[0]):
+            return None
+        rows = conn.execute(
+            f"""
+            SELECT recommendation_summary_json
+            FROM thread_summaries
+            WHERE is_archived_scope = ?
+                AND recommendation_summary_json IS NOT NULL
+            ORDER BY
+                recommendation_score DESC,
+                recommendation_total_tokens DESC,
+                thread_key ASC
+            {limit_clause}
+            """,  # nosec B608 - fixed LIMIT fragment; values remain bound
+            ["all-history" if include_archived else "active", *params],
+        ).fetchall()
+    return [json.loads(str(row[0])) for row in rows]
+
+
 def _extend_fact_filters(
     where_clause: str,
     params: list[Any],
     *,
+    include_archived: bool,
     min_score: float | None,
 ) -> str:
     clauses = ["json_array_length(rf.recommendations_json) > 0"]
+    if not include_archived:
+        clauses.append("rf.is_archived = 0")
     if min_score is not None:
         clauses.append("rf.recommendation_score >= ?")
         params.append(min_score)

--- a/src/codex_usage_tracker/store/recommendation_schema.py
+++ b/src/codex_usage_tracker/store/recommendation_schema.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 
-MIGRATION_NAMES = {20: "persist versioned recommendation facts"}
+MIGRATION_NAMES = {
+    20: "persist versioned recommendation facts",
+    21: "materialize recommendation thread summaries",
+}
 
 _INDEX_STATEMENTS = (
     "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_scope "
@@ -16,6 +19,14 @@ _INDEX_STATEMENTS = (
     "ON recommendation_facts(thread_key, recommendation_score DESC, event_timestamp DESC)",
     "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_primary "
     "ON recommendation_facts(primary_recommendation_key, recommendation_score DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_rank_all "
+    "ON recommendation_facts(recommendation_score DESC, total_tokens DESC, "
+    "event_timestamp, record_id) "
+    "WHERE json_array_length(recommendations_json) > 0",
+    "CREATE INDEX IF NOT EXISTS idx_recommendation_facts_rank_active "
+    "ON recommendation_facts(recommendation_score DESC, total_tokens DESC, "
+    "event_timestamp, record_id) "
+    "WHERE is_archived = 0 AND json_array_length(recommendations_json) > 0",
 )
 _INDEX_DROP_STATEMENTS = tuple(
     statement.replace("CREATE INDEX IF NOT EXISTS ", "DROP INDEX IF EXISTS ").split(" ON ", 1)[0]
@@ -72,6 +83,44 @@ def create_recommendation_fact_tables(conn: sqlite3.Connection) -> None:
             record_count INTEGER NOT NULL DEFAULT 0,
             updated_at TEXT NOT NULL
         );
+        """
+    )
+    create_recommendation_fact_indexes(conn)
+
+
+def add_recommendation_thread_summaries(conn: sqlite3.Connection) -> None:
+    """Extend existing summary/state tables with exact recommendation rollups."""
+    summary_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(thread_summaries)").fetchall()
+    }
+    for name, definition in (
+        ("recommendation_score", "REAL NOT NULL DEFAULT 0"),
+        ("recommendation_total_tokens", "INTEGER NOT NULL DEFAULT 0"),
+        ("recommendation_summary_json", "TEXT"),
+    ):
+        if name not in summary_columns:
+            conn.execute(f"ALTER TABLE thread_summaries ADD COLUMN {name} {definition}")
+
+    state_columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(recommendation_fact_state)").fetchall()
+    }
+    if "thread_summaries_complete" not in state_columns:
+        conn.execute(
+            """
+            ALTER TABLE recommendation_fact_state
+            ADD COLUMN thread_summaries_complete INTEGER NOT NULL DEFAULT 0
+            """
+        )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_thread_summaries_scope_recommendations
+        ON thread_summaries(
+            is_archived_scope,
+            recommendation_score DESC,
+            recommendation_total_tokens DESC,
+            thread_key
+        )
         """
     )
     create_recommendation_fact_indexes(conn)

--- a/src/codex_usage_tracker/store/refresh_callbacks.py
+++ b/src/codex_usage_tracker/store/refresh_callbacks.py
@@ -5,4 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Callable
 
-DerivedFactSyncCallback = Callable[[sqlite3.Connection, tuple[str, ...], bool], None]
+DerivedFactSyncCallback = Callable[
+    [sqlite3.Connection, tuple[str, ...], frozenset[str], bool],
+    None,
+]

--- a/src/codex_usage_tracker/store/refresh_stream.py
+++ b/src/codex_usage_tracker/store/refresh_stream.py
@@ -381,7 +381,12 @@ class _RefreshStreamWriter:
         self.timings.add("compression_facts", started)
         if self.derived_fact_sync is not None:
             recommendation_started = perf_counter()
-            self.derived_fact_sync(conn, finalized.record_ids, full_rebuild)
+            self.derived_fact_sync(
+                conn,
+                finalized.record_ids,
+                finalized.affected_thread_keys,
+                full_rebuild,
+            )
             self.timings.add("recommendation_facts", recommendation_started)
         emit_refresh_progress(
             self.progress_callback,

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -16,7 +16,7 @@ from codex_usage_tracker.core.schema import (
     USAGE_EVENT_SCHEMA_CHECKSUM,
 )
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -108,6 +108,7 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         (18, schema_source_index.migrate_source_file_line_index),
         (19, compression_schema.add_candidate_record_metadata),
         (20, recommendation_schema.create_recommendation_fact_tables),
+        (21, recommendation_schema.add_recommendation_thread_summaries),
     )
 
 
@@ -716,13 +717,8 @@ def _record_migration(conn: sqlite3.Connection, version: int) -> None:
 
 
 def _migration_record_exists(conn: sqlite3.Connection, version: int) -> bool:
-    return (
-        conn.execute(
-            "SELECT 1 FROM schema_migrations WHERE version = ?",
-            (version,),
-        ).fetchone()
-        is not None
-    )
+    row = conn.execute("SELECT 1 FROM schema_migrations WHERE version = ?", (version,)).fetchone()
+    return row is not None
 
 
 def _ensure_columns(conn: sqlite3.Connection, columns: dict[str, str]) -> None:

--- a/src/codex_usage_tracker/store/thread_summaries.py
+++ b/src/codex_usage_tracker/store/thread_summaries.py
@@ -32,9 +32,14 @@ def rebuild_thread_summaries(
 
     before = conn.total_changes
     normalized_thread_keys = sorted({key for key in thread_keys or [] if key})
+    recommendation_rows = _saved_recommendation_summaries(
+        conn,
+        thread_keys=normalized_thread_keys or None,
+    )
     if not normalized_thread_keys:
         conn.execute("DELETE FROM thread_summaries")
         _insert_thread_summary_scopes(conn, updated_at=_summary_timestamp())
+        _restore_recommendation_summaries(conn, recommendation_rows)
         return conn.total_changes - before
     updated_at = _summary_timestamp()
     for start in range(0, len(normalized_thread_keys), _THREAD_KEY_BATCH_SIZE):
@@ -45,7 +50,59 @@ def rebuild_thread_summaries(
             chunk,
         )
         _insert_thread_summary_scopes(conn, updated_at=updated_at, thread_keys=chunk)
+    _restore_recommendation_summaries(conn, recommendation_rows)
     return conn.total_changes - before
+
+
+def _saved_recommendation_summaries(
+    conn: sqlite3.Connection,
+    *,
+    thread_keys: list[str] | None,
+) -> list[sqlite3.Row]:
+    conditions = ["recommendation_summary_json IS NOT NULL"]
+    params: list[str] = []
+    if thread_keys:
+        placeholders = ", ".join("?" for _ in thread_keys)
+        conditions.append(f"thread_key IN ({placeholders})")
+        params.extend(thread_keys)
+    where_clause = f"WHERE {' AND '.join(conditions)}"
+    return conn.execute(
+        f"""
+        SELECT thread_key, is_archived_scope, recommendation_score,
+            recommendation_total_tokens, recommendation_summary_json,
+            max_recommendation_score, primary_recommendation
+        FROM thread_summaries
+        {where_clause}
+        """,  # nosec B608 - only generated placeholders; values remain bound
+        params,
+    ).fetchall()
+
+
+def _restore_recommendation_summaries(
+    conn: sqlite3.Connection,
+    rows: list[sqlite3.Row],
+) -> None:
+    conn.executemany(
+        """
+        UPDATE thread_summaries
+        SET recommendation_score = ?, recommendation_total_tokens = ?,
+            recommendation_summary_json = ?, max_recommendation_score = ?,
+            primary_recommendation = ?
+        WHERE thread_key = ? AND is_archived_scope = ?
+        """,
+        [
+            (
+                row["recommendation_score"],
+                row["recommendation_total_tokens"],
+                row["recommendation_summary_json"],
+                row["max_recommendation_score"],
+                row["primary_recommendation"],
+                row["thread_key"],
+                row["is_archived_scope"],
+            )
+            for row in rows
+        ],
+    )
 
 
 def _summary_timestamp() -> str:

--- a/tests/reports/test_indexed_recommendations.py
+++ b/tests/reports/test_indexed_recommendations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -84,6 +85,19 @@ def test_indexed_recommendations_match_legacy_payload(
             reasoning_output_tokens=40_000,
             total_tokens=250_050,
         ),
+        replace(
+            _usage_event(
+                record_id="archived-call",
+                session_id="session-archived",
+                thread_key="thread:archived",
+                event_timestamp="2026-07-12T13:00:00Z",
+                cumulative_total_tokens=900_000,
+            ),
+            input_tokens=250_000,
+            cached_input_tokens=1_000,
+            total_tokens=250_050,
+            is_archived=1,
+        ),
     ]
     upsert_usage_events(events, db_path=db_path)
     with connect(db_path) as conn:
@@ -93,17 +107,23 @@ def test_indexed_recommendations_match_legacy_payload(
             allowance_path=allowance_path,
         )
 
-    arguments = {
+    arguments: dict[str, Any] = {
         "db_path": db_path,
         "pricing_path": pricing_path,
         "allowance_path": allowance_path,
         "projects_path": projects_path,
-        "limit": 1,
+        "limit": 10,
     }
     legacy = build_recommendations_report(**arguments)
     indexed = build_indexed_recommendations_report(**arguments)
 
     assert indexed.payload == legacy.payload
+
+    archived_arguments = {**arguments, "include_archived": True}
+    archived_legacy = build_recommendations_report(**archived_arguments)
+    archived_indexed = build_indexed_recommendations_report(**archived_arguments)
+
+    assert archived_indexed.payload == archived_legacy.payload
 
 
 def test_recommendations_fall_back_when_materialized_facts_are_missing(
@@ -126,7 +146,7 @@ def test_recommendations_fall_back_when_materialized_facts_are_missing(
         total_tokens=250_050,
     )
     upsert_usage_events([event], db_path=db_path)
-    arguments = {
+    arguments: dict[str, Any] = {
         "db_path": db_path,
         "pricing_path": pricing_path,
         "allowance_path": allowance_path,

--- a/tests/store/test_compression_runs.py
+++ b/tests/store/test_compression_runs.py
@@ -171,7 +171,7 @@ def test_candidate_record_metadata_migration_backfills_existing_claims(
         conn.execute("PRAGMA user_version = 18")
     with connect(db_path) as conn:
         init_db(conn)
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 20
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 21
     with connect(db_path) as conn:
         conn.execute("DELETE FROM usage_events WHERE record_id = ?", ("record-cmp_old",))
 

--- a/tests/store/test_recommendation_queries.py
+++ b/tests/store/test_recommendation_queries.py
@@ -5,12 +5,15 @@ from pathlib import Path
 
 from codex_usage_tracker.recommendation_engine.materialization import (
     sync_recommendation_facts,
+    sync_thread_recommendation_summaries,
 )
-from codex_usage_tracker.store.api import upsert_usage_events
+from codex_usage_tracker.store.api import init_db, upsert_usage_events
 from codex_usage_tracker.store.connection import connect
 from codex_usage_tracker.store.recommendation_queries import (
     query_recommendation_fact_page,
+    query_recommendation_thread_summaries,
 )
+from codex_usage_tracker.store.thread_summaries import rebuild_thread_summaries
 from tests.store_dashboard_helpers import _usage_event
 
 
@@ -21,7 +24,7 @@ def test_recommendation_fact_page_orders_and_counts_before_limiting(tmp_path: Pa
             _usage_event(
                 record_id="lower-score",
                 session_id="session-lower",
-                thread_key="thread:lower",
+                thread_key="thread:shared",
                 event_timestamp="2026-07-13T12:00:00Z",
                 cumulative_total_tokens=900_000,
             ),
@@ -31,7 +34,7 @@ def test_recommendation_fact_page_orders_and_counts_before_limiting(tmp_path: Pa
             _usage_event(
                 record_id="higher-score",
                 session_id="session-higher",
-                thread_key="thread:higher",
+                thread_key="thread:shared",
                 event_timestamp="2026-07-13T13:00:00Z",
                 cumulative_total_tokens=900_000,
             ),
@@ -42,16 +45,157 @@ def test_recommendation_fact_page_orders_and_counts_before_limiting(tmp_path: Pa
     with connect(db_path) as conn:
         sync_recommendation_facts(conn, record_ids=[event.record_id for event in events])
         conn.execute(
-            "UPDATE recommendation_facts SET recommendation_score = 10 WHERE record_id = ?",
-            ("lower-score",),
+            """
+            UPDATE recommendation_facts
+            SET recommendation_score = 10,
+                primary_recommendation_key = 'lower',
+                secondary_recommendation_keys_json = '["shared"]',
+                recommendations_json = '[{"key":"lower","title":"Lower"}]'
+            WHERE record_id = 'lower-score'
+            """
         )
         conn.execute(
-            "UPDATE recommendation_facts SET recommendation_score = 20 WHERE record_id = ?",
-            ("higher-score",),
+            """
+            UPDATE recommendation_facts
+            SET recommendation_score = 20,
+                primary_recommendation_key = 'higher',
+                secondary_recommendation_keys_json = '["shared"]',
+                recommendations_json = '[{"key":"higher","title":"Higher"}]'
+            WHERE record_id = 'higher-score'
+            """
         )
+        sync_thread_recommendation_summaries(conn)
 
     page = query_recommendation_fact_page(db_path=db_path, limit=1)
 
     assert page.total_count == 2
     assert [row["record_id"] for row in page.rows] == ["higher-score"]
     assert page.rows[0]["fact_recommendation_score"] == 20
+
+    summaries = query_recommendation_thread_summaries(db_path=db_path, limit=1)
+
+    assert summaries is not None
+    assert summaries[0]["thread"] == "shared"
+    assert summaries[0]["call_count"] == 2
+    assert summaries[0]["session_count"] == 2
+    assert summaries[0]["total_tokens"] == 1_000
+    assert summaries[0]["recommendation_score"] == 30
+    assert summaries[0]["primary_recommendation"] == {
+        "key": "higher",
+        "title": "Higher",
+    }
+    assert summaries[0]["secondary_signals"] == ["lower", "shared"]
+    with connect(db_path) as conn:
+        rebuild_thread_summaries(conn)
+
+    assert query_recommendation_thread_summaries(db_path=db_path, limit=1) == summaries
+
+
+def test_recommendation_thread_summaries_refresh_only_affected_threads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    events = _thread_events("first", "second")
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id for event in events])
+        conn.execute(
+            """
+            UPDATE recommendation_facts
+            SET recommendation_score = 10,
+                recommendations_json = '[{"key":"initial"}]',
+                primary_recommendation_key = 'initial'
+            """
+        )
+        sync_thread_recommendation_summaries(conn)
+        untouched_before = conn.execute(
+            """
+            SELECT recommendation_summary_json
+            FROM thread_summaries
+            WHERE thread_key = 'thread:second' AND is_archived_scope = 'active'
+            """
+        ).fetchone()[0]
+        conn.execute(
+            """
+            UPDATE recommendation_facts
+            SET recommendation_score = 40,
+                recommendations_json = '[{"key":"updated"}]',
+                primary_recommendation_key = 'updated'
+            WHERE record_id = 'record-first'
+            """
+        )
+        sync_thread_recommendation_summaries(conn, thread_keys=("thread:first",))
+        untouched_after = conn.execute(
+            """
+            SELECT recommendation_summary_json
+            FROM thread_summaries
+            WHERE thread_key = 'thread:second' AND is_archived_scope = 'active'
+            """
+        ).fetchone()[0]
+
+    summaries = query_recommendation_thread_summaries(db_path=db_path, limit=2)
+
+    assert summaries is not None
+    assert [summary["thread"] for summary in summaries] == ["first", "second"]
+    assert summaries[0]["recommendation_score"] == 40
+    assert untouched_after == untouched_before
+
+
+def test_v21_migration_backfills_all_summaries_before_incremental_refresh(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    events = _thread_events("first", "second")
+    upsert_usage_events(events, db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id for event in events])
+        conn.execute("DROP INDEX idx_thread_summaries_scope_recommendations")
+        conn.execute("ALTER TABLE thread_summaries DROP COLUMN recommendation_score")
+        conn.execute("ALTER TABLE thread_summaries DROP COLUMN recommendation_total_tokens")
+        conn.execute("ALTER TABLE thread_summaries DROP COLUMN recommendation_summary_json")
+        conn.execute("ALTER TABLE recommendation_fact_state DROP COLUMN thread_summaries_complete")
+        conn.execute("DELETE FROM schema_migrations WHERE version = 21")
+        conn.execute("PRAGMA user_version = 20")
+        init_db(conn)
+        sync_recommendation_facts(conn, record_ids=[events[0].record_id])
+
+    summaries = query_recommendation_thread_summaries(db_path=db_path, limit=10)
+
+    assert summaries is not None
+    assert {summary["thread"] for summary in summaries} == {"first", "second"}
+
+
+def test_recommendation_thread_summaries_defer_noncanonical_threads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    event = replace(
+        _usage_event(
+            record_id="child",
+            session_id="child-session",
+            thread_key="session:child-session",
+            event_timestamp="2026-07-13T12:00:00Z",
+            cumulative_total_tokens=900_000,
+        ),
+        thread_name=None,
+        parent_session_id="parent-session",
+        parent_thread_name="parent",
+    )
+    upsert_usage_events([event], db_path=db_path)
+    with connect(db_path) as conn:
+        sync_recommendation_facts(conn, record_ids=[event.record_id])
+
+    assert query_recommendation_thread_summaries(db_path=db_path) is None
+
+
+def _thread_events(*threads: str):
+    return [
+        _usage_event(
+            record_id=f"record-{thread}",
+            session_id=f"session-{thread}",
+            thread_key=f"thread:{thread}",
+            event_timestamp=f"2026-07-13T1{index}:00:00Z",
+            cumulative_total_tokens=900_000,
+        )
+        for index, thread in enumerate(threads)
+    ]

--- a/tests/store/test_refresh_callbacks.py
+++ b/tests/store/test_refresh_callbacks.py
@@ -12,10 +12,15 @@ def test_refresh_derived_fact_callback_receives_full_and_append_targets(
 ) -> None:
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
-    calls: list[tuple[tuple[str, ...], bool, bool]] = []
+    calls: list[tuple[tuple[str, ...], frozenset[str], bool, bool]] = []
 
-    def sync(conn, record_ids: tuple[str, ...], full_rebuild: bool) -> None:
-        calls.append((record_ids, full_rebuild, conn.in_transaction))
+    def sync(
+        conn,
+        record_ids: tuple[str, ...],
+        thread_keys: frozenset[str],
+        full_rebuild: bool,
+    ) -> None:
+        calls.append((record_ids, thread_keys, full_rebuild, conn.in_transaction))
 
     refresh_usage_index(
         codex_home=codex_home,
@@ -45,7 +50,9 @@ def test_refresh_derived_fact_callback_receives_full_and_append_targets(
     )
 
     assert len(calls) == 2
-    assert calls[0][1:] == (True, True)
-    assert calls[1][1:] == (False, True)
+    assert calls[0][2:] == (True, True)
+    assert calls[1][2:] == (False, True)
     assert len(calls[0][0]) > 0
     assert len(calls[1][0]) == 1
+    assert calls[0][1]
+    assert calls[1][1]

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -79,12 +79,12 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "20"
+    assert meta["schema_version"] == "21"
     assert meta["parser_skipped_events"] == "0"
     state = schema_state(db_path)
-    assert state["schema_version"] == 20
+    assert state["schema_version"] == 21
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 21))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 22))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -711,7 +711,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 20
+    assert user_version == 21
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -809,8 +809,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 20
-    assert [row["version"] for row in migrations] == list(range(1, 21))
+    assert user_version == 21
+    assert [row["version"] for row in migrations] == list(range(1, 22))
     assert "idx_usage_source_file_line" in indexes
 
 

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -68,9 +68,9 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 20
+    assert state["schema_version"] == 21
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 21))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 22))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
@@ -106,7 +106,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "20"
+    assert metadata["schema_version"] == "21"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -141,13 +141,24 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
             row["name"]
             for row in conn.execute("PRAGMA table_info(compression_revision_state)").fetchall()
         }
+        thread_summary_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(thread_summaries)").fetchall()
+        }
         usage_indexes = {
             row["name"] for row in conn.execute("PRAGMA index_list(usage_events)").fetchall()
         }
+        recommendation_indexes = {
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(recommendation_facts)").fetchall()
+        }
 
-    assert versions == list(range(1, 21))
-    assert user_version == 20
+    assert versions == list(range(1, 22))
+    assert user_version == 21
     assert "idx_usage_source_file_line" in usage_indexes
+    assert {
+        "idx_recommendation_facts_rank_active",
+        "idx_recommendation_facts_rank_all",
+    } <= recommendation_indexes
     assert {
         "parsed_prefix_tail_hash",
         "parsed_row_count",
@@ -156,6 +167,11 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
         "source_inode",
     } <= source_columns
     assert {"call_generation", "command_generation", "file_generation"} <= revision_columns
+    assert {
+        "recommendation_score",
+        "recommendation_total_tokens",
+        "recommendation_summary_json",
+    } <= thread_summary_columns
     assert {
         "content_index_features",
         "conversation_turns",


### PR DESCRIPTION
## Summary
- materialize exact recommendation thread summaries during full and incremental refresh
- hydrate only the bounded ranked call page on the common unfiltered path
- add active/all-history ranked indexes and schema v21 migration coverage
- preserve exact legacy payloads, archived behavior, stale-fact fallback, and generic thread summary rebuilds
- record PR 2B benchmark evidence in the dashboard query pipeline roadmap

## Performance
Synthetic 400,000-row recommendation request:
- legacy fallback: 29.96s
- indexed median: 134.6ms
- indexed p95: 151.1ms over 20 runs
- fresh process: 144.9ms

This removes roughly 99.5% of request latency by moving invariant thread aggregation to refresh time and hydrating only the requested call rows.

## Validation
- Agent Maintainer full profile: PASS (`20260714T025944106675Z-full-5f6235128361`)
- 824 tests passed; 88% coverage
- Ruff, Mypy, Pyright, Xenon, Tach, compileall, and dashboard JS syntax passed
- package build, Twine check, and `scripts/check_release.py --dist` passed
- independent review findings for archived scope and v20-to-v21 partial migration were fixed and regression-tested

Refs #244