### PR TITLE
Fix full refresh deduplication index performance

### DIFF
--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -171,6 +171,7 @@ OTEL_REFRESH_COUNTER_KEYS = (
 )
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 SQLITE_VARIABLE_BATCH_SIZE = 500
+_USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH = frozenset({"idx_usage_canonical_fingerprint"})
 RefreshProgressCallback = Callable[[dict[str, object]], None]
 
 
@@ -773,7 +774,7 @@ def _deferred_usage_event_indexes(
         (str(row["name"]), str(row["sql"]))
         for row in conn.execute(
             f"""
-            SELECT name, sql
+            SELECT name, sql, tbl_name
             FROM sqlite_master
             WHERE type = 'index'
               AND tbl_name IN ({placeholders})
@@ -781,6 +782,10 @@ def _deferred_usage_event_indexes(
             ORDER BY name
             """,  # nosec B608 - placeholders are generated, values remain parameterized
             table_names,
+        )
+        if not (
+            str(row["tbl_name"]) == "usage_events"
+            and str(row["name"]) in _USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH
         )
     ]
     for name, _sql in indexes:

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -119,6 +119,7 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     observed_source_indexes: list[list[str]] = []
+    observed_usage_indexes: list[list[str]] = []
     original_upsert = stream_module.upsert_source_records_from_events
 
     def recording_upsert(conn, *, events):
@@ -131,6 +132,21 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
                     FROM sqlite_master
                     WHERE type = 'index'
                       AND tbl_name = 'source_records'
+                      AND sql IS NOT NULL
+                    ORDER BY name
+                    """
+                )
+            ]
+        )
+        observed_usage_indexes.append(
+            [
+                str(row["name"])
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND tbl_name = 'usage_events'
                       AND sql IS NOT NULL
                     ORDER BY name
                     """
@@ -150,6 +166,8 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
 
     assert observed_source_indexes
     assert all(not names for names in observed_source_indexes)
+    assert observed_usage_indexes
+    assert all(names == ["idx_usage_canonical_fingerprint"] for names in observed_usage_indexes)
     with connect(db_path) as conn:
         restored = {
             str(row["name"])


### PR DESCRIPTION
## Summary

- Preserve `idx_usage_canonical_fingerprint` while full refresh defers other bulk-load indexes.
- Keep duplicate-classification lookups indexed as `usage_events` grows.
- Extend the full-refresh index regression test to verify that only the required usage-event index remains during ingestion.

## Why This Change

A full rebuild previously dropped every schema-owned `usage_events` index before ingestion. Each batch still called duplicate classification, which performs a fingerprint lookup per row. Without the partial canonical fingerprint index, those lookups repeatedly scanned the growing table and made first-time `setup` or `refresh` appear hung while consuming CPU.

## User-Visible Behavior

First-time setup and full refresh no longer enter the pathological unindexed duplicate-classification path.

Synthetic benchmark evidence using the same unprofiled workload before and after the change:

- 10,000 rows: serial `9.713s` to `4.210s`; parallel `10.019s` to `4.181s`.
- 100,000 rows: the pre-fix run was terminated after exceeding 11 minutes; after the fix, serial completed in `44.531s` and parallel in `29.806s`.
- Serial and parallel database fingerprints remained equivalent.

## Privacy Impact

None. The change affects SQLite index deferral only. Profiling and benchmarks used repository-generated synthetic logs; no real Codex session content is included.

## Packaging Or Release Impact

None. No package metadata, schema version, CLI contract, or bundled asset changes.

## Commands Run

- `python -m pytest -q tests/store/test_refresh_parallel.py tests/store/test_usage_deduplication.py` — 14 passed
- `python -m ruff check .` — passed
- `python -m ruff format --check` on changed files — passed
- `python -m mypy --follow-imports=skip src/codex_usage_tracker/store/api.py` — passed
- `python -m compileall -q src` — passed
- Dashboard JavaScript `node --check` loop — passed
- `python scripts/check_release.py` — passed
- `python -m build` and `python -m twine check dist/*` — passed
- Full pytest suite — 1,483 passed, with one unrelated existing project-label assertion failure in `test_mcp_wrappers_smoke`

Repository-wide baseline notes: full mypy currently reports 23 errors in untouched modules, and repository-wide Ruff format check reports 66 unrelated files that would be reformatted.

## Screenshots

- Not applicable.

## Follow-Up

The 100,000-row parallel benchmark still exceeds the repository's sub-20-second target because content indexing remains the dominant phase. That is separate from this full-refresh deduplication regression and can be profiled independently.
