### PR TITLE
refactor: compose tracker application services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,15 @@ Install the repository's pinned profiling tools with `uv sync --group performanc
 
 Use GitNexus for repository orientation, architecture, execution-flow tracing, subsystem discovery, and broad change-impact analysis.
 
+Start unfamiliar or cross-cutting GitNexus work with the repository context resource, then open only the relevant cluster or process:
+
+| Resource | Use for |
+| -------- | ------- |
+| `gitnexus://repo/codex-usage-tracker/context` | Codebase overview and index-freshness check |
+| `gitnexus://repo/codex-usage-tracker/clusters` | Functional-area discovery |
+| `gitnexus://repo/codex-usage-tracker/processes` | Execution-flow discovery |
+| `gitnexus://repo/codex-usage-tracker/process/{name}` | One selected step-by-step execution trace |
+
 Use Serena for exact symbol definitions, references, implementations, type-aware navigation, diagnostics, and symbol-level edits or refactors.
 
 For unfamiliar or cross-cutting work, use GitNexus to identify where to investigate, then use Serena to verify the exact symbols before editing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,21 @@ and `interfaces/` owns transport. Existing `reports/` builders remain private
 compatibility delegates until their algorithms move behind analytics contracts;
 they do not own canonical strategy selection.
 
+### Application composition root
+
+`application/paths.py` defines the complete local path set consumed by current
+application services. `application/protocols.py` defines the narrow clock,
+repository, pricing, and dashboard-target boundaries. `application/container.py`
+builds one immutable `ApplicationContainer` for those dependencies and shares
+one job service across refresh, analysis, evidence, allowance, and job polling.
+
+CLI, MCP, and HTTP adapters may select default local paths, but they must compose
+the container once and pass its paths and services inward. Application and
+analytics modules must not import global default paths or consult the user home
+implicitly. Tests that use temporary paths build a custom container without
+monkeypatching module globals. This is manual constructor injection; the project
+does not use a dependency-injection framework.
+
 The aggregate index preserves every parsed row in `usage_events` for source provenance. A versioned strict fingerprint links exact copies of the same logged model call, and the `canonical_usage_events` view selects one physical representative for default totals. Only high-confidence fingerprint matches are excluded; ambiguous or merely similar calls remain canonical. If the original source disappears, the surviving physical copy is promoted without changing the logical call identity.
 
 Materialized facts may retain physical rows so source replacement and local evidence remain auditable. Unscoped aggregate and compression-fact reads join the canonical view, while explicit deduplication diagnostics report physical, canonical, and excluded counts separately.

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -824,10 +824,82 @@ commit as each roadmap task.
   checkpoint lands. Focused Home, Limits, Calls, Threads, and Thread Calls
   routes remain protected until exact parity and performance gates pass.
 
+## Task 28 - Application Composition Root and Dependency Protocols
+
+- Stable task ID: `ARCH-COMPOSE-01`.
+- Status: complete on `pivot/28-composition-root`; Task 27.5 recorded
+  `PROCEED` before implementation began.
+- Branch: `pivot/28-composition-root`.
+- Commits: `refactor: compose tracker application services` (this task; exact
+  SHA is recorded in Git/PR history).
+- Composition contract:
+  - frozen `ApplicationPaths` owns the Codex home, database, pricing,
+    allowance, rate-card, threshold, and project paths;
+  - frozen `ApplicationContainer` owns those paths, one clock, narrow
+    repositories/providers, one shared `JobService`, the analysis catalog, and
+    dashboard-target resolution;
+  - CLI, HTTP v2, and the selected-profile MCP server compose the container at
+    their interface boundary and pass it inward;
+  - application and analytics modules no longer import `core.paths`, and
+    status requests no longer consult `Path.home()` implicitly;
+  - compatibility analysis delegates receive the exact container paths through
+    immutable request context instead of reopening module-global defaults.
+- Changed files: new `application/container.py`, `application/paths.py`,
+  `application/protocols.py`, and their tests; path/context injection across
+  status, query, evidence, allowance, refresh, analytics compatibility, CLI,
+  HTTP v2, the live server, and core MCP registration; architecture
+  documentation and the user-approved GitNexus resource navigation table.
+- Focused verification:
+  - required container/protocol, MCP, and interface suite:
+    `92 passed in 10.67s`;
+  - expanded application/analytics/HTTP/CLI slice:
+    `110 passed in 3.26s`;
+  - `ruff check` over the changed application, analytics, interface, and test
+    surfaces: passed;
+  - Pyright over `src/codex_usage_tracker/application`: 0 errors;
+  - custom temporary-container tests reject default-home access, preserve exact
+    paths, bind all seven core MCP tools, and prove the job/result repository is
+    shared.
+- Independent review:
+  - one final reviewer reported two actionable findings; both were accepted as
+    `R1` and `R2`;
+  - `R1` moved live HTTP v2 composition to server startup so async jobs remain
+    visible across separate request-handler connections;
+  - `R2` preserves the configured projects path through both CLI and live HTTP
+    composition;
+  - the focused post-review regression slice passed `34 tests in 3.40s`, and
+    the bounded application, analytics, MCP, interface, and server recheck
+    passed `456 tests in 31.18s`;
+  - reviewer-efficiency attribution timed out once and was recorded with token
+    status `pending`, as required; it did not block the task.
+- Full verification:
+  - `.venv/bin/python -m pytest -q`: `1912 passed in 118.84s`;
+  - `.venv/bin/python -m ruff check .`: passed;
+  - `.venv/bin/python -m mypy`: passed;
+  - `.venv/bin/python -m pyright --pythonpath .venv/bin/python src`: 0 errors
+    and the seven inherited lazy-export warnings;
+  - compileall, release-readiness checks, and `git diff --check`: passed.
+- Architecture evidence:
+  - the final GitNexus `detect-changes --scope all` mapped 96 changed symbols
+    to 15 affected execution flows and classified the cross-cutting composition
+    change as high risk, which triggered the full verification gate;
+  - Tach still reports the eight dependency-direction violations recorded by
+    Task 27.5. This task introduced no new violation; Task 30 remains their
+    assigned owner.
+- Deviations from plan: `RequestContext` gained a non-serialized
+  `application_paths` field so compatibility strategies can use the composed
+  path set without creating an analytics-to-default-path dependency. Core MCP
+  registration gained explicit container-bound handler adapters while retaining
+  the unbound compatibility functions for direct callers. No DI framework,
+  route, schema, table, or public payload changed.
+- Follow-up risks: full/developer MCP compatibility registration remains the
+  Task 29 extraction target. The known Tach direction violations and remaining
+  explicit adapter work remain Task 30 scope. Focused Home, Limits, Calls,
+  Threads, and Thread Calls route protections are unchanged.
+
 ## Remaining Planned Tasks
 
-Task 27.5 is complete once this independent checkpoint lands. Tasks 28 through
-45 remain planned in the approved implementation roadmap, and no later `0.24`
-task may begin before that checkpoint. Add a full entry using the format above
-when each task becomes active; do not mark a task complete without its named
-focused and full verification evidence.
+Tasks 27.5 and 28 are complete. Tasks 29 through 45 remain planned in the
+approved implementation roadmap. Add a full entry using the format above when
+each task becomes active; do not mark a task complete without its named focused
+and full verification evidence.

--- a/src/codex_usage_tracker/analytics/analysis_catalog.py
+++ b/src/codex_usage_tracker/analytics/analysis_catalog.py
@@ -17,13 +17,8 @@ from codex_usage_tracker.analytics.analysis_models import (
 from codex_usage_tracker.analytics.strategies.protocol import AnalysisStrategy
 from codex_usage_tracker.application.context import RequestContext
 from codex_usage_tracker.application.errors import RequestValidationError
+from codex_usage_tracker.application.paths import ApplicationPaths
 from codex_usage_tracker.core.contracts import MessageV1
-from codex_usage_tracker.core.paths import (
-    DEFAULT_ALLOWANCE_PATH,
-    DEFAULT_DB_PATH,
-    DEFAULT_PRICING_PATH,
-    DEFAULT_PROJECTS_PATH,
-)
 from codex_usage_tracker.recommendation_engine import api as recommendation_api
 from codex_usage_tracker.recommendation_engine.query import RecommendationFactsUnavailableError
 from codex_usage_tracker.reports import agentic as agentic_reports
@@ -94,8 +89,15 @@ class _CompatibilityStrategy:
         missing = _missing_facts(entry, request, context)
         if missing:
             return _fallback_report(entry, context, missing)
+        if context.application_paths is None:
+            return _fallback_report(entry, context, ("application_paths",))
         try:
-            legacy = _run_compatibility_delegate(self.delegate, request, context)
+            legacy = _run_compatibility_delegate(
+                self.delegate,
+                request,
+                context,
+                context.application_paths,
+            )
         except (FileNotFoundError, RecommendationFactsUnavailableError) as exc:
             return _fallback_report(entry, context, (type(exc).__name__,))
         return _legacy_report(entry, context, legacy)
@@ -252,7 +254,10 @@ def _missing_facts(
 
 
 def _run_compatibility_delegate(
-    delegate: CompatibilityDelegate, request: AnalysisRequest, context: RequestContext
+    delegate: CompatibilityDelegate,
+    request: AnalysisRequest,
+    context: RequestContext,
+    paths: ApplicationPaths,
 ) -> object:
     common = {
         "since": request.filters.since,
@@ -268,18 +273,18 @@ def _run_compatibility_delegate(
             "workflow_churn": "workflow_churn",
         }.get(request.goal, "token_waste")
         return agentic_reports.build_agentic_investigation_report(
-            db_path=DEFAULT_DB_PATH,
-            pricing_path=DEFAULT_PRICING_PATH,
-            allowance_path=DEFAULT_ALLOWANCE_PATH,
-            projects_path=DEFAULT_PROJECTS_PATH,
+            db_path=paths.db_path,
+            pricing_path=paths.pricing_path,
+            allowance_path=paths.allowance_path,
+            projects_path=paths.projects_path,
             goal=legacy_goal,
             thread=request.filters.thread_key,
             **common,
         )
     if delegate == "subagent":
         return subagent_reports.build_subagent_usage_report(
-            db_path=DEFAULT_DB_PATH,
-            pricing_path=DEFAULT_PRICING_PATH,
+            db_path=paths.db_path,
+            pricing_path=paths.pricing_path,
             since=request.filters.since,
             parent_thread=request.filters.parent_thread_key,
             agent_role=request.filters.subagent_role,
@@ -290,10 +295,10 @@ def _run_compatibility_delegate(
         )
     if delegate == "recommendations":
         return recommendation_api.build_recommendations_report(
-            db_path=DEFAULT_DB_PATH,
-            pricing_path=DEFAULT_PRICING_PATH,
-            allowance_path=DEFAULT_ALLOWANCE_PATH,
-            projects_path=DEFAULT_PROJECTS_PATH,
+            db_path=paths.db_path,
+            pricing_path=paths.pricing_path,
+            allowance_path=paths.allowance_path,
+            projects_path=paths.projects_path,
             model=request.filters.model,
             effort=request.filters.effort,
             thread=request.filters.thread_key,
@@ -302,10 +307,10 @@ def _run_compatibility_delegate(
             **{key: common[key] for key in ("since", "until", "include_archived", "privacy_mode")},
         )
     return report_api.build_hypothesis_test_report(
-        db_path=DEFAULT_DB_PATH,
-        pricing_path=DEFAULT_PRICING_PATH,
-        allowance_path=DEFAULT_ALLOWANCE_PATH,
-        projects_path=DEFAULT_PROJECTS_PATH,
+        db_path=paths.db_path,
+        pricing_path=paths.pricing_path,
+        allowance_path=paths.allowance_path,
+        projects_path=paths.projects_path,
         question=f"Analyze {request.goal.replace('_', ' ')} using local aggregate facts.",
         thread=request.filters.thread_key,
         **common,

--- a/src/codex_usage_tracker/application/allowance.py
+++ b/src/codex_usage_tracker/application/allowance.py
@@ -27,7 +27,6 @@ from codex_usage_tracker.allowance_intelligence.service import (
 from codex_usage_tracker.application.allowance_models import AllowanceRequest, AllowanceResult
 from codex_usage_tracker.application.errors import RequestContextError, RequestValidationError
 from codex_usage_tracker.core.dashboard_targets import build_limits_target_v2
-from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
 from codex_usage_tracker.jobs.adapters import AnalysisJobAdapter, request_hash
 from codex_usage_tracker.jobs.models import JobStatusV1
 from codex_usage_tracker.jobs.service import MAX_SEMANTIC_JOBS, JobService
@@ -155,7 +154,7 @@ _RUNTIMES: weakref.WeakKeyDictionary[JobService, AllowanceAnalysisRuntime] = (
 def get_allowance(
     request: AllowanceRequest,
     *,
-    db_path: Path = DEFAULT_DB_PATH,
+    db_path: Path,
     now: datetime | None = None,
     job_service: JobService | None = None,
     runtime: AllowanceAnalysisRuntime | None = None,

--- a/src/codex_usage_tracker/application/container.py
+++ b/src/codex_usage_tracker/application/container.py
@@ -1,0 +1,153 @@
+"""Application composition root with explicit local dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from codex_usage_tracker.analytics.analysis_catalog import (
+    ANALYSIS_CATALOG,
+    AnalysisCatalogEntry,
+)
+from codex_usage_tracker.analytics.analysis_models import AnalysisGoal
+from codex_usage_tracker.application.context import RequestContext, build_request_context
+from codex_usage_tracker.application.paths import ApplicationPaths
+from codex_usage_tracker.application.protocols import (
+    Clock,
+    DashboardTargetResolver,
+    PricingProvider,
+    RepositorySet,
+)
+from codex_usage_tracker.application.requests import RequestScope
+from codex_usage_tracker.core.dashboard_targets import build_dashboard_target_v2
+from codex_usage_tracker.jobs.service import JobService
+from codex_usage_tracker.parser.api import find_session_logs
+from codex_usage_tracker.pricing.allowance_rate_card import load_bundled_rate_card
+from codex_usage_tracker.pricing.config import PricingConfig, load_pricing_config
+from codex_usage_tracker.store.api import (
+    query_request_context_facts,
+    query_status_context_facts,
+)
+
+AnalysisCatalog = Mapping[AnalysisGoal, AnalysisCatalogEntry]
+
+
+@dataclass(frozen=True)
+class SystemClock:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class StoreUsageRepository:
+    db_path: Path
+
+    def request_context_facts(
+        self,
+        *,
+        scope: dict[str, object],
+        priced_models: set[str],
+        credit_models: set[str],
+        prefer_materialized_active: bool,
+    ) -> dict[str, object]:
+        query = (
+            query_status_context_facts
+            if prefer_materialized_active
+            else query_request_context_facts
+        )
+        return query(
+            db_path=self.db_path,
+            scope=scope,
+            priced_models=priced_models,
+            credit_models=credit_models,
+        )
+
+
+@dataclass(frozen=True)
+class LocalSourceRepository:
+    codex_home: Path
+
+    def session_logs(self, *, include_archived: bool) -> tuple[Path, ...]:
+        return tuple(find_session_logs(self.codex_home, include_archived=include_archived))
+
+
+@dataclass(frozen=True)
+class LocalPricingProvider:
+    def load(self, path: Path) -> PricingConfig:
+        return load_pricing_config(path)
+
+    def credit_rate_card(self) -> dict[str, object]:
+        return load_bundled_rate_card()
+
+
+@dataclass(frozen=True)
+class CoreDashboardTargetResolver:
+    def resolve(
+        self,
+        *,
+        evidence_kind: str,
+        selector_id: str,
+        history: str,
+        analysis_id: str | None = None,
+        target_purpose: str = "evidence",
+    ) -> dict[str, object]:
+        return build_dashboard_target_v2(
+            evidence_kind=evidence_kind,
+            selector_id=selector_id,
+            history=history,
+            analysis_id=analysis_id,
+            target_purpose=target_purpose,
+        )
+
+
+@dataclass(frozen=True)
+class ApplicationContainer:
+    paths: ApplicationPaths
+    clock: Clock
+    repositories: RepositorySet
+    jobs: JobService
+    analyses: AnalysisCatalog
+    dashboard_targets: DashboardTargetResolver
+    pricing: PricingProvider
+
+    def request_context(
+        self,
+        scope: RequestScope,
+        *,
+        prefer_materialized_active: bool = False,
+    ) -> RequestContext:
+        return build_request_context(
+            db_path=self.paths.db_path,
+            pricing_path=self.paths.pricing_path,
+            scope=scope,
+            prefer_materialized_active=prefer_materialized_active,
+            usage_repository=self.repositories.usage,
+            pricing_provider=self.pricing,
+            clock=self.clock,
+            application_paths=self.paths,
+        )
+
+
+def build_application_container(
+    paths: ApplicationPaths,
+    *,
+    clock: Clock | None = None,
+) -> ApplicationContainer:
+    jobs = JobService()
+    repositories = RepositorySet(
+        usage=StoreUsageRepository(paths.db_path),
+        sources=LocalSourceRepository(paths.codex_home),
+        analysis_results=jobs,
+        jobs=jobs,
+    )
+    return ApplicationContainer(
+        paths=paths,
+        clock=clock or SystemClock(),
+        repositories=repositories,
+        jobs=jobs,
+        analyses=ANALYSIS_CATALOG,
+        dashboard_targets=CoreDashboardTargetResolver(),
+        pricing=LocalPricingProvider(),
+    )

--- a/src/codex_usage_tracker/application/context.py
+++ b/src/codex_usage_tracker/application/context.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from codex_usage_tracker.application.errors import RequestContextError
+from codex_usage_tracker.application.protocols import Clock, PricingProvider, UsageRepository
 from codex_usage_tracker.application.requests import RequestScope
 from codex_usage_tracker.core.contracts import AccountingContextV1, FreshnessV1, ScopeV1
 from codex_usage_tracker.pricing.allowance_rate_card import (
@@ -28,6 +29,7 @@ _FRESHNESS_THRESHOLD_SECONDS = 300
 
 if TYPE_CHECKING:
     from codex_usage_tracker.application.analyze import AnalysisRuntime
+    from codex_usage_tracker.application.paths import ApplicationPaths
 
 
 @dataclass(frozen=True)
@@ -44,6 +46,7 @@ class RequestContext:
     credit_coverage: float | None
     service_tier_coverage: float | None
     analysis_runtime: AnalysisRuntime | None = field(default=None, repr=False, compare=False)
+    application_paths: ApplicationPaths | None = field(default=None, repr=False, compare=False)
 
     @property
     def accounting(self) -> AccountingContextV1:
@@ -65,34 +68,58 @@ def build_request_context(
     pricing_path: Path,
     scope: RequestScope,
     prefer_materialized_active: bool = False,
+    usage_repository: UsageRepository | None = None,
+    pricing_provider: PricingProvider | None = None,
+    clock: Clock | None = None,
+    application_paths: ApplicationPaths | None = None,
 ) -> RequestContext:
     """Build bounded context without reports, database creation, or migrations."""
     scope_contract = scope.to_contract()
     if not db_path.exists() and not db_path.is_symlink():
-        return _empty_context(scope_contract)
+        return _empty_context(scope_contract, application_paths=application_paths)
     if not db_path.is_file():
         raise RequestContextError(f"database path must be a regular file: {db_path}")
 
-    pricing = load_pricing_config(pricing_path)
-    credit_card = load_bundled_rate_card()
+    pricing = (
+        load_pricing_config(pricing_path)
+        if pricing_provider is None
+        else pricing_provider.load(pricing_path)
+    )
+    credit_card = (
+        load_bundled_rate_card()
+        if pricing_provider is None
+        else pricing_provider.credit_rate_card()
+    )
     try:
-        query_facts = (
-            query_status_context_facts
-            if prefer_materialized_active
-            else query_request_context_facts
-        )
-        facts = query_facts(
-            db_path=db_path,
-            scope=scope.to_payload(),
-            priced_models=_priced_model_names(pricing),
-            credit_models=_credit_model_names(credit_card),
-        )
+        if usage_repository is None:
+            query_facts = (
+                query_status_context_facts
+                if prefer_materialized_active
+                else query_request_context_facts
+            )
+            facts = query_facts(
+                db_path=db_path,
+                scope=scope.to_payload(),
+                priced_models=_priced_model_names(pricing),
+                credit_models=_credit_model_names(credit_card),
+            )
+        else:
+            facts = usage_repository.request_context_facts(
+                scope=scope.to_payload(),
+                priced_models=_priced_model_names(pricing),
+                credit_models=_credit_model_names(credit_card),
+                prefer_materialized_active=prefer_materialized_active,
+            )
     except InvalidDatabasePathError as exc:
         raise RequestContextError(str(exc)) from exc
     source_revision = _optional_string(facts.get("source_revision"))
     return RequestContext(
         source_revision=source_revision,
-        freshness=_freshness(facts, source_revision),
+        freshness=_freshness(
+            facts,
+            source_revision,
+            now=clock.now() if clock is not None else datetime.now(timezone.utc),
+        ),
         scope=scope_contract,
         physical_rows=_int_value(facts["physical_rows"]),
         canonical_rows=_int_value(facts["canonical_rows"]),
@@ -100,10 +127,15 @@ def build_request_context(
         pricing_coverage=_optional_float(facts.get("pricing_coverage")),
         credit_coverage=_optional_float(facts.get("credit_coverage")),
         service_tier_coverage=_optional_float(facts.get("service_tier_coverage")),
+        application_paths=application_paths,
     )
 
 
-def _empty_context(scope: ScopeV1) -> RequestContext:
+def _empty_context(
+    scope: ScopeV1,
+    *,
+    application_paths: ApplicationPaths | None = None,
+) -> RequestContext:
     freshness = FreshnessV1(
         latest_indexed_event_at=None,
         source_revision=None,
@@ -123,17 +155,23 @@ def _empty_context(scope: ScopeV1) -> RequestContext:
         pricing_coverage=None,
         credit_coverage=None,
         service_tier_coverage=None,
+        application_paths=application_paths,
     )
 
 
-def _freshness(facts: dict[str, object], source_revision: str | None) -> FreshnessV1:
+def _freshness(
+    facts: dict[str, object],
+    source_revision: str | None,
+    *,
+    now: datetime,
+) -> FreshnessV1:
     latest = _optional_string(facts.get("latest_indexed_event_at"))
     refreshed = _optional_string(facts.get("refresh_completed_at"))
     if _int_value(facts["canonical_rows"]) == 0:
         state = "empty"
         reason = "The selected scope contains no canonical usage rows."
     else:
-        age = _age_seconds(refreshed or latest)
+        age = _age_seconds(refreshed or latest, now=now)
         if age is None:
             state = "unknown"
             reason = "The index has no parseable freshness timestamp."
@@ -154,7 +192,7 @@ def _freshness(facts: dict[str, object], source_revision: str | None) -> Freshne
     )
 
 
-def _age_seconds(value: str | None) -> float | None:
+def _age_seconds(value: str | None, *, now: datetime) -> float | None:
     if value is None:
         return None
     try:
@@ -163,7 +201,7 @@ def _age_seconds(value: str | None) -> float | None:
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
-    return max(0.0, (datetime.now(timezone.utc) - parsed).total_seconds())
+    return max(0.0, (now - parsed).total_seconds())
 
 
 def _priced_model_names(pricing: PricingConfig) -> set[str]:

--- a/src/codex_usage_tracker/application/evidence.py
+++ b/src/codex_usage_tracker/application/evidence.py
@@ -12,7 +12,6 @@ from codex_usage_tracker.application.query import query_usage
 from codex_usage_tracker.application.query_models import QueryFilters, QueryRequest
 from codex_usage_tracker.application.requests import RequestScope
 from codex_usage_tracker.core.contracts import EvidenceV1
-from codex_usage_tracker.core.paths import DEFAULT_DB_PATH, DEFAULT_PRICING_PATH
 from codex_usage_tracker.evidence.models import (
     EvidenceHistoryMismatchError,
     EvidenceRequest,
@@ -60,12 +59,15 @@ _ALLOWANCE_METRICS = (
 def get_evidence(
     request: EvidenceRequest,
     *,
-    db_path: Path = DEFAULT_DB_PATH,
-    pricing_path: Path = DEFAULT_PRICING_PATH,
+    db_path: Path,
+    pricing_path: Path | None = None,
+    allowance_path: Path | None = None,
     job_service: JobService | None = None,
     context: RequestContext | None = None,
 ) -> EvidenceResult:
     """Resolve one request with a single scope/revision context."""
+    resolved_pricing_path = pricing_path or db_path.with_name("pricing.json")
+    resolved_allowance_path = allowance_path or db_path.with_name("allowance.json")
     scope = RequestScope(
         history=request.history,
         thread_key=request.selector_id if request.selector_kind == "thread" else None,
@@ -73,8 +75,17 @@ def get_evidence(
     if context is not None and context.scope != scope.to_contract():
         raise RequestContextError("evidence context scope does not match the request")
     if context is None and _requires_request_context(request):
-        context = build_request_context(db_path=db_path, pricing_path=pricing_path, scope=scope)
-    repository = _LocalEvidenceRepository(db_path, context, job_service)
+        context = build_request_context(
+            db_path=db_path,
+            pricing_path=resolved_pricing_path,
+            scope=scope,
+        )
+    repository = _LocalEvidenceRepository(
+        db_path,
+        resolved_allowance_path,
+        context,
+        job_service,
+    )
     return resolve_evidence(request, repository)
 
 
@@ -87,9 +98,14 @@ def _requires_request_context(request: EvidenceRequest) -> bool:
 
 class _LocalEvidenceRepository(EvidenceRepository):
     def __init__(
-        self, db_path: Path, context: RequestContext | None, job_service: JobService | None
+        self,
+        db_path: Path,
+        allowance_path: Path,
+        context: RequestContext | None,
+        job_service: JobService | None,
     ) -> None:
         self.db_path = db_path
+        self.allowance_path = allowance_path
         self.context = context
         if job_service is None:
             from codex_usage_tracker.application.refresh import default_job_service
@@ -162,6 +178,7 @@ class _LocalEvidenceRepository(EvidenceRepository):
                 history=cast(Any, history),
             ),
             db_path=self.db_path,
+            allowance_path=self.allowance_path,
             context=self.context,
         )
         records = tuple(

--- a/src/codex_usage_tracker/application/paths.py
+++ b/src/codex_usage_tracker/application/paths.py
@@ -1,0 +1,19 @@
+"""Explicit local paths supplied by interface composition roots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ApplicationPaths:
+    """All local filesystem dependencies needed by core application services."""
+
+    codex_home: Path
+    db_path: Path
+    pricing_path: Path
+    allowance_path: Path
+    rate_card_path: Path
+    thresholds_path: Path
+    projects_path: Path

--- a/src/codex_usage_tracker/application/protocols.py
+++ b/src/codex_usage_tracker/application/protocols.py
@@ -1,0 +1,79 @@
+"""Narrow dependency protocols consumed by current application services."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from codex_usage_tracker.jobs.models import JobKind, JobStatusV1
+from codex_usage_tracker.pricing.config import PricingConfig
+
+
+@runtime_checkable
+class Clock(Protocol):
+    def now(self) -> datetime: ...
+
+
+@runtime_checkable
+class UsageRepository(Protocol):
+    def request_context_facts(
+        self,
+        *,
+        scope: dict[str, object],
+        priced_models: set[str],
+        credit_models: set[str],
+        prefer_materialized_active: bool,
+    ) -> dict[str, object]: ...
+
+
+@runtime_checkable
+class SourceRepository(Protocol):
+    def session_logs(self, *, include_archived: bool) -> tuple[Path, ...]: ...
+
+
+@runtime_checkable
+class AnalysisResultRepository(Protocol):
+    def completed_results(
+        self,
+        *,
+        kind: JobKind,
+        result_schema: str,
+        source_revision: str | None,
+        limit: int,
+    ) -> tuple[Mapping[str, object], ...]: ...
+
+
+@runtime_checkable
+class JobRepository(Protocol):
+    def status(self, job_id: str, *, include_result: bool = False) -> JobStatusV1: ...
+
+
+@runtime_checkable
+class DashboardTargetResolver(Protocol):
+    def resolve(
+        self,
+        *,
+        evidence_kind: str,
+        selector_id: str,
+        history: str,
+        analysis_id: str | None = None,
+        target_purpose: str = "evidence",
+    ) -> dict[str, object]: ...
+
+
+@runtime_checkable
+class PricingProvider(Protocol):
+    def load(self, path: Path) -> PricingConfig: ...
+
+    def credit_rate_card(self) -> dict[str, object]: ...
+
+
+@dataclass(frozen=True)
+class RepositorySet:
+    usage: UsageRepository
+    sources: SourceRepository
+    analysis_results: AnalysisResultRepository
+    jobs: JobRepository

--- a/src/codex_usage_tracker/application/query.py
+++ b/src/codex_usage_tracker/application/query.py
@@ -21,11 +21,6 @@ from codex_usage_tracker.application.query_validation import (
     validate_query_request,
 )
 from codex_usage_tracker.application.requests import RequestScope
-from codex_usage_tracker.core.paths import (
-    DEFAULT_ALLOWANCE_PATH,
-    DEFAULT_DB_PATH,
-    DEFAULT_PRICING_PATH,
-)
 from codex_usage_tracker.pricing.allowance_usage import annotate_rows_with_allowance
 from codex_usage_tracker.pricing.config import PricingConfig, load_pricing_config
 from codex_usage_tracker.pricing.costing import estimate_cost_usd
@@ -37,12 +32,14 @@ from codex_usage_tracker.store.connection import connect
 def query_usage(
     request: QueryRequest,
     *,
-    db_path: Path = DEFAULT_DB_PATH,
-    pricing_path: Path = DEFAULT_PRICING_PATH,
-    allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
+    db_path: Path,
+    pricing_path: Path | None = None,
+    allowance_path: Path | None = None,
     context: RequestContext | None = None,
 ) -> QueryResult:
     """Execute one validated canonical query with revision-bound keyset pagination."""
+    resolved_pricing_path = pricing_path or db_path.with_name("pricing.json")
+    resolved_allowance_path = allowance_path or db_path.with_name("allowance.json")
     normalized = validate_query_request(request)
     scope = RequestScope(
         since=normalized.filters.since,
@@ -90,14 +87,14 @@ def query_usage(
     has_more = len(rows) > normalized.limit
     page = rows[: normalized.limit]
     total_matched = int(page[0].pop("_total_matched")) if page else 0
-    pricing = load_pricing_config(pricing_path)
+    pricing = load_pricing_config(resolved_pricing_path)
     for row in page:
         row.pop("_total_matched", None)
         _attach_estimates(
             row,
             normalized.measures,
             pricing=pricing,
-            allowance_path=allowance_path,
+            allowance_path=resolved_allowance_path,
         )
     next_cursor = None
     if has_more and page:

--- a/src/codex_usage_tracker/application/refresh.py
+++ b/src/codex_usage_tracker/application/refresh.py
@@ -19,7 +19,6 @@ from codex_usage_tracker.application.context import build_request_context
 from codex_usage_tracker.application.requests import RefreshRequest, RequestScope
 from codex_usage_tracker.core.contracts import payload_mapping
 from codex_usage_tracker.core.models import RefreshResult
-from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME, DEFAULT_DB_PATH, DEFAULT_PRICING_PATH
 from codex_usage_tracker.jobs.adapters import RefreshJobAdapter, request_hash
 from codex_usage_tracker.jobs.models import JobStatusV1
 from codex_usage_tracker.jobs.service import JobService
@@ -161,8 +160,8 @@ def default_job_service() -> JobService:
 def plan_refresh(
     request: RefreshRequest,
     *,
-    codex_home: Path = DEFAULT_CODEX_HOME,
-    db_path: Path = DEFAULT_DB_PATH,
+    codex_home: Path,
+    db_path: Path,
 ) -> RefreshPlan:
     """Plan from bounded file/store facts without creating or migrating a database."""
     logs = find_session_logs(codex_home, include_archived=request.history == "all")
@@ -217,9 +216,9 @@ def plan_refresh(
 def refresh_usage(
     request: RefreshRequest,
     *,
-    codex_home: Path = DEFAULT_CODEX_HOME,
-    db_path: Path = DEFAULT_DB_PATH,
-    pricing_path: Path = DEFAULT_PRICING_PATH,
+    codex_home: Path,
+    db_path: Path,
+    pricing_path: Path,
     job_service: JobService | None = None,
     coordinator: RefreshCoordinator | None = None,
     refresh_fn: RefreshFunction = refresh_usage_index,

--- a/src/codex_usage_tracker/application/refresh.py
+++ b/src/codex_usage_tracker/application/refresh.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Generic, Literal, TypeVar
 
 from codex_usage_tracker.application.context import build_request_context
+from codex_usage_tracker.application.protocols import SourceRepository
 from codex_usage_tracker.application.requests import RefreshRequest, RequestScope
 from codex_usage_tracker.core.contracts import payload_mapping
 from codex_usage_tracker.core.models import RefreshResult
@@ -162,9 +163,14 @@ def plan_refresh(
     *,
     codex_home: Path,
     db_path: Path,
+    source_repository: SourceRepository | None = None,
 ) -> RefreshPlan:
     """Plan from bounded file/store facts without creating or migrating a database."""
-    logs = find_session_logs(codex_home, include_archived=request.history == "all")
+    logs = (
+        source_repository.session_logs(include_archived=request.history == "all")
+        if source_repository is not None
+        else find_session_logs(codex_home, include_archived=request.history == "all")
+    )
     if not db_path.exists():
         return RefreshPlan(
             "sync" if not logs else "async",
@@ -219,6 +225,7 @@ def refresh_usage(
     codex_home: Path,
     db_path: Path,
     pricing_path: Path,
+    source_repository: SourceRepository | None = None,
     job_service: JobService | None = None,
     coordinator: RefreshCoordinator | None = None,
     refresh_fn: RefreshFunction = refresh_usage_index,
@@ -245,14 +252,26 @@ def refresh_usage(
 
     if request.execution == "sync":
         with lock:
-            observed = planner(request, codex_home=codex_home, db_path=db_path)
+            observed = _plan_refresh(
+                planner,
+                request,
+                codex_home=codex_home,
+                db_path=db_path,
+                source_repository=source_repository,
+            )
             explicit = RefreshPlan(
                 "sync", "explicit_sync", observed.changed_source_files, observed.added_bytes
             )
             return CompletedOrJob(result=execute(explicit))
     if request.execution == "auto":
         with lock:
-            observed = planner(request, codex_home=codex_home, db_path=db_path)
+            observed = _plan_refresh(
+                planner,
+                request,
+                codex_home=codex_home,
+                db_path=db_path,
+                source_repository=source_repository,
+            )
             if observed.execution == "sync":
                 return CompletedOrJob(result=execute(observed))
 
@@ -265,7 +284,13 @@ def refresh_usage(
 
     def worker() -> dict[str, object]:
         with lock:
-            observed = planner(request, codex_home=codex_home, db_path=db_path)
+            observed = _plan_refresh(
+                planner,
+                request,
+                codex_home=codex_home,
+                db_path=db_path,
+                source_repository=source_repository,
+            )
             async_plan = RefreshPlan(
                 "async",
                 "explicit_async" if request.execution == "async" else observed.reason,
@@ -275,6 +300,24 @@ def refresh_usage(
             return execute(async_plan)
 
     return CompletedOrJob(job=runtime.start(key, worker))
+
+
+def _plan_refresh(
+    planner: Planner,
+    request: RefreshRequest,
+    *,
+    codex_home: Path,
+    db_path: Path,
+    source_repository: SourceRepository | None,
+) -> RefreshPlan:
+    if source_repository is None:
+        return planner(request, codex_home=codex_home, db_path=db_path)
+    return planner(
+        request,
+        codex_home=codex_home,
+        db_path=db_path,
+        source_repository=source_repository,
+    )
 
 
 def _completed_payload(

--- a/src/codex_usage_tracker/application/requests.py
+++ b/src/codex_usage_tracker/application/requests.py
@@ -14,7 +14,6 @@ from codex_usage_tracker.application.errors import RequestValidationError
 from codex_usage_tracker.application.query_models import QueryRequest as QueryRequest
 from codex_usage_tracker.core.contracts import ScopeV1
 from codex_usage_tracker.core.contracts.serialization import payload_mapping
-from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME, DEFAULT_DB_PATH, DEFAULT_PRICING_PATH
 from codex_usage_tracker.evidence.models import EvidenceRequest as EvidenceRequest
 
 HistoryScope: TypeAlias = Literal["active", "all"]
@@ -142,10 +141,10 @@ class RequestScope:
 class StatusRequest:
     scope: RequestScope = field(default_factory=RequestScope)
     freshness_threshold_seconds: int | float = 300
-    db_path: Path = DEFAULT_DB_PATH
-    pricing_path: Path = DEFAULT_PRICING_PATH
-    codex_home: Path = DEFAULT_CODEX_HOME
-    home: Path = field(default_factory=Path.home)
+    db_path: Path | None = None
+    pricing_path: Path | None = None
+    codex_home: Path | None = None
+    home: Path | None = None
     mcp_profile: McpProfile = "core"
 
     def __post_init__(self) -> None:

--- a/src/codex_usage_tracker/application/status.py
+++ b/src/codex_usage_tracker/application/status.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime, timezone
+from pathlib import Path
 
 from codex_usage_tracker.application.context import RequestContext, build_request_context
+from codex_usage_tracker.application.errors import RequestContextError
+from codex_usage_tracker.application.protocols import Clock, PricingProvider
 from codex_usage_tracker.application.requests import StatusRequest
 from codex_usage_tracker.core.contracts import FreshnessV1, payload_mapping
 from codex_usage_tracker.core.conversational_readiness import conversational_readiness
@@ -27,24 +30,57 @@ CORE_TOOL_NAMES = (
 )
 
 
-def get_status(request: StatusRequest) -> dict[str, object]:
+def get_status(
+    request: StatusRequest,
+    *,
+    context: RequestContext | None = None,
+    clock: Clock | None = None,
+    pricing_provider: PricingProvider | None = None,
+) -> dict[str, object]:
     """Return codex-usage-tracker.status.v2 without starting background work."""
-    result, _context = _build_status(request)
+    result, _context = _build_status(
+        request,
+        context=context,
+        clock=clock,
+        pricing_provider=pricing_provider,
+    )
     return result
 
 
-def _build_status(request: StatusRequest) -> tuple[dict[str, object], RequestContext]:
-    context = build_request_context(
-        db_path=request.db_path,
-        pricing_path=request.pricing_path,
-        scope=request.scope,
-        prefer_materialized_active=True,
+def _build_status(
+    request: StatusRequest,
+    *,
+    context: RequestContext | None = None,
+    clock: Clock | None = None,
+    pricing_provider: PricingProvider | None = None,
+) -> tuple[dict[str, object], RequestContext]:
+    db_path = _required_path(request.db_path, "db_path")
+    pricing_path = _required_path(request.pricing_path, "pricing_path")
+    codex_home = _required_path(request.codex_home, "codex_home")
+    home = _required_path(request.home, "home")
+    if context is None:
+        context = build_request_context(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=request.scope,
+            prefer_materialized_active=True,
+            pricing_provider=pricing_provider,
+            clock=clock,
+        )
+    now = clock.now() if clock is not None else datetime.now(timezone.utc)
+    freshness = _freshness_for_threshold(
+        context.freshness,
+        request.freshness_threshold_seconds,
+        now=now,
     )
-    freshness = _freshness_for_threshold(context.freshness, request.freshness_threshold_seconds)
     context = replace(context, freshness=freshness)
-    pricing_config = load_pricing_config(request.pricing_path)
-    readiness = conversational_readiness(codex_home=request.codex_home)
-    service = _service_status(request)
+    pricing_config = (
+        load_pricing_config(pricing_path)
+        if pricing_provider is None
+        else pricing_provider.load(pricing_path)
+    )
+    readiness = conversational_readiness(codex_home=codex_home)
+    service = _service_status(home)
     pricing_state = (
         "malformed"
         if pricing_config.error
@@ -91,12 +127,20 @@ def _build_status(request: StatusRequest) -> tuple[dict[str, object], RequestCon
     return result, context
 
 
-def _freshness_for_threshold(freshness: FreshnessV1, threshold: float) -> FreshnessV1:
+def _freshness_for_threshold(
+    freshness: FreshnessV1,
+    threshold: float,
+    *,
+    now: datetime,
+) -> FreshnessV1:
     if freshness.state in {"empty", "unknown"}:
         state = freshness.state
         reason = freshness.reason
     else:
-        age = _age_seconds(freshness.refresh_completed_at or freshness.latest_indexed_event_at)
+        age = _age_seconds(
+            freshness.refresh_completed_at or freshness.latest_indexed_event_at,
+            now=now,
+        )
         if age is None:
             state = "unknown"
             reason = "The index has no parseable freshness timestamp."
@@ -117,7 +161,7 @@ def _freshness_for_threshold(freshness: FreshnessV1, threshold: float) -> Freshn
     )
 
 
-def _age_seconds(value: str | None) -> float | None:
+def _age_seconds(value: str | None, *, now: datetime) -> float | None:
     if value is None:
         return None
     try:
@@ -126,14 +170,20 @@ def _age_seconds(value: str | None) -> float | None:
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
-    return max(0.0, (datetime.now(timezone.utc) - parsed).total_seconds())
+    return max(0.0, (now - parsed).total_seconds())
 
 
-def _service_status(request: StatusRequest) -> DashboardServiceStatus:
+def _service_status(home: Path) -> DashboardServiceStatus:
     try:
-        return dashboard_service_status(home=request.home)
+        return dashboard_service_status(home=home)
     except (OSError, RuntimeError, ValueError) as exc:
         return DashboardServiceStatus(False, False, False, 47821, f"unavailable: {exc}")
+
+
+def _required_path(value: Path | None, name: str) -> Path:
+    if value is None:
+        raise RequestContextError(f"status request requires {name}")
+    return value
 
 
 def _service_payload(service: DashboardServiceStatus) -> dict[str, object]:

--- a/src/codex_usage_tracker/interfaces/cli/commands.py
+++ b/src/codex_usage_tracker/interfaces/cli/commands.py
@@ -18,6 +18,8 @@ from codex_usage_tracker.analytics.analysis_models import (
     AnalysisRequest,
     ComparisonWindow,
 )
+from codex_usage_tracker.application.container import build_application_container
+from codex_usage_tracker.application.paths import ApplicationPaths
 from codex_usage_tracker.application.query_models import (
     ALL_QUERY_MEASURES,
     QUERY_ENTITY_CAPABILITIES,
@@ -30,6 +32,7 @@ from codex_usage_tracker.application.query_models import (
 from codex_usage_tracker.application.requests import HistoryScope, StatusRequest
 from codex_usage_tracker.core.contracts import payload_mapping
 from codex_usage_tracker.core.dashboard_targets import build_dashboard_target_v2
+from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME
 from codex_usage_tracker.dashboard_service import dashboard_service_status
 from codex_usage_tracker.interfaces.http.v2 import ApplicationHttpV2Services
 
@@ -59,6 +62,8 @@ def run_status(
     request = StatusRequest(
         db_path=args.db,
         pricing_path=args.pricing,
+        codex_home=DEFAULT_CODEX_HOME,
+        home=DEFAULT_CODEX_HOME.parent,
         scope=_scope(args),
     )
     _write_json((services or _default_services(args)).status(request), stdout)
@@ -153,13 +158,18 @@ def warn_legacy_alias(
 
 
 def _default_services(args: argparse.Namespace) -> CliApplicationServices:
-    return ApplicationHttpV2Services(
-        db_path=args.db,
-        pricing_path=args.pricing,
-        allowance_path=args.allowance,
-        rate_card_path=args.rate_card,
-        thresholds_path=args.thresholds,
+    container = build_application_container(
+        ApplicationPaths(
+            codex_home=DEFAULT_CODEX_HOME,
+            db_path=args.db,
+            pricing_path=args.pricing,
+            allowance_path=args.allowance,
+            rate_card_path=args.rate_card,
+            thresholds_path=args.thresholds,
+            projects_path=args.projects,
+        )
     )
+    return ApplicationHttpV2Services(container=container)
 
 
 def _scope(args: argparse.Namespace):

--- a/src/codex_usage_tracker/interfaces/http/v2.py
+++ b/src/codex_usage_tracker/interfaces/http/v2.py
@@ -181,6 +181,7 @@ class ApplicationHttpV2Services:
             codex_home=self.codex_home,
             db_path=self.db_path,
             pricing_path=self.pricing_path,
+            source_repository=self.application.repositories.sources,
             job_service=self.job_service,
         )
         return outcome.result if outcome.result is not None else outcome.job

--- a/src/codex_usage_tracker/interfaces/http/v2.py
+++ b/src/codex_usage_tracker/interfaces/http/v2.py
@@ -19,10 +19,14 @@ from codex_usage_tracker.analytics.analysis_models import (
 from codex_usage_tracker.application.allowance import get_allowance
 from codex_usage_tracker.application.allowance_models import AllowanceRequest
 from codex_usage_tracker.application.analyze import AnalysisRuntime, analyze_usage
-from codex_usage_tracker.application.context import build_request_context
+from codex_usage_tracker.application.container import (
+    ApplicationContainer,
+    build_application_container,
+)
 from codex_usage_tracker.application.errors import ApplicationError
 from codex_usage_tracker.application.evidence import get_evidence
 from codex_usage_tracker.application.job_status import get_job_status
+from codex_usage_tracker.application.paths import ApplicationPaths
 from codex_usage_tracker.application.query import query_usage
 from codex_usage_tracker.application.query_models import (
     ALL_QUERY_MEASURES,
@@ -31,7 +35,7 @@ from codex_usage_tracker.application.query_models import (
     QueryRequest,
 )
 from codex_usage_tracker.application.query_validation import normalize_query_filters
-from codex_usage_tracker.application.refresh import default_job_service, refresh_usage
+from codex_usage_tracker.application.refresh import refresh_usage
 from codex_usage_tracker.application.requests import (
     JobStatusRequest,
     RefreshRequest,
@@ -44,6 +48,7 @@ from codex_usage_tracker.core.paths import (
     DEFAULT_CODEX_HOME,
     DEFAULT_DB_PATH,
     DEFAULT_PRICING_PATH,
+    DEFAULT_PROJECTS_PATH,
     DEFAULT_RATE_CARD_PATH,
     DEFAULT_THRESHOLDS_PATH,
 )
@@ -112,25 +117,62 @@ class ApplicationHttpV2Services:
     rate_card_path: Path = DEFAULT_RATE_CARD_PATH
     thresholds_path: Path = DEFAULT_THRESHOLDS_PATH
     codex_home: Path = DEFAULT_CODEX_HOME
+    projects_path: Path = DEFAULT_PROJECTS_PATH
+    container: ApplicationContainer | None = None
 
     def __post_init__(self) -> None:
-        self.job_service = default_job_service()
+        if self.container is None:
+            self.container = build_application_container(
+                ApplicationPaths(
+                    codex_home=self.codex_home,
+                    db_path=self.db_path,
+                    pricing_path=self.pricing_path,
+                    allowance_path=self.allowance_path,
+                    rate_card_path=self.rate_card_path,
+                    thresholds_path=self.thresholds_path,
+                    projects_path=self.projects_path,
+                )
+            )
+        else:
+            self.codex_home = self.container.paths.codex_home
+            self.db_path = self.container.paths.db_path
+            self.pricing_path = self.container.paths.pricing_path
+            self.allowance_path = self.container.paths.allowance_path
+            self.rate_card_path = self.container.paths.rate_card_path
+            self.thresholds_path = self.container.paths.thresholds_path
+            self.projects_path = self.container.paths.projects_path
+        self.job_service = self.container.jobs
         self.analysis_runtime = AnalysisRuntime(
             job_service=self.job_service,
+            catalog=self.container.analyses,
             pricing_fingerprint=_path_fingerprint(self.pricing_path),
             rate_card_fingerprint=_path_fingerprint(self.rate_card_path),
             thresholds_fingerprint=_path_fingerprint(self.thresholds_path),
             catalog_version=_catalog_fingerprint(),
         )
 
+    @property
+    def application(self) -> ApplicationContainer:
+        if self.container is None:
+            raise RuntimeError("application container was not initialized")
+        return self.container
+
     def status(self, request: StatusRequest) -> object:
+        context = self.application.request_context(
+            request.scope,
+            prefer_materialized_active=True,
+        )
         return get_status(
             replace(
                 request,
                 db_path=self.db_path,
                 pricing_path=self.pricing_path,
                 codex_home=self.codex_home,
-            )
+                home=self.codex_home.parent,
+            ),
+            context=context,
+            clock=self.application.clock,
+            pricing_provider=self.application.pricing,
         )
 
     def refresh(self, request: RefreshRequest) -> object:
@@ -145,10 +187,8 @@ class ApplicationHttpV2Services:
 
     def analyze(self, request: AnalysisRequest) -> object:
         normalized = replace(request, filters=normalize_query_filters(request.filters))
-        context = build_request_context(
-            db_path=self.db_path,
-            pricing_path=self.pricing_path,
-            scope=_request_scope(normalized.filters, normalized.history),
+        context = self.application.request_context(
+            _request_scope(normalized.filters, normalized.history)
         )
         outcome = analyze_usage(
             normalized,
@@ -157,11 +197,16 @@ class ApplicationHttpV2Services:
         return outcome.completed if outcome.completed is not None else outcome.job
 
     def query(self, request: QueryRequest) -> object:
+        normalized = replace(request, filters=normalize_query_filters(request.filters))
+        context = self.application.request_context(
+            _request_scope(normalized.filters, normalized.history)
+        )
         return query_usage(
-            request,
+            normalized,
             db_path=self.db_path,
             pricing_path=self.pricing_path,
             allowance_path=self.allowance_path,
+            context=context,
         )
 
     def evidence(self, request: EvidenceRequest) -> object:
@@ -169,6 +214,7 @@ class ApplicationHttpV2Services:
             request,
             db_path=self.db_path,
             pricing_path=self.pricing_path,
+            allowance_path=self.allowance_path,
             job_service=self.job_service,
         )
 

--- a/src/codex_usage_tracker/interfaces/mcp/core_tools.py
+++ b/src/codex_usage_tracker/interfaces/mcp/core_tools.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from codex_usage_tracker.application.allowance import AllowanceAnalysisRuntime, get_allowance
 from codex_usage_tracker.application.allowance_models import AllowanceRequest
+from codex_usage_tracker.application.container import ApplicationContainer
 from codex_usage_tracker.application.context import build_request_context
 from codex_usage_tracker.application.evidence import get_evidence
 from codex_usage_tracker.application.job_status import JobStatusService, get_job_status
@@ -27,7 +28,12 @@ from codex_usage_tracker.core.contracts import (
     enforce_payload_budget,
     envelope_payload,
 )
-from codex_usage_tracker.core.paths import DEFAULT_CODEX_HOME, DEFAULT_DB_PATH, DEFAULT_PRICING_PATH
+from codex_usage_tracker.core.paths import (
+    DEFAULT_ALLOWANCE_PATH,
+    DEFAULT_CODEX_HOME,
+    DEFAULT_DB_PATH,
+    DEFAULT_PRICING_PATH,
+)
 from codex_usage_tracker.evidence.models import EvidenceRequest
 from codex_usage_tracker.interfaces.mcp.models import McpProfile
 from codex_usage_tracker.interfaces.mcp.query_analysis_tools import (
@@ -129,7 +135,13 @@ def build_usage_allowance(
     now: datetime | None = None,
     job_service: JobService | None = None,
     runtime: AllowanceAnalysisRuntime | None = None,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        now = now or container.clock.now()
+        job_service = job_service or container.jobs
     request = AllowanceRequest(
         operation=cast(Any, operation),
         window=cast(Any, window),
@@ -146,10 +158,14 @@ def build_usage_allowance(
         job_service=job_service,
         runtime=runtime,
     )
-    context = build_request_context(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        scope=RequestScope(privacy_mode="strict"),
+    context = (
+        container.request_context(RequestScope(privacy_mode="strict"))
+        if container is not None
+        else build_request_context(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=RequestScope(privacy_mode="strict"),
+        )
     )
     state = result.payload.get("state")
     job_id = result.payload.get("job_id")
@@ -193,8 +209,15 @@ def build_usage_evidence(
     analysis_id: str | None = None,
     db_path: Path = DEFAULT_DB_PATH,
     pricing_path: Path = DEFAULT_PRICING_PATH,
+    allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
     job_service: JobService | None = None,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        allowance_path = container.paths.allowance_path
+        job_service = job_service or container.jobs
     request = EvidenceRequest(
         selector_kind=cast(Any, selector_kind),
         selector_id=selector_id,
@@ -208,11 +231,16 @@ def build_usage_evidence(
         history=cast(HistoryScope, request.history),
         thread_key=request.selector_id if request.selector_kind == "thread" else None,
     )
-    context = build_request_context(db_path=db_path, pricing_path=pricing_path, scope=scope)
+    context = (
+        container.request_context(scope)
+        if container is not None
+        else build_request_context(db_path=db_path, pricing_path=pricing_path, scope=scope)
+    )
     result = get_evidence(
         request,
         db_path=db_path,
         pricing_path=pricing_path,
+        allowance_path=allowance_path,
         job_service=job_service,
         context=context,
     )
@@ -237,8 +265,14 @@ def build_usage_status(
     codex_home: Path = DEFAULT_CODEX_HOME,
     home: Path | None = None,
     profile: str = "core",
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
     """Build the core status envelope with explicit testable local dependencies."""
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        codex_home = container.paths.codex_home
+        home = home or codex_home.parent
     request = StatusRequest(
         db_path=db_path,
         pricing_path=pricing_path,
@@ -246,7 +280,19 @@ def build_usage_status(
         home=home or Path.home(),
         mcp_profile=cast(McpProfile, profile),
     )
-    result, context = _build_status(request)
+    if container is None:
+        result, context = _build_status(request)
+    else:
+        context = container.request_context(
+            request.scope,
+            prefer_materialized_active=True,
+        )
+        result, context = _build_status(
+            request,
+            context=context,
+            clock=container.clock,
+            pricing_provider=container.pricing,
+        )
     next_action = cast(dict[str, object], result["next_action"])
     payload = envelope_payload(
         tool="usage_status",
@@ -284,7 +330,12 @@ def build_usage_refresh(
     db_path: Path = DEFAULT_DB_PATH,
     pricing_path: Path = DEFAULT_PRICING_PATH,
     codex_home: Path = DEFAULT_CODEX_HOME,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        codex_home = container.paths.codex_home
     request = RefreshRequest(
         history=cast(HistoryScope, history),
         aggregate_only=aggregate_only,
@@ -295,11 +346,16 @@ def build_usage_refresh(
         db_path=db_path,
         pricing_path=pricing_path,
         codex_home=codex_home,
+        job_service=None if container is None else container.jobs,
     )
-    context = build_request_context(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        scope=RequestScope(history=request.history),
+    context = (
+        container.request_context(RequestScope(history=request.history))
+        if container is not None
+        else build_request_context(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=RequestScope(history=request.history),
+        )
     )
     if outcome.result is not None:
         result_schema = REFRESH_SCHEMA
@@ -340,13 +396,22 @@ def build_usage_job_status(
     db_path: Path = DEFAULT_DB_PATH,
     pricing_path: Path = DEFAULT_PRICING_PATH,
     job_service: JobStatusService | None = None,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        job_service = job_service or container.jobs
     request = JobStatusRequest(job_id=job_id, include_result=include_result)
     status = get_job_status(request, job_service=job_service)
-    context = build_request_context(
-        db_path=db_path,
-        pricing_path=pricing_path,
-        scope=RequestScope(),
+    context = (
+        container.request_context(RequestScope())
+        if container is not None
+        else build_request_context(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=RequestScope(),
+        )
     )
     payload = envelope_payload(
         tool="usage_job_status",

--- a/src/codex_usage_tracker/interfaces/mcp/core_tools.py
+++ b/src/codex_usage_tracker/interfaces/mcp/core_tools.py
@@ -346,6 +346,7 @@ def build_usage_refresh(
         db_path=db_path,
         pricing_path=pricing_path,
         codex_home=codex_home,
+        source_repository=(None if container is None else container.repositories.sources),
         job_service=None if container is None else container.jobs,
     )
     context = (

--- a/src/codex_usage_tracker/interfaces/mcp/query_analysis_tools.py
+++ b/src/codex_usage_tracker/interfaces/mcp/query_analysis_tools.py
@@ -22,7 +22,9 @@ from codex_usage_tracker.application.analyze import (
     AnalyzeResult,
     analyze_usage,
 )
+from codex_usage_tracker.application.container import ApplicationContainer
 from codex_usage_tracker.application.context import RequestContext, build_request_context
+from codex_usage_tracker.application.paths import ApplicationPaths
 from codex_usage_tracker.application.query import query_usage
 from codex_usage_tracker.application.query_models import QueryFilters, QueryRequest, QueryResult
 from codex_usage_tracker.application.query_validation import normalize_query_filters
@@ -36,8 +38,10 @@ from codex_usage_tracker.core.contracts import (
 from codex_usage_tracker.core.json_contracts import validate_json_payload_contract
 from codex_usage_tracker.core.paths import (
     DEFAULT_ALLOWANCE_PATH,
+    DEFAULT_CODEX_HOME,
     DEFAULT_DB_PATH,
     DEFAULT_PRICING_PATH,
+    DEFAULT_PROJECTS_PATH,
     DEFAULT_RATE_CARD_PATH,
     DEFAULT_THRESHOLDS_PATH,
 )
@@ -124,14 +128,26 @@ def build_usage_query(
     allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
     query_service: QueryService = query_usage,
     context_builder: ContextBuilder = build_request_context,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    if container is not None:
+        db_path = container.paths.db_path
+        pricing_path = container.paths.pricing_path
+        allowance_path = container.paths.allowance_path
     request = _query_request(
         entity, measures, filters, group_by, order_by, order, limit, cursor, history
     )
     normalized = normalize_query_filters(request.filters)
     request = replace(request, filters=normalized)
-    context = context_builder(
-        db_path=db_path, pricing_path=pricing_path, scope=_request_scope(normalized, history)
+    scope = _request_scope(normalized, history)
+    context = (
+        container.request_context(scope)
+        if container is not None
+        else context_builder(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=scope,
+        )
     )
     result = query_service(
         request,
@@ -166,19 +182,51 @@ def build_usage_analyze(
     execution: str = "auto",
     db_path: Path = DEFAULT_DB_PATH,
     pricing_path: Path = DEFAULT_PRICING_PATH,
+    allowance_path: Path = DEFAULT_ALLOWANCE_PATH,
     rate_card_path: Path = DEFAULT_RATE_CARD_PATH,
     thresholds_path: Path = DEFAULT_THRESHOLDS_PATH,
+    projects_path: Path = DEFAULT_PROJECTS_PATH,
+    codex_home: Path = DEFAULT_CODEX_HOME,
     runtime: AnalysisRuntime | None = None,
     catalog: Mapping[AnalysisGoal, AnalysisCatalogEntry] = ANALYSIS_CATALOG,
     job_service: JobService | None = None,
     analysis_service: AnalysisService = analyze_usage,
     context_builder: ContextBuilder = build_request_context,
+    container: ApplicationContainer | None = None,
 ) -> dict[str, object]:
+    paths = (
+        container.paths
+        if container is not None
+        else ApplicationPaths(
+            codex_home=codex_home,
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            rate_card_path=rate_card_path,
+            thresholds_path=thresholds_path,
+            projects_path=projects_path,
+        )
+    )
+    if container is not None:
+        db_path = paths.db_path
+        pricing_path = paths.pricing_path
+        rate_card_path = paths.rate_card_path
+        thresholds_path = paths.thresholds_path
+        catalog = container.analyses
+        job_service = job_service or container.jobs
     request = _analysis_request(goal, filters, history, evidence_limit, comparison, execution)
     normalized = normalize_query_filters(request.filters)
     request = replace(request, filters=normalized)
-    context = context_builder(
-        db_path=db_path, pricing_path=pricing_path, scope=_request_scope(normalized, history)
+    scope = _request_scope(normalized, history)
+    context = (
+        container.request_context(scope)
+        if container is not None
+        else context_builder(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            scope=scope,
+            application_paths=paths,
+        )
     )
     runtime = runtime or _analysis_runtime(
         pricing_path, rate_card_path, thresholds_path, catalog, job_service

--- a/src/codex_usage_tracker/interfaces/mcp/registry.py
+++ b/src/codex_usage_tracker/interfaces/mcp/registry.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from functools import cache, lru_cache
+from functools import cache, lru_cache, wraps
 
+from codex_usage_tracker.application.container import ApplicationContainer
 from codex_usage_tracker.interfaces.mcp.compatibility_tools import (
     ADVANCED_TOOL_NAMES,
     COMPATIBILITY_TOOL_NAMES,
@@ -12,6 +13,13 @@ from codex_usage_tracker.interfaces.mcp.compatibility_tools import (
     compatibility_handler,
 )
 from codex_usage_tracker.interfaces.mcp.core_tools import (
+    build_usage_allowance,
+    build_usage_analyze,
+    build_usage_evidence,
+    build_usage_job_status,
+    build_usage_query,
+    build_usage_refresh,
+    build_usage_status,
     usage_allowance,
     usage_analyze,
     usage_evidence,
@@ -206,7 +214,10 @@ def tool_specs() -> tuple[ToolSpec, ...]:
     return specs
 
 
-def handler_for_profile(spec: ToolSpec, profile: McpProfile) -> Callable[..., object]:
+def handler_for_profile(
+    spec: ToolSpec,
+    profile: McpProfile,
+) -> Callable[..., object]:
     """Preserve existing overlapping handlers outside the core-only server."""
     if profile == "core":
         return spec.handler
@@ -215,6 +226,134 @@ def handler_for_profile(spec: ToolSpec, profile: McpProfile) -> Callable[..., ob
     if spec.minimum_profile == "developer":
         return developer_handler(spec.name)
     return spec.handler
+
+
+def bound_core_handlers(
+    container: ApplicationContainer,
+) -> dict[str, Callable[..., object]]:
+    @wraps(usage_status)
+    def bound_usage_status() -> dict[str, object]:
+        return build_usage_status(container=container)
+
+    @wraps(usage_refresh)
+    def bound_usage_refresh(
+        history: str = "active",
+        aggregate_only: bool = True,
+        execution: str = "auto",
+    ) -> dict[str, object]:
+        return build_usage_refresh(
+            history=history,
+            aggregate_only=aggregate_only,
+            execution=execution,
+            container=container,
+        )
+
+    @wraps(usage_analyze)
+    def bound_usage_analyze(
+        goal: str,
+        filters: dict[str, object] | None = None,
+        history: str = "active",
+        evidence_limit: int = 8,
+        comparison: dict[str, object] | None = None,
+        execution: str = "auto",
+    ) -> dict[str, object]:
+        return build_usage_analyze(
+            goal=goal,
+            filters=filters,
+            history=history,
+            evidence_limit=evidence_limit,
+            comparison=comparison,
+            execution=execution,
+            container=container,
+        )
+
+    @wraps(usage_query)
+    def bound_usage_query(
+        entity: str,
+        measures: list[str],
+        filters: dict[str, object] | None = None,
+        group_by: list[str] | None = None,
+        order_by: str | None = None,
+        order: str = "desc",
+        limit: int = 20,
+        cursor: str | None = None,
+        history: str = "active",
+    ) -> dict[str, object]:
+        return build_usage_query(
+            entity=entity,
+            measures=measures,
+            filters=filters,
+            group_by=group_by,
+            order_by=order_by,
+            order=order,
+            limit=limit,
+            cursor=cursor,
+            history=history,
+            container=container,
+        )
+
+    @wraps(usage_evidence)
+    def bound_usage_evidence(
+        selector_kind: str,
+        selector_id: str,
+        section: str = "summary",
+        limit: int = 20,
+        cursor: str | None = None,
+        history: str = "active",
+        analysis_id: str | None = None,
+    ) -> dict[str, object]:
+        return build_usage_evidence(
+            selector_kind=selector_kind,
+            selector_id=selector_id,
+            section=section,
+            limit=limit,
+            cursor=cursor,
+            history=history,
+            analysis_id=analysis_id,
+            container=container,
+        )
+
+    @wraps(usage_allowance)
+    def bound_usage_allowance(
+        operation: str,
+        window: str = "weekly",
+        range: str = "8w",  # noqa: A002 - public roadmap field name.
+        cursor: str | None = None,
+        limit: int = 50,
+        analysis_id: str | None = None,
+        execution: str = "auto",
+    ) -> dict[str, object]:
+        return build_usage_allowance(
+            operation=operation,
+            window=window,
+            range_preset=range,
+            cursor=cursor,
+            limit=limit,
+            analysis_id=analysis_id,
+            execution=execution,
+            container=container,
+        )
+
+    @wraps(usage_job_status)
+    def bound_usage_job_status(
+        job_id: str,
+        include_result: bool = False,
+    ) -> dict[str, object]:
+        return build_usage_job_status(
+            job_id=job_id,
+            include_result=include_result,
+            container=container,
+        )
+
+    return {
+        "usage_status": bound_usage_status,
+        "usage_refresh": bound_usage_refresh,
+        "usage_analyze": bound_usage_analyze,
+        "usage_query": bound_usage_query,
+        "usage_evidence": bound_usage_evidence,
+        "usage_allowance": bound_usage_allowance,
+        "usage_job_status": bound_usage_job_status,
+    }
 
 
 def _full_tool_spec(name: str) -> ToolSpec:

--- a/src/codex_usage_tracker/interfaces/mcp/runtime.py
+++ b/src/codex_usage_tracker/interfaces/mcp/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from inspect import getdoc
 
+from codex_usage_tracker.application.container import ApplicationContainer
 from codex_usage_tracker.interfaces.mcp.models import McpProfile, ToolSpec
 from mcp.server.fastmcp import FastMCP
 
@@ -11,14 +12,26 @@ from mcp.server.fastmcp import FastMCP
 compatibility_mcp = FastMCP("codex-usage-tracker")
 
 
-def build_mcp_server(profile: McpProfile) -> FastMCP:
+def build_mcp_server(
+    profile: McpProfile,
+    *,
+    container: ApplicationContainer | None = None,
+) -> FastMCP:
     """Build an isolated server containing exactly the selected profile."""
     from codex_usage_tracker.interfaces.mcp.profiles import tools_for_profile
-    from codex_usage_tracker.interfaces.mcp.registry import handler_for_profile
+    from codex_usage_tracker.interfaces.mcp.registry import (
+        bound_core_handlers,
+        handler_for_profile,
+    )
 
     server = FastMCP("codex-usage-tracker")
+    bound = (
+        bound_core_handlers(container)
+        if profile == "core" and container is not None
+        else None
+    )
     for spec in tools_for_profile(profile):
-        handler = handler_for_profile(spec, profile)
+        handler = bound[spec.name] if bound is not None else handler_for_profile(spec, profile)
         server.tool(name=spec.name, description=_tool_description(spec, handler))(handler)
     return server
 

--- a/src/codex_usage_tracker/interfaces/mcp/server.py
+++ b/src/codex_usage_tracker/interfaces/mcp/server.py
@@ -6,6 +6,17 @@ import os
 from collections.abc import Mapping
 from typing import cast
 
+from codex_usage_tracker.application.container import build_application_container
+from codex_usage_tracker.application.paths import ApplicationPaths
+from codex_usage_tracker.core.paths import (
+    DEFAULT_ALLOWANCE_PATH,
+    DEFAULT_CODEX_HOME,
+    DEFAULT_DB_PATH,
+    DEFAULT_PRICING_PATH,
+    DEFAULT_PROJECTS_PATH,
+    DEFAULT_RATE_CARD_PATH,
+    DEFAULT_THRESHOLDS_PATH,
+)
 from codex_usage_tracker.interfaces.mcp.models import McpProfile
 from codex_usage_tracker.interfaces.mcp.runtime import build_mcp_server
 
@@ -30,7 +41,18 @@ def main(profile: McpProfile | None = None) -> None:
         selected_profile = configured_profile() if profile is None else profile
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
-    build_mcp_server(selected_profile).run()
+    container = build_application_container(
+        ApplicationPaths(
+            codex_home=DEFAULT_CODEX_HOME,
+            db_path=DEFAULT_DB_PATH,
+            pricing_path=DEFAULT_PRICING_PATH,
+            allowance_path=DEFAULT_ALLOWANCE_PATH,
+            rate_card_path=DEFAULT_RATE_CARD_PATH,
+            thresholds_path=DEFAULT_THRESHOLDS_PATH,
+            projects_path=DEFAULT_PROJECTS_PATH,
+        )
+    )
+    build_mcp_server(selected_profile, container=container).run()
 
 
 if __name__ == "__main__":

--- a/src/codex_usage_tracker/server/api.py
+++ b/src/codex_usage_tracker/server/api.py
@@ -23,6 +23,7 @@ from codex_usage_tracker.core.paths import (
 from codex_usage_tracker.dashboard.api import (
     generate_dashboard,
 )
+from codex_usage_tracker.interfaces.http.v2 import ApplicationHttpV2Services, HttpV2Facade
 from codex_usage_tracker.server import compression_routes
 from codex_usage_tracker.server import utils as server_utils
 from codex_usage_tracker.server.analysis_jobs import AnalysisJobRegistry
@@ -104,6 +105,17 @@ def serve_dashboard(
         max_entries=4,
         max_payload_bytes=8 * 1_024 * 1_024,
     )
+    http_v2_facade = HttpV2Facade(
+        ApplicationHttpV2Services(
+            db_path=db_path,
+            pricing_path=pricing_path,
+            allowance_path=allowance_path,
+            rate_card_path=rate_card_path,
+            thresholds_path=thresholds_path,
+            projects_path=projects_path,
+            codex_home=codex_home,
+        )
+    )
     handler = partial(
         _UsageDashboardHandler,
         directory=str(output.parent),
@@ -130,6 +142,7 @@ def serve_dashboard(
         compression_jobs=compression_jobs,
         query_cache=query_cache,
         allowance_query_cache=allowance_query_cache,
+        http_v2_facade=http_v2_facade,
     )
     server = ThreadingHTTPServer((host, port), handler)
     legacy_url = f"http://{_url_host(host)}:{port}/{output.name}"

--- a/src/codex_usage_tracker/server/handler.py
+++ b/src/codex_usage_tracker/server/handler.py
@@ -13,6 +13,7 @@ from urllib.parse import parse_qs, urlparse
 
 from codex_usage_tracker.core.i18n import normalize_language
 from codex_usage_tracker.core.paths import DEFAULT_RATE_CARD_PATH
+from codex_usage_tracker.interfaces.http.v2 import HttpV2Facade
 from codex_usage_tracker.server import allowance, allowance_v2, compression_routes
 from codex_usage_tracker.server import context as server_context
 from codex_usage_tracker.server import usage_refresh as server_usage_refresh
@@ -98,6 +99,7 @@ class _UsageDashboardHandler(
         compression_jobs: compression_routes.CompressionJobRegistry | None = None,
         query_cache: AggregateQueryCache | None = None,
         allowance_query_cache: AggregateQueryCache | None = None,
+        http_v2_facade: HttpV2Facade | None = None,
         dashboard_path: Path | None = None,
         context_api_enabled: bool = False,
         context_api_state: ContextApiState | None = None,
@@ -133,7 +135,7 @@ class _UsageDashboardHandler(
         self._compression_jobs = compression_jobs or compression_routes.CompressionJobRegistry()
         self._query_cache = query_cache or AggregateQueryCache()
         self._allowance_query_cache = allowance_query_cache or allowance.new_query_cache()
-        self._configure_http_v2()
+        self._configure_http_v2(http_v2_facade)
         super().__init__(*args, **kwargs)
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib hook name

--- a/src/codex_usage_tracker/server/http_v2.py
+++ b/src/codex_usage_tracker/server/http_v2.py
@@ -22,6 +22,7 @@ class _HttpV2Handler(Protocol):
     _allowance_path: Path
     _rate_card_path: Path
     _thresholds_path: Path
+    _projects_path: Path
     _codex_home: Path
 
     def _has_valid_api_token(self, params: dict[str, list[str]]) -> bool: ...
@@ -30,7 +31,10 @@ class _HttpV2Handler(Protocol):
 class HttpV2RouteMixin:
     """Attach stable v2 application services to each localhost request handler."""
 
-    def _configure_http_v2(self) -> None:
+    def _configure_http_v2(self, facade: HttpV2Facade | None = None) -> None:
+        if facade is not None:
+            self._http_v2_facade = facade
+            return
         handler = cast(_HttpV2Handler, self)
         self._http_v2_facade = HttpV2Facade(
             ApplicationHttpV2Services(
@@ -39,6 +43,7 @@ class HttpV2RouteMixin:
                 allowance_path=handler._allowance_path,
                 rate_card_path=handler._rate_card_path,
                 thresholds_path=handler._thresholds_path,
+                projects_path=handler._projects_path,
                 codex_home=handler._codex_home,
             )
         )

--- a/tests/analytics/test_strategy_protocol.py
+++ b/tests/analytics/test_strategy_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +11,7 @@ from codex_usage_tracker.analytics.analysis_catalog import ANALYSIS_CATALOG
 from codex_usage_tracker.analytics.analysis_models import AnalysisRequest, ComparisonWindow
 from codex_usage_tracker.analytics.strategies.protocol import AnalysisStrategy
 from codex_usage_tracker.application.context import RequestContext
+from codex_usage_tracker.application.paths import ApplicationPaths
 from codex_usage_tracker.application.query_models import QueryFilters
 from codex_usage_tracker.core.contracts import FreshnessV1, ScopeV1
 
@@ -20,6 +22,7 @@ def _context(
     pricing_coverage: float | None = 1.0,
     service_tier_coverage: float | None = 0.8,
 ) -> RequestContext:
+    root = Path("/synthetic/codex-usage-tracker")
     return RequestContext(
         source_revision="generation:7",
         freshness=FreshnessV1(
@@ -44,6 +47,15 @@ def _context(
         pricing_coverage=pricing_coverage,
         credit_coverage=0.9,
         service_tier_coverage=service_tier_coverage,
+        application_paths=ApplicationPaths(
+            codex_home=root / ".codex",
+            db_path=root / "usage.sqlite3",
+            pricing_path=root / "pricing.json",
+            allowance_path=root / "allowance.json",
+            rate_card_path=root / "rate-card.json",
+            thresholds_path=root / "thresholds.json",
+            projects_path=root / "projects.json",
+        ),
     )
 
 

--- a/tests/application/test_container.py
+++ b/tests/application/test_container.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.application.container import build_application_container
+from codex_usage_tracker.application.paths import ApplicationPaths
+from codex_usage_tracker.application.requests import RequestScope
+
+
+class _FixedClock:
+    def now(self) -> datetime:
+        return datetime(2026, 7, 23, 18, 0, tzinfo=timezone.utc)
+
+
+def _paths(tmp_path: Path) -> ApplicationPaths:
+    return ApplicationPaths(
+        codex_home=tmp_path / "codex",
+        db_path=tmp_path / "usage.sqlite3",
+        pricing_path=tmp_path / "pricing.json",
+        allowance_path=tmp_path / "allowance.json",
+        rate_card_path=tmp_path / "rate-card.json",
+        thresholds_path=tmp_path / "thresholds.json",
+        projects_path=tmp_path / "projects.json",
+    )
+
+
+def test_container_is_frozen_and_preserves_custom_paths(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    container = build_application_container(paths, clock=_FixedClock())
+
+    assert container.paths is paths
+    assert container.clock.now() == datetime(2026, 7, 23, 18, 0, tzinfo=timezone.utc)
+    with pytest.raises(FrozenInstanceError):
+        container.paths = _paths(tmp_path / "other")  # type: ignore[misc]
+
+
+def test_container_shares_one_job_repository_and_does_not_read_default_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        Path,
+        "home",
+        classmethod(lambda cls: (_ for _ in ()).throw(AssertionError("default home accessed"))),
+    )
+
+    container = build_application_container(_paths(tmp_path), clock=_FixedClock())
+
+    assert container.repositories.jobs is container.jobs
+    assert container.repositories.analysis_results is container.jobs
+    context = container.request_context(RequestScope())
+    assert context.freshness.state == "empty"
+    assert context.application_paths is container.paths
+    assert not tmp_path.joinpath("usage.sqlite3").exists()

--- a/tests/application/test_protocols.py
+++ b/tests/application/test_protocols.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+
+from codex_usage_tracker.application.protocols import (
+    AnalysisResultRepository,
+    Clock,
+    DashboardTargetResolver,
+    JobRepository,
+    PricingProvider,
+    SourceRepository,
+    UsageRepository,
+)
+from codex_usage_tracker.jobs.service import JobService
+from codex_usage_tracker.pricing.config import PricingConfig
+
+
+class _Clock:
+    def now(self) -> datetime:
+        return datetime(2026, 7, 23, tzinfo=timezone.utc)
+
+
+class _UsageRepository:
+    def request_context_facts(
+        self,
+        *,
+        scope: dict[str, object],
+        priced_models: set[str],
+        credit_models: set[str],
+        prefer_materialized_active: bool,
+    ) -> dict[str, object]:
+        return {"scope": scope}
+
+
+class _SourceRepository:
+    def session_logs(self, *, include_archived: bool) -> tuple[Path, ...]:
+        return ()
+
+
+class _PricingProvider:
+    def load(self, path: Path) -> PricingConfig:
+        return PricingConfig(path=path, models={}, loaded=False)
+
+    def credit_rate_card(self) -> dict[str, object]:
+        return {}
+
+
+class _DashboardTargets:
+    def resolve(
+        self,
+        *,
+        evidence_kind: str,
+        selector_id: str,
+        history: str,
+        analysis_id: str | None = None,
+        target_purpose: str = "evidence",
+    ) -> dict[str, object]:
+        return {"selector_id": selector_id}
+
+
+def test_protocols_accept_only_the_current_narrow_service_shapes() -> None:
+    assert isinstance(_Clock(), Clock)
+    assert isinstance(_UsageRepository(), UsageRepository)
+    assert isinstance(_SourceRepository(), SourceRepository)
+    assert isinstance(_PricingProvider(), PricingProvider)
+    assert isinstance(_DashboardTargets(), DashboardTargetResolver)
+    assert isinstance(JobService(), JobRepository)
+    assert isinstance(JobService(), AnalysisResultRepository)
+
+
+def test_application_and_analytics_do_not_import_default_global_paths() -> None:
+    package = Path(__file__).parents[2] / "src" / "codex_usage_tracker"
+    offenders: list[str] = []
+    for root_name in ("application", "analytics"):
+        for path in sorted(package.joinpath(root_name).rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            if any(
+                isinstance(node, ast.ImportFrom)
+                and node.module == "codex_usage_tracker.core.paths"
+                for node in ast.walk(tree)
+            ):
+                offenders.append(str(path.relative_to(package)))
+
+    assert offenders == []

--- a/tests/application/test_protocols.py
+++ b/tests/application/test_protocols.py
@@ -64,6 +64,7 @@ def test_protocols_accept_only_the_current_narrow_service_shapes() -> None:
     assert isinstance(_Clock(), Clock)
     assert isinstance(_UsageRepository(), UsageRepository)
     assert isinstance(_SourceRepository(), SourceRepository)
+    assert _SourceRepository().session_logs(include_archived=False) == ()
     assert isinstance(_PricingProvider(), PricingProvider)
     assert isinstance(_DashboardTargets(), DashboardTargetResolver)
     assert isinstance(JobService(), JobRepository)
@@ -77,8 +78,7 @@ def test_application_and_analytics_do_not_import_default_global_paths() -> None:
         for path in sorted(package.joinpath(root_name).rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             if any(
-                isinstance(node, ast.ImportFrom)
-                and node.module == "codex_usage_tracker.core.paths"
+                isinstance(node, ast.ImportFrom) and node.module == "codex_usage_tracker.core.paths"
                 for node in ast.walk(tree)
             ):
                 offenders.append(str(path.relative_to(package)))

--- a/tests/application/test_refresh.py
+++ b/tests/application/test_refresh.py
@@ -22,6 +22,16 @@ from codex_usage_tracker.jobs.service import JobService
 from codex_usage_tracker.store.sources import SourceParsePlan
 
 
+class _SourceRepository:
+    def __init__(self, logs: tuple[Path, ...]) -> None:
+        self.logs = logs
+        self.include_archived: bool | None = None
+
+    def session_logs(self, *, include_archived: bool) -> tuple[Path, ...]:
+        self.include_archived = include_archived
+        return self.logs
+
+
 def test_planner_constants_and_missing_database_have_no_side_effect(tmp_path: Path) -> None:
     db_path = tmp_path / "state" / "usage.sqlite3"
     plan = plan_refresh(RefreshRequest(), codex_home=tmp_path / ".codex", db_path=db_path)
@@ -31,6 +41,23 @@ def test_planner_constants_and_missing_database_have_no_side_effect(tmp_path: Pa
     assert plan.execution == "sync"
     assert plan.changed_source_files == 0
     assert not db_path.exists()
+
+
+def test_planner_uses_injected_source_repository(tmp_path: Path) -> None:
+    source = tmp_path / "events.jsonl"
+    source.write_text("{}\n", encoding="utf-8")
+    repository = _SourceRepository((source,))
+
+    plan = plan_refresh(
+        RefreshRequest(history="all"),
+        codex_home=tmp_path / ".codex",
+        db_path=tmp_path / "usage.sqlite3",
+        source_repository=repository,
+    )
+
+    assert repository.include_archived is True
+    assert plan.reason == "untracked_source"
+    assert plan.changed_source_files == 1
 
 
 def test_explicit_sync_preserves_history_and_aggregate_only(tmp_path: Path) -> None:

--- a/tests/interfaces/cli/test_commands.py
+++ b/tests/interfaces/cli/test_commands.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from codex_usage_tracker.analytics.analysis_models import AnalysisRequest
 from codex_usage_tracker.application.query_models import QueryRequest
 from codex_usage_tracker.application.requests import StatusRequest
+from codex_usage_tracker.interfaces.cli import commands as commands_module
 from codex_usage_tracker.interfaces.cli.commands import (
     run_analyze,
     run_open,
@@ -44,6 +45,17 @@ def test_status_prints_the_application_contract_as_json() -> None:
     assert json.loads(stdout.getvalue())["schema"] == "codex-usage-tracker.status.v2"
     assert isinstance(services.request, StatusRequest)
     assert services.request.db_path == Path("usage.db")
+
+
+def test_default_services_preserve_the_configured_projects_path(tmp_path: Path) -> None:
+    projects_path = tmp_path / "custom-projects.json"
+    args = build_parser().parse_args(
+        ["--projects", str(projects_path), "status", "--json"]
+    )
+
+    services = commands_module._default_services(args)
+
+    assert services.application.paths.projects_path == projects_path
 
 
 def test_query_builds_the_typed_v2_request() -> None:

--- a/tests/interfaces/http/test_v2_server.py
+++ b/tests/interfaces/http/test_v2_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 import urllib.error
 import urllib.request
@@ -9,12 +10,24 @@ from functools import partial
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 
+from codex_usage_tracker.interfaces.http.v2 import ApplicationHttpV2Services, HttpV2Facade
 from codex_usage_tracker.server.api import _UsageDashboardHandler
 from tests.store_dashboard_helpers import _http_error_json, _read_json
 
 
 @contextmanager
 def _v2_server(tmp_path: Path) -> Iterator[str]:
+    facade = HttpV2Facade(
+        ApplicationHttpV2Services(
+            db_path=tmp_path / "usage.sqlite3",
+            pricing_path=tmp_path / "pricing.json",
+            allowance_path=tmp_path / "allowance.json",
+            rate_card_path=tmp_path / "rate-card.json",
+            thresholds_path=tmp_path / "thresholds.json",
+            projects_path=tmp_path / "projects.json",
+            codex_home=tmp_path / ".codex",
+        )
+    )
     handler = partial(
         _UsageDashboardHandler,
         directory=str(tmp_path),
@@ -31,6 +44,7 @@ def _v2_server(tmp_path: Path) -> Iterator[str]:
         context_chars=2000,
         api_token="test-token",
         refresh_lock=threading.Lock(),
+        http_v2_facade=facade,
     )
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -41,6 +55,32 @@ def _v2_server(tmp_path: Path) -> Iterator[str]:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+
+
+def test_live_v2_async_job_survives_a_separate_poll_request(tmp_path: Path) -> None:
+    with _v2_server(tmp_path) as base_url:
+        request = urllib.request.Request(
+            f"{base_url}/api/v2/analyze",
+            data=json.dumps(
+                {
+                    "goal": "token_waste",
+                    "execution": "async",
+                }
+            ).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "X-Codex-Usage-Token": "test-token",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310
+            started = json.load(response)
+        polled = _read_json(
+            f"{base_url}/api/v2/jobs/{started['job_id']}?include_result=1"
+        )
+
+    assert polled["job_id"] == started["job_id"]
+    assert polled["state"] in {"queued", "running", "completed"}
 
 
 def test_live_v2_capabilities_and_dynamic_job_routes_are_json(tmp_path: Path) -> None:

--- a/tests/mcp/test_tool_profiles.py
+++ b/tests/mcp/test_tool_profiles.py
@@ -62,10 +62,15 @@ def test_selected_profile_server_reads_the_environment(
         monkeypatch.delenv(server.PROFILE_ENV, raising=False)
     else:
         monkeypatch.setenv(server.PROFILE_ENV, configured)
+
+    def build(profile: str, *, container: object) -> SimpleNamespace:
+        assert container is not None
+        return SimpleNamespace(run=lambda: selected.append(profile))
+
     monkeypatch.setattr(
         server,
         "build_mcp_server",
-        lambda profile: SimpleNamespace(run=lambda: selected.append(profile)),
+        build,
     )
 
     server.main()
@@ -133,6 +138,47 @@ def test_core_binds_stable_adapters_once() -> None:
     assert list(registered).count("usage_analyze") == list(registered).count("usage_query") == 1
     assert list(registered).count("usage_evidence") == 1
     assert status_spec.data_class == "administrative"
+
+
+def test_core_can_bind_one_explicit_application_container(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_usage_tracker.application import status
+    from codex_usage_tracker.application.container import build_application_container
+    from codex_usage_tracker.application.paths import ApplicationPaths
+    from codex_usage_tracker.dashboard_service import DashboardServiceStatus
+    from codex_usage_tracker.interfaces.mcp.core_tools import usage_status
+
+    monkeypatch.setattr(
+        status,
+        "dashboard_service_status",
+        lambda *, home: DashboardServiceStatus(False, False, False, 47821, str(home)),
+    )
+    monkeypatch.setattr(
+        Path,
+        "home",
+        classmethod(lambda _cls: (_ for _ in ()).throw(AssertionError("default home accessed"))),
+    )
+    container = build_application_container(
+        ApplicationPaths(
+            codex_home=tmp_path / ".codex",
+            db_path=tmp_path / "usage.sqlite3",
+            pricing_path=tmp_path / "pricing.json",
+            allowance_path=tmp_path / "allowance.json",
+            rate_card_path=tmp_path / "rate-card.json",
+            thresholds_path=tmp_path / "thresholds.json",
+            projects_path=tmp_path / "projects.json",
+        )
+    )
+
+    server = build_mcp_server("core", container=container)
+    registered = server._tool_manager._tools
+    payload = registered["usage_status"].fn()
+
+    assert registered["usage_status"].fn is not usage_status
+    assert payload["result"]["sources"]["canonical_rows"] == 0
+    assert container.repositories.jobs is container.jobs
 
 
 def test_core_status_returns_bounded_v2_envelope(

--- a/tests/server/test_server_api.py
+++ b/tests/server/test_server_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_usage_tracker.interfaces.http.v2 import ApplicationHttpV2Services, HttpV2Facade
 from codex_usage_tracker.server import api as server_api
 from codex_usage_tracker.server.query_cache import AggregateQueryCache
 
@@ -79,6 +80,10 @@ def test_serve_dashboard_opens_react_dashboard_and_prints_legacy_fallback(
     query_cache = handler.keywords["query_cache"]
     assert isinstance(query_cache, AggregateQueryCache)
     assert query_cache.max_entries == 64
+    facade = handler.keywords["http_v2_facade"]
+    assert isinstance(facade, HttpV2Facade)
+    assert isinstance(facade.services, ApplicationHttpV2Services)
+    assert facade.services.application.paths.projects_path == tmp_path / "projects.json"
 
 
 def test_serve_dashboard_starts_requested_refresh_after_binding(


### PR DESCRIPTION
## Summary
- add frozen application paths, dependency protocols, and one composition container
- bind CLI, HTTP v2, live server, and core MCP adapters to explicit shared services
- remove application/analytics default-path imports and inject deterministic clocks and compatibility paths
- preserve curated GitNexus resource navigation in AGENTS.md

## Validation
- 1912 full-suite tests passed before the final review fixes
- 456 bounded application/analytics/MCP/interface/server tests passed after the fixes
- Ruff, mypy, Pyright, compileall, release checks, Markdown lint, and diff checks passed
- GitNexus final impact: 96 symbols, 15 flows, high risk

## Review
- single final reviewer: 2 findings, both accepted and fixed
- R1: share live HTTP v2 jobs across handler connections
- R2: preserve configured projects paths in CLI and live HTTP composition
- reviewer token attribution recorded as pending after one timeout

## Roadmap
Completes Task 28 / ARCH-COMPOSE-01. Task 29 owns full/developer MCP compatibility extraction; Task 30 owns the eight pre-existing Tach direction violations.