### PR TITLE
test: preserve PR 291 contributor credit

### DIFF
--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -180,6 +180,7 @@ OTEL_REFRESH_COUNTER_KEYS = (
 )
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 SQLITE_VARIABLE_BATCH_SIZE = 500
+_USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH = frozenset({"idx_usage_canonical_fingerprint"})
 RefreshProgressCallback = Callable[[dict[str, object]], None]
 
 
@@ -1059,7 +1060,7 @@ def _deferred_usage_event_indexes(
         (str(row["name"]), str(row["sql"]))
         for row in conn.execute(
             f"""
-            SELECT name, sql
+            SELECT name, sql, tbl_name
             FROM sqlite_master
             WHERE type = 'index'
               AND tbl_name IN ({placeholders})
@@ -1067,6 +1068,10 @@ def _deferred_usage_event_indexes(
             ORDER BY name
             """,  # nosec B608 - placeholders are generated, values remain parameterized
             table_names,
+        )
+        if not (
+            str(row["tbl_name"]) == "usage_events"
+            and str(row["name"]) in _USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH
         )
     ]
     for name, _sql in indexes:

--- a/src/codex_usage_tracker/store/api.py
+++ b/src/codex_usage_tracker/store/api.py
@@ -180,7 +180,6 @@ OTEL_REFRESH_COUNTER_KEYS = (
 )
 __all__ = ["EVENT_COLUMNS", "SCHEMA_VERSION", "SchemaMigrationError", "init_db"]
 SQLITE_VARIABLE_BATCH_SIZE = 500
-_USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH = frozenset({"idx_usage_canonical_fingerprint"})
 RefreshProgressCallback = Callable[[dict[str, object]], None]
 
 
@@ -1060,7 +1059,7 @@ def _deferred_usage_event_indexes(
         (str(row["name"]), str(row["sql"]))
         for row in conn.execute(
             f"""
-            SELECT name, sql, tbl_name
+            SELECT name, sql
             FROM sqlite_master
             WHERE type = 'index'
               AND tbl_name IN ({placeholders})
@@ -1068,10 +1067,6 @@ def _deferred_usage_event_indexes(
             ORDER BY name
             """,  # nosec B608 - placeholders are generated, values remain parameterized
             table_names,
-        )
-        if not (
-            str(row["tbl_name"]) == "usage_events"
-            and str(row["name"]) in _USAGE_EVENT_INDEXES_REQUIRED_DURING_REFRESH
         )
     ]
     for name, _sql in indexes:

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -119,6 +119,7 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
     codex_home = _make_codex_home(tmp_path)
     db_path = tmp_path / "usage.sqlite3"
     observed_source_indexes: list[list[str]] = []
+    observed_usage_indexes: list[list[str]] = []
     original_upsert = stream_module.upsert_source_records_from_events
 
     def recording_upsert(conn, *, events):
@@ -131,6 +132,21 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
                     FROM sqlite_master
                     WHERE type = 'index'
                       AND tbl_name = 'source_records'
+                      AND sql IS NOT NULL
+                    ORDER BY name
+                    """
+                )
+            ]
+        )
+        observed_usage_indexes.append(
+            [
+                str(row["name"])
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'index'
+                      AND tbl_name = 'usage_events'
                       AND sql IS NOT NULL
                     ORDER BY name
                     """
@@ -150,6 +166,8 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
 
     assert observed_source_indexes
     assert all(not names for names in observed_source_indexes)
+    assert observed_usage_indexes
+    assert all(names == ["idx_usage_canonical_fingerprint"] for names in observed_usage_indexes)
     with connect(db_path) as conn:
         restored = {
             str(row["name"])

--- a/tests/store/test_refresh_parallel.py
+++ b/tests/store/test_refresh_parallel.py
@@ -167,7 +167,7 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
     assert observed_source_indexes
     assert all(not names for names in observed_source_indexes)
     assert observed_usage_indexes
-    assert all(names == ["idx_usage_canonical_fingerprint"] for names in observed_usage_indexes)
+    assert all(not names for names in observed_usage_indexes)
     with connect(db_path) as conn:
         restored = {
             str(row["name"])
@@ -181,6 +181,18 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
                 """
             )
         }
+        restored_usage_indexes = {
+            str(row["name"])
+            for row in conn.execute(
+                """
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'index'
+                  AND tbl_name = 'usage_events'
+                  AND sql IS NOT NULL
+                """
+            )
+        }
     assert restored == {
         "idx_call_diagnostic_facts_aggregate",
         "idx_call_diagnostic_facts_record",
@@ -190,6 +202,7 @@ def test_full_refresh_defers_and_restores_bulk_load_indexes(
         "idx_source_records_shape_adapter",
         "idx_source_records_source_line",
     }
+    assert "idx_usage_canonical_fingerprint" in restored_usage_indexes
 
 
 def test_parallel_parse_submission_queue_is_bounded(tmp_path: Path, monkeypatch) -> None:

--- a/tests/store/test_usage_deduplication.py
+++ b/tests/store/test_usage_deduplication.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,6 +20,7 @@ from codex_usage_tracker.store.dedupe_queries import (
     query_dedupe_counts,
     query_dedupe_diagnostics,
 )
+from codex_usage_tracker.store.deduplication import classify_usage_rows
 from codex_usage_tracker.store.summary_queries import query_summary
 from codex_usage_tracker.store.usage_api_queries import (
     query_usage_api_event_count,
@@ -57,6 +59,40 @@ def test_clone_copy_is_physical_but_not_billable(tmp_path: Path) -> None:
         )
 
 
+def test_existing_fingerprint_lookup_is_batched() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE usage_events (
+            usage_fingerprint TEXT,
+            record_id TEXT NOT NULL,
+            is_duplicate INTEGER NOT NULL
+        )
+        """
+    )
+    rows = [
+        {
+            "record_id": f"record-{index}",
+            "usage_fingerprint": f"fingerprint-{index}",
+            "canonical_record_id": f"canonical-{index}",
+        }
+        for index in range(1_201)
+    ]
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+
+    classified = classify_usage_rows(conn, rows)
+
+    lookup_queries = [
+        statement
+        for statement in statements
+        if statement.startswith("SELECT usage_fingerprint, record_id FROM usage_events ")
+    ]
+    assert len(lookup_queries) == 3
+    assert all(row["is_duplicate"] == 0 for row in classified)
+
+
 def test_copied_allowance_rows_do_not_contribute_intervals_or_generation(tmp_path: Path) -> None:
     first = replace(
         _event("first", "/first.jsonl"),
@@ -78,8 +114,12 @@ def test_copied_allowance_rows_do_not_contribute_intervals_or_generation(tmp_pat
         total_tokens=200,
         cumulative_total_tokens=300,
     )
-    copied_first = replace(first, record_id="copied-first", session_id="copy", source_file="/copy-1.jsonl")
-    copied_second = replace(second, record_id="copied-second", session_id="copy", source_file="/copy-2.jsonl")
+    copied_first = replace(
+        first, record_id="copied-first", session_id="copy", source_file="/copy-1.jsonl"
+    )
+    copied_second = replace(
+        second, record_id="copied-second", session_id="copy", source_file="/copy-2.jsonl"
+    )
     db_path = tmp_path / "usage.sqlite3"
     upsert_usage_events([first, second, copied_first, copied_second], db_path)
 
@@ -97,7 +137,9 @@ def test_copied_allowance_rows_do_not_contribute_intervals_or_generation(tmp_pat
         conn.execute(
             "UPDATE usage_events SET rate_limit_primary_used_percent=99 WHERE record_id='copied-second'"
         )
-        assert not materialize_allowance_intelligence(conn, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+        assert not materialize_allowance_intelligence(
+            conn, now=datetime(2026, 7, 14, tzinfo=timezone.utc)
+        )
         assert tuple(
             conn.execute(
                 "SELECT allowance_generation, source_revision FROM allowance_source_state"


### PR DESCRIPTION
## Summary

- retain nrlcode original PR #291 commit and authorship in branch history
- keep the faster 0.23 batched deduplication implementation instead of preserving the canonical fingerprint index during bulk refresh
- extend full-refresh coverage to prove usage indexes are deferred and restored
- add a regression test proving 1,201 fingerprint lookups use three bounded queries rather than one query per row

## Performance reconciliation

PR #291 correctly identified the old per-row dedupe lookup problem. On top of the batched implementation released in 0.23.0, keeping the canonical fingerprint index measured slower on the same synthetic 10k workload: about 10.0% slower serial median, 4.45% slower parallel median, and 15.9% slower parallel p95. The follow-up commit therefore retains the released runtime behavior while preserving the contributed diagnosis, test direction, and original authored commit.

## Validation

- 15 focused refresh/deduplication tests passed
- Ruff check passed
- release readiness checks passed

Important: merge this PR with a merge commit, not squash, so nrlcode authored commit remains reachable from main and GitHub can recognize the contribution.