### PR TITLE
chore: add agent-perf development workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,12 @@ Recommended milestones:
 
 Use patch releases for public blockers such as broken PyPI installs, missing package data, broken CLI entry points, privacy leaks, bad plugin installs, or bad runtime pins. Put planned stabilization work into the next minor release instead of bundling it into a patch.
 
+## Performance Work
+
+Use the `agent-perf` skill and CLI when optimizing localhost API endpoints, dashboard refreshes, report generation, content indexing, parser or SQLite hot paths, or other latency- or CPU-sensitive code, and when investigating a performance regression or making a speedup claim.
+
+Install the repository's pinned profiling tools with `uv sync --group performance`. Profile the smallest repeatable workload with synthetic or anonymized inputs; never profile production, live private databases, arbitrary processes, or real Codex session content. Record the identical workload without a profiler before making a performance claim. Change one suspected cause at a time, rerun the unprofiled workload, and use `agent-perf compare` only to compare attribution evidence rather than as proof of a speedup.
+
 ## Validation
 
 Run focused tests first, then broader checks. Run the full local CI gate before opening or updating PRs that touch release, packaging, CLI contracts, MCP behavior, dashboard behavior, privacy behavior, schemas, generated docs/assets, or bundled plugin/skill files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ dev = [
   "zizmor>=1.26.1; python_version >= '3.11'",
 ]
 
+[dependency-groups]
+performance = [
+  "agent-perf @ git+https://github.com/douglasmonsky/agent-perf.git@132158e9e1848c6c1f04cbf309f9786603fb52b9; python_version >= '3.11'",
+  "scalene==2.3.0; python_version >= '3.11'",
+]
+
 [project.scripts]
 codex-usage-tracker = "codex_usage_tracker.cli:main"
 


### PR DESCRIPTION
## Summary

- require the `agent-perf` workflow for API, dashboard, indexing, SQLite, and other performance-sensitive work
- add a pinned dev-only performance dependency group with `agent-perf` and Scalene 2.3.0
- document synthetic-input, privacy, baseline-timing, and attribution requirements

## Why

Performance changes should start from repeatable profiling evidence and should not expose private Codex usage content. The tooling is kept out of published package metadata while remaining reproducible for repository development.

## Validation

- `python scripts/check_release.py`
- `uv pip compile pyproject.toml --group performance`
- `python -m build`
- `python -m twine check ...`
- `git diff --check`
