### PR TITLE
docs: add 0.24 foundation audit checkpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist/
 .DS_Store
 tmp/
 .cache/
+/.gitnexus/
 
 .codex/*
 !.codex/tasks.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,22 @@ Use the `agent-perf` skill and CLI when optimizing localhost API endpoints, dash
 
 Install the repository's pinned profiling tools with `uv sync --group performance`. Profile the smallest repeatable workload with synthetic or anonymized inputs; never profile production, live private databases, arbitrary processes, or real Codex session content. Record the identical workload without a profiler before making a performance claim. Change one suspected cause at a time, rerun the unprofiled workload, and use `agent-perf compare` only to compare attribution evidence rather than as proof of a speedup.
 
+### Code intelligence tools
+
+Use GitNexus for repository orientation, architecture, execution-flow tracing, subsystem discovery, and broad change-impact analysis.
+
+Use Serena for exact symbol definitions, references, implementations, type-aware navigation, diagnostics, and symbol-level edits or refactors.
+
+For unfamiliar or cross-cutting work, use GitNexus to identify where to investigate, then use Serena to verify the exact symbols before editing.
+
+Treat GitNexus relationships as navigational guidance. Treat Serena as authoritative for precise symbol resolution and modification.
+
+Confirm architectural conclusions against the source and relevant tests before changing behavior. Use `agent-perf` and an identical unprofiled workload for performance evidence; GitNexus may locate a hot path but does not prove a regression or speedup.
+
+Do not repeat the same lookup in both tools unless validating an uncertain relationship or investigating conflicting results.
+
+Refresh the GitNexus index after major branch changes, file moves, or architectural refactors.
+
 ## Validation
 
 Run focused tests first, then broader checks. Run the full local CI gate before opening or updating PRs that touch release, packaging, CLI contracts, MCP behavior, dashboard behavior, privacy behavior, schemas, generated docs/assets, or bundled plugin/skill files.
@@ -159,6 +175,27 @@ Run focused tests first, then broader checks. Run the full local CI gate before 
 ## Source Inspection And Tool Output
 
 Large command outputs in Codex chat can be visually compacted by the transcript renderer. When inspecting source, especially after broad `rg`, `sed`, `nl`, generated dashboard assets, logs, or workflow output, do not treat a mangled rendered snippet as proof that the file is corrupt. Prefer small targeted file windows, `git diff`, `python -m py_compile`, focused tests, and CI as the source of truth. If exact syntax matters, inspect a narrow range or use a parser/compiler rather than relying on large printed source dumps.
+
+Use this progressive inspection ladder:
+
+1. Choose one first locator based on the question:
+   - Use GitNexus for an unfamiliar subsystem, cross-cutting architecture, execution flow, dependency cycle, or broad change impact.
+   - Use Serena for a known code symbol, exact definition, callers, references, implementations, types, diagnostics, or a symbol-level edit.
+   - Use `rg -n` for an exact string, route, configuration key, SQL fragment, schema field, error text, documentation claim, or non-symbol asset.
+   - Use `rg --files` when the filename or owning directory is unknown.
+2. Do not run all locators by default. After GitNexus selects a code path, use Serena only on the relevant symbol before editing. After `rg` finds an exact non-code match, inspect that narrow file window directly.
+3. Inspect symbol metadata, callers, and references before requesting source bodies.
+4. Read the smallest useful source window, normally one symbol or roughly 80-160 lines.
+5. Expand only to a dependency, caller, test, or contract needed to answer the current question.
+6. Run the smallest relevant validation, then broaden checks in proportion to risk.
+
+Start GitNexus searches with a small result limit and without `--content`; request full symbol content only after selecting the relevant process or symbol. Use Serena symbol overviews and reference queries before reading whole files. Do not dump entire directories, generated bundles, large JSON, full database rows, or multiple long files into one tool response.
+
+Within one uninterrupted task, do not reread unchanged files, guidance, roadmap sections, or the complete diff unless context was compacted, the branch or guidance changed, evidence conflicts, or exact verification requires it. Persist durable cross-cutting findings in the active task report or execution ledger and reuse them. For edits, prefer a path-scoped diff; inspect the complete diff once when it reaches a stable review checkpoint.
+
+Redirect oversized machine output to an ignored temporary file and extract a bounded summary with `rg`, `jq`, a parser, or a short read-only script. Keep the exact command and artifact path when the full result is evidence, but do not stream the full artifact into the conversation. Batch independent narrow lookups when useful, but do not concatenate unrelated large outputs.
+
+These rules optimize context use, not correctness. Reopen source or rerun evidence whenever behavior, safety, privacy, or a public contract remains uncertain.
 
 ```bash
 python -m ruff check .

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -761,35 +761,73 @@ commit as each roadmap task.
 ## Task 27.5 - Foundation Audit and 0.24 Plan Confirmation
 
 - Stable task ID: `ARCH-AUDIT-00`
-- Status: planned; blocked on Task 27 and successful completion of the `0.23`
-  release gate.
+- Status: complete; Task 27 and the `0.23.0` release gate completed before
+  evidence collection, and this checkpoint recorded `PROCEED`.
 - Branch: `pivot/27.5-foundation-audit`
-- Commits: pending; prescribed commit is
-  `docs: add 0.24 foundation audit checkpoint`.
-- Audit report: `docs/superpowers/reports/0.24-foundation-audit.md` (pending).
-- Audited commit SHA: pending.
-- Decision: pending; must be exactly `PROCEED`, `AMEND`, or `STOP`.
-- Changed files: pending.
-- Focused verification: pending; record the exact documentation, dependency,
-  architecture-analysis, migration, storage-integrity, canonical-accounting,
-  and public-contract commands used.
-- Full verification: pending; record all results without hiding failures.
-- Architecture graph or generated inventory artifacts: pending.
-- Migration fixtures tested: pending.
-- Findings assigned to Tasks 28-33: pending.
-- Maintainer approval reference: not required for `PROCEED`; pending and
-  mandatory for `AMEND` or `STOP`.
-- Deviations from plan: none; this planned entry does not authorize production
-  refactoring or silent roadmap amendments.
-- Follow-up risks: Tasks 28-39 and all other `0.24` implementation work remain
-  blocked until this entry records `PROCEED` or a maintainer-approved `AMEND`.
-  A `STOP` decision blocks implementation and requires a separate
-  maintainer-approved redesign.
+- Commits: `docs: add 0.24 foundation audit checkpoint` (this checkpoint;
+  exact SHA is recorded in Git/PR history).
+- Audit report: `docs/superpowers/reports/0.24-foundation-audit.md`.
+- Audited commit SHA: `589e10a1afeca72e47d6b2d5777cd8189d292996`.
+- Decision: `PROCEED`.
+- Changed files:
+  `docs/superpowers/reports/0.24-foundation-audit.md`,
+  `docs/roadmap/mcp-first-pivot-execution.md`, `.gitignore`, and `AGENTS.md`.
+  The latter two add the user-approved ignored GitNexus index and
+  context-efficient GitNexus/Serena/source/test workflow; the 548 MiB local
+  `.gitnexus/` index and IntelliJ `.idea/` directory remain untracked.
+- Focused verification:
+  - migration, canonical accounting, refresh, content, OTel, allowance,
+    contract, core MCP, profile, and HTTP-v2 suite: `126 passed in 11.35s`;
+  - fresh temporary SQLite database: schema/user version 34, 34 migration
+    records, 38 physical tables, `integrity_check=ok`,
+    `foreign_key_check=[]`, and normal `foreign_keys=0`;
+  - `ruff check .`: passed;
+  - `.venv/bin/python -m pyright --pythonpath .venv/bin/python src`: 0 errors,
+    7 existing lazy-export warnings;
+  - `python scripts/check_release.py`: passed;
+  - `npx markdownlint-cli2`: passed;
+  - synthetic isolated doctor: completed with the expected warning-only
+    missing-local-setup result.
+- Full verification: `.venv/bin/python -m pytest -q`:
+  `1907 passed in 116.87s`.
+- Architecture graph and inventory evidence:
+  - Tach map: 381 modules, 1,327 edges, 3 non-trivial SCCs;
+  - `tach check`: the 8 pre-existing direction violations recorded in the
+    report, assigned to Tasks 28-30;
+  - GitNexus at the audited SHA: 1,348 files, 25,190 symbols, 54,349
+    relationships, 1,311 clusters, and 300 processes;
+  - `gitnexus check --cycles --json`: 7 file-level cycles, including
+    analytics/application, store/schema, store/refresh, frontend, and one
+    generated-bundle cycle.
+- Migration fixtures tested: unversioned legacy aggregate through v34; fresh
+  v34; representative v23, v24, v25, v27, v28, v31, and v33 states; canonical
+  rebuild; OTel v30/v31; malformed legacy failure/partial-commit evidence;
+  refresh idempotency and CSV compatibility. Every retained SQLite fixture
+  returned `integrity_check=ok` and zero `foreign_key_check` rows.
+- Findings assigned to Tasks 28-33:
+  - Task 28: composition, status, repository, evidence, focused-route, and
+    refresh workflow ownership;
+  - Task 29: MCP extraction and registration cycles;
+  - Task 30: dependency direction, explicit adapters, contract isolation, and
+    remaining cycles;
+  - Task 31: foreign-key enforcement, atomic migration failure,
+    transaction/rebuild/cache-write safety, cascade and retained migration
+    fixtures;
+  - Task 32: indexed byte-offset context retrieval and inspected-byte budgets;
+  - Task 33: persistent generic jobs/results and recovery.
+- Maintainer approval reference: not required for `PROCEED`.
+- Deviations from plan: no production behavior or schema changed. GitNexus
+  added independent graph evidence and user-approved repository guidance; no
+  roadmap task was broadened.
+- Follow-up risks: the report contains 14 assigned findings and no blocker or
+  unassigned high-severity finding. Task 28 may start only after this audit
+  checkpoint lands. Focused Home, Limits, Calls, Threads, and Thread Calls
+  routes remain protected until exact parity and performance gates pass.
 
 ## Remaining Planned Tasks
 
-Task 27.5 and Tasks 28 through 45 remain planned in the approved implementation
-roadmap. Task 27.5 is the exclusive entry gate for `0.24`; no later `0.24` task
-may begin or run in parallel with it. Add a full entry using the format above
+Task 27.5 is complete once this independent checkpoint lands. Tasks 28 through
+45 remain planned in the approved implementation roadmap, and no later `0.24`
+task may begin before that checkpoint. Add a full entry using the format above
 when each task becomes active; do not mark a task complete without its named
 focused and full verification evidence.

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -758,8 +758,38 @@ commit as each roadmap task.
   content/fact indexing pipeline rather than dashboard availability or focused
   endpoint hydration; it is recorded for 0.24 performance hardening.
 
+## Task 27.5 - Foundation Audit and 0.24 Plan Confirmation
+
+- Stable task ID: `ARCH-AUDIT-00`
+- Status: planned; blocked on Task 27 and successful completion of the `0.23`
+  release gate.
+- Branch: `pivot/27.5-foundation-audit`
+- Commits: pending; prescribed commit is
+  `docs: add 0.24 foundation audit checkpoint`.
+- Audit report: `docs/superpowers/reports/0.24-foundation-audit.md` (pending).
+- Audited commit SHA: pending.
+- Decision: pending; must be exactly `PROCEED`, `AMEND`, or `STOP`.
+- Changed files: pending.
+- Focused verification: pending; record the exact documentation, dependency,
+  architecture-analysis, migration, storage-integrity, canonical-accounting,
+  and public-contract commands used.
+- Full verification: pending; record all results without hiding failures.
+- Architecture graph or generated inventory artifacts: pending.
+- Migration fixtures tested: pending.
+- Findings assigned to Tasks 28-33: pending.
+- Maintainer approval reference: not required for `PROCEED`; pending and
+  mandatory for `AMEND` or `STOP`.
+- Deviations from plan: none; this planned entry does not authorize production
+  refactoring or silent roadmap amendments.
+- Follow-up risks: Tasks 28-39 and all other `0.24` implementation work remain
+  blocked until this entry records `PROCEED` or a maintainer-approved `AMEND`.
+  A `STOP` decision blocks implementation and requires a separate
+  maintainer-approved redesign.
+
 ## Remaining Planned Tasks
 
-Tasks 28 through 45 remain planned in the approved implementation roadmap. Add
-a full entry using the format above when each task becomes active; do not mark a
-task complete without its named focused and full verification evidence.
+Task 27.5 and Tasks 28 through 45 remain planned in the approved implementation
+roadmap. Task 27.5 is the exclusive entry gate for `0.24`; no later `0.24` task
+may begin or run in parallel with it. Add a full entry using the format above
+when each task becomes active; do not mark a task complete without its named
+focused and full verification evidence.

--- a/docs/roadmap/mcp-first-pivot.md
+++ b/docs/roadmap/mcp-first-pivot.md
@@ -22,7 +22,7 @@ continues to support setup, automation, recovery, export, and compatibility.
 | --- | --- | --- |
 | `0.22.0` | Stable MCP core profile, shared contracts, truthful positioning, and generic job facade | Existing dashboard and old tools still work; old tools move to the `full` profile. |
 | `0.23.0` | Evidence Console becomes the default; CLI and HTTP v2 ship | Old pages remain direct-link routes and old CLI names remain aliases. |
-| `0.24.0` | Architecture, database integrity, context offsets, and infrastructure hardening | Old pages are notice-only; old APIs and aliases remain supported. |
+| `0.24.0` | Task 27.5 foundation audit, then architecture, database integrity, context offsets, and infrastructure hardening | Implementation starts only after `PROCEED` or a maintainer-approved `AMEND`; old pages are notice-only and old APIs and aliases remain supported. |
 | `0.25.0` | Expired dashboard, static, MCP, CLI, and HTTP compatibility is removed | Only documented stable and advanced surfaces remain. |
 | `0.26.0` | Feature-free stabilization and pre-1.0 contract hardening | No new public surface; migration and package gates prove the final state. |
 
@@ -57,6 +57,32 @@ A compatibility endpoint cannot be removed while its stable replacement fails
 functional parity, performs an unbounded dashboard scan, or regresses the
 recorded route budget.
 
+## Pre-0.24 Foundation Gate
+
+After Task 27 and the successful `0.23` release gate, Task 27.5
+(`ARCH-AUDIT-00`) audits canonical accounting, migrations, table ownership,
+transaction boundaries, dependency direction, and public-contract leakage. It
+produces `docs/superpowers/reports/0.24-foundation-audit.md` and records exactly
+one decision: `PROCEED`, `AMEND`, or `STOP`.
+
+No Task 28-39 implementation work may begin or run in parallel with Task 27.5.
+`PROCEED` opens the `0.24` implementation gate. `AMEND` opens it only after
+maintainer approval and corresponding roadmap edits. `STOP` blocks the gate and
+does not authorize an autonomous rewrite. The `0.24` release gate also requires
+no unassigned `BLOCKER` or `HIGH` foundation finding and requires every approved
+amendment to be represented in the roadmap.
+
+The sequence is:
+
+```text
+Complete 0.23 gate
+    -> Task 27.5 foundation audit
+    -> PROCEED or approved AMEND
+    -> Tasks 28-33 foundation refactor
+    -> remaining 0.24 hardening and release gate
+    -> 0.25 deletion and sunset work
+```
+
 ## Compatibility Policy
 
 Compatibility is bounded by [the deprecation ledger](../deprecations.md). An
@@ -71,3 +97,5 @@ named failing tests, implements only its declared interfaces, and records
 verification and risks in the
 [execution ledger](mcp-first-pivot-execution.md). Release, compatibility, schema,
 and public-contract changes require an independent reviewer before merge.
+Task 28 additionally depends on Task 27.5 recording `PROCEED` or a
+maintainer-approved `AMEND`.

--- a/docs/superpowers/plans/2026-07-21-mcp-first-product-pivot.md
+++ b/docs/superpowers/plans/2026-07-21-mcp-first-product-pivot.md
@@ -10,6 +10,10 @@
 
 **Approved design:** `docs/superpowers/specs/2026-07-21-mcp-first-product-pivot-design.md`
 
+**Program size:** 46 tasks: Tasks 1-45 retain their existing numbers, with the
+human-visible Task 27.5 checkpoint (`ARCH-AUDIT-00`) inserted between Tasks 27
+and 28.
+
 ## Global Constraints
 
 - Baseline repository state is `main` at `bf383e1f4d9e206f3ba8cb004075bc3e87bc3fa6` and published package `0.21.0`.
@@ -43,7 +47,7 @@
 | --- | --- | --- |
 | `0.22.0` | Stable MCP core profile, shared contracts, truthful product positioning, generic job facade | Existing dashboard and old tools still function; old tools are `full` profile |
 | `0.23.0` | Evidence Console becomes default; CLI and HTTP v2 ship | Old dashboard pages are direct-link compatibility routes; old CLI names remain aliases |
-| `0.24.0` | Python architecture refit, database integrity, context offsets, infrastructure hardening | Old pages are notice-only; old APIs and aliases remain supported |
+| `0.24.0` | Foundation audit, Python architecture refit, database integrity, context offsets, infrastructure hardening | No implementation begins before Task 27.5 records `PROCEED` or a maintainer-approved `AMEND`; old pages are notice-only and old APIs and aliases remain supported |
 | `0.25.0` | Expired dashboard, static, MCP, CLI, and HTTP compatibility removed | Only documented stable and advanced surfaces remain |
 | `0.26.0` | Feature-free stabilization release for pre-1.0 contract hardening | No new public surface; migration and package gates prove final state |
 
@@ -59,6 +63,10 @@ Task 6-14 Core application services and tools
 Task 15-17 Compatibility isolation and 0.22 release
    |
 Task 18-27 Evidence Console, CLI, HTTP v2, and 0.23 release
+   |
+Task 27.5 Foundation audit and 0.24 plan confirmation
+   |
+Record PROCEED or maintainer-approved AMEND
    |
 Task 28-39 Architecture, integrity, CI/release, and 0.24 release
    |
@@ -1867,9 +1875,495 @@ git commit -m "chore: prepare 0.23.0 Evidence Console release"
 
 ---
 
+## Pre-0.24 entry checkpoint
+
+The `0.23` release gate must complete before this checkpoint begins. No Task
+28-39 implementation branch may start, run in parallel, or merge until Task
+27.5 records `PROCEED` or a maintainer approves its `AMEND` result. A `STOP`
+result blocks the `0.24` implementation program and does not authorize a
+rewrite.
+
+```text
+Complete 0.23 gate
+    |
+Task 27.5 foundation audit
+    |
+Record PROCEED or approved AMEND
+    |
+Tasks 28-33 foundation refactor
+    |
+Remaining 0.24 hardening and release gate
+    |
+0.25 deletion and sunset work
+```
+
+### Task 27.5: Foundation Audit and 0.24 Plan Confirmation
+
+**Release:** Pre-`0.24` entry checkpoint
+
+**Stable task ID:** `ARCH-AUDIT-00`
+
+**Depends on:** Task 27 and successful completion of the `0.23` release gate
+
+**Blocks:** Tasks 28-39 and all other `0.24` implementation work
+
+**Implementation type:** Audit, evidence collection, and roadmap confirmation
+
+**Production behavior change:** None
+
+**Maintainer decision required:** Only for an `AMEND` or `STOP` result
+
+**Files:**
+
+- Create: `docs/superpowers/reports/0.24-foundation-audit.md`
+- Optionally create: repeatable audit-only scripts, dependency-graph helpers,
+  synthetic test fixtures, or generated inventory artifacts
+- Modify only when evidence requires it: architecture/storage claims in the
+  roadmap or directly related documentation
+- Modify after maintainer approval only: Tasks 28-39 when the decision is
+  `AMEND`
+
+#### Purpose
+
+Before enforcing the new application-service boundaries, inspect the actual
+repository and prove whether the existing accounting, persistence, migration,
+and public-contract foundations can support the MCP-first pivot without a
+foundation rewrite.
+
+The audit must distinguish:
+
+1. a healthy data core surrounded by an overgrown application shell;
+2. remediable foundation defects requiring amendments to Tasks 28-33;
+3. incompatible core semantics that invalidate the current `0.24` plan.
+
+The audit must not assume that the foundation is either healthy or rotten. It
+must produce evidence.
+
+#### Non-goals
+
+Task 27.5 must not:
+
+- refactor packages;
+- move production modules;
+- introduce the application composition root;
+- change public MCP, HTTP, CLI, or dashboard contracts;
+- change SQLite tables or migrations;
+- delete compatibility paths;
+- redesign canonical identity;
+- rewrite accounting algorithms;
+- begin the dashboard sunset;
+- perform external user validation;
+- expand privacy scope beyond identifying inaccurate documentation claims;
+- authorize a full rewrite automatically.
+
+Small audit scripts, dependency-graph helpers, test fixtures, and documentation
+may be added when needed to collect repeatable evidence. They must not become
+new production abstractions.
+
+#### Required audit artifact
+
+Create `docs/superpowers/reports/0.24-foundation-audit.md`. The report must
+contain all sections below.
+
+##### 1. Baseline and scope
+
+Record:
+
+- audited Git commit;
+- package version;
+- SQLite schema version;
+- current public MCP tools;
+- current HTTP route families;
+- current top-level CLI commands;
+- current dashboard destinations;
+- Python package/module inventory;
+- migration-fixture inventory;
+- commands used to collect evidence.
+
+State whether the checkout was clean when evidence was collected.
+
+##### 2. Interface-to-storage execution map
+
+For every stable or intended-to-remain interface entry point, map the complete
+execution path:
+
+```text
+interface entry point
+    -> interface adapter
+    -> application/orchestration service
+    -> deterministic domain service
+    -> repository/query service
+    -> SQLite tables or source logs
+```
+
+Cover at minimum:
+
+- every core MCP tool;
+- HTTP API v2 routes;
+- stable CLI commands;
+- Evidence Console data routes;
+- refresh and rebuild paths;
+- allowance analysis;
+- canonical accounting;
+- evidence retrieval;
+- background analysis jobs.
+
+Classify each path as:
+
+- `COMPLIANT`: already follows the intended dependency direction;
+- `BYPASS`: reaches repositories, SQL, globals, or report internals directly;
+- `DUPLICATED`: reimplements domain behavior owned elsewhere;
+- `AMBIGUOUS`: ownership cannot be determined.
+
+Every `BYPASS`, `DUPLICATED`, or `AMBIGUOUS` result must map to a specific
+existing `0.24` task or a proposed roadmap amendment.
+
+##### 3. Python dependency and ownership audit
+
+Generate or document:
+
+- package-level dependency graph;
+- module-level strongly connected components;
+- imports from interface packages into storage internals;
+- imports from storage into application or interface layers;
+- import-time registration or mutable-global side effects;
+- modules with mixed interface, domain, and persistence responsibilities;
+- duplicated implementations of the same analytical concept.
+
+Compare the observed graph with the intended direction:
+
+```text
+interfaces
+    |
+application
+    |
+analytics / evidence / jobs
+    |
+store / ingest / core
+```
+
+For every violation, record the importing module, imported module, reason for
+the violation, desired owner, remediation task, and whether it blocks Task 28.
+Do not count test-only imports as production violations unless they reveal that
+production behavior cannot be instantiated without global state.
+
+##### 4. SQL table ownership matrix
+
+Inventory every application-owned SQLite table and classify it as exactly one
+of:
+
+- `SOURCE_OBSERVATION`
+- `CANONICAL_RECORD`
+- `DERIVED_MATERIALIZATION`
+- `CACHE`
+- `JOB_STATE`
+- `USER_CONFIGURATION`
+- `CONTENT_EVIDENCE`
+- `SEARCH_INDEX`
+- `DEPRECATED`
+
+For every table, record:
+
+- schema introduction version;
+- authoritative owner module;
+- writer functions or services;
+- reader functions or services;
+- transaction owner;
+- deletion and cascade behavior;
+- whether the table is rebuildable;
+- rebuild source;
+- whether it participates in canonical identity;
+- whether it leaks directly into a public API schema;
+- migration coverage;
+- integrity risks.
+
+Every table must have one declared write owner. Multiple low-level helper
+functions are acceptable only when they are called through the same ownership
+boundary.
+
+Flag tables with:
+
+- multiple incompatible writers;
+- undocumented direct SQL writes;
+- unclear source-of-truth status;
+- report-specific data treated as canonical state;
+- derived data that cannot be rebuilt;
+- deletion behavior that depends on foreign keys not being enforced;
+- public API identity coupled to an unstable physical row ID.
+
+##### 5. Write-path and transaction audit
+
+For each write workflow, identify:
+
+- transaction start and commit owner;
+- tables mutated;
+- failure and rollback behavior;
+- retry or idempotency behavior;
+- interaction with refresh cursors;
+- interaction with canonical promotion;
+- interaction with allowance materialization;
+- interaction with background jobs;
+- cleanup behavior.
+
+Cover at minimum:
+
+- initial database creation;
+- incremental refresh;
+- full rebuild;
+- canonical deduplication;
+- original-row deletion and canonical promotion;
+- content-index refresh;
+- OTel enrichment;
+- allowance recomputation;
+- persistent analysis-job creation and completion;
+- purge and reset commands;
+- schema migration.
+
+Explicitly identify workflows in which two services mutate the same logical
+aggregate under different transaction semantics.
+
+##### 6. Canonical-domain invariant audit
+
+Document the authoritative implementation and storage representation for:
+
+- physical usage-event identity;
+- logical/canonical usage identity;
+- copied-session suppression;
+- canonical representative promotion;
+- pricing and service-tier provenance;
+- allowance observations and cycles;
+- evidence references;
+- source revision and freshness;
+- project/thread/call identity;
+- background-analysis identity.
+
+For each invariant, answer:
+
+1. Is it defined in one authoritative domain implementation?
+2. Is it persisted in one authoritative representation?
+3. Is it duplicated in route-, report-, CLI-, dashboard-, or MCP-specific code?
+4. Can it be tested without invoking an interface layer?
+5. Can Tasks 28-33 preserve it without changing user-visible semantics?
+
+Any invariant with incompatible authoritative definitions is a potential
+`STOP` condition.
+
+##### 7. Public contract leakage audit
+
+Inspect the core MCP schemas, HTTP API v2 schemas, stable CLI JSON output, and
+Evidence Console contracts. Classify every public field as:
+
+- stable domain value;
+- deterministic derived value;
+- evidence/provenance value;
+- storage implementation detail;
+- physical database identifier;
+- deprecated compatibility field.
+
+Flag:
+
+- `SELECT *`-style serialization;
+- public models constructed directly from SQLite rows;
+- public identifiers that cannot survive a rebuild;
+- route-specific representations of the same domain entity;
+- duplicated schema definitions across MCP, HTTP, CLI, and frontend code;
+- fields whose meaning differs by interface;
+- public contracts dependent on table or column names.
+
+Determine whether stable contracts can be preserved by adapters or whether any
+public identity is irreconcilably tied to the current storage layout.
+
+##### 8. SQL integrity and migration evidence
+
+Using temporary copies only:
+
+- create a fresh database at the current schema version;
+- migrate every retained historical fixture;
+- migrate representative databases from multiple prior public versions;
+- run `PRAGMA integrity_check`;
+- run `PRAGMA foreign_key_check`;
+- test canonical promotion after deleting an original physical row;
+- test deletion or replacement of parent rows with dependent materializations;
+- test interrupted or failed migration rollback where supported;
+- test refresh after migration;
+- test rebuild equivalence for rebuildable tables;
+- verify schema version and migration idempotency.
+
+Record exact commands, fixture names, row counts before and after, and any
+differences accepted as intentional.
+
+Task 27.5 may expose that normal connections do not yet enable foreign keys.
+That known defect alone does not imply `STOP`; map it to the existing
+SQLite-hardening task unless integrity cannot be restored safely.
+
+##### 9. Current documentation truth audit
+
+Review only claims directly relevant to the architecture and storage contract.
+At minimum, identify and correct roadmap assumptions that claim the normal
+database is aggregate-only when current defaults also persist bounded content
+evidence.
+
+Do not expand this task into a privacy redesign. The requirement is only that
+the roadmap and audit accurately describe current behavior.
+
+##### 10. Risk register
+
+Create a table with:
+
+- finding ID;
+- severity: `BLOCKER`, `HIGH`, `MEDIUM`, or `LOW`;
+- affected invariant;
+- evidence;
+- likely consequence;
+- owning roadmap task;
+- whether the existing task is sufficient;
+- proposed amendment;
+- maintainer decision required.
+
+No `BLOCKER` or unassigned `HIGH` finding may remain when the task is marked
+complete.
+
+##### 11. Decision
+
+End the report with exactly one decision.
+
+###### `PROCEED`
+
+Use when:
+
+- canonical accounting invariants have coherent authoritative owners;
+- table write ownership can be made explicit without changing core semantics;
+- retained migration fixtures pass or have bounded fixes already covered by
+  Tasks 28-33;
+- public contracts can be isolated through adapters;
+- discovered architecture violations are addressable by the current `0.24`
+  plan;
+- no foundation rewrite is justified.
+
+###### `AMEND`
+
+Use when:
+
+- the core remains retainable;
+- no full rewrite is justified;
+- Tasks 28-33 are insufficient or incorrectly ordered;
+- additional bounded `0.24` tasks or acceptance criteria are required.
+
+An `AMEND` result must include exact roadmap edits. Those edits require
+maintainer approval before Task 28 starts.
+
+###### `STOP`
+
+Use only when evidence shows at least one of:
+
+- canonical accounting has incompatible authoritative definitions;
+- multiple write paths implement irreconcilable semantics for the same logical
+  state;
+- retained databases cannot be migrated safely without destructive rebuilding;
+- core public identities cannot be separated from unstable physical storage
+  identities;
+- foundational invariants cannot be preserved through the planned
+  strangler-style refactor;
+- data-integrity failures cannot be repaired by bounded changes to Tasks 28-33.
+
+`STOP` does not authorize an autonomous rewrite. It blocks implementation and
+requires a separate maintainer-approved redesign.
+
+##### 12. Roadmap reconciliation
+
+If the decision is `PROCEED`, record that Tasks 28-33 remain sufficient and
+list all findings assigned to each task.
+
+If the decision is `AMEND`, update the roadmap only after maintainer approval.
+Do not silently broaden existing tasks while performing the audit.
+
+If the decision is `STOP`, do not alter Tasks 28-39 beyond recording the block.
+
+#### Required implementation method
+
+The Task 27.5 executor must:
+
+1. start from a clean checkout at the completed `0.23` checkpoint;
+2. read Tasks 28-33 before collecting evidence;
+3. collect dependency, interface, SQL ownership, and migration evidence;
+4. add audit-only scripts or tests where repeatability requires them;
+5. write the audit report;
+6. assign every finding to an existing task or proposed amendment;
+7. record one decision: `PROCEED`, `AMEND`, or `STOP`;
+8. run documentation, manifest, architecture-analysis, and audit-script tests;
+9. obtain maintainer approval for `AMEND` or `STOP`;
+10. commit the completed audit independently from Task 28.
+
+#### Acceptance criteria
+
+Task 27.5 is complete only when:
+
+- `docs/superpowers/reports/0.24-foundation-audit.md` exists;
+- the audited commit and schema version are recorded;
+- every intended stable interface has an execution-path classification;
+- every application-owned table appears in the ownership matrix;
+- every table has a declared write owner or a blocking finding;
+- every core write workflow has a transaction owner;
+- every canonical invariant has an authoritative implementation identified;
+- all direct interface-to-storage bypasses are listed;
+- all public contract/storage leaks are listed;
+- retained migration fixtures have recorded results;
+- `integrity_check` and `foreign_key_check` results are recorded;
+- every finding maps to Tasks 28-33 or an explicit proposed amendment;
+- no unassigned `BLOCKER` or `HIGH` finding remains;
+- the final decision is exactly `PROCEED`, `AMEND`, or `STOP`;
+- Task 28 is blocked unless the decision is `PROCEED` or an `AMEND` is
+  approved;
+- no production refactor is mixed into the audit commit.
+
+#### Suggested verification commands
+
+Use the repository's current equivalents of:
+
+```bash
+python -m pytest <migration and storage integrity tests>
+python -m pytest <canonical accounting tests>
+python -m pytest <public contract tests>
+tach check
+pyright
+ruff check .
+python -m codex_usage_tracker doctor
+sqlite3 <temporary-db> "PRAGMA integrity_check;"
+sqlite3 <temporary-db> "PRAGMA foreign_key_check;"
+```
+
+Do not invent nonexistent test paths. Resolve current test modules by searching
+the repository and record the exact commands actually used.
+
+#### Completion evidence
+
+The execution-ledger entry must contain:
+
+- audit report path;
+- audited commit SHA;
+- decision;
+- changed files;
+- verification commands and results;
+- architecture graph or generated inventory artifacts;
+- migration fixtures tested;
+- findings assigned to Tasks 28-33;
+- maintainer approval reference when the result is `AMEND` or `STOP`.
+
+#### Prescribed commit
+
+```bash
+git add docs/superpowers/reports/0.24-foundation-audit.md docs/roadmap/mcp-first-pivot-execution.md
+git commit -m "docs: add 0.24 foundation audit checkpoint"
+```
+
+---
+
 ## Release 0.24.0 - Architecture, integrity, and delivery hardening
 
 ### Task 28: Add an application composition root and dependency protocols
+
+**Depends on:** Task 27.5 with a `PROCEED` decision or a
+maintainer-approved `AMEND`
 
 **Files:**
 
@@ -2601,6 +3095,7 @@ git commit -m "refactor: retire legacy dashboard workbenches"
 
 **Files:**
 
+- Require: `docs/superpowers/reports/0.24-foundation-audit.md`
 - Create: `docs/releases/0.24.0.md`
 - Create: `docs/upgrading-to-0.24.0.md`
 - Create: `docs/releases/0.24.0-artifact-manifest-example.json`
@@ -2613,6 +3108,11 @@ git commit -m "refactor: retire legacy dashboard workbenches"
 
 **Release acceptance:**
 
+- Task 27.5 records `PROCEED` or a maintainer-approved `AMEND`; a `STOP`
+  decision prevents this gate from starting.
+- No unassigned `BLOCKER` or `HIGH` foundation finding remains.
+- Every approved audit amendment is represented in this roadmap and its
+  execution ledger before the release gate starts.
 - Python architecture has zero Tach cycles and `root_module="forbid"`.
 - Application services run from custom temporary paths without global defaults.
 - Default MCP server is explicitly constructed and has no import-registration side effects.
@@ -2625,14 +3125,20 @@ git commit -m "refactor: retire legacy dashboard workbenches"
 - Complexity budgets pass.
 - Legacy dashboard workbenches are notice-only and make no old API calls.
 
-- [ ] **Step 1: Run architecture/integrity focused gates.**
+- [ ] **Step 1: Confirm the foundation-audit entry gate.** Verify the audit
+  report path, audited commit, final decision, risk assignments, migration
+  evidence, and any maintainer approval. Stop if the decision is `STOP`, any
+  `BLOCKER` or unassigned `HIGH` finding remains, or an approved amendment is
+  absent from the roadmap.
+
+- [ ] **Step 2: Run architecture/integrity focused gates.**
 
 ```bash
 tach check
 python -m pytest tests/architecture tests/store/test_connection_integrity.py tests/store/test_foreign_key_cascades.py tests/jobs/test_persisted_jobs.py tests/context/test_byte_offset_reads.py -q
 ```
 
-- [ ] **Step 2: Run complete quality and product gates.**
+- [ ] **Step 3: Run complete quality and product gates.**
 
 ```bash
 python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
@@ -2655,11 +3161,14 @@ git diff --check
 
 Expected: all PASS.
 
-- [ ] **Step 3: Run one TestPyPI promotion rehearsal using the new artifact workflow.** Verify downloaded TestPyPI hashes equal the build manifest before enabling the production environment.
+- [ ] **Step 4: Run one TestPyPI promotion rehearsal using the new artifact workflow.** Verify downloaded TestPyPI hashes equal the build manifest before enabling the production environment.
 
-- [ ] **Step 4: Record release evidence.** Include architecture graph summary, integrity check output, schema version/migration, offset performance evidence, coverage, complexity budgets, action pin inventory, and artifact hashes.
+- [ ] **Step 5: Record release evidence.** Include the foundation-audit report,
+  decision and finding assignments; architecture graph summary; integrity check
+  output; schema version/migration; offset performance evidence; coverage;
+  complexity budgets; action pin inventory; and artifact hashes.
 
-- [ ] **Step 5: Commit.**
+- [ ] **Step 6: Commit.**
 
 ```bash
 git add README.md CHANGELOG.md pyproject.toml docs/releases/0.24.0.md docs/upgrading-to-0.24.0.md docs/releases/0.24.0-artifact-manifest-example.json docs/roadmap/mcp-first-pivot-execution.md docs/release-checklist.md tests/golden_questions/test_core_tools.py
@@ -3186,15 +3695,15 @@ git commit -m "chore: prepare 0.26.0 contract-stabilization release"
 | MCP-first product positioning and accurate public claims | 1-2, 17, 27, 42, 45 | Public-doc tests, package metadata, release notes |
 | Seven-tool default profile and compatibility isolation | 3, 12-16, 41, 45 | Tool inventory snapshots and installed-plugin smoke |
 | Shared envelope, scope, messages, findings, and evidence | 4-5, 9-14, 25, 45 | JSON contract registry and exact fixtures |
-| Generic job lifecycle | 7-8, 11, 14, 33, 44 | Job adapter, persistence, recovery, and fault tests |
+| Generic job lifecycle | 7-8, 11, 14, 27.5, 33, 44 | Audit ownership map, job adapter, persistence, recovery, and fault tests |
 | Evidence Console route model | 18-23, 27 | Route catalog, URL aliases, browser acceptance |
 | Dashboard feature sunset | 23-24, 38, 40-43 | Parity record, zero-network notices, removed-source inventory |
 | CLI simplification | 26, 41-43, 45 | Parser inventories, alias lifecycle, help snapshots |
-| HTTP API v2 | 25, 28-30, 41, 45 | Route inventory, schema equality, architecture gates |
+| HTTP API v2 and public-contract isolation | 25, 27.5, 28-30, 41, 45 | Audit leakage map, route inventory, schema equality, architecture gates |
 | Focused dashboard query performance and freshness | 19-20, 25, 27, 34, 41, 45 | Filter/sort/count parity, 100k route budgets, incremental-refresh visibility |
-| Application architecture and dependency direction | 28-30 | Container tests, Tach, secondary import regression |
-| SQLite integrity and migration safety | 31-33, 39, 45 | Foreign-key checks, migration fixtures, upgrade smokes |
-| Context-read performance | 32, 39, 45 | Payload equivalence and inspected-byte performance ratchet |
+| Application composition root and dependency direction | 27.5, 28-30 | Foundation audit, container tests, Tach, secondary import regression |
+| SQLite ownership, integrity, and migration safety | 27.5, 31-33, 39, 45 | Table/write-owner audit, foreign-key checks, migration fixtures, upgrade smokes |
+| Context indexing and read performance | 27.5, 32, 39, 45 | Audit ownership map, payload equivalence, inspected-byte performance ratchet |
 | Coverage and false-green prevention | 34, 39, 43-45 | 85% branch coverage, 90% changed lines, work-proof contracts |
 | Immutable CI and release promotion | 35-36, 39, 43, 45 | Action-pin tests and identical public artifact hashes |
 | Product/package complexity reduction | 24, 37-43, 45 | Blocking budgets and baseline/final comparison |
@@ -3204,6 +3713,10 @@ git commit -m "chore: prepare 0.26.0 contract-stabilization release"
 
 Tasks may run in parallel only when they do not edit the same contracts or depend on an unmerged interface. The preferred execution remains sequential; this map exists for a coordinator using isolated worktrees.
 
+Task 27.5 is an exclusive entry gate. No `0.24` implementation track may run
+in parallel with it, and no Task 28-39 branch may begin until it records
+`PROCEED` or a maintainer approves its `AMEND`.
+
 | After completion of | Tasks that may run concurrently | Merge order constraint |
 | --- | --- | --- |
 | 5 | 6 and 7 | Merge 6 before 8; merge 7 before 8 and 11 |
@@ -3211,6 +3724,7 @@ Tasks may run in parallel only when they do not edit the same contracts or depen
 | 14 | 15 and documentation preparation for 16 | Merge 15 before 16 |
 | 18 | 19 and 20 | Merge both before 21 and 23 |
 | 21 | 22 and 24 | Merge both before 27; 23 depends on 19-22 |
+| 27 and completed `0.23` gate | 27.5 only | Record `PROCEED` or approved `AMEND` before any Task 28-39 work |
 | 28 | 31 and 32 | Merge both before 30 only when domain paths are stable; otherwise 30 merges first and both rebase |
 | 30 | 34 and 35 | Merge independently; 36 depends on 35 and current release checks |
 | 31-33 | 37 and 38 | Merge 38 before 39; 37 must remeasure after 38 |
@@ -3232,6 +3746,8 @@ The pivot is complete only when all statements below are true:
 - [ ] Legacy static dashboard and workbench source are absent from distributions.
 - [ ] Stable CLI help contains only the simplified hierarchy.
 - [ ] HTTP API v2, MCP, and CLI share request/response models.
+- [ ] Task 27.5 records `PROCEED` or an approved `AMEND`, with no unassigned
+  `BLOCKER` or `HIGH` foundation finding.
 - [ ] Tach blocks cycles and upward dependencies.
 - [ ] SQLite foreign keys and integrity checks are enabled and tested.
 - [ ] Context reads use validated byte offsets with a correct fallback.

--- a/docs/superpowers/reports/0.24-foundation-audit.md
+++ b/docs/superpowers/reports/0.24-foundation-audit.md
@@ -1,0 +1,651 @@
+# Codex Usage Tracker 0.24 Foundation Audit
+
+- Date: 2026-07-23
+- Stable task ID: `ARCH-AUDIT-00`
+- Audited commit: `589e10a1afeca72e47d6b2d5777cd8189d292996`
+- Package version: `0.23.0`
+- SQLite schema version: `34`
+
+This is the exclusive pre-0.24 checkpoint required by Task 27.5. It audits
+the released 0.23 foundation without changing production code, public
+contracts, migrations, or runtime behavior.
+
+## 1. Baseline and scope
+
+### Public inventory
+
+| Surface | Audited inventory |
+| --- | --- |
+| Core MCP profile | 7 tools: `usage_status`, `usage_refresh`, `usage_analyze`, `usage_query`, `usage_evidence`, `usage_allowance`, `usage_job_status` |
+| Full MCP profile | 59 tools: the 7 core tools plus compatibility and advanced tools |
+| Developer MCP profile | 64 tools: the full profile plus 5 experimental developer tools |
+| HTTP API v2 | 8 routes: `GET /api/v2/status`, `POST /api/v2/refresh`, `POST /api/v2/analyze`, `POST /api/v2/query`, `POST /api/v2/evidence`, `POST /api/v2/allowance`, `GET /api/v2/jobs/{job_id}`, `GET /api/v2/capabilities` |
+| Stable CLI | 11 top-level commands: `setup`, `status`, `doctor`, `refresh`, `analyze`, `query`, `open`, `export`, `config`, `service`, `admin` |
+| CLI compatibility | 34 hidden but parseable top-level aliases retained through 0.24 |
+| Evidence Console | Primary: Home, Explore with Calls/Threads modes, Limits. Contextual: Evidence. Utility: Settings. Legacy workbenches remain compatibility routes but are absent from primary navigation. |
+| Python inventory | 385 modules in 26 package directories beneath `src/codex_usage_tracker` |
+| Frontend inventory | 363 TypeScript/TSX source and test files |
+| SQLite inventory | 38 physical tables on a fresh database: 34 application/logical tables plus 4 FTS5 shadow tables |
+
+The 34 logical tables are all inventoried in section 4. `content_fts_config`,
+`content_fts_data`, `content_fts_docsize`, and `content_fts_idx` are
+SQLite-owned FTS5 shadows and are covered with `content_fts`.
+
+### Migration-fixture inventory
+
+The retained synthetic coverage includes:
+
+- an unversioned legacy aggregate table migrated through versions 1-34;
+- a legacy database followed by an idempotent refresh;
+- a fresh version-34 database with all migration ledger entries;
+- explicit upgrades from v23, v24, v25, v27, v28, v31, and v33 states;
+- canonical-copy backfill and timestamp-rewrite reclassification;
+- recommendation and allowance derivative invalidation after canonical rebuild;
+- OTel v30 tables and v31 resume-anchor preservation;
+- malformed legacy schema failure and doctor error reporting;
+- CSV compatibility after a legacy migration.
+
+The broad legacy fixture traverses every migration. Dedicated fixtures do not
+yet exist for v13 content introduction, v15-v17 compression introduction,
+v20-v21 recommendation introduction, v26 canonical indexes, or v30 OTel
+introduction. That is a coverage gap, not observed corruption, and is assigned
+to Task 31.
+
+### Evidence commands
+
+The audit used these commands from the audited checkout:
+
+```text
+git status --short --branch
+python imports over interfaces.mcp.profiles and interfaces.http.v2
+rg over parser, store, application, interface, server, CLI, and frontend routes
+python fresh-database inventory using store.connection.connect and store.schema.init_db
+.venv/bin/python -m pytest --collect-only -q -p no:tach
+  tests/store/test_store_migrations.py
+  tests/store/test_usage_deduplication_migration.py
+  tests/store/test_otel_schema.py
+pytest -q tests/store/test_store_migrations.py tests/store/test_usage_deduplication.py
+  tests/store/test_usage_deduplication_migration.py
+  tests/store/test_content_index_refresh.py tests/store/test_otel_schema.py
+  tests/store/test_otel_refresh.py tests/store/test_allowance_materialization.py
+  tests/application/test_refresh.py tests/core/test_json_contracts.py
+  tests/core/contracts tests/mcp/test_core_query_tool.py
+  tests/mcp/test_core_analyze_tool.py tests/mcp/test_core_allowance_tool.py
+  tests/mcp/test_tool_profiles.py tests/server/test_server_allowance_v2.py
+tach check
+gitnexus status
+gitnexus list
+gitnexus query "<audit concept>" --limit 12
+gitnexus context <symbol> --file <path> --limit 20
+gitnexus check --cycles --json
+ruff check .
+.venv/bin/python -m pyright --pythonpath .venv/bin/python src
+synthetic run_doctor(codex_home=<empty temp home>, db_path=<empty temp database>)
+.venv/bin/python -m pytest tests/store/test_store_migrations.py
+  tests/store/test_usage_deduplication_migration.py
+  tests/store/test_otel_schema.py -q
+  --basetemp /tmp/codex-usage-task-27.5-migrations.Zls3KN/pytest
+read-only sqlite scan over every retained *.sqlite3 fixture using
+  PRAGMA user_version, integrity_check, and foreign_key_check
+```
+
+The exact results available when this report was drafted are recorded in
+sections 3 and 8 and in the execution ledger.
+
+### Checkout state
+
+The committed source tree was clean at the audited SHA. Opening the managed
+worktree in IntelliJ created an untracked `.idea/` directory before the final
+evidence pass. That IDE-only directory was not read as architectural evidence,
+is not included in this checkpoint, and does not change the audited source
+state.
+
+## 2. Interface-to-storage execution map
+
+Classification uses the Task 27.5 definitions. “Domain” below means the
+deterministic accounting, allowance, evidence, analytics, pricing, or parser
+logic between orchestration and persistence.
+
+### Core MCP tools
+
+| Entry | Execution path | Class | Remediation |
+| --- | --- | --- | --- |
+| `usage_status` | `interfaces.mcp.core_tools` -> `application.status.get_status` -> `application.context.build_request_context` -> `store.api.query_status_context_facts` / pricing and source facts -> `usage_events`, `refresh_meta`, compression generation, source logs metadata | `COMPLIANT` with construction debt | Task 28 injects the context and repository ports instead of default paths. |
+| `usage_refresh` | `interfaces.mcp.core_tools` -> `application.refresh.refresh_usage` / `RefreshCoordinator` -> refresh planner -> `store.api.refresh_usage_index` -> `store.refresh_stream` -> parser and materializers -> usage, source, content, allowance, recommendation, compression, and OTel tables | `COMPLIANT` with an over-broad repository facade | Tasks 28 and 30 isolate composition and package direction; Task 31 hardens transaction/integrity behavior. |
+| `usage_analyze` | `interfaces.mcp.query_analysis_tools` -> `application.analyze.analyze_usage` -> `AnalysisRuntime` -> analytics strategy catalog -> store query/report functions -> canonical and derived tables | `BYPASS` | Analytics strategies still reach store/report internals and the MCP adapter caches default runtimes. Tasks 28-30 own the correction; Task 33 persists jobs. |
+| `usage_query` | `interfaces.mcp.query_analysis_tools` -> `application.query.query_usage` -> query validation/pricing -> `store.api.query_canonical_usage_v2` -> `canonical_usage_events` and derived facts | `COMPLIANT` with repository leakage | Task 28 introduces a query protocol so the application service does not import the store facade directly. |
+| `usage_evidence` | `interfaces.mcp.core_tools` -> `application.evidence.get_evidence` -> evidence selectors -> usage record/thread/allowance queries and bounded source evidence -> canonical, thread-summary, allowance, content/source tables or one selected source-log slice | `BYPASS` | The application service imports multiple store implementations and lazily obtains a global job service. Tasks 28, 30, and 32 own ports and indexed byte-range retrieval. |
+| `usage_allowance` | `interfaces.mcp.core_tools` -> `application.allowance.get_allowance` -> allowance domain services/materializer -> direct connection and schema initialization -> allowance and canonical tables | `BYPASS` | The application service opens SQLite directly, while `store.allowance_materialization` imports higher-level domain and pricing code. Tasks 28-31 own composition, direction, and write ownership. |
+| `usage_job_status` | `interfaces.mcp.core_tools` -> `application.job_status.get_job_status` -> process-local `JobService` -> refresh/analysis/allowance adapter state | `COMPLIANT` for the current process, incomplete for durability | Task 33 owns persistent generic job/result storage and recovery. |
+
+### HTTP API v2
+
+`interfaces.http.v2.ApplicationHttpV2Services` calls the same seven
+application operations as the core MCP adapters. Request decoding, size
+budgets, strict unknown-field rejection, and response serialization remain in
+the adapter.
+
+| Route family | Class | Evidence and assignment |
+| --- | --- | --- |
+| status, refresh, analyze, query, evidence, allowance, job status | `COMPLIANT` at the transport boundary, `BYPASS` during construction | The route does not issue SQL, but imports concrete default paths, builds `JobService`/`AnalysisRuntime`, and imports the analytics catalog. Task 28 moves this construction to the composition root; Tasks 29-30 remove registration/import cycles. |
+| capabilities | `DUPLICATED` | Capability values are assembled from analytics/query/allowance constants inside the HTTP adapter while MCP and CLI expose related inventories separately. Task 28 gives capabilities one application owner; Task 30 enforces that interfaces only adapt it. |
+
+The v2 adapter can preserve all current payloads. No v2 identity is
+irreconcilably coupled to a table layout.
+
+### Stable CLI
+
+| Command | Execution path | Class | Remediation |
+| --- | --- | --- | --- |
+| `status`, `analyze`, `query`, `open` | `interfaces.cli.parser` -> `interfaces.cli.commands` -> `CliApplicationServices` -> application services/evidence target adapter | `COMPLIANT` with construction debt | Task 28 owns default dependency construction. |
+| `refresh` | stable namespace -> retained lifecycle implementation -> store refresh facade -> refresh stream/parser/materializers | `BYPASS` | Preserve spelling and output while Task 28 routes it through the application refresh service. |
+| `setup`, `doctor` | stable namespace -> lifecycle/diagnostics modules -> filesystem, MCP diagnostics, schema/status queries | `BYPASS` | Task 28 supplies environment/diagnostic ports; Task 30 removes the current core-to-diagnostics reverse edge. |
+| `export` | stable namespace -> legacy export implementation -> `store.exports`, including `SELECT *` from `canonical_usage_events` | `BYPASS` | Task 28 adds an export use case/repository; Task 30 prevents storage-row contracts from becoming CLI contracts. |
+| `config` | stable namespace -> cloned retained config actions -> pricing/allowance/project files | `COMPLIANT` as a compatibility adapter | Task 28 centralizes paths and filesystem ports without changing subcommands. |
+| `service` | stable namespace -> cloned dashboard service/serve actions -> server composition | `BYPASS` | Task 28 owns server construction. |
+| `admin` | stable namespace -> cloned rebuild/reset/diagnostic/support/MCP actions -> store/server/diagnostics internals | `BYPASS` | Tasks 28-30 isolate administrative use cases; Task 31 owns purge/reset integrity. |
+
+The 34 hidden aliases share these implementations. They remain supported
+through 0.24 and do not justify duplicate 0.24 domain logic.
+
+### Evidence Console and focused localhost routes
+
+| Consumer/path | Execution path | Class | Remediation |
+| --- | --- | --- | --- |
+| Home: `/api/status`, `/api/readiness`, `/api/summary` | React query modules -> server handlers -> bounded status/home queries -> canonical/refresh/summary tables | `BYPASS` | These remain performance-sensitive compatibility routes. Tasks 28-30 may adapt them behind shared application services only after exact parity. |
+| Explore Calls: `/api/calls`, `/api/call` | React calls queries -> focused server route -> indexed call/detail queries -> canonical usage and diagnostic facts | `BYPASS` | Tasks 28-30 isolate the focused repository without replacing its query plan. Task 39/41 performance gates remain mandatory. |
+| Explore Threads: `/api/threads`, `/api/thread-calls` | React explore queries -> focused server route -> thread summary/paged call queries -> `thread_summaries`, canonical usage, recommendation facts | `BYPASS` | Same preservation requirement; the focused route is not deprecated until v2 parity and route budgets pass. |
+| Limits: `/api/allowance/*` and `/api/v2/allowance` | React allowance queries -> allowance handlers/application service -> allowance domain/materialization -> canonical and allowance tables | `DUPLICATED` | v1 handlers and v2 application service expose overlapping operation models. Tasks 28-30 consolidate ownership while preserving v1 through 0.24. |
+| Evidence: `/api/v2/evidence`, `/api/call`, `/api/context` | React Evidence/Call Investigator -> v2 application evidence or focused v1 detail/context -> usage/content/source repositories -> bounded selected-call evidence | `DUPLICATED` | Task 28 creates one evidence port; Task 32 replaces line rescans with indexed byte ranges while keeping explicit content gating. |
+| Settings and refresh: `/api/status`, `/api/refresh/start`, `/api/refresh/status`, `/api/v2/refresh` | React -> server refresh registry or v2 application coordinator -> store refresh | `DUPLICATED` | Process-local server and application refresh registries overlap. Tasks 28 and 33 consolidate lifecycle/persistence. |
+| Legacy investigation, diagnostics, reports, compression routes | React compatibility pages -> `server.*` handlers -> diagnostics/report/compression internals -> derived/content/canonical tables | `BYPASS` | Tasks 28-30 strangle the routes behind application services; 0.25 removes only after the recorded compatibility window. |
+
+### Refresh, rebuild, accounting, and jobs
+
+- Incremental refresh is parser-driven and uses canonical classification before
+  rebuilding dependent facts. It is coherent but the store facade owns too
+  much orchestration: `BYPASS`, Tasks 28-31.
+- Full rebuild deletes tracker-owned state in one transaction and invokes a
+  separate refresh transaction. It is source-rebuildable but not atomic across
+  the empty interval: `AMBIGUOUS`, Task 31.
+- Canonical accounting is centralized on
+  `core.usage_identity`, `store.deduplication`, and the
+  `canonical_usage_events` view: `COMPLIANT`.
+- Allowance analysis has one deterministic domain implementation but inverted
+  store imports and overlapping route adapters: `BYPASS`/`DUPLICATED`, Tasks
+  28-31.
+- Background jobs share `jobs.service.JobService` and adapter contracts but
+  retain process-local records in three runtimes: `DUPLICATED`, Task 33.
+
+## 3. Python dependency and ownership audit
+
+### Observed package direction
+
+The dominant graph is:
+
+```text
+interfaces/server/cli
+        |
+        v
+application --------> analytics / evidence / jobs
+        |                    |
+        v                    v
+store <---------------- parser / pricing / core
+```
+
+The intended graph is:
+
+```text
+interfaces
+    |
+application
+    |
+analytics / evidence / jobs
+    |
+store / ingest / core
+```
+
+The observed graph is close enough for a strangler refactor, but not yet
+enforceable. `tach check` reports eight existing import violations:
+
+| Importing module | Imported owner | Why it exists | Desired owner | Task | Blocks Task 28? |
+| --- | --- | --- | --- | --- | --- |
+| `core.conversational_readiness` | `diagnostics.mcp.check_mcp_config` | Core status assembles environment diagnostics | Application status/diagnostic port | 28, 30 | No; Task 28 creates the port first |
+| `core.conversational_readiness` | `diagnostics.mcp.check_mcp_runtime` | Same mixed readiness responsibility | Application status/diagnostic port | 28, 30 | No |
+| `store.allowance_materialization` | `allowance_intelligence.contracts.AllowanceCohort` | Store materializer owns domain interpretation | Allowance application/domain service | 28, 30 | No |
+| `store.allowance_materialization` | `allowance_intelligence.cycles.MODEL_VERSION` | Store stamps domain model version | Allowance domain service | 30 | No |
+| `store.allowance_materialization` | `allowance_intelligence.cycles.derive_allowance_cycles` | Store invokes domain derivation | Allowance domain service with repository port | 28, 30 | No |
+| `store.allowance_materialization` | `allowance_intelligence.cycles.observed_plan_type` | Store invokes domain interpretation | Allowance domain service | 30 | No |
+| `store.allowance_materialization` | `pricing.allowance_config.load_allowance_config` | Store reads configuration | Composition/application service | 28, 30 | No |
+| `store.allowance_materialization` | `pricing.allowance_usage.annotate_rows_with_allowance` | Store computes pricing/credit estimates | Allowance domain/application service | 28, 30 | No |
+
+### Strongly connected components
+
+The module graph contains three non-trivial SCCs:
+
+1. A 16-module MCP/status/diagnostics cycle:
+   `application.status`, `cli.mcp_dashboard`, `cli.mcp_investigations`,
+   `cli.mcp_server`, `cli.mcp_visualization`,
+   `core.conversational_readiness`, `diagnostics.api`, `diagnostics.mcp`,
+   `interfaces.mcp.compatibility_tools`, `core_tools`, `developer_tools`,
+   `profiles`, `registry`, `runtime`, `server`, and `server.status`.
+2. A 7-module schema cycle:
+   `store.allowance_observations`, `compression_revisions`,
+   `compression_schema`, `deduplication_schema`, `schema`,
+   `source_records`, and `thread_summaries`.
+3. A 5-module store/refresh cycle:
+   `store.__init__`, `store.api`, `store.refresh`,
+   `store.refresh_parse`, and `store.refresh_stream`.
+
+Task 29 directly owns the MCP extraction and import-side-effect registration.
+Task 30 owns zero-cycle enforcement and package direction. Task 31 may retain
+an internal migration registry, but it must not require runtime repository
+modules to import the root schema facade.
+
+The relocated GitNexus index independently reported 25,190 symbols, 54,349
+relationships, 1,311 clusters, and 300 processes at the audited SHA.
+`gitnexus check --cycles --json` found seven file-level cycles. Its graph uses
+file imports rather than Tach's declared module boundaries, so the results are
+complementary rather than numerically identical:
+
+- `analytics.analysis_catalog -> application.context ->
+  application.analyze -> analytics.analysis_catalog`;
+- `analytics.analysis_models -> application.requests ->
+  analytics.analysis_models`;
+- `store.allowance_observations -> store.schema ->
+  store.deduplication_schema -> store.allowance_observations`;
+- `store.api -> store.refresh -> store.api`;
+- two frontend source cycles in visualization/i18n and
+  overview-query/endpoint-cache code;
+- one generated dashboard-bundle cycle, which is not an authoritative source
+  dependency.
+
+GitNexus symbol context also confirmed that
+`usage_identity_from_values` has exactly three production callers:
+`parser.jsonl_values.build_usage_event`,
+`store.deduplication.classify_usage_rows`, and
+`store.deduplication_schema._backfill_usage_identity`. That corroborates the
+single canonical-identity owner identified in section 6.
+
+### Mutable globals and import-time construction
+
+Observed process-global state includes:
+
+- `_DEFAULT_COORDINATOR`, `_COORDINATORS_BY_SERVICE`, and refresh locks in
+  `application.refresh`;
+- weak-key runtime registries in `application.allowance`;
+- cached default analysis runtimes in the MCP query adapter;
+- cached MCP tool catalogs and lazy compatibility/developer handlers;
+- `_REFRESH_JOB_REGISTRY` in the legacy MCP/server path;
+- server response/result caches.
+
+The declarative MCP catalog itself is deterministic, but importing registry
+modules imports concrete core handlers and contributes to the large SCC.
+Task 28 must create explicit construction; Task 29 must make MCP registration
+side-effect free; Task 33 must replace process-local job truth with persistent
+job state.
+
+### Mixed responsibilities and duplicated concepts
+
+| Area | Current overlap | Required owner |
+| --- | --- | --- |
+| Status/readiness | core, diagnostics, application, MCP, server | Application status service using environment/store ports |
+| Refresh lifecycle | application coordinator, server job registry, legacy MCP registry, store facade | Application refresh use case + persistent generic jobs |
+| Allowance | application opens SQLite; store imports domain/pricing; v1 and v2 handlers assemble related payloads | Allowance domain service + repository protocol |
+| Evidence | application evidence service plus focused `/api/call` and `/api/context` paths | Evidence application service + bounded evidence repository |
+| Query capability/schema | application models, HTTP capability assembly, MCP metadata, CLI contracts, frontend types | Application contract with transport adapters |
+| Recommendation/compression materialization | higher-level engines write store-owned tables directly | Domain writer service behind repository transaction |
+
+These are ownership defects around a coherent data core, not incompatible
+domain implementations.
+
+## 4. SQL table ownership matrix
+
+“Public leak” means a storage-shaped row can reach a public adapter; it does
+not mean that every listed table is exposed by default. “Rebuild source” is
+the authoritative input used to reconstruct the table.
+
+| Table | Class / introduced | Declared write owner | Principal readers | Tx/delete/rebuild/canonical/public/migration notes |
+| --- | --- | --- | --- | --- |
+| `schema_migrations` | `CACHE`, v2 | `store.schema` migration runner | schema state/doctor | Migration functions and their ledger entries are intended to share a transaction, but `executescript()` commits earlier steps before a later validation failure; retained metadata; rebuild by replaying migrations; no canonical role; schema state exposes a shaped migration list; fresh/legacy/idempotency coverage. Risk F-13. |
+| `usage_events` | `CANONICAL_RECORD`, v1; canonical columns v24-25; tier columns v30 | `store.refresh_stream` through `store.api.upsert_usage_events` | all canonical query/report/evidence services | Refresh transaction; parent of most facts; rebuild from source logs and OTel enrichment; authoritative physical and canonical classification; physical `record_id` is public; extensive legacy/dedup/refresh coverage. |
+| `refresh_meta` | `CACHE`, v1 | Shared today: `store.api.record_refresh_metadata` owns refresh counters; `store.home_queries` upserts `home_usage_metrics_v1`; `store.recommendation_schema` invalidates that key | status/home/doctor | Refresh counters commit in a separate metadata transaction; Home metrics commit on the Home query connection; recommendation invalidation deletes the Home key in its caller transaction. Task 28 must provide one cache repository boundary and Task 31 must document each transaction owner. Risks F-05/F-14. |
+| `thread_summaries` | `DERIVED_MATERIALIZATION`, v5; recommendation fields v21 | `store.thread_summaries.rebuild_thread_summaries` | focused threads, reports, recommendations | Refresh/canonical rebuild transaction; explicitly deleted/rebuilt from canonical usage and recommendation facts; thread identity participates indirectly; rows shape v1 focused responses; canonical rebuild coverage. |
+| `source_files` | `SOURCE_OBSERVATION`, v6; cursor v7; revision fields v17 | `store.sources` under refresh stream | refresh planner, status, context indexing | Refresh transaction; replaced/removed with source lifecycle; rebuild from source logs; source revision input, not canonical identity; cursor metadata appears only as provenance/status; refresh and migration coverage. |
+| `call_diagnostic_facts` | `DERIVED_MATERIALIZATION`, v9 | diagnostic fact sync under refresh | diagnostics, focused calls, analysis | FK cascade declared; refresh deletes explicitly before parent replacement; rebuild from parsed source segments; `record_id` couples to physical evidence; shaped public diagnostic rows; fresh/legacy coverage. |
+| `diagnostic_snapshots` | `CACHE`, v10 | diagnostics snapshot service | diagnostics server/MCP | Snapshot-specific transaction; purge/recompute; rebuild from canonical facts or explicit source scan; no canonical role; payload JSON is adapted publicly; fresh migration and diagnostic tests. |
+| `allowance_observations` | `SOURCE_OBSERVATION`, v11; provenance/index additions v29/v32 | `store.allowance_observations.sync_*` called by refresh/canonical promotion | allowance domain/materializer/status | Refresh/promotion transaction; explicit delete plus declared FK cascade; rebuild from canonical usage rate-limit fields; canonical rows only; shaped allowance APIs; migration/dedup/materialization coverage. |
+| `source_records` | `SOURCE_OBSERVATION`, v12 | `store.source_records.sync_source_records` | evidence/content/compression | Refresh/replacement transaction; explicit delete plus FK cascade; rebuild from usage/source logs; physical `record_id` evidence link; bounded provenance may be public; legacy migration coverage. |
+| `content_index_features` | `CACHE`, v13 | `store.schema` / content index setup | status/settings/content search | Migration/refresh transaction; rebuild during content-index setup; no canonical role; feature state appears in status; fresh migration and content-refresh coverage. |
+| `conversation_turns` | `CONTENT_EVIDENCE`, v13 | `store.content_index_event_store` under content refresh | evidence, diagnostics, compression | Refresh/replacement transaction; declared FK cascade; rebuild from source logs; physical record association; bounded local evidence only; content-refresh coverage. |
+| `tool_calls` | `CONTENT_EVIDENCE`, v13 | `store.content_index_event_store` | evidence, diagnostics, compression | Refresh/replacement transaction; record cascade and turn `SET NULL`; rebuild from source logs; physical evidence keys; explicit local payloads; content-refresh coverage. |
+| `command_runs` | `CONTENT_EVIDENCE`, v13 | `store.content_index_event_store` | evidence, diagnostics, compression | Same ownership; rebuildable; physical evidence link; safe command labels may be public; content-refresh coverage. |
+| `file_events` | `CONTENT_EVIDENCE`, v13 | `store.content_index_event_store` | evidence, diagnostics, compression | Same ownership; rebuildable; hashed/basename path evidence; content-refresh coverage. |
+| `content_fragments` | `CONTENT_EVIDENCE`, v13 | `store.content_persistence` under content refresh | explicit content search/context/evidence | Refresh/replacement transaction; cascades declared; rebuild from source logs; physical record/turn link; raw fragment output is explicitly gated; content-refresh coverage. |
+| `content_fts` and 4 shadows | `SEARCH_INDEX`, v13 | `store.content_index` FTS synchronization | explicit content search | Cleared/rebuilt around content replacement; external-content FTS backed by `content_fragments`; no canonical role and no default public leak; content-refresh coverage. Shadows are SQLite-owned. |
+| `investigation_runs` | `JOB_STATE`, v14 | `store.investigation_runs` | investigation routes/MCP | Per-run store transaction; bounded retention/purge; results are reproducible from canonical/content evidence but records are retained job history; run IDs public to compatibility tools; migration and investigation tests. |
+| `compression_runs` | `JOB_STATE`, v15 | `store.compression_runs` | compression APIs/MCP | Explicit run lifecycle transactions; candidates cascade only if FK enforcement is enabled; results reproducible from facts; run ID public; compression migration/cache coverage. |
+| `compression_candidates` | `DERIVED_MATERIALIZATION`, v15 | `store.compression_candidates` through compression analysis | compression APIs/MCP/evidence | Same run transaction; declared cascade from run; rebuild from detector facts; no canonical identity; candidate IDs public compatibility evidence; migration/compression tests. |
+| `compression_candidate_records` | `DERIVED_MATERIALIZATION`, v15; metadata v19 | `store.compression_candidates` | compression evidence | Candidate write transaction; declared candidate cascade; rebuild from detector results and canonical record metadata; physical record IDs retained as evidence; migration/compression tests. |
+| `compression_source_state` | `CACHE`, v15 | `store.compression_revisions` | query cursors/cache invalidation | Refresh transaction increments generation; singleton reset/rebuild; authoritative source revision input; generation is public provenance; cache/revision tests. |
+| `compression_record_facts` | `DERIVED_MATERIALIZATION`, v16 | `store.compression_fact_sync` | detectors/compression queries | Refresh/fact transaction; explicit deletion and declared usage cascade; rebuild from canonical/content facts; physical record ID; compatibility APIs adapt rows; compression fact tests. |
+| `compression_sequence_facts` | `DERIVED_MATERIALIZATION`, v16 | `store.compression_fact_sync` | detectors | Same; declared usage cascade; rebuildable; physical evidence ID; compatibility-only exposure; compression fact tests. |
+| `compression_thread_facts` | `DERIVED_MATERIALIZATION`, v16 | `store.compression_fact_sync` | detectors | Same; explicit rebuild; thread/record evidence but no FK; compatibility exposure; compression tests. |
+| `compression_fact_state` | `CACHE`, v16 | `store.compression_schema.stamp_compression_fact_state` | compression cache validation | Same fact transaction; singleton rebuild; no public identity; migration/compression tests. |
+| `compression_revision_state` | `CACHE`, v17 | `store.compression_revisions` | detector/cache invalidation | Refresh/fact transactions; singleton rebuild from source generation; public only as provenance; revision/cache tests. |
+| `recommendation_facts` | `DERIVED_MATERIALIZATION`, v20 | `recommendation_engine.materialization` through recommendation materializer | Home/Explore/reports/analysis | Refresh/backfill transaction; explicit deletion and declared usage cascade; rebuild from canonical usage; physical record evidence; shaped recommendation fields public; canonical rebuild/recommendation coverage. |
+| `recommendation_fact_state` | `CACHE`, v20 | `recommendation_engine.materialization` | recommendation cache validation | Same transaction; invalidated on canonical promotion; rebuild from canonical usage; no public identity; canonical rebuild coverage. |
+| `allowance_source_state` | `CACHE`, v27 | `store.allowance_materialization` | allowance service/cursors | Savepoint within caller transaction; singleton invalidated/rebuilt from canonical observations; source revision public provenance; v27-v29 and materialization coverage. |
+| `allowance_cycles` | `DERIVED_MATERIALIZATION`, v27 | allowance materialization service, currently implemented in `store.allowance_materialization` | allowance status/series/analysis | Savepoint; parent of intervals; delete/rebuild from canonical observations; cycle IDs are deterministic public evidence IDs; v27-v29/materialization coverage. Inverted ownership is F-02. |
+| `allowance_intervals` | `DERIVED_MATERIALIZATION`, v27 | same allowance materialization service | allowance series/evidence/analysis | Savepoint; declared cycle cascade; full delete/rebuild; deterministic interval evidence IDs public; v27-v29/materialization coverage. |
+| `allowance_analysis_snapshots` | `CACHE`, v27 | `allowance_intelligence.analysis` | allowance analysis/job result | Application/domain transaction; bounded cached result; rebuild from cycles/intervals; snapshot ID is public job evidence; allowance analysis coverage. |
+| `otel_completion_sources` | `SOURCE_OBSERVATION`, v30; anchor v31 | `store.otel_ingest` | OTel incremental refresh/status | OTel transaction separate from JSONL refresh; cursor row rebuilt by rescanning OTel source; no canonical identity; status-only provenance; v30/v31 and OTel refresh coverage. |
+| `otel_completion_events` | `SOURCE_OBSERVATION`, v30 | `store.otel_ingest`, matched by `store.otel_reconciliation` | reconciliation/diagnostics | OTel transaction; retained match state; rebuild from OTel logs then reconcile; enrichment joins canonical groups; physical matched ID is internal provenance; OTel schema/refresh/reconciliation coverage. |
+
+Every logical table now has a declared write owner. Three ownership boundaries
+are not yet enforced in code:
+
+1. allowance materialization is implemented in `store` but owns domain and
+   pricing behavior;
+2. recommendation/compression higher-level services write repository tables
+   through multiple concrete helpers;
+3. refresh metadata and OTel work commit separately from the primary refresh;
+4. `refresh_meta` is a shared namespace with three independently coordinated
+   mutation paths.
+
+They map to Tasks 28-31 and do not require a schema rewrite. The intended
+coordinating owner is the Task 28 application cache repository: refresh owns
+refresh-counter writes, Home owns metric-cache fills, and recommendation
+reconciliation owns invalidation through that one boundary. Task 31 records
+and tests the transaction boundary for each operation.
+
+## 5. Write-path and transaction audit
+
+| Workflow | Transaction and mutations | Failure/retry/cursor/canonical behavior | Finding |
+| --- | --- | --- | --- |
+| Initial database creation | `connect()` appears to own commit/rollback around `init_db`, but migration functions use `sqlite3.executescript()` | On success, migrations 1-34 create all tables/indexes/views and ledger rows. On a later validation failure, earlier scripts and ledger rows can already be committed outside the outer rollback: F-13. Re-running remains partly idempotent. | F-01/F-13, Task 31. |
+| Incremental refresh | `store.refresh_stream` uses one `connect()` context and `BEGIN IMMEDIATE` for source cursor, usage rows, content, canonical promotion, allowance observations, recommendations, compression facts/revisions | Parse/write failure rolls back the primary refresh; source cursor advances with the same transaction; fingerprint promotion synchronizes allowance and invalidates recommendations | Coherent aggregate transaction. Follow-on OTel and metadata transactions create a bounded partial-completion window: F-05. |
+| Full rebuild | Admin/store rebuild commits deletion of tracker-owned rows, then calls refresh in a later transaction | Crash between phases leaves an empty but source-rebuildable DB; retry rebuild/refresh restores it; original logs are not deleted | F-06, Task 31. |
+| Canonical deduplication | Classification runs before upsert; canonical rebuilds/promotion run in the caller transaction | Batched fingerprint lookup; deterministic representative; retry idempotent by IDs and UPSERT | Coherent. |
+| Original-row deletion and promotion | Source replacement deletes dependent rows and original usage row, then `promote_orphaned_fingerprints` updates one survivor and syncs allowance/recommendation state in the same refresh transaction | Stable ordering by timestamp/source/line/record ID; focused test proves 1 surviving canonical row and derived cleanup | Coherent. |
+| Content-index refresh | Primary refresh transaction clears FTS, deletes source-owned content rows, inserts normalized evidence, and rebuilds FTS | Rollback restores prior DB state; source cursor is co-transactional; FTS is rebuildable | Coherent, but Task 32 should replace source line rescans with byte offsets. |
+| OTel enrichment | Separate OTel ingest/reconciliation transaction after primary JSONL refresh; captured enrichment is restored across source replacement | Idempotent fingerprints/cursors; failure can leave new usage un-enriched until retry without corrupting canonical token accounting | F-05, Tasks 28/31. |
+| Allowance recomputation | `materialize_allowance_intelligence` uses a savepoint and replaces cycles/intervals/source state from canonical observations | Failure rolls back to savepoint; unchanged canonical source revision is a no-op; copied rows do not advance generation | Coherent semantics; inverted layer ownership F-02. |
+| Analysis job creation/completion | Refresh, analysis, and allowance runtimes mutate process-local dictionaries under locks; adapters expose status/results | Process loss discards queued/running/completed state; semantic reuse exists only in process; no durable cleanup/recovery | F-04, Task 33. |
+| Purge/reset | Administrative helpers delete tracker-owned state; full reset/rebuild later rehydrates from source logs | With FK enforcement off, some correctness depends on explicit child deletion and table order; retries are rebuild-based | F-01/F-06, Task 31. |
+| Schema migration | `init_db` applies missing migrations and ledger entries sequentially; several migration functions call `executescript()` | Malformed legacy input preserves its one usage row and reports an actionable error, but the reproduced failed run leaves `user_version=1`, 29 ledger rows, and later-created tables committed. Applied migrations do not rerun. | Non-atomic failure F-13 plus retained-version gaps F-07, Task 31. |
+
+Two logical aggregates currently span different transaction semantics:
+
+- refresh commits canonical/content facts, OTel enrichment, and refresh metadata
+  in separate transactions;
+- generic jobs expose one lifecycle contract while three process-local runtime
+  stores and legacy server registries own mutations independently.
+
+Both are bounded and already assigned to Tasks 28, 31, and 33.
+
+## 6. Canonical-domain invariant audit
+
+| Invariant | Authoritative implementation / representation | Duplicated? Testable below interfaces? Preserve in Tasks 28-33? |
+| --- | --- | --- |
+| Physical usage-event identity | `parser.jsonl_values._record_id`: SHA-256 of session ID, turn ID, event timestamp, cumulative total, and event total; stored as `usage_events.record_id` | One parser owner; some synthetic tests supply IDs directly. Yes. Preserve exactly. |
+| Logical/canonical usage identity | `core.usage_identity.usage_identity_from_values`, versioned `usage-fingerprint-v2` and `canonical-usage-v1`; stored in fingerprint/canonical columns plus `is_duplicate` | One domain owner. Migration reuses it. Yes. Preserve exactly. |
+| Copied-session suppression | `store.deduplication.classify_usage_rows`; canonical view `WHERE is_duplicate=0` | Query/report code consistently uses canonical view/predicate, with some duplicated SQL spelling. Directly tested. Preserve and centralize repository predicates. |
+| Representative promotion | `store.deduplication.promote_orphaned_fingerprints`, stable timestamp/source/line/ID order | One owner. Direct focused test. Preserve. |
+| Pricing/service-tier provenance | Parser/OTel normalization persists `service_tier`, `fast`, source, confidence; pricing estimates use versioned config and coverage/confidence fields | Estimate attachment exists in application query and older routes/reports, so representation is duplicated but not contradictory. Direct pricing/OTel tests. Tasks 28-30 centralize. |
+| Allowance observations/cycles | Observations derive only from canonical usage; `allowance_intelligence.cycles` derives cycles; materialized in allowance tables with source revision/model version | Domain algorithm is singular, but persistence calls it from the wrong layer. Direct domain/materialization tests. Preserve. |
+| Evidence references | Call evidence uses physical `record_id`; logical duplicate diagnostics use canonical ID/fingerprint; thread evidence uses `thread_key`; source/content evidence stores physical provenance | Multiple adapters shape links, but selector meaning is consistent. Direct evidence tests. Tasks 28/32 isolate. |
+| Source revision/freshness | Compression source generation and refresh metadata form `generation:<n>`; request contexts bind cursors/jobs to source revision | Route payloads repeat the value but do not define a competing revision. Direct query/context tests. Preserve. |
+| Project identity | `core.projects._project_key`: stable 16-hex SHA-256 prefix of resolved project root; privacy adapters redact labels/paths | One owner; frontend consumes shaped values. Directly testable. Preserve. |
+| Thread identity | Parser prefers `thread:<thread_name>`, then parent thread, then parent session, then session; legacy query fallback supports old empty keys | One primary owner plus intentional legacy fallback. Directly testable. Preserve compatibility through migration/refill. |
+| Call identity | Public call selector is physical `record_id`; query cursors additionally bind source revision and sort identity | One physical identity definition. A full rebuild from unchanged logs reproduces it because it excludes file path/line number. Preserve adapter field. |
+| Background-analysis identity | Random process-local job ID; semantic reuse hashes request/config/source revision | One generic adapter contract but three runtime stores. Directly testable, not durable. Task 33 persists without changing public IDs. |
+
+No invariant has incompatible authoritative definitions. The few duplicate
+representations are adapter or query-shaping duplication and can be removed
+without changing semantics.
+
+## 7. Public contract leakage audit
+
+### Field classification
+
+The stable schema families classify as follows:
+
+| Contract | Stable domain values | Deterministic derived values | Evidence/provenance | Storage/physical/deprecated |
+| --- | --- | --- | --- | --- |
+| MCP envelope v1 | `tool`, `result_schema`, `result`, `scope`, `accounting`, `warnings`, `limitations`, `next_actions` | `generated_at`, dashboard targets | `request_id`, `source_revision`, `freshness`, `data_class` | No table names. `request_id` is transport identity, not DB identity. |
+| Status v2 | parser/source/pricing/accounting/readiness/MCP/service states and next action | coverage/state summaries | source revision and refresh timestamps | No raw row serialization. |
+| Refresh v2 | planner, scope, accounting and refresh outcome | counts/progress | freshness/source revision | Source-file cursor columns are not public. |
+| Query v2 | `entity`, `columns`, requested measures/group values, totals | cost/credit estimates, coverage/confidence, next cursor, dashboard target | source-revision-bound opaque cursor | Call entity exposes physical `record_id`; other entity keys are domain identities. Internal `_pricing_*` and `_total_matched` fields are removed. |
+| Evidence result v1 | selector, bounded records | next cursor/dashboard target | source schema/evidence selectors | Call selectors expose physical `record_id` intentionally; adapters control fields. |
+| Analysis v2 | goal, summary, findings, methodology, messages, limitations | strategy/version, suggested questions, accounting | analysis/evidence IDs, source revision, destinations | No table/column contract. |
+| Job v1 | kind/state/stage/progress/error/result schema/result | request hash and timestamps | `job_id`, source revision | Process-local storage is an implementation detail but the ID itself can remain stable after Task 33. |
+| Allowance results | operation/range/window/status/series/cycles/intervals and estimates | capacity/forecast/confidence/coverage | cycle/interval/evidence IDs, source/model versions | Current v1 rows are close to table shapes; v2 adapter can preserve them through explicit models. |
+| Stable CLI JSON | documented schema ID plus command-specific domain payload | formatted summaries/counts | source/freshness/accounting evidence | `export` still derives columns via `SELECT *`; physical `record_id` and compatibility fields must be frozen by an adapter before schema changes. |
+| Evidence Console focused payloads | call/thread/summary/allowance values | scores, estimates, labels, counts | record/thread/source freshness fields | Several v1 payloads are constructed from `row_to_dict` and are therefore storage-shaped. Frontend TS duplicates those shapes. |
+
+### Leakage findings
+
+- `store.exports` uses `SELECT * FROM canonical_usage_events`; a new SQLite
+  column can silently become a CSV column. This is F-03, Tasks 28/30.
+- Several focused v1 query functions convert selected SQLite rows through
+  `row_to_dict`. Their SELECT lists are often explicit, but the contract is
+  owned by query text rather than a public model. This is F-03.
+- Compression and allowance compatibility repositories use internal
+  `SELECT *`, then decoder functions. These are bounded compatibility
+  surfaces, but decoders must remain the only public adapter.
+- Physical `record_id` is intentionally public for call/evidence selection.
+  It is deterministic from source-independent event facts and survives a
+  rebuild from unchanged logs. It is not an irreparable storage leak.
+- MCP, HTTP, CLI, server JSON contracts, and frontend TypeScript repeat some
+  field lists. The definitions agree today; Task 28 should give each stable
+  application result one owner and equality tests.
+- No stable contract exposes a SQLite table name or requires consumers to
+  issue SQL.
+
+Conclusion: stable contracts can be preserved by explicit adapters. No public
+identity requires retaining the current table layout.
+
+## 8. SQL integrity and migration evidence
+
+### Fresh database
+
+A temporary fresh database initialized with `connect()` and `init_db()` gave:
+
+```text
+PRAGMA user_version: 34
+schema_migrations rows: 34 (versions 1 through 34)
+physical tables: 38
+logical/application tables: 34
+PRAGMA integrity_check: ok
+PRAGMA foreign_key_check: []
+PRAGMA foreign_keys: 0
+```
+
+The empty foreign-key check proves the fresh schema contains no current
+orphan; `foreign_keys=0` proves normal connections do not enforce declared
+cascades. This known defect is repairable under Task 31 and is not a `STOP`
+condition.
+
+### Retained and representative database integrity
+
+The exact 18-test command in the evidence list passed, and a read-only scan
+then ran both integrity pragmas against every SQLite fixture it retained.
+Every one of the 18 databases returned `integrity_check=ok` and zero
+`foreign_key_check` rows. The fixture-level before/after accounting was:
+
+| Test ID / scenario | Before | Persisted after test | Integrity / FK |
+| --- | --- | --- | --- |
+| `test_init_db_migrates_legacy_aggregate_table_without_data_loss` | v1, 1 usage row | v34, 34 ledger rows, 1 usage row | ok / 0 |
+| `test_refresh_is_idempotent_after_legacy_migration` | v1, 1 legacy row + 1 source event | v34, 34 ledger rows, 2 usage rows after two refreshes | ok / 0 |
+| `test_init_db_records_all_schema_migrations_for_new_database` | empty | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_init_db_upgrades_v25_database_without_changing_physical_rows` | v25, 25 ledger rows, 1 usage row | v34, 34 ledger rows, same 1 usage row | ok / 0 |
+| `test_init_db_upgrades_v27_allowance_indexes_to_v28` | v27, 27 ledger rows, 0 usage rows | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_init_db_upgrades_v28_with_allowance_plan_provenance` | v28, 28 ledger rows, 0 usage rows | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_init_db_upgrades_v31_with_all_history_allowance_index` | v31, 31 ledger rows, 0 usage rows | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_init_db_upgrades_v33_with_focused_call_indexes_without_data_loss` | v33, 33 ledger rows, 1 usage row | v34, 34 ledger rows, same 1 usage row after two initializations | ok / 0 |
+| `test_init_db_does_not_rerun_applied_migrations` | v34, 34 ledger rows | unchanged v34/34, 0 usage rows | ok / 0 |
+| `test_csv_export_keeps_current_columns_after_legacy_migration` | v1, 1 usage row | v34, 34 ledger rows, 1 usage row and 1 exported row | ok / 0 |
+| `test_malformed_legacy_schema_reports_actionable_error_without_data_loss` | malformed v1, 1 usage row | v1, **29 ledger rows**, 1 usage row | ok / 0 |
+| `test_doctor_reports_malformed_legacy_schema_without_traceback` | malformed v1, 1 usage row | v1, **29 ledger rows**, 1 usage row | ok / 0 |
+| `test_new_database_has_canonical_usage_schema_and_index` | empty | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_v23_backfill_marks_copied_legacy_usage_duplicate` | v1 shape, 2 physical usage rows | v34, 34 ledger rows, 2 physical / 1 canonical | ok / 0 |
+| `test_v25_reclassifies_clone_rewritten_timestamps` | v24 marker, 2 physical / 2 canonical | v34, 34 ledger rows, 2 physical / 1 canonical | ok / 0 |
+| `test_canonical_rebuild_discards_stale_allowance_intelligence` | v34 with 4 stale allowance rows | v34, 34 ledger rows, 0 usage rows and 0 stale allowance rows | ok / 0 |
+| `test_schema_migration_creates_otel_sidecar_tables` | empty | v34, 34 ledger rows, 0 usage rows | ok / 0 |
+| `test_cursor_anchor_migration_preserves_existing_source_state` | standalone 1-table OTel cursor fixture, 1 row | same 1 table/row with preserved offsets and added null anchor | ok / 0 |
+
+The two malformed fixtures are the failed-migration assertion: data survives
+and SQLite structural integrity remains valid, but transaction atomicity does
+not. Task 31's existing rollback-on-exception requirement must change their
+postcondition to the original schema/ledger state, not merely retain row
+content.
+
+### Focused suite
+
+The recorded focused command ran 126 tests and passed:
+
+```text
+126 passed in 11.35s
+```
+
+The complete repository suite also passed:
+
+```text
+1907 passed in 116.87s
+```
+
+Additional gates:
+
+- `ruff check .`: passed.
+- `.venv/bin/python -m pyright --pythonpath .venv/bin/python src`: passed
+  with 0 errors and 7 existing lazy-export warnings.
+- `python scripts/check_release.py`: passed.
+- `npx markdownlint-cli2`: passed.
+- synthetic `run_doctor(...)`: command completed with schema
+  `codex-usage-tracker-doctor-v1`; the overall result was `warn` because the
+  isolated temporary home intentionally contained no installed plugin,
+  pricing file, or Codex sessions.
+- `tach check`: failed with the eight existing direction violations recorded
+  in section 3. This is expected baseline evidence, not a hidden gate pass.
+- `gitnexus check --cycles --json`: returned `cycles_found` with the seven
+  file-level cycles recorded in section 3. This is expected audit evidence.
+
+Key row-count evidence from those tests:
+
+| Scenario | Before/result | After/asserted result |
+| --- | --- | --- |
+| Legacy aggregate migration | 1 legacy usage row | 1 physical/canonical usage row, 1 source record, all 34 migration rows, zero diagnostic/recommendation facts |
+| Refresh after migration | 1 legacy row plus 1 synthetic source event | first refresh parses 1; second parses 0; physical count remains 2 |
+| v23 copied legacy backfill | 2 physical copies | 1 fingerprint group, 1 canonical row |
+| v25 clone timestamp rewrite | 2 formerly canonical rows | 1 canonical row, 1 thread call, 1 allowance observation, 1 recommendation fact |
+| Copy suppression | 3 physical rows | 2 canonical rows; canonical total 225 versus physical total 325 |
+| Original source replacement | original + copy, 1 canonical | copy promoted; 1 canonical; allowance references only copy; stale recommendations/state cleared |
+| Copied allowance observations | 4 physical rows, 2 logical calls | 2 observations; 300 canonical tokens; copy-only mutation does not change allowance generation |
+
+The migration tests also prove current indexes at v34, no rerun of applied
+migrations, data preservation for v25/v33 upgrades, allowance index/provenance
+upgrades at v28/v29/v32, malformed legacy error reporting and row
+preservation, and current CSV compatibility. They explicitly expose, rather
+than conceal, the malformed-input partial-commit defect.
+
+### Rebuild and dependent deletion
+
+- Canonical promotion after original-row deletion passes and explicitly
+  synchronizes allowance observations while invalidating stale recommendation
+  materialization.
+- Content refresh tests pass for replacement and FTS rebuild behavior.
+- OTel schema/refresh tests pass for v30 table creation, v31 cursor continuity,
+  incremental ingestion, and reconciliation.
+- Derived allowance, recommendation, thread, compression, and content tables
+  all have rebuild inputs. No irreplaceable derived state was found.
+- Enforced-FK behavior is not yet a release invariant because connections
+  leave it off. Task 31 must enable it and add cascade/purge/rebuild fixtures
+  before relying on the declarations.
+
+### Remaining migration evidence gap
+
+There is no fixture archive for every released version and no dedicated
+current-minus-one fixture that runs the complete refresh/rebuild/integrity
+sequence. Task 31 already calls for retained migration fixtures and integrity
+checks; F-07 makes the exact missing versions explicit.
+
+## 9. Current documentation truth audit
+
+The active product documentation is consistent:
+
+- normal refresh stores aggregate usage plus the bounded local content/event
+  index;
+- `--aggregate-only` retains the older aggregate-only SQLite posture;
+- shareable dashboard/CLI/support outputs remain aggregate-first and omit raw
+  indexed content unless an explicit local content operation is requested;
+- Evidence Console context/content loading is local, bounded, and explicit.
+
+The pivot design, implementation plan, and roadmap now state this actual
+default. Older historical plans sometimes describe the dashboard or a
+specific diagnostic payload as aggregate-only; those scoped historical claims
+do not redefine current database behavior. No privacy redesign is needed for
+Task 27.5.
+
+## 10. Risk register
+
+| ID | Severity | Invariant | Evidence / consequence | Owner | Existing task sufficient? | Amendment / decision |
+| --- | --- | --- | --- | --- | --- | --- |
+| F-01 | HIGH | Referential integrity | `PRAGMA foreign_keys=0` on a normal fresh connection. Declared cascades are not enforced, so new delete paths could orphan facts. | Task 31 | Yes | Enable per connection; test migrations, cascades, purge, replacement, rebuild, and `foreign_key_check`. No maintainer decision. |
+| F-02 | HIGH | Allowance ownership | `store.allowance_materialization` imports domain cycles and pricing, producing six Tach direction failures. Layer refactors could create competing writers. | Tasks 28, 30, 31 | Yes | Move orchestration/domain computation above a repository protocol while keeping one transaction owner. No maintainer decision. |
+| F-03 | HIGH | Public contract isolation | CLI export uses `SELECT *`; focused v1 and compatibility decoders are often row-shaped; TS repeats schemas. A schema addition could leak publicly. | Tasks 28, 30 | Yes | Explicit application result models/adapters and schema equality tests. Preserve v1/CSV fields through 0.24. |
+| F-04 | HIGH | Job lifecycle | Refresh, analysis, allowance, and legacy server jobs keep process-local mutable records. Restart loses truth and reuse. | Task 33 | Yes | Persist generic jobs/results and recovery without changing job envelope IDs. |
+| F-05 | MEDIUM | Refresh atomicity/freshness | Primary refresh, OTel reconciliation, and final metadata commit separately. Failure can temporarily show complete canonical rows with stale enrichment/metadata. | Tasks 28, 31 | Yes | Define one workflow owner and resumable phases; keep primary transaction bounded. |
+| F-06 | MEDIUM | Rebuild availability | Full rebuild commits deletion before the separate refresh. Crash leaves an empty but recoverable store. | Task 31 | Yes | Stage/swap or record resumable rebuild state; add interruption fixture. |
+| F-07 | MEDIUM | Migration safety | Broad legacy traversal passes, but dedicated v13, v15-17, v20-21, v26, v30, and current-minus-one retained fixtures are absent. | Task 31 | Yes | Add representative retained fixtures and exact integrity/refresh/rebuild checks. |
+| F-08 | MEDIUM | Dependency direction | Three SCCs and eight Tach violations prevent enforcement and secondary-interface composition. | Tasks 28-30 | Yes | Composition root, MCP extraction, zero-cycle Tach gates. |
+| F-09 | MEDIUM | Evidence retrieval performance | Selected source evidence can still locate content through line-oriented source access instead of persisted byte ranges. Large logs can regress blocking calls. | Task 32 | Yes | Persist byte offsets, prove payload equivalence, and ratchet inspected bytes. |
+| F-10 | MEDIUM | Dashboard performance/freshness | Active Home/Limits/Calls/Threads depend on focused v1 routes whose bounded query plans outperform a generic facade. Premature v2 replacement would regress 0.23 gains. | Tasks 28-30, 39, 41 | Yes | Preserve routes until functional, count/filter/cost, freshness, and 100k budget parity gates pass. |
+| F-11 | LOW | Thread identity compatibility | New rows have deterministic thread keys, but legacy empty keys require fallback predicates and additional indexes. | Tasks 30, 31 | Yes | Preserve fallback until migration/backfill can prove parity. |
+| F-12 | LOW | Documentation drift | Historical scoped “aggregate-only” wording can be mistaken for current storage posture. | Task 30 | Yes | Freeze current storage/privacy language alongside adapter contracts; the later documentation gate may improve presentation. |
+| F-13 | HIGH | Migration atomicity | `executescript()` commits earlier migrations outside `connect()` rollback. The malformed v1 fixture retains its row but also retains 29 ledger rows and later-created tables after `SchemaMigrationError`. | Task 31 | Yes | Fulfill the existing rollback-on-exception requirement across `init_db`; assert unchanged schema/ledger/data after an interrupted or failed migration, then rerun retained fixtures and both integrity pragmas. |
+| F-14 | MEDIUM | Cache write ownership | `store.api`, `store.home_queries`, and `store.recommendation_schema` independently mutate keys in `refresh_meta` under different transaction owners. Refactors can leave stale Home metrics or erase unrelated metadata. | Tasks 28, 31 | Yes | Introduce one cache repository protocol, keep key-specific application owners, and test fill/invalidate/refresh transaction boundaries. |
+
+There are no `BLOCKER` findings. Every `HIGH` finding has a named existing
+0.24 owner and bounded acceptance work.
+
+Non-blocking repository note: IntelliJ creates an untracked `.idea/` directory
+in this managed worktree. It remains excluded from the checkpoint and has no
+runtime or roadmap impact.
+
+## 11. Decision
+
+Decision: **PROCEED**
+
+Canonical accounting has coherent authoritative owners, physical and logical
+identities are deterministic, copied-session suppression and promotion pass
+direct tests, successful retained migrations preserve data, the failed
+migration defect is bounded by Task 31's existing rollback requirement,
+derived tables are rebuildable, and public contracts can be isolated with
+adapters.
+
+The foundation is a healthy data core surrounded by an overgrown application
+and compatibility shell. The observed defects justify Tasks 28-33; they do
+not justify a foundation rewrite or a silent roadmap amendment.
+
+## 12. Roadmap reconciliation
+
+Tasks 28-33 remain sufficient and retain their existing order:
+
+| Task | Assigned findings and required preservation |
+| --- | --- |
+| Task 28: composition root and protocols | F-02, F-03, F-05, F-08, F-10, F-14. Inject paths, repositories, environment diagnostics, clocks, job services, and a single cache repository boundary. Preserve focused-route implementations until parity gates pass. |
+| Task 29: MCP extraction | F-08. Remove the 16-module MCP/status cycle and import-time handler construction without changing the 7/59/64 tool inventories. |
+| Task 30: domain boundaries and Tach | F-02, F-03, F-08, F-11, F-12. Make application/domain ownership explicit, eliminate cycles/reverse imports, and freeze adapter plus storage/privacy documentation contracts. |
+| Task 31: SQLite integrity and migrations | F-01, F-02, F-05, F-06, F-07, F-11, F-13, F-14. Enable foreign keys, prove cascades and retained upgrades, make migration failure atomic, define cache transaction ownership, and harden interrupted rebuilds. |
+| Task 32: indexed context offsets | F-09. Persist byte ranges, preserve explicit content gating/payloads, and enforce inspected-byte budgets. |
+| Task 33: persistent generic jobs | F-04. Persist lifecycle/result state and recovery for refresh, analysis, allowance, and later infrastructure jobs. |
+
+Cross-cutting performance finding F-10 remains an acceptance constraint on
+Tasks 28-30 and the later performance/release gates. No generic v2 facade may
+replace or deprecate the focused Home, Limits, Calls, Threads, or Thread Calls
+routes until exact functional parity, filtering/sorting/count parity,
+cost/credit parity, incremental-freshness behavior, and the named large-history
+budgets pass.
+
+Task 28 may begin only after this audit checkpoint is committed independently.

--- a/docs/superpowers/specs/2026-07-21-mcp-first-product-pivot-design.md
+++ b/docs/superpowers/specs/2026-07-21-mcp-first-product-pivot-design.md
@@ -594,6 +594,19 @@ get_job_status(request: JobStatusRequest) -> JobStatusV1
 
 CLI, MCP, and HTTP adapters invoke these functions. No interface reconstructs reports independently.
 
+### 13.4 Pre-0.24 foundation audit
+
+Before the `0.24` application and persistence refactor begins, Task 27.5
+performs a foundation audit to verify that canonical accounting, migration,
+table-ownership, and public-contract assumptions remain valid. The audit may
+confirm the plan, propose bounded amendments requiring maintainer approval, or
+block implementation. It does not authorize an autonomous rewrite.
+
+The audit is the entry gate for the composition root, dependency boundaries,
+SQLite integrity, migration safety, persistent jobs, and context indexing
+implemented by Tasks 28-33. Those tasks may begin only after the audit records
+`PROCEED` or a maintainer approves an `AMEND`; `STOP` blocks implementation.
+
 ## 14. HTTP API v2
 
 The Evidence Console and MCP adapters share application services, but the live frontend receives a small HTTP surface.

--- a/tests/packaging/test_public_docs.py
+++ b/tests/packaging/test_public_docs.py
@@ -24,6 +24,42 @@ def test_mcp_first_roadmap_names_the_normative_release_sequence() -> None:
     assert positions == sorted(positions)
 
 
+def test_mcp_first_roadmap_gates_024_on_foundation_audit() -> None:
+    summary = (REPO_ROOT / "docs/roadmap/mcp-first-pivot.md").read_text(encoding="utf-8")
+    execution = (REPO_ROOT / "docs/roadmap/mcp-first-pivot-execution.md").read_text(
+        encoding="utf-8"
+    )
+    plan = (REPO_ROOT / "docs/superpowers/plans/2026-07-21-mcp-first-product-pivot.md").read_text(
+        encoding="utf-8"
+    )
+    design = (
+        REPO_ROOT / "docs/superpowers/specs/2026-07-21-mcp-first-product-pivot-design.md"
+    ).read_text(encoding="utf-8")
+
+    task_headings = [
+        line.split(":", maxsplit=1)[0].removeprefix("### Task ")
+        for line in plan.splitlines()
+        if line.startswith("### Task ")
+    ]
+    expected_task_headings = [
+        *(str(task_number) for task_number in range(1, 28)),
+        "27.5",
+        *(str(task_number) for task_number in range(28, 46)),
+    ]
+
+    assert task_headings == expected_task_headings
+    assert "**Stable task ID:** `ARCH-AUDIT-00`" in plan
+    assert "**Program size:** 46 tasks" in plan
+    assert (
+        "**Depends on:** Task 27.5 with a `PROCEED` decision or a\nmaintainer-approved `AMEND`"
+    ) in plan
+
+    assert "## Pre-0.24 Foundation Gate" in summary
+    assert "No Task 28-39 implementation work may begin" in summary
+    assert "## Task 27.5 - Foundation Audit and 0.24 Plan Confirmation" in execution
+    assert "### 13.4 Pre-0.24 foundation audit" in design
+
+
 def test_deprecation_ledger_has_required_compatibility_columns() -> None:
     deprecations = (REPO_ROOT / "docs/deprecations.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- record the Task 27.5 foundation audit and PROCEED decision
- map all 14 findings to Tasks 28-33, including migration atomicity and shared cache ownership
- document retained-database integrity, architecture, contract, and performance-preservation evidence
- add targeted GitNexus/Serena inspection guidance and ignore the local GitNexus index

## Validation
- 1907 tests passed
- 126 focused tests passed
- 18 retained migration/schema tests passed; all retained SQLite fixtures returned integrity_check=ok and no foreign-key violations
- ruff, pyright, markdownlint, and release checks passed
- one final reviewer: 5 findings, 5 accepted and addressed