### PR TITLE
perf: seek directly to indexed call context

### DIFF
--- a/.agent-maintainer/change-plans/indexed-context-offsets.md
+++ b/.agent-maintainer/change-plans/indexed-context-offsets.md
@@ -1,0 +1,100 @@
++++
+id = "indexed-context-offsets"
+kind = "cohesive-migration"
+status = "complete"
+base_ref = "origin/main"
+expires = 2026-08-07
+allowed_paths = [
+  ".agent-maintainer/change-plans/indexed-context-offsets.md",
+  "docs/architecture.md",
+  "docs/roadmap/mcp-first-pivot-execution.md",
+  "scripts/benchmark_context_offsets.py",
+  "scripts/benchmark_synthetic_history.py",
+  "src/codex_usage_tracker/context/**",
+  "src/codex_usage_tracker/core/models.py",
+  "src/codex_usage_tracker/core/schema.py",
+  "src/codex_usage_tracker/parser/jsonl_v1.py",
+  "src/codex_usage_tracker/parser/jsonl_values.py",
+  "src/codex_usage_tracker/store/context_offsets.py",
+  "src/codex_usage_tracker/store/schema.py",
+  "src/codex_usage_tracker/store/schema_query_indexes.py",
+  "src/codex_usage_tracker/store/sources.py",
+  "tests/context/test_byte_offset_reads.py",
+  "tests/context/test_byte_offset_safety.py",
+  "tests/core/test_schema.py",
+  "tests/store/test_context_offsets.py",
+  "tests/store/test_otel_schema.py",
+  "tests/store/test_store_dashboard_mcp.py",
+  "tests/store/test_store_migrations.py",
+]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 25
+max_changed_lines = 1600
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+
+# Cohesive Change Plan: Indexed Context Offsets
+
+## Purpose
+
+Complete MCP-first pivot Task 32 by persisting exact JSONL byte offsets and
+using them for bounded, provenance-validated selected-call context reads.
+
+## Why this change intentionally large
+
+The schema migration, parser cursor, source-provenance validation, bounded seek
+reader, sequential fallback, diagnostics, migration fixtures, equivalence
+tests, and 100,000-line synthetic ratchet form one safety contract. The added
+lines are predominantly explicit cross-platform and fallback coverage plus the
+reproducible performance harness.
+
+## Why this should not be split smaller
+
+Landing offsets without provenance checks could trust replaced files. Landing
+the seek path without payload-equivalence and inspected-byte evidence could
+silently change explicit context or make an unverified speed claim. The schema,
+reader, tests, benchmark, and architecture note therefore ship together.
+
+## What allowed to change
+
+- One additive nullable usage-event byte-offset column and schema migration.
+- Parser byte-position tracking, validated offset resolution, bounded context
+  seeking, unchanged sequential fallback, and aggregate diagnostics.
+- Synthetic tests, benchmark helpers, architecture notes, and execution-ledger
+  evidence required by Task 32.
+
+## What must not change
+
+- No raw context is persisted in SQLite, dashboard payloads, support bundles, or
+  default exports.
+- No offset is trusted after source provenance becomes stale.
+- No context payload, redaction, tool-output default, quick/full mode, or
+  compatibility route is removed or weakened.
+- No unrelated dashboard, API, analytics, or Task 33 work is included.
+
+## Verification plan
+
+- Exact ASCII and multibyte UTF-8 offsets with LF and CRLF input.
+- Append, rewrite, clone, stale-provenance, malformed-line, and old-row
+  fallback coverage.
+- Quick/full, tool-output, compaction, boundary, and normalized payload
+  equivalence.
+- A synthetic 100,000-line final target with less than 5% of bytes inspected
+  and at least 5x speedup over five-run sequential medians.
+- Focused tests, full Python/coverage gates, static checks, release checks, and
+  one final read-only review.
+
+## Rollback plan
+
+Revert the task commit. Schema v35 is additive and nullable, so retained
+databases remain readable; without the seek path, null or ignored offsets use
+the existing sequential reader.
+
+## Follow-up ratchet work
+
+Keep the 100,000-line inspected-byte and median-speed ratchet on future context
+reader changes. Task 33 and later tasks must not reuse raw context offsets as a
+generic job cursor or broaden stored raw-content scope.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,19 @@ Shareable outputs remain aggregate-first and must omit indexed/raw content unles
 - `interfaces/http/v2.py` is the stable localhost HTTP adapter. It decodes bounded strict requests and serializes shared application contracts; it calls `application/` services directly and never routes through MCP handlers. `server/handler.py` retains Host, Origin, and local-token enforcement at the transport boundary, while `server/route_inventory.py` records exposure, execution, history, cache, and byte budgets.
 - `costing.py`, `pricing_config.py`, `pricing_openai.py`, `pricing_estimates.py`, and `allowance.py` own cost, credit, rate-card, and allowance annotation. Keep estimate confidence and source metadata attached to rows.
 - `projects.py`, `threads.py`, and `recommendations.py` annotate aggregate rows with project identity, thread relationships, and actionable signals. Project privacy redaction belongs in `projects.py` so CLI, MCP, dashboard, CSV, and support-bundle surfaces share behavior.
-- `context.py` is the normal path for explicit selected-call raw context. It reads one selected source file on demand, applies redaction and size limits, omits tool output by default, and keeps full serialized group analysis explicit.
+- `context/` is the normal path for explicit selected-call raw context. Refresh records
+  the token event's exact UTF-8 byte offset on each new usage row. A context read
+  uses that offset only while the stored path, file identity, size, modification
+  time, and parsed-prefix provenance still match the current source and the
+  opened descriptor still matches that validated identity snapshot. It seeks a
+  configurable bounded window before the token event, verifies the target
+  timestamp and token totals, and requires either source start or a preceding
+  turn boundary so compaction, diagnostic carry state, and scoped parse-error
+  counts stay complete. Otherwise it scans sequentially. Offset and fallback
+  reads share the same parser, redaction, size limits, tool-output policy, and
+  quick/full serialized analysis. Optional diagnostics report
+  `offset_seek` or `sequential_fallback`, the fallback reason, and inspected source
+  bytes without exposing raw context.
 - `diagnostic_snapshots.py` owns persisted diagnostic snapshot refresh/load orchestration. Snapshot modules should stay synthetic-testable and avoid raw transcript persistence in aggregate diagnostic facts.
 - `dashboard.py` builds aggregate-first static dashboard payloads and writes HTML/assets. `server.py` adds localhost refresh, compatibility `/api/usage`, SQL-backed live API slices, and explicit lazy context loading.
 - `frontend/dashboard/` owns the React dashboard. The packaged React HTML embeds only a database-free boot payload (authentication, localization, and data-scope defaults), then hydrates aggregate data through the localhost APIs. It should render server/API payloads rather than becoming an independent source of usage calculations.
@@ -204,4 +216,4 @@ python scripts/benchmark_dashboard_routes.py --sizes 100000 --iterations 3 --ski
 
 Dashboard UI changes should also be opened in a browser and checked at desktop and mobile widths for overflow, overlap, stale state, and shareable-output behavior.
 
-Run the enforced dashboard route budget after changing focused query services, response caching, or frontend query orchestration. Run `python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds` after changing broader SQLite filters, dashboard payload loading, or indexes. Run `python scripts/benchmark_synthetic_history.py --rows 1000 --with-source-logs --json --enforce-thresholds` after changing source-log refresh, content indexing, explicit context loading, or source-log diagnostics. Run the 500k benchmark before release work when practical.
+Run the enforced dashboard route budget after changing focused query services, response caching, or frontend query orchestration. Run `python scripts/benchmark_synthetic_history.py --rows 10000 100000 --json --enforce-thresholds` after changing broader SQLite filters, dashboard payload loading, or indexes. Run `python scripts/benchmark_synthetic_history.py --rows 1000 --with-source-logs --json --enforce-thresholds` after changing source-log refresh, content indexing, explicit context loading, or source-log diagnostics. That source-log fixture pads its final target source to 100,000 lines; its offset ratchet requires equivalent offset/fallback payloads, less than 5% of source bytes inspected, and at least a 5x five-run median speedup. Run the 500k benchmark before release work when practical.

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -1053,9 +1053,8 @@ commit as each roadmap task.
 
 ## Task 31 - Enforce SQLite Foreign Keys and Integrity Checks
 
-- Status: implementation, primary verification, one final review, and
-  accepted-finding rechecks are complete on `pivot/31-sqlite-integrity`; PR
-  landing remains.
+- Status: complete; `pivot/31-sqlite-integrity` landed through PR #298 as
+  squash commit `920d2dbbefacb31820877a2e04c601a6baafda83`.
 - Connection and migration contract:
   - every runtime SQLite connection is centralized through the verified shared
     policy or explicitly configures that policy for the in-memory allowance
@@ -1138,9 +1137,82 @@ commit as each roadmap task.
   relationship must update the exact foreign-key inventory test and cleanup
   coverage.
 
+## Task 32 - Add Indexed Byte Offsets for Bounded Context Retrieval
+
+- Status: implementation, final review, and verification are complete on
+  `pivot/32-indexed-context-offsets`; PR landing remains.
+- Schema and ingestion contract:
+  - schema v35 adds one nullable `usage_events.source_byte_offset`; existing
+    rows migrate in place with null offsets and retain sequential fallback;
+  - binary JSONL parsing records the exact token-event byte position for ASCII
+    and multibyte UTF-8 under LF and CRLF newlines;
+  - append-only refresh preserves existing offsets and records new offsets,
+    while rewritten and cloned files cannot reuse stale provenance.
+- Read contract:
+  - the selected-call loader validates path, size, modification time, inode,
+    device/prefix provenance, offset bounds, and the already-open descriptor
+    identity before seeking;
+  - a configurable 128 KiB pre-target window must contain the selected turn
+    plus source start or a preceding semantic turn anchor, otherwise the
+    existing sequential reader runs;
+  - the target token line must match the requested timestamp plus cumulative
+    and last-call token values, preventing another call in the same turn from
+    satisfying a corrupted offset;
+  - offset and fallback modes share parsing, redaction, limits, tool-output
+    controls, compaction handling, malformed-line behavior, and quick/full
+    serialized estimates, and neither reads beyond the target token event;
+  - opt-in diagnostics report `offset_seek` or `sequential_fallback`, a bounded
+    reason, and actual inspected source bytes.
+- Focused verification:
+  - Task 32 offset, provenance, migration, and context suites: `60 passed`;
+  - broader parser, store, context, schema, and privacy slice: `331 passed`;
+  - targeted Ruff and Pyright report zero findings.
+- Performance evidence:
+  - the prescribed synthetic source-log benchmark pads the final target source
+    to exactly 100,000 lines and compares five-run medians;
+  - latest unprofiled result: 131,478 of 9,071,823 bytes inspected (`1.4493%`),
+    `0.005884s` offset median versus `0.183515s` sequential median (`31.189x`),
+    with byte-for-byte equivalent normalized payloads and all thresholds green;
+  - Agent Perf run `20260724T043235Z-63247a16` attributes only `0.08%` of
+    application work to `_read_context_from_offset`; the deliberately forced
+    fallback remains concentrated in JSON envelope scanning. The earlier
+    baseline profile produced no attributable samples, so the identical
+    unprofiled ratchet—not profiler comparison—is the speed claim.
+- Full verification:
+  - complete Python suite: `1998 passed in 115.81s`;
+  - coverage suite: `1998 passed`, 88% aggregate coverage;
+  - source and built-distribution release checks, wheel/sdist builds, Twine
+    validation, and an installed-package smoke test all pass;
+  - Ruff, Pyright, MyPy, Tach, Deptry, Vulture, Bandit, compileall, packaged
+    dashboard JavaScript syntax, Markdown, YAML, TOML, and diff checks pass
+    with only the repository's reviewed existing Bandit/YAML warnings;
+  - the full Agent Maintainer gate still reports inherited repository-wide
+    file-length, historical-document formatting, Pyright-test, and Xenon
+    findings. The roadmap-required legacy migration inventory test remains over
+    the generic file limit, while changed production files stay within their
+    ratchets and the task-specific and named direct gates above pass without
+    suppressing or relaxing findings;
+  - the single final read-only review reported four findings (one high, two
+    medium, one low); all four were accepted and fixed with same-turn target
+    identity, descriptor TOCTOU, pre-turn carry-anchor, and parse-error scoping
+    regressions. Reviewer token attribution and tokens per accepted finding are
+    `pending` because the one permitted usage-index refresh timed out.
+- Deviations from plan:
+  - the repository's current provenance owner is `store/sources.py`, not the
+    historical `source_records.py` path named by the roadmap;
+  - context entry formatting and benchmark ratchet logic moved into focused
+    helper modules, and the additive migration uses the existing query-index
+    schema owner, keeping changed production files under their active
+    file-length ratchets.
+- Follow-up risks:
+  - pre-v35 rows use sequential fallback until their source is reindexed;
+  - a selected turn whose pre-token context exceeds 128 KiB deliberately falls
+    back rather than risking an incomplete offset result.
+
 ## Remaining Planned Tasks
 
-Tasks 27.5 through 31 are complete through Task 31 primary verification. Tasks
-32 through 45 remain planned in the approved implementation roadmap. Add a full
-entry using the format above when each task becomes active; do not mark a task
-complete without its named focused and full verification evidence.
+Tasks 27.5 through 31 are complete, and Task 32 is complete through final
+verification pending PR landing. Tasks 33 through 45 remain planned in the
+approved implementation roadmap. Add a full entry using the format above when
+each task becomes active; do not mark a task complete without its named focused
+and full verification evidence.

--- a/scripts/benchmark_context_offsets.py
+++ b/scripts/benchmark_context_offsets.py
@@ -1,0 +1,224 @@
+"""Synthetic context-offset performance helpers."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from statistics import median
+from typing import Any, Protocol, TypeVar
+
+from codex_usage_tracker.context.api import load_call_context
+from codex_usage_tracker.parser.state import ParserState
+from codex_usage_tracker.store.api import connect, init_db
+from codex_usage_tracker.store.sources import upsert_source_file_metadata
+
+SYNTHETIC_CONTEXT_RATCHET_LINES = 100_000
+T = TypeVar("T")
+
+
+class SourceLogBundleLike(Protocol):
+    @property
+    def paths(self) -> frozenset[Path]: ...
+
+    @property
+    def line_counts(self) -> dict[Path, int]: ...
+
+
+def record_synthetic_source_metadata(
+    db_path: Path,
+    source_bundle: SourceLogBundleLike,
+) -> None:
+    parsed_files = [
+        (path, [], {}, ParserState(), source_bundle.line_counts[path])
+        for path in sorted(source_bundle.paths)
+    ]
+    with connect(db_path) as conn:
+        init_db(conn)
+        upsert_source_file_metadata(conn, parsed_files=parsed_files)
+
+
+def benchmark_context_loads(
+    *,
+    db_path: Path,
+    row_count: int,
+) -> dict[str, Any]:
+    targets = {
+        "early": 0,
+        "middle": row_count // 2,
+        "late": row_count - 1,
+    }
+    timings: dict[str, float] = {}
+    loads: dict[str, dict[str, Any]] = {}
+    context_load_seconds: float | None = None
+    context_payload_json_bytes: int | None = None
+    source_scan_ms: float | None = None
+    serialized_estimate_ms: float | None = None
+    for label, index in targets.items():
+        record_id = f"record-{index:08d}"
+        payload, elapsed = _time_call(
+            lambda record_id=record_id: load_call_context(
+                record_id=record_id,
+                db_path=db_path,
+                max_chars=0,
+                max_entries=0,
+                include_tool_output=True,
+                include_compaction_history=True,
+                diagnostics=True,
+            )
+        )
+        timing_name = f"context_load_{label}_line_seconds"
+        timings[timing_name] = elapsed
+        raw_diagnostics = payload.get("diagnostics")
+        diagnostics: dict[str, Any] = raw_diagnostics if isinstance(raw_diagnostics, dict) else {}
+        loads[label] = {
+            "record_id": record_id,
+            "seconds": elapsed,
+            "entries_returned": len(payload.get("entries") or []),
+            "visible_char_count": payload.get("visible_char_count"),
+            "visible_token_estimate": payload.get("visible_token_estimate"),
+            "context_payload_json_bytes": diagnostics.get("json_bytes"),
+            "source_scan_ms": diagnostics.get("source_scan_ms"),
+            "serialized_estimate_ms": diagnostics.get("serialized_estimate_ms"),
+            "context_read_strategy": diagnostics.get("context_read_strategy"),
+            "context_read_reason": diagnostics.get("context_read_reason"),
+            "inspected_source_bytes": diagnostics.get("inspected_source_bytes"),
+        }
+        if label == "middle":
+            context_load_seconds = elapsed
+            context_payload_json_bytes = _optional_int(diagnostics.get("json_bytes"))
+            source_scan_ms = _optional_float(diagnostics.get("source_scan_ms"))
+            serialized_estimate_ms = _optional_float(diagnostics.get("serialized_estimate_ms"))
+    offset_ratchet = _benchmark_context_offset_ratchet(
+        db_path=db_path,
+        record_id=f"record-{row_count - 1:08d}",
+    )
+    timings.update(offset_ratchet["timings"])
+    return {
+        "timings": timings,
+        "loads": loads,
+        "context_load_seconds": context_load_seconds,
+        "context_payload_json_bytes": context_payload_json_bytes,
+        "source_scan_ms": source_scan_ms,
+        "serialized_estimate_ms": serialized_estimate_ms,
+        "offset_ratchet": offset_ratchet["result"],
+        "ratchet_failures": offset_ratchet["failures"],
+    }
+
+
+def _benchmark_context_offset_ratchet(
+    *,
+    db_path: Path,
+    record_id: str,
+    sample_count: int = 5,
+) -> dict[str, Any]:
+    def load() -> dict[str, Any]:
+        return load_call_context(
+            record_id=record_id,
+            db_path=db_path,
+            max_chars=0,
+            max_entries=0,
+            include_tool_output=True,
+            include_compaction_history=True,
+            diagnostics=True,
+        )
+
+    load()
+    offset_samples = [_time_call(load) for _sample in range(sample_count)]
+    offset_payload = offset_samples[-1][0]
+    with connect(db_path) as conn:
+        stored_offset = conn.execute(
+            "SELECT source_byte_offset FROM usage_events WHERE record_id = ?",
+            (record_id,),
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (record_id,),
+        )
+    try:
+        load()
+        sequential_samples = [_time_call(load) for _sample in range(sample_count)]
+        sequential_payload = sequential_samples[-1][0]
+    finally:
+        with connect(db_path) as conn:
+            conn.execute(
+                "UPDATE usage_events SET source_byte_offset = ? WHERE record_id = ?",
+                (stored_offset, record_id),
+            )
+
+    offset_seconds = median(sample[1] for sample in offset_samples)
+    sequential_seconds = median(sample[1] for sample in sequential_samples)
+    offset_diagnostics = offset_payload["diagnostics"]
+    sequential_diagnostics = sequential_payload["diagnostics"]
+    source_line_number = int(offset_diagnostics["source_line_number"])
+    source_file_bytes = int(offset_diagnostics["source_file_bytes"])
+    inspected_source_bytes = int(offset_diagnostics["inspected_source_bytes"])
+    inspected_ratio = inspected_source_bytes / source_file_bytes if source_file_bytes else 1.0
+    speedup = sequential_seconds / offset_seconds if offset_seconds else float("inf")
+    comparable_offset = dict(offset_payload)
+    comparable_offset.pop("diagnostics", None)
+    comparable_sequential = dict(sequential_payload)
+    comparable_sequential.pop("diagnostics", None)
+    equivalent = comparable_offset == comparable_sequential
+    applicable = source_line_number >= SYNTHETIC_CONTEXT_RATCHET_LINES
+    failures: list[str] = []
+    if applicable and inspected_ratio >= 0.05:
+        failures.append(
+            "context offset seek inspected "
+            f"{inspected_ratio:.2%} of source bytes; expected less than 5%"
+        )
+    if applicable and speedup < 5.0:
+        failures.append(f"context offset seek speedup {speedup:.2f}x was below required 5.00x")
+    if applicable and not equivalent:
+        failures.append("context offset and sequential payloads were not equivalent")
+    result = {
+        "status": (
+            "pass" if applicable and not failures else "fail" if failures else "not_applicable"
+        ),
+        "sample_count": sample_count,
+        "source_line_number": source_line_number,
+        "source_file_bytes": source_file_bytes,
+        "offset_inspected_source_bytes": inspected_source_bytes,
+        "offset_inspected_ratio": round(inspected_ratio, 6),
+        "offset_median_seconds": round(offset_seconds, 6),
+        "sequential_median_seconds": round(sequential_seconds, 6),
+        "speedup": round(speedup, 3),
+        "payloads_equivalent": equivalent,
+        "offset_strategy": offset_diagnostics.get("context_read_strategy"),
+        "sequential_strategy": sequential_diagnostics.get("context_read_strategy"),
+    }
+    return {
+        "timings": {
+            "context_offset_seek_median_seconds": round(offset_seconds, 6),
+            "context_sequential_fallback_median_seconds": round(
+                sequential_seconds,
+                6,
+            ),
+        },
+        "result": result,
+        "failures": failures,
+    }
+
+
+def _time_call(action: Callable[[], T]) -> tuple[T, float]:
+    start = time.perf_counter()
+    value = action()
+    return value, round(time.perf_counter() - start, 6)
+
+
+def _optional_int(value: object) -> int | None:
+    if not isinstance(value, (str, int, float)):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: object) -> float | None:
+    if not isinstance(value, (str, int, float)):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/scripts/benchmark_synthetic_history.py
+++ b/scripts/benchmark_synthetic_history.py
@@ -20,7 +20,12 @@ SRC_PATH = REPO_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from codex_usage_tracker.context.api import load_call_context  # noqa: E402
+from benchmark_context_offsets import (  # noqa: E402
+    SYNTHETIC_CONTEXT_RATCHET_LINES,
+    benchmark_context_loads,
+    record_synthetic_source_metadata,
+)
+
 from codex_usage_tracker.core.models import UsageEvent  # noqa: E402
 from codex_usage_tracker.dashboard.api import dashboard_payload  # noqa: E402
 from codex_usage_tracker.reports.api import (  # noqa: E402
@@ -87,12 +92,14 @@ T = TypeVar("T")
 class SourceLogRecord:
     source_file: Path
     line_number: int
+    source_byte_offset: int
 
 
 @dataclass(frozen=True)
 class SourceLogBundle:
     records: list[SourceLogRecord]
     paths: frozenset[Path]
+    line_counts: dict[Path, int]
     bytes_written: int
 
 
@@ -218,6 +225,8 @@ def benchmark_size(
             db_path=db_path,
             refresh_links=False,
         )
+    if source_bundle:
+        record_synthetic_source_metadata(db_path, source_bundle)
     refresh_usage_event_links(db_path=db_path)
     populate_seconds = time.perf_counter() - populate_start
 
@@ -337,7 +346,7 @@ def benchmark_size(
     context_metrics: dict[str, Any] = {}
     if source_bundle:
         timings["dashboard_payload_with_source_logs_seconds"] = dashboard_payload_active_seconds
-        context_metrics = _benchmark_context_loads(
+        context_metrics = benchmark_context_loads(
             db_path=db_path,
             row_count=row_count,
         )
@@ -347,6 +356,7 @@ def benchmark_size(
         row_count=row_count,
         threshold_scale=threshold_scale,
     )
+    threshold_failures.extend(context_metrics.get("ratchet_failures", []))
     return {
         "rows": row_count,
         "db_path": str(db_path),
@@ -380,6 +390,7 @@ def benchmark_size(
         "context_payload_json_bytes": context_metrics.get("context_payload_json_bytes"),
         "source_scan_ms": context_metrics.get("source_scan_ms"),
         "serialized_estimate_ms": context_metrics.get("serialized_estimate_ms"),
+        "context_offset_ratchet": context_metrics.get("offset_ratchet"),
         "threshold_status": "fail" if threshold_failures else "pass",
         "thresholds": threshold_results,
         "threshold_failures": threshold_failures,
@@ -465,65 +476,6 @@ def _fail_on_source_log_open(source_paths: frozenset[Path]) -> Iterator[None]:
         Path.open = original_open  # type: ignore[method-assign]
 
 
-def _benchmark_context_loads(
-    *,
-    db_path: Path,
-    row_count: int,
-) -> dict[str, Any]:
-    targets = {
-        "early": 0,
-        "middle": row_count // 2,
-        "late": row_count - 1,
-    }
-    timings: dict[str, float] = {}
-    loads: dict[str, dict[str, Any]] = {}
-    context_load_seconds: float | None = None
-    context_payload_json_bytes: int | None = None
-    source_scan_ms: float | None = None
-    serialized_estimate_ms: float | None = None
-    for label, index in targets.items():
-        record_id = f"record-{index:08d}"
-        payload, elapsed = _time_call(
-            lambda record_id=record_id: load_call_context(
-                record_id=record_id,
-                db_path=db_path,
-                max_chars=0,
-                max_entries=0,
-                include_tool_output=True,
-                include_compaction_history=True,
-                diagnostics=True,
-            )
-        )
-        timing_name = f"context_load_{label}_line_seconds"
-        timings[timing_name] = elapsed
-        diagnostics = (
-            payload.get("diagnostics") if isinstance(payload.get("diagnostics"), dict) else {}
-        )
-        loads[label] = {
-            "record_id": record_id,
-            "seconds": elapsed,
-            "entries_returned": len(payload.get("entries") or []),
-            "visible_char_count": payload.get("visible_char_count"),
-            "visible_token_estimate": payload.get("visible_token_estimate"),
-            "context_payload_json_bytes": diagnostics.get("json_bytes"),
-            "source_scan_ms": diagnostics.get("source_scan_ms"),
-            "serialized_estimate_ms": diagnostics.get("serialized_estimate_ms"),
-        }
-        if label == "middle":
-            context_load_seconds = elapsed
-            context_payload_json_bytes = _optional_int(diagnostics.get("json_bytes"))
-            source_scan_ms = _optional_float(diagnostics.get("source_scan_ms"))
-            serialized_estimate_ms = _optional_float(diagnostics.get("serialized_estimate_ms"))
-    return {
-        "timings": timings,
-        "loads": loads,
-        "context_load_seconds": context_load_seconds,
-        "context_payload_json_bytes": context_payload_json_bytes,
-        "source_scan_ms": source_scan_ms,
-        "serialized_estimate_ms": serialized_estimate_ms,
-    }
-
-
 def _evaluate_thresholds(
     timings: dict[str, float],
     *,
@@ -552,48 +504,60 @@ def _evaluate_thresholds(
     return results, failures
 
 
-def _optional_int(value: object) -> int | None:
-    try:
-        return int(value) if value is not None else None
-    except (TypeError, ValueError):
-        return None
-
-
-def _optional_float(value: object) -> float | None:
-    try:
-        return float(value) if value is not None else None
-    except (TypeError, ValueError):
-        return None
-
-
 def _write_synthetic_source_logs(source_dir: Path, row_count: int) -> SourceLogBundle:
-    events_per_file = 500
+    events_per_file = 25_000
     records: list[SourceLogRecord | None] = [None] * row_count
     lines_by_path: dict[Path, list[str]] = {}
+    bytes_by_path: dict[Path, int] = {}
     for index in range(row_count):
         path = _synthetic_source_file(source_dir, index, events_per_file=events_per_file)
         lines = lines_by_path.setdefault(path, [])
         if not lines:
-            lines.append(_jsonl_line("session_meta", {"id": f"session-{index % 2500:04d}"}))
+            session_line = _jsonl_line(
+                "session_meta",
+                {"id": f"session-{index % 2500:04d}"},
+            )
+            lines.append(session_line)
+            bytes_by_path[path] = len(session_line.encode("utf-8"))
         turn_id = f"turn-{index:08d}"
-        for envelope in _synthetic_source_envelopes(index, turn_id):
-            lines.append(json.dumps(envelope, separators=(",", ":"), sort_keys=True) + "\n")
+        token_byte_offset = 0
+        envelopes = _synthetic_source_envelopes(index, turn_id)
+        if index == row_count - 1:
+            anchor_line = _jsonl_line(
+                "turn_context",
+                {"turn_id": "synthetic-offset-anchor", "model": "gpt-5.5"},
+            )
+            padding_count = max(
+                0,
+                SYNTHETIC_CONTEXT_RATCHET_LINES - len(lines) - len(envelopes) - 1,
+            )
+            padding_line = _jsonl_line("synthetic_padding", {})
+            lines.extend([padding_line] * padding_count)
+            bytes_by_path[path] += len(padding_line.encode("utf-8")) * padding_count
+            lines.append(anchor_line)
+            bytes_by_path[path] += len(anchor_line.encode("utf-8"))
+        for envelope_index, envelope in enumerate(envelopes):
+            line = json.dumps(envelope, separators=(",", ":"), sort_keys=True) + "\n"
+            if envelope_index == len(envelopes) - 1:
+                token_byte_offset = bytes_by_path[path]
+            lines.append(line)
+            bytes_by_path[path] += len(line.encode("utf-8"))
         records[index] = SourceLogRecord(
             source_file=path,
             line_number=len(lines),
+            source_byte_offset=token_byte_offset,
         )
 
-    bytes_written = 0
     for path, lines in lines_by_path.items():
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = "".join(lines)
         path.write_text(payload, encoding="utf-8")
-        bytes_written += len(payload.encode("utf-8"))
 
     return SourceLogBundle(
         records=[record for record in records if record is not None],
         paths=frozenset(lines_by_path),
-        bytes_written=bytes_written,
+        line_counts={path: len(lines) for path, lines in lines_by_path.items()},
+        bytes_written=sum(bytes_by_path.values()),
     )
 
 
@@ -799,6 +763,9 @@ def _synthetic_events(
             event_timestamp=f"2026-05-{day:02d}T12:{index % 60:02d}:00Z",
             source_file=source_file,
             line_number=source_record.line_number if source_record is not None else index + 1,
+            source_byte_offset=(
+                source_record.source_byte_offset if source_record is not None else None
+            ),
             turn_id=f"turn-{index:08d}",
             turn_timestamp=f"2026-05-{day:02d}T12:{index % 60:02d}:00Z",
             cwd=f"/tmp/project-{index % 50}",

--- a/src/codex_usage_tracker/context/api.py
+++ b/src/codex_usage_tracker/context/api.py
@@ -11,6 +11,8 @@ from codex_usage_tracker.context.constants import (
     CONTEXT_MODES,
     DEFAULT_CONTEXT_CHARS,
     DEFAULT_CONTEXT_ENTRIES,
+    DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES,
+    normalize_context_mode,
 )
 from codex_usage_tracker.context.loader import (
     attach_context_diagnostics,
@@ -18,10 +20,7 @@ from codex_usage_tracker.context.loader import (
     context_source_location,
     load_context_usage_record,
 )
-from codex_usage_tracker.context.reader import (
-    _normalize_context_mode,
-    _read_context_for_usage_record,
-)
+from codex_usage_tracker.context.reader import _read_context_for_usage_record
 from codex_usage_tracker.context.token_estimates import (
     estimate_visible_tokens,
 )
@@ -29,6 +28,7 @@ from codex_usage_tracker.context.values import (
     optional_str,
 )
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store.context_offsets import resolve_context_offset
 
 __all__ = (
     "CONTEXT_MODE_FULL",
@@ -36,6 +36,7 @@ __all__ = (
     "CONTEXT_MODES",
     "DEFAULT_CONTEXT_CHARS",
     "DEFAULT_CONTEXT_ENTRIES",
+    "DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES",
     "load_call_context",
 )
 
@@ -49,6 +50,7 @@ def load_call_context(
     include_compaction_history: bool = False,
     diagnostics: bool = False,
     mode: str = CONTEXT_MODE_QUICK,
+    max_backward_bytes: int = DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES,
 ) -> dict[str, Any]:
     """Load logged turn context for one model call from its source JSONL file.
 
@@ -56,7 +58,7 @@ def load_call_context(
     context is not written back to SQLite or embedded in the dashboard HTML.
     """
 
-    context_mode = _normalize_context_mode(mode)
+    context_mode = normalize_context_mode(mode)
     diagnostic_payload: dict[str, Any] | None = {} if diagnostics else None
     row = load_context_usage_record(
         db_path=db_path,
@@ -64,15 +66,24 @@ def load_call_context(
         diagnostic_payload=diagnostic_payload,
     )
     source_file, source_file_bytes, line_number = context_source_location(row, record_id=record_id)
+    offset_resolution = resolve_context_offset(
+        record_id=record_id,
+        source_file=source_file,
+        db_path=db_path,
+    )
     loaded = _read_context_for_usage_record(
         row=row,
         source_file=source_file,
         line_number=line_number,
+        source_byte_offset=offset_resolution.byte_offset,
+        context_read_reason=offset_resolution.reason,
+        source_metadata=offset_resolution.source_metadata,
         max_chars=max_chars,
         max_entries=max_entries,
         include_tool_output=include_tool_output,
         include_compaction_history=include_compaction_history,
         context_mode=context_mode,
+        max_backward_bytes=max_backward_bytes,
     )
     visible_estimate = estimate_visible_tokens(
         loaded.estimate_entries, optional_str(row.get("model"))

--- a/src/codex_usage_tracker/context/constants.py
+++ b/src/codex_usage_tracker/context/constants.py
@@ -2,6 +2,16 @@
 
 DEFAULT_CONTEXT_CHARS = 20_000
 DEFAULT_CONTEXT_ENTRIES = 80
+DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES = 131_072
 CONTEXT_MODE_QUICK = "quick"
 CONTEXT_MODE_FULL = "full"
 CONTEXT_MODES = {CONTEXT_MODE_QUICK, CONTEXT_MODE_FULL}
+
+
+def normalize_context_mode(mode: str) -> str:
+    normalized = str(mode or CONTEXT_MODE_QUICK).strip().lower()
+    if normalized not in CONTEXT_MODES:
+        raise ValueError(
+            f"Unsupported context mode: {mode}. Expected one of: {', '.join(sorted(CONTEXT_MODES))}"
+        )
+    return normalized

--- a/src/codex_usage_tracker/context/entries.py
+++ b/src/codex_usage_tracker/context/entries.py
@@ -1,0 +1,142 @@
+"""Build and limit reader-facing context entries."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from codex_usage_tracker.context.action_timing import normalize_millisecond_value
+from codex_usage_tracker.context.values import nonnegative_float, optional_str, redact_text
+
+
+def context_envelope_from_line(line: str) -> tuple[dict[str, Any] | None, bool]:
+    try:
+        envelope = json.loads(line)
+    except json.JSONDecodeError:
+        return None, True
+    if not isinstance(envelope, dict):
+        return None, False
+    return envelope, False
+
+
+def context_envelope_parts(
+    envelope: dict[str, Any],
+) -> tuple[str, dict[str, Any], str | None]:
+    raw_payload = envelope.get("payload")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+    return (
+        optional_str(envelope.get("type")) or "unknown",
+        payload,
+        optional_str(envelope.get("timestamp")),
+    )
+
+
+def is_token_count_boundary(
+    line_number: int,
+    token_line: int,
+    entry_type: str,
+    payload: dict[str, Any],
+) -> bool:
+    return (
+        line_number >= token_line
+        and entry_type == "event_msg"
+        and payload.get("type") == "token_count"
+    )
+
+
+def summarized_context_entry(
+    line_number: int,
+    timestamp: str | None,
+    entry_type: str,
+    summarized: dict[str, Any],
+) -> dict[str, Any]:
+    return context_entry(
+        line_number,
+        timestamp,
+        entry_type,
+        summarized["label"],
+        summarized["text"],
+        tool_output_omitted=bool(summarized.get("tool_output_omitted")),
+        token_usage=summarized.get("token_usage")
+        if isinstance(summarized.get("token_usage"), dict)
+        else None,
+        compaction=summarized.get("compaction")
+        if isinstance(summarized.get("compaction"), dict)
+        else None,
+        action_duration_ms=nonnegative_float(summarized.get("action_duration_ms")),
+    )
+
+
+def context_entry(
+    line_number: int,
+    timestamp: str | None,
+    entry_type: str,
+    label: str,
+    text: str,
+    *,
+    tool_output_omitted: bool = False,
+    token_usage: dict[str, Any] | None = None,
+    compaction: dict[str, Any] | None = None,
+    action_duration_ms: float | None = None,
+) -> dict[str, Any]:
+    entry = {
+        "line_number": line_number,
+        "timestamp": timestamp,
+        "type": entry_type,
+        "label": label,
+        "text": redact_text(text),
+        "truncated": False,
+    }
+    if tool_output_omitted:
+        entry["tool_output_omitted"] = True
+    if token_usage:
+        entry["token_usage"] = token_usage
+    if compaction:
+        entry["compaction"] = compaction
+    if action_duration_ms is not None:
+        entry["action_timing"] = {
+            "reported_duration_ms": normalize_millisecond_value(action_duration_ms),
+            "duration_source": "event.duration_ms",
+        }
+    return entry
+
+
+def limit_entries(
+    entries: list[dict[str, Any]],
+    max_chars: int,
+    max_entries: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    limited_reversed: list[dict[str, Any]] = []
+    remaining = None if max_chars <= 0 else max_chars
+    omitted_entries = 0
+    omitted_chars = 0
+    selected = entries if max_entries <= 0 else entries[-max_entries:]
+
+    for entry in reversed(selected):
+        text = str(entry.get("text") or "")
+        if remaining is None:
+            limited_reversed.append(entry)
+            continue
+        if remaining <= 0:
+            omitted_entries += 1
+            omitted_chars += len(text)
+            continue
+        if len(text) > remaining:
+            entry = dict(entry)
+            entry["text"] = text[:remaining] + "\n[TRUNCATED]"
+            entry["truncated"] = True
+            omitted_chars += len(text) - remaining
+            remaining = 0
+        else:
+            remaining -= len(text)
+        limited_reversed.append(entry)
+
+    limited = list(reversed(limited_reversed))
+    return limited, {
+        "older_entries": 0 if max_entries <= 0 else max(0, len(entries) - max_entries),
+        "over_budget_entries": omitted_entries,
+        "over_budget_chars": omitted_chars,
+        "max_chars": max_chars,
+        "max_entries": max_entries,
+        "returned_entries": len(limited),
+    }

--- a/src/codex_usage_tracker/context/loader.py
+++ b/src/codex_usage_tracker/context/loader.py
@@ -21,6 +21,9 @@ class LoadedContextData:
     serialized_estimate_ms: float
     action_timing: dict[str, Any]
     source_scan_ms: float
+    context_read_strategy: str
+    context_read_reason: str
+    inspected_source_bytes: int
 
 
 def elapsed_ms(started_at: float) -> float:
@@ -123,6 +126,9 @@ def attach_context_diagnostics(
     diagnostic_payload["serialized_estimate_ms"] = loaded.serialized_estimate_ms
     diagnostic_payload["source_file_bytes"] = source_file_bytes
     diagnostic_payload["source_line_number"] = line_number
+    diagnostic_payload["context_read_strategy"] = loaded.context_read_strategy
+    diagnostic_payload["context_read_reason"] = loaded.context_read_reason
+    diagnostic_payload["inspected_source_bytes"] = loaded.inspected_source_bytes
     diagnostic_payload["entries_before_limit"] = int(loaded.omitted.get("total_entries") or 0)
     diagnostic_payload["entries_returned"] = len(loaded.entries)
     payload["diagnostics"] = diagnostic_payload

--- a/src/codex_usage_tracker/context/offset_window.py
+++ b/src/codex_usage_tracker/context/offset_window.py
@@ -1,0 +1,147 @@
+"""Validated bounded source reads for indexed context offsets."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.context.values import optional_str
+from codex_usage_tracker.store.sources import (
+    SourceFileMetadata,
+    source_file_handle_metadata_matches,
+)
+
+
+@dataclass(frozen=True)
+class ContextOffsetWindow:
+    prefix_lines: tuple[bytes, ...]
+    target_line: bytes
+    first_line_number: int
+    inspected_source_bytes: int
+    failure_reason: str | None = None
+
+
+def read_context_offset_window(
+    *,
+    path: Path,
+    token_line: int,
+    source_byte_offset: int,
+    source_metadata: SourceFileMetadata | None,
+    target_usage_row: dict[str, Any],
+    max_backward_bytes: int,
+) -> ContextOffsetWindow:
+    window_start = max(0, source_byte_offset - max(0, max_backward_bytes))
+    with path.open("rb") as handle:
+        if source_metadata is None or not source_file_handle_metadata_matches(
+            handle,
+            source_metadata,
+        ):
+            return _failed_window("stale_provenance")
+        handle.seek(window_start)
+        prefix = handle.read(source_byte_offset - window_start)
+        inspected_source_bytes = len(prefix)
+        if window_start > 0:
+            newline_index = prefix.find(b"\n")
+            if newline_index < 0:
+                return _failed_window(
+                    "turn_start_outside_window",
+                    inspected_source_bytes,
+                )
+            prefix = prefix[newline_index + 1 :]
+        if prefix and not prefix.endswith(b"\n"):
+            return _failed_window("invalid_offset", inspected_source_bytes)
+        target_line = handle.readline()
+        inspected_source_bytes += len(target_line)
+    if not target_line:
+        return _failed_window("invalid_offset", inspected_source_bytes)
+    if not _target_token_event_matches(target_line, target_usage_row):
+        return _failed_window("target_mismatch", inspected_source_bytes)
+    prefix_lines = tuple(prefix.splitlines(keepends=True))
+    return ContextOffsetWindow(
+        prefix_lines=prefix_lines,
+        target_line=target_line,
+        first_line_number=token_line - len(prefix_lines),
+        inspected_source_bytes=inspected_source_bytes,
+    )
+
+
+def _failed_window(
+    reason: str,
+    inspected_source_bytes: int = 0,
+) -> ContextOffsetWindow:
+    return ContextOffsetWindow((), b"", 0, inspected_source_bytes, reason)
+
+
+def _target_token_event_matches(
+    line: bytes,
+    target_usage_row: dict[str, Any],
+) -> bool:
+    target = _token_event_target(line)
+    if target is None:
+        return False
+    timestamp, last_usage, total_usage = target
+    return timestamp == optional_str(target_usage_row.get("event_timestamp")) and (
+        _target_usage_values_match(last_usage, total_usage, target_usage_row)
+    )
+
+
+def _token_event_target(
+    line: bytes,
+) -> tuple[str | None, dict[str, Any], dict[str, Any]] | None:
+    try:
+        envelope = json.loads(line)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(envelope, dict):
+        return None
+    raw_payload = envelope.get("payload")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+    if envelope.get("type") != "event_msg" or payload.get("type") != "token_count":
+        return None
+    raw_info = payload.get("info")
+    info: dict[str, Any] = raw_info if isinstance(raw_info, dict) else {}
+    raw_last_usage = info.get("last_token_usage")
+    last_usage: dict[str, Any] = raw_last_usage if isinstance(raw_last_usage, dict) else {}
+    raw_total_usage = info.get("total_token_usage")
+    total_usage: dict[str, Any] = raw_total_usage if isinstance(raw_total_usage, dict) else {}
+    return optional_str(envelope.get("timestamp")), last_usage, total_usage
+
+
+def _target_usage_values_match(
+    last_usage: dict[str, Any],
+    total_usage: dict[str, Any],
+    target_usage_row: dict[str, Any],
+) -> bool:
+    expected_fields = (
+        (last_usage, "input_tokens", "input_tokens"),
+        (last_usage, "cached_input_tokens", "cached_input_tokens"),
+        (last_usage, "output_tokens", "output_tokens"),
+        (last_usage, "reasoning_output_tokens", "reasoning_output_tokens"),
+        (last_usage, "total_tokens", "total_tokens"),
+        (total_usage, "input_tokens", "cumulative_input_tokens"),
+        (total_usage, "cached_input_tokens", "cumulative_cached_input_tokens"),
+        (total_usage, "output_tokens", "cumulative_output_tokens"),
+        (
+            total_usage,
+            "reasoning_output_tokens",
+            "cumulative_reasoning_output_tokens",
+        ),
+        (total_usage, "total_tokens", "cumulative_total_tokens"),
+    )
+    return all(
+        _target_integer_matches(values.get(source_key), target_usage_row.get(row_key))
+        for values, source_key, row_key in expected_fields
+    )
+
+
+def _target_integer_matches(value: object, expected: object) -> bool:
+    if isinstance(value, (bool, float)):
+        return False
+    try:
+        parsed = int(value) if isinstance(value, (int, str)) else None
+        expected_value = int(expected) if isinstance(expected, (int, str)) else None
+    except ValueError:
+        return False
+    return parsed is not None and parsed == expected_value

--- a/src/codex_usage_tracker/context/reader.py
+++ b/src/codex_usage_tracker/context/reader.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from time import perf_counter
 from typing import Any
 
+from codex_usage_tracker.context import entries as context_entries
 from codex_usage_tracker.context.action_timing import (
     annotate_action_timing,
-    normalize_millisecond_value,
 )
 from codex_usage_tracker.context.constants import (
     CONTEXT_MODE_FULL,
-    CONTEXT_MODE_QUICK,
-    CONTEXT_MODES,
+    DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES,
 )
 from codex_usage_tracker.context.loader import (
     LoadedContextData,
@@ -23,6 +21,7 @@ from codex_usage_tracker.context.loader import (
     bounded_context_entries,
     elapsed_ms,
 )
+from codex_usage_tracker.context.offset_window import read_context_offset_window
 from codex_usage_tracker.context.serialized import (
     collect_serialized_envelope,
     quick_serialized_context_estimate,
@@ -37,10 +36,9 @@ from codex_usage_tracker.context.token_estimates import (
     context_encoding,
 )
 from codex_usage_tracker.context.values import (
-    nonnegative_float,
     optional_str,
-    redact_text,
 )
+from codex_usage_tracker.store.sources import SourceFileMetadata
 
 
 def _read_context_for_usage_record(
@@ -48,11 +46,15 @@ def _read_context_for_usage_record(
     row: dict[str, Any],
     source_file: Path,
     line_number: int,
+    source_byte_offset: int | None,
+    context_read_reason: str,
+    source_metadata: SourceFileMetadata | None,
     max_chars: int,
     max_entries: int,
     include_tool_output: bool,
     include_compaction_history: bool,
     context_mode: str,
+    max_backward_bytes: int = DEFAULT_CONTEXT_SEEK_BACKWARD_BYTES,
 ) -> LoadedContextData:
     source_scan_started = perf_counter()
     (
@@ -62,10 +64,18 @@ def _read_context_for_usage_record(
         serialized_estimate,
         serialized_estimate_ms,
         action_timing,
+        context_read_strategy,
+        resolved_read_reason,
+        inspected_source_bytes,
     ) = _read_context_entries(
         path=source_file,
         token_line=line_number,
         target_turn_id=optional_str(row.get("turn_id")),
+        source_byte_offset=source_byte_offset,
+        context_read_reason=context_read_reason,
+        source_metadata=source_metadata,
+        target_usage_row=row,
+        max_backward_bytes=max_backward_bytes,
         max_chars=bounded_context_chars(max_chars),
         max_entries=bounded_context_entries(max_entries),
         include_tool_output=include_tool_output,
@@ -81,16 +91,10 @@ def _read_context_for_usage_record(
         serialized_estimate_ms=serialized_estimate_ms,
         action_timing=action_timing,
         source_scan_ms=elapsed_ms(source_scan_started),
+        context_read_strategy=context_read_strategy,
+        context_read_reason=resolved_read_reason,
+        inspected_source_bytes=inspected_source_bytes,
     )
-
-
-def _normalize_context_mode(mode: str) -> str:
-    normalized = str(mode or CONTEXT_MODE_QUICK).strip().lower()
-    if normalized not in CONTEXT_MODES:
-        raise ValueError(
-            f"Unsupported context mode: {mode}. Expected one of: {', '.join(sorted(CONTEXT_MODES))}"
-        )
-    return normalized
 
 
 @dataclass
@@ -107,6 +111,8 @@ class _ContextReadState:
     serialized_raw_char_count: int = 0
     omitted_parse_errors: int = 0
     current_turn_id: str | None = None
+    target_turn_found: bool = False
+    pre_target_turn_boundary_found: bool = False
     pending_compactions: list[dict[str, Any]] = field(default_factory=list)
     pending_diagnostic_events: list[dict[str, Any]] = field(default_factory=list)
 
@@ -115,6 +121,11 @@ def _read_context_entries(
     path: Path,
     token_line: int,
     target_turn_id: str | None,
+    source_byte_offset: int | None,
+    context_read_reason: str,
+    source_metadata: SourceFileMetadata | None,
+    target_usage_row: dict[str, Any],
+    max_backward_bytes: int,
     max_chars: int,
     max_entries: int,
     include_tool_output: bool,
@@ -128,24 +139,136 @@ def _read_context_entries(
     dict[str, Any],
     float,
     dict[str, Any],
+    str,
+    str,
+    int,
 ]:
-    state = _new_context_read_state(target_turn_id, model, context_mode)
+    if source_byte_offset is not None and target_turn_id is not None:
+        offset_result = _read_context_from_offset(
+            path=path,
+            token_line=token_line,
+            target_turn_id=target_turn_id,
+            source_byte_offset=source_byte_offset,
+            source_metadata=source_metadata,
+            target_usage_row=target_usage_row,
+            max_backward_bytes=max_backward_bytes,
+            include_tool_output=include_tool_output,
+            include_compaction_history=include_compaction_history,
+            model=model,
+            context_mode=context_mode,
+        )
+        state, offset_inspected_bytes, offset_failure_reason = offset_result
+        if state is not None:
+            return (
+                *_context_read_result(state, max_chars=max_chars, max_entries=max_entries),
+                "offset_seek",
+                context_read_reason,
+                offset_inspected_bytes,
+            )
+        context_read_reason = offset_failure_reason or "invalid_offset"
+    else:
+        offset_inspected_bytes = 0
+    if target_turn_id is None:
+        context_read_reason = "missing_turn_id"
 
-    with path.open(encoding="utf-8") as handle:
-        for line_number, line in enumerate(handle, 1):
+    state, inspected_source_bytes = _read_context_sequentially(
+        path=path,
+        token_line=token_line,
+        target_turn_id=target_turn_id,
+        include_tool_output=include_tool_output,
+        include_compaction_history=include_compaction_history,
+        model=model,
+        context_mode=context_mode,
+    )
+    return (
+        *_context_read_result(state, max_chars=max_chars, max_entries=max_entries),
+        "sequential_fallback",
+        context_read_reason,
+        offset_inspected_bytes + inspected_source_bytes,
+    )
+
+
+def _read_context_from_offset(
+    *,
+    path: Path,
+    token_line: int,
+    target_turn_id: str,
+    source_byte_offset: int,
+    source_metadata: SourceFileMetadata | None,
+    target_usage_row: dict[str, Any],
+    max_backward_bytes: int,
+    include_tool_output: bool,
+    include_compaction_history: bool,
+    model: str | None,
+    context_mode: str,
+) -> tuple[_ContextReadState | None, int, str | None]:
+    window = read_context_offset_window(
+        path=path,
+        token_line=token_line,
+        source_byte_offset=source_byte_offset,
+        source_metadata=source_metadata,
+        target_usage_row=target_usage_row,
+        max_backward_bytes=max_backward_bytes,
+    )
+    if window.failure_reason is not None:
+        return None, window.inspected_source_bytes, window.failure_reason
+    state = _new_context_read_state(target_turn_id, model, context_mode)
+    for line_number, raw_line in enumerate(
+        window.prefix_lines,
+        window.first_line_number,
+    ):
+        _scan_context_line(
+            state=state,
+            line_number=line_number,
+            line=raw_line.decode("utf-8"),
+            token_line=token_line,
+            include_tool_output=include_tool_output,
+            include_compaction_history=include_compaction_history,
+        )
+    target_matched = _scan_context_line(
+        state=state,
+        line_number=token_line,
+        line=window.target_line.decode("utf-8"),
+        token_line=token_line,
+        include_tool_output=include_tool_output,
+        include_compaction_history=include_compaction_history,
+    )
+    if not target_matched:
+        return None, window.inspected_source_bytes, "target_mismatch"
+    if not state.target_turn_found:
+        return None, window.inspected_source_bytes, "turn_start_outside_window"
+    if window.first_line_number > 1 and not state.pre_target_turn_boundary_found:
+        return None, window.inspected_source_bytes, "context_anchor_outside_window"
+    return state, window.inspected_source_bytes, None
+
+
+def _read_context_sequentially(
+    *,
+    path: Path,
+    token_line: int,
+    target_turn_id: str | None,
+    include_tool_output: bool,
+    include_compaction_history: bool,
+    model: str | None,
+    context_mode: str,
+) -> tuple[_ContextReadState, int]:
+    state = _new_context_read_state(target_turn_id, model, context_mode)
+    inspected_source_bytes = 0
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, 1):
             if line_number > token_line:
                 break
+            inspected_source_bytes += len(raw_line)
             if _scan_context_line(
                 state=state,
                 line_number=line_number,
-                line=line,
+                line=raw_line.decode("utf-8"),
                 token_line=token_line,
                 include_tool_output=include_tool_output,
                 include_compaction_history=include_compaction_history,
             ):
                 break
-
-    return _context_read_result(state, max_chars=max_chars, max_entries=max_entries)
+    return state, inspected_source_bytes
 
 
 def _new_context_read_state(
@@ -168,16 +291,6 @@ def _new_context_read_state(
     )
 
 
-def _context_envelope_from_line(line: str) -> tuple[dict[str, Any] | None, bool]:
-    try:
-        envelope = json.loads(line)
-    except json.JSONDecodeError:
-        return None, True
-    if not isinstance(envelope, dict):
-        return None, False
-    return envelope, False
-
-
 def _scan_context_line(
     state: _ContextReadState,
     line_number: int,
@@ -186,13 +299,19 @@ def _scan_context_line(
     include_tool_output: bool,
     include_compaction_history: bool,
 ) -> bool:
-    envelope, parse_error = _context_envelope_from_line(line)
+    envelope, parse_error = context_entries.context_envelope_from_line(line)
     if parse_error:
         state.omitted_parse_errors += 1
         return False
     if envelope is None:
         return False
-    entry_type, payload, timestamp = _context_envelope_parts(envelope)
+    entry_type, payload, timestamp = context_entries.context_envelope_parts(envelope)
+    token_count_boundary = context_entries.is_token_count_boundary(
+        line_number,
+        token_line,
+        entry_type,
+        payload,
+    )
     if entry_type == "turn_context":
         _start_turn_context(state, line_number, line, timestamp, envelope, payload)
         return False
@@ -205,35 +324,12 @@ def _scan_context_line(
         include_compaction_history=include_compaction_history,
     )
     if _pending_summary_handled(state, line_number, timestamp, entry_type, summarized):
-        return False
+        return token_count_boundary
     if summarized is not None:
         state.candidates.append(
-            _summarized_context_entry(line_number, timestamp, entry_type, summarized)
+            context_entries.summarized_context_entry(line_number, timestamp, entry_type, summarized)
         )
-    return _is_token_count_boundary(line_number, token_line, entry_type, payload)
-
-
-def _context_envelope_parts(envelope: dict[str, Any]) -> tuple[str, dict[str, Any], str | None]:
-    raw_payload = envelope.get("payload")
-    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
-    return (
-        optional_str(envelope.get("type")) or "unknown",
-        payload,
-        optional_str(envelope.get("timestamp")),
-    )
-
-
-def _is_token_count_boundary(
-    line_number: int,
-    token_line: int,
-    entry_type: str,
-    payload: dict[str, Any],
-) -> bool:
-    return (
-        line_number >= token_line
-        and entry_type == "event_msg"
-        and payload.get("type") == "token_count"
-    )
+    return token_count_boundary
 
 
 def _start_turn_context(
@@ -247,7 +343,9 @@ def _start_turn_context(
     was_collecting = state.collecting
     state.current_turn_id = optional_str(payload.get("turn_id"))
     state.collecting = state.target_turn_id is None or state.current_turn_id == state.target_turn_id
+    _update_turn_parse_error_scope(state)
     if state.collecting:
+        state.target_turn_found = True
         _reset_selected_turn_context(state)
         _collect_serialized_context(state, line, envelope, "turn_context", payload)
         carried_compactions = (
@@ -256,7 +354,7 @@ def _start_turn_context(
             else []
         )
         state.candidates = [
-            _context_entry(
+            context_entries.context_entry(
                 line_number,
                 timestamp,
                 "turn_context",
@@ -269,6 +367,14 @@ def _start_turn_context(
         ]
     state.pending_compactions = []
     state.pending_diagnostic_events = []
+
+
+def _update_turn_parse_error_scope(state: _ContextReadState) -> None:
+    if state.target_turn_id is not None and not state.collecting:
+        state.pre_target_turn_boundary_found = True
+        state.omitted_parse_errors = 0
+    elif state.target_turn_id is None and state.target_turn_found:
+        state.omitted_parse_errors = 0
 
 
 def _reset_selected_turn_context(state: _ContextReadState) -> None:
@@ -312,13 +418,15 @@ def _pending_summary_handled(
         return True
     if entry_type == "compacted":
         state.pending_compactions = [
-            _summarized_context_entry(line_number, timestamp, entry_type, summarized)
+            context_entries.summarized_context_entry(line_number, timestamp, entry_type, summarized)
         ]
         return True
     if summarized.get("carry_into_next_turn") is True:
         state.pending_diagnostic_events = [
             *state.pending_diagnostic_events,
-            _summarized_context_entry(line_number, timestamp, entry_type, summarized),
+            context_entries.summarized_context_entry(
+                line_number, timestamp, entry_type, summarized
+            ),
         ][-8:]
     return True
 
@@ -353,106 +461,12 @@ def _context_read_result(
     serialized_estimate_ms = elapsed_ms(serialized_started)
     candidates = dedupe_chat_message_echoes(state.candidates)
     action_timing = annotate_action_timing(candidates)
-    limited, omitted = _limit_entries(candidates, max_chars=max_chars, max_entries=max_entries)
+    limited, omitted = context_entries.limit_entries(
+        candidates,
+        max_chars=max_chars,
+        max_entries=max_entries,
+    )
     omitted["parse_errors"] = state.omitted_parse_errors
     omitted["target_turn_id"] = state.target_turn_id
     omitted["total_entries"] = len(candidates)
     return limited, omitted, candidates, serialized_estimate, serialized_estimate_ms, action_timing
-
-
-def _summarized_context_entry(
-    line_number: int,
-    timestamp: str | None,
-    entry_type: str,
-    summarized: dict[str, Any],
-) -> dict[str, Any]:
-    return _context_entry(
-        line_number,
-        timestamp,
-        entry_type,
-        summarized["label"],
-        summarized["text"],
-        tool_output_omitted=bool(summarized.get("tool_output_omitted")),
-        token_usage=summarized.get("token_usage")
-        if isinstance(summarized.get("token_usage"), dict)
-        else None,
-        compaction=summarized.get("compaction")
-        if isinstance(summarized.get("compaction"), dict)
-        else None,
-        action_duration_ms=nonnegative_float(summarized.get("action_duration_ms")),
-    )
-
-
-def _context_entry(
-    line_number: int,
-    timestamp: str | None,
-    entry_type: str,
-    label: str,
-    text: str,
-    *,
-    tool_output_omitted: bool = False,
-    token_usage: dict[str, Any] | None = None,
-    compaction: dict[str, Any] | None = None,
-    action_duration_ms: float | None = None,
-) -> dict[str, Any]:
-    entry = {
-        "line_number": line_number,
-        "timestamp": timestamp,
-        "type": entry_type,
-        "label": label,
-        "text": redact_text(text),
-        "truncated": False,
-    }
-    if tool_output_omitted:
-        entry["tool_output_omitted"] = True
-    if token_usage:
-        entry["token_usage"] = token_usage
-    if compaction:
-        entry["compaction"] = compaction
-    if action_duration_ms is not None:
-        entry["action_timing"] = {
-            "reported_duration_ms": normalize_millisecond_value(action_duration_ms),
-            "duration_source": "event.duration_ms",
-        }
-    return entry
-
-
-def _limit_entries(
-    entries: list[dict[str, Any]],
-    max_chars: int,
-    max_entries: int,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    limited_reversed: list[dict[str, Any]] = []
-    remaining = None if max_chars <= 0 else max_chars
-    omitted_entries = 0
-    omitted_chars = 0
-    selected = entries if max_entries <= 0 else entries[-max_entries:]
-
-    for entry in reversed(selected):
-        text = str(entry.get("text") or "")
-        if remaining is None:
-            limited_reversed.append(entry)
-            continue
-        if remaining <= 0:
-            omitted_entries += 1
-            omitted_chars += len(text)
-            continue
-        if len(text) > remaining:
-            entry = dict(entry)
-            entry["text"] = text[:remaining] + "\n[TRUNCATED]"
-            entry["truncated"] = True
-            omitted_chars += len(text) - remaining
-            remaining = 0
-        else:
-            remaining -= len(text)
-        limited_reversed.append(entry)
-
-    limited = list(reversed(limited_reversed))
-    return limited, {
-        "older_entries": 0 if max_entries <= 0 else max(0, len(entries) - max_entries),
-        "over_budget_entries": omitted_entries,
-        "over_budget_chars": omitted_chars,
-        "max_chars": max_chars,
-        "max_entries": max_entries,
-        "returned_entries": len(limited),
-    }

--- a/src/codex_usage_tracker/core/models.py
+++ b/src/codex_usage_tracker/core/models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 
+from codex_usage_tracker.core.schema import USAGE_EVENT_COLUMN_NAMES
+
 
 @dataclass(frozen=True)
 class SessionInfo:
@@ -75,6 +77,7 @@ class UsageEvent:
     fast: int | None = None
     service_tier_source: str | None = None
     service_tier_confidence: str | None = None
+    source_byte_offset: int | None = None
 
     @property
     def uncached_input_tokens(self) -> int:
@@ -104,7 +107,7 @@ class UsageEvent:
         row["cache_ratio"] = self.cache_ratio
         row["reasoning_output_ratio"] = self.reasoning_output_ratio
         row["context_window_percent"] = self.context_window_percent
-        return row
+        return {column: row[column] for column in USAGE_EVENT_COLUMN_NAMES}
 
 
 @dataclass(frozen=True)

--- a/src/codex_usage_tracker/core/schema.py
+++ b/src/codex_usage_tracker/core/schema.py
@@ -16,6 +16,15 @@ class UsageColumn:
     repairable: bool = False
 
 
+CALL_ORIGIN_REPAIR_COLUMNS: dict[str, str] = dict.fromkeys(
+    ("call_initiator", "call_initiator_reason", "call_initiator_confidence"), "TEXT"
+)
+DASHBOARD_HELPER_REPAIR_COLUMNS = {
+    "is_archived": "INTEGER NOT NULL DEFAULT 0",
+    "thread_call_index": "INTEGER",
+} | dict.fromkeys(("thread_key", "previous_record_id", "next_record_id"), "TEXT")
+
+
 USAGE_EVENT_COLUMNS = (
     UsageColumn("record_id", "TEXT PRIMARY KEY", "TEXT"),
     UsageColumn("session_id", "TEXT NOT NULL", "TEXT"),
@@ -24,6 +33,7 @@ USAGE_EVENT_COLUMNS = (
     UsageColumn("event_timestamp", "TEXT NOT NULL", "TEXT"),
     UsageColumn("source_file", "TEXT NOT NULL", "TEXT"),
     UsageColumn("line_number", "INTEGER NOT NULL", "INTEGER"),
+    UsageColumn("source_byte_offset", "INTEGER", "INTEGER", repairable=True),
     UsageColumn("turn_id", "TEXT", "TEXT", repairable=True),
     UsageColumn("turn_timestamp", "TEXT", "TEXT", repairable=True),
     UsageColumn("cwd", "TEXT", "TEXT", repairable=True),

--- a/src/codex_usage_tracker/parser/jsonl_v1.py
+++ b/src/codex_usage_tracker/parser/jsonl_v1.py
@@ -114,6 +114,7 @@ def parse_codex_jsonl_v1(
     with path.open("rb") as handle:
         if start_byte > 0:
             handle.seek(start_byte)
+        source_byte_offset = start_byte
         for line_number, raw_line in enumerate(handle, start_line + 1):
             final_line_number = line_number
             _handle_jsonl_line(
@@ -121,10 +122,12 @@ def parse_codex_jsonl_v1(
                 index=index,
                 state=state,
                 line_number=line_number,
+                source_byte_offset=source_byte_offset,
                 raw_line=raw_line,
                 stats=stats,
                 entry_observer=entry_observer,
             )
+            source_byte_offset += len(raw_line)
 
     return ParsedUsageFile(
         events=state.events,
@@ -175,6 +178,7 @@ def _handle_jsonl_line(
     index: dict[str, SessionInfo],
     state: _JsonlParseState,
     line_number: int,
+    source_byte_offset: int,
     raw_line: bytes,
     stats: MutableMapping[str, int] | None,
     entry_observer: JsonlEntryObserver | None,
@@ -192,6 +196,7 @@ def _handle_jsonl_line(
         index=index,
         state=state,
         line_number=line_number,
+        source_byte_offset=source_byte_offset,
         envelope=envelope,
         payload=payload,
         stats=stats,
@@ -207,6 +212,7 @@ def _handle_decoded_jsonl_entry(
     index: dict[str, SessionInfo],
     state: _JsonlParseState,
     line_number: int,
+    source_byte_offset: int,
     envelope: dict[str, Any],
     payload: dict[str, Any],
     stats: MutableMapping[str, int] | None,
@@ -239,6 +245,7 @@ def _handle_decoded_jsonl_entry(
         index=index,
         state=state,
         line_number=line_number,
+        source_byte_offset=source_byte_offset,
         timestamp=timestamp,
         envelope=envelope,
         payload=payload,
@@ -267,6 +274,7 @@ def _handle_token_count_event(
     index: dict[str, SessionInfo],
     state: _JsonlParseState,
     line_number: int,
+    source_byte_offset: int,
     timestamp: str,
     envelope: dict[str, Any],
     payload: dict[str, Any],
@@ -291,6 +299,7 @@ def _handle_token_count_event(
     event = _build_token_count_event(
         path=path,
         line_number=line_number,
+        source_byte_offset=source_byte_offset,
         timestamp=timestamp,
         envelope=envelope,
         session_id=effective_session_id,
@@ -426,6 +435,7 @@ def _build_token_count_event(
     *,
     path: Path,
     line_number: int,
+    source_byte_offset: int,
     timestamp: str,
     envelope: dict[str, Any],
     session_id: str,
@@ -443,6 +453,7 @@ def _build_token_count_event(
         return build_usage_event(
             path=path,
             line_number=line_number,
+            source_byte_offset=source_byte_offset,
             event_timestamp=timestamp,
             session_id=session_id,
             session_info=session_info,

--- a/src/codex_usage_tracker/parser/jsonl_values.py
+++ b/src/codex_usage_tracker/parser/jsonl_values.py
@@ -33,6 +33,7 @@ def build_usage_event(
     rate_limits: object = None,
     upstream_usage_id: str | None = None,
     stats: MutableMapping[str, int] | None = None,
+    source_byte_offset: int | None = None,
 ) -> UsageEvent:
     input_tokens = required_usage_int(last_usage, "input_tokens", stats=stats)
     cached_input_tokens = required_usage_int(last_usage, "cached_input_tokens", stats=stats)
@@ -61,6 +62,7 @@ def build_usage_event(
         event_timestamp=event_timestamp,
         source_file=str(path),
         line_number=line_number,
+        source_byte_offset=source_byte_offset,
         turn_id=optional_str(current_turn.get("turn_id")),
         turn_timestamp=optional_str(current_turn.get("turn_timestamp")),
         cwd=optional_str(current_turn.get("cwd")),

--- a/src/codex_usage_tracker/store/context_offsets.py
+++ b/src/codex_usage_tracker/store/context_offsets.py
@@ -1,0 +1,78 @@
+"""Validated lookup for persisted source byte offsets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
+from codex_usage_tracker.store.connection import connect_read_only
+from codex_usage_tracker.store.sources import (
+    SourceFileMetadata,
+    validated_source_file_metadata,
+)
+
+
+@dataclass(frozen=True)
+class ContextOffsetResolution:
+    """One safe seek decision and its bounded diagnostic reason."""
+
+    byte_offset: int | None
+    strategy: str
+    reason: str
+    source_metadata: SourceFileMetadata | None = None
+
+
+def resolve_context_offset(
+    *,
+    record_id: str,
+    source_file: Path,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> ContextOffsetResolution:
+    """Return an offset only when current source provenance still matches."""
+    with connect_read_only(db_path, timeout=1.0) as conn:
+        row = conn.execute(
+            """
+            SELECT
+                usage_events.source_file,
+                usage_events.source_byte_offset,
+                source_files.size_bytes,
+                source_files.mtime_ns,
+                source_files.parsed_until_byte,
+                source_files.parsed_prefix_tail_hash,
+                source_files.source_device,
+                source_files.source_inode
+            FROM usage_events
+            JOIN source_files
+              ON source_files.source_file = usage_events.source_file
+            WHERE usage_events.record_id = ?
+            LIMIT 1
+            """,
+            (record_id,),
+        ).fetchone()
+    if row is None:
+        return ContextOffsetResolution(None, "sequential_fallback", "missing_provenance")
+
+    persisted_path = Path(str(row["source_file"]))
+    if persisted_path.resolve() != source_file.resolve():
+        return ContextOffsetResolution(
+            None,
+            "sequential_fallback",
+            "source_path_mismatch",
+        )
+
+    raw_offset = row["source_byte_offset"]
+    if raw_offset is None:
+        return ContextOffsetResolution(None, "sequential_fallback", "missing_offset")
+    byte_offset = int(raw_offset)
+    if byte_offset < 0 or byte_offset >= int(row["size_bytes"]):
+        return ContextOffsetResolution(None, "sequential_fallback", "invalid_offset")
+    source_metadata = validated_source_file_metadata(source_file, row)
+    if source_metadata is None:
+        return ContextOffsetResolution(None, "sequential_fallback", "stale_provenance")
+    return ContextOffsetResolution(
+        byte_offset,
+        "offset_seek",
+        "validated",
+        source_metadata,
+    )

--- a/src/codex_usage_tracker/store/schema.py
+++ b/src/codex_usage_tracker/store/schema.py
@@ -13,15 +13,10 @@ import codex_usage_tracker.store.otel_schema as otel_schema
 import codex_usage_tracker.store.recommendation_schema as recommendation_schema
 import codex_usage_tracker.store.schema_query_indexes as schema_query_indexes
 import codex_usage_tracker.store.source_record_schema as source_record_schema
-from codex_usage_tracker.core.schema import (
-    USAGE_EVENT_COLUMN_NAMES,
-    USAGE_EVENT_CREATE_COLUMNS_SQL,
-    USAGE_EVENT_REPAIR_COLUMNS,
-    USAGE_EVENT_SCHEMA_CHECKSUM,
-)
+from codex_usage_tracker.core import schema as usage_schema
 from codex_usage_tracker.store.connection import execute_script
 
-SCHEMA_VERSION = 34
+SCHEMA_VERSION = 35
 MIGRATION_NAMES = {
     1: "create usage_events aggregate fact table",
     2: "track schema migration checksum metadata",
@@ -44,14 +39,7 @@ MIGRATION_NAMES = {
     **allowance_schema.MIGRATION_NAMES,
     **otel_schema.MIGRATION_NAMES,
 }
-CALL_ORIGIN_REPAIR_COLUMNS: dict[str, str] = dict.fromkeys(
-    ("call_initiator", "call_initiator_reason", "call_initiator_confidence"), "TEXT"
-)
-DASHBOARD_HELPER_REPAIR_COLUMNS = {
-    "is_archived": "INTEGER NOT NULL DEFAULT 0",
-    "thread_call_index": "INTEGER",
-} | dict.fromkeys(("thread_key", "previous_record_id", "next_record_id"), "TEXT")
-REQUIRED_USAGE_EVENT_COLUMNS = list(USAGE_EVENT_COLUMN_NAMES)
+REQUIRED_USAGE_EVENT_COLUMNS = list(usage_schema.USAGE_EVENT_COLUMN_NAMES)
 
 
 class SchemaMigrationError(RuntimeError):
@@ -133,7 +121,8 @@ def _schema_migrations() -> tuple[tuple[int, Callable[[sqlite3.Connection], None
         (31, otel_schema.add_otel_cursor_resume_anchor),
         (32, allowance_schema.add_allowance_all_history_query_index),
         (33, recommendation_schema.create_recommendation_fact_indexes),
-        (34, _migrate_v34),
+        (34, schema_query_indexes.migrate_focused_call_indexes),
+        (35, schema_query_indexes.add_context_source_byte_offset),
     )
 
 
@@ -171,7 +160,7 @@ def _migrate_v1(conn: sqlite3.Connection) -> None:
         conn,
         f"""
         CREATE TABLE IF NOT EXISTS usage_events (
-            {USAGE_EVENT_CREATE_COLUMNS_SQL}
+            {usage_schema.USAGE_EVENT_CREATE_COLUMNS_SQL}
         );
 
         CREATE TABLE IF NOT EXISTS refresh_meta (
@@ -180,7 +169,7 @@ def _migrate_v1(conn: sqlite3.Connection) -> None:
         );
         """,
     )
-    _ensure_columns(conn, USAGE_EVENT_REPAIR_COLUMNS)
+    _ensure_columns(conn, usage_schema.USAGE_EVENT_REPAIR_COLUMNS)
     execute_script(
         conn,
         """
@@ -200,11 +189,11 @@ def _migrate_v2(conn: sqlite3.Connection) -> None:
 
 
 def _migrate_v3(conn: sqlite3.Connection) -> None:
-    _ensure_columns(conn, CALL_ORIGIN_REPAIR_COLUMNS)
+    _ensure_columns(conn, usage_schema.CALL_ORIGIN_REPAIR_COLUMNS)
 
 
 def _migrate_v4(conn: sqlite3.Connection) -> None:
-    _ensure_columns(conn, DASHBOARD_HELPER_REPAIR_COLUMNS)
+    _ensure_columns(conn, usage_schema.DASHBOARD_HELPER_REPAIR_COLUMNS)
     execute_script(
         conn,
         """
@@ -216,11 +205,6 @@ def _migrate_v4(conn: sqlite3.Connection) -> None:
             ON usage_events(thread_key, event_timestamp, cumulative_total_tokens);
         """,
     )
-
-
-def _migrate_v34(conn: sqlite3.Connection) -> None:
-    recommendation_schema.create_recommendation_fact_indexes(conn)
-    schema_query_indexes.add_call_explorer_parent_lookup_indexes(conn)
 
 
 def _migrate_v5(conn: sqlite3.Connection) -> None:
@@ -298,7 +282,7 @@ def _migrate_v7(conn: sqlite3.Connection) -> None:
 
 
 def _migrate_v8(conn: sqlite3.Connection) -> None:
-    _ensure_columns(conn, USAGE_EVENT_REPAIR_COLUMNS)
+    _ensure_columns(conn, usage_schema.USAGE_EVENT_REPAIR_COLUMNS)
     execute_script(
         conn,
         """
@@ -722,7 +706,7 @@ def _record_migration(conn: sqlite3.Connection, version: int) -> None:
         (
             version,
             MIGRATION_NAMES[version],
-            USAGE_EVENT_SCHEMA_CHECKSUM,
+            usage_schema.USAGE_EVENT_SCHEMA_CHECKSUM,
             datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         ),
     )

--- a/src/codex_usage_tracker/store/schema_query_indexes.py
+++ b/src/codex_usage_tracker/store/schema_query_indexes.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import sqlite3
 
 from codex_usage_tracker.store.connection import execute_script
+from codex_usage_tracker.store.recommendation_schema import (
+    create_recommendation_fact_indexes,
+)
 
 MIGRATION_NAMES = {
     18: "index usage events by source file and line",
     22: "cover diagnostic fact lookups",
     23: "cover diagnostic fact aggregation",
     34: "index focused call explorer sorts, sources, and parent lookups",
+    35: "add source byte offsets to usage events",
 }
 
 
@@ -24,6 +28,17 @@ def migrate_source_file_line_index(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_usage_source_file_line "
         "ON usage_events(source_file, line_number)"
     )
+
+
+def migrate_focused_call_indexes(conn: sqlite3.Connection) -> None:
+    create_recommendation_fact_indexes(conn)
+    add_call_explorer_parent_lookup_indexes(conn)
+
+
+def add_context_source_byte_offset(conn: sqlite3.Connection) -> None:
+    columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(usage_events)")}
+    if "source_byte_offset" not in columns:
+        conn.execute("ALTER TABLE usage_events ADD COLUMN source_byte_offset INTEGER")
 
 
 def add_diagnostic_lookup_index(conn: sqlite3.Connection) -> None:

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, BinaryIO, TypeAlias
 
 from codex_usage_tracker.core.models import UsageEvent
 from codex_usage_tracker.parser.state import (
@@ -146,6 +147,42 @@ def _source_metadata_matches(
         and int(row["mtime_ns"]) == metadata.mtime_ns
         and _filesystem_id_key(row["source_inode"]) == metadata.source_inode
         and content_matches
+    )
+
+
+def source_file_metadata_matches(path: Path, row: sqlite3.Row) -> bool:
+    """Validate one persisted source row against its current local file."""
+    return validated_source_file_metadata(path, row) is not None
+
+
+def validated_source_file_metadata(
+    path: Path,
+    row: sqlite3.Row,
+) -> SourceFileMetadata | None:
+    """Return the exact validated file identity snapshot, when still current."""
+    try:
+        metadata = _source_file_metadata(path)
+        if metadata is None:
+            return None
+        return metadata if _source_metadata_matches(path, row, metadata) else None
+    except OSError:
+        return None
+
+
+def source_file_handle_metadata_matches(
+    handle: BinaryIO,
+    metadata: SourceFileMetadata,
+) -> bool:
+    """Confirm an open descriptor is the file identity that was validated."""
+    try:
+        stat = os.fstat(handle.fileno())
+    except OSError:
+        return False
+    return (
+        int(stat.st_size) == metadata.size_bytes
+        and int(stat.st_mtime_ns) == metadata.mtime_ns
+        and _serialize_filesystem_id(int(stat.st_dev)) == metadata.source_device
+        and _serialize_filesystem_id(int(stat.st_ino)) == metadata.source_inode
     )
 
 

--- a/src/codex_usage_tracker/store/sources.py
+++ b/src/codex_usage_tracker/store/sources.py
@@ -150,11 +150,6 @@ def _source_metadata_matches(
     )
 
 
-def source_file_metadata_matches(path: Path, row: sqlite3.Row) -> bool:
-    """Validate one persisted source row against its current local file."""
-    return validated_source_file_metadata(path, row) is not None
-
-
 def validated_source_file_metadata(
     path: Path,
     row: sqlite3.Row,

--- a/tests/context/test_byte_offset_reads.py
+++ b/tests/context/test_byte_offset_reads.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.context.api import load_call_context
+from codex_usage_tracker.store.api import query_session_usage, refresh_usage_index
+from codex_usage_tracker.store.connection import connect
+from tests.store_dashboard_helpers import (
+    SESSION_ID,
+    _entry,
+    _make_codex_home,
+    _token_event,
+    _write_jsonl,
+)
+
+
+def _without_diagnostics(payload: dict[str, object]) -> dict[str, object]:
+    normalized = copy.deepcopy(payload)
+    normalized.pop("diagnostics", None)
+    return normalized
+
+
+@pytest.mark.parametrize(
+    ("mode", "include_tool_output", "include_compaction_history"),
+    [
+        ("quick", False, False),
+        ("quick", True, True),
+        ("full", False, True),
+        ("full", True, False),
+    ],
+)
+def test_offset_and_sequential_context_payloads_are_equivalent(
+    tmp_path: Path,
+    mode: str,
+    include_tool_output: bool,
+    include_compaction_history: bool,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+
+    offset_payload = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        include_tool_output=include_tool_output,
+        include_compaction_history=include_compaction_history,
+        diagnostics=True,
+        mode=mode,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (row["record_id"],),
+        )
+    sequential_payload = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        include_tool_output=include_tool_output,
+        include_compaction_history=include_compaction_history,
+        diagnostics=True,
+        mode=mode,
+    )
+
+    assert offset_payload["diagnostics"]["context_read_strategy"] == "offset_seek"
+    assert sequential_payload["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert (
+        offset_payload["diagnostics"]["inspected_source_bytes"]
+        < Path(str(row["source_file"])).stat().st_size
+    )
+    assert _without_diagnostics(offset_payload) == _without_diagnostics(sequential_payload)
+
+
+def test_stale_offset_falls_back_without_changing_context_payload(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_path = Path(str(row["source_file"]))
+
+    expected = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+    with source_path.open("ab") as handle:
+        handle.write(b"{not valid json\n")
+    actual = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert actual["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert actual["diagnostics"]["context_read_reason"] == "stale_provenance"
+    assert _without_diagnostics(actual) == _without_diagnostics(expected)
+
+
+def test_offset_falls_back_when_turn_start_is_outside_backward_window(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+
+    expected = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+        max_backward_bytes=1,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (row["record_id"],),
+        )
+    sequential = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert expected["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert expected["diagnostics"]["context_read_reason"] == "turn_start_outside_window"
+    assert (
+        expected["diagnostics"]["inspected_source_bytes"]
+        > sequential["diagnostics"]["inspected_source_bytes"]
+    )
+    assert _without_diagnostics(expected) == _without_diagnostics(sequential)
+
+
+def test_invalid_offset_alignment_falls_back_to_equivalent_payload(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = source_byte_offset + 1 "
+            "WHERE record_id = ?",
+            (row["record_id"],),
+        )
+
+    fallback = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (row["record_id"],),
+        )
+    sequential = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert fallback["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert fallback["diagnostics"]["context_read_reason"] == "invalid_offset"
+    assert _without_diagnostics(fallback) == _without_diagnostics(sequential)
+
+
+def test_offset_and_sequential_reads_match_with_malformed_json(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    original = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_path = Path(str(original["source_file"]))
+    token_offset = int(original["source_byte_offset"])
+    source_bytes = source_path.read_bytes()
+    source_path.write_bytes(
+        source_bytes[:token_offset] + b"{malformed synthetic json\n" + source_bytes[token_offset:]
+    )
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+
+    offset_payload = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (row["record_id"],),
+        )
+    sequential_payload = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert offset_payload["omitted"]["parse_errors"] == 1
+    assert sequential_payload["omitted"]["parse_errors"] == 1
+    assert _without_diagnostics(offset_payload) == _without_diagnostics(sequential_payload)
+
+
+def test_offset_and_sequential_reads_match_near_file_boundaries(tmp_path: Path) -> None:
+    session_id = "019f9000-0000-7000-8000-000000000032"
+    codex_home = tmp_path / ".codex"
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "07"
+        / "24"
+        / f"rollout-2026-07-24T00-00-00-{session_id}.jsonl"
+    )
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [{"id": session_id, "thread_name": "Offset boundaries"}],
+    )
+    _write_jsonl(
+        log_path,
+        [
+            _entry("session_meta", {"id": session_id}),
+            _entry("turn_context", {"turn_id": "near-start", "model": "gpt-5.5"}),
+            _token_event(100, 100),
+            *[
+                _entry(
+                    "response_item",
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": f"filler-{index}"}],
+                    },
+                )
+                for index in range(12)
+            ],
+            _entry("turn_context", {"turn_id": "near-end", "model": "gpt-5.5"}),
+            _token_event(300, 200),
+        ],
+    )
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    rows = {
+        str(row["turn_id"]): row
+        for row in query_session_usage(db_path=db_path, session_id=session_id)
+    }
+
+    assert rows["near-start"]["line_number"] == 3
+    assert rows["near-end"]["line_number"] == 17
+    for turn_id in ("near-start", "near-end"):
+        row = rows[turn_id]
+        offset_payload = load_call_context(
+            str(row["record_id"]),
+            db_path=db_path,
+            max_chars=0,
+            max_entries=0,
+            diagnostics=True,
+        )
+        with connect(db_path) as conn:
+            conn.execute(
+                "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+                (row["record_id"],),
+            )
+        sequential_payload = load_call_context(
+            str(row["record_id"]),
+            db_path=db_path,
+            max_chars=0,
+            max_entries=0,
+            diagnostics=True,
+        )
+
+        assert offset_payload["diagnostics"]["context_read_strategy"] == "offset_seek"
+        assert _without_diagnostics(offset_payload) == _without_diagnostics(sequential_payload)

--- a/tests/context/test_byte_offset_safety.py
+++ b/tests/context/test_byte_offset_safety.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import codex_usage_tracker.context.api as context_api
+from codex_usage_tracker.context.api import load_call_context
+from codex_usage_tracker.store.api import query_session_usage, refresh_usage_index
+from codex_usage_tracker.store.connection import connect
+from tests.store_dashboard_helpers import (
+    SESSION_ID,
+    _entry,
+    _make_codex_home,
+    _token_event,
+    _write_jsonl,
+)
+
+
+def _without_diagnostics(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(payload)
+    normalized.pop("diagnostics", None)
+    return normalized
+
+
+def _write_context_source(
+    tmp_path: Path,
+    *,
+    session_id: str,
+    rows: list[dict[str, object] | str],
+) -> tuple[Path, Path]:
+    codex_home = tmp_path / ".codex"
+    log_path = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "07"
+        / "24"
+        / f"rollout-2026-07-24T00-00-00-{session_id}.jsonl"
+    )
+    _write_jsonl(
+        codex_home / "session_index.jsonl",
+        [{"id": session_id, "thread_name": "Offset safety"}],
+    )
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(row if isinstance(row, str) else json.dumps(row))
+            handle.write("\n")
+    return codex_home, log_path
+
+
+def test_valid_token_line_for_later_call_cannot_satisfy_requested_record(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    rows = query_session_usage(db_path=db_path, session_id=SESSION_ID)
+    first, later = rows[0], rows[1]
+    expected = load_call_context(
+        str(first["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = ? WHERE record_id = ?",
+            (later["source_byte_offset"], first["record_id"]),
+        )
+
+    actual = load_call_context(
+        str(first["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert actual["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert actual["diagnostics"]["context_read_reason"] == "target_mismatch"
+    assert _without_diagnostics(actual) == _without_diagnostics(expected)
+
+
+def test_replacement_between_validation_and_open_forces_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_path = Path(str(row["source_file"]))
+    original_reader = context_api._read_context_for_usage_record
+    replaced = False
+
+    def replace_then_read(**kwargs: Any) -> Any:
+        nonlocal replaced
+        if not replaced:
+            replacement = source_path.with_suffix(".replacement")
+            replacement.write_bytes(source_path.read_bytes())
+            os.replace(replacement, source_path)
+            replaced = True
+        return original_reader(**kwargs)
+
+    monkeypatch.setattr(
+        context_api,
+        "_read_context_for_usage_record",
+        replace_then_read,
+    )
+
+    payload = load_call_context(
+        str(row["record_id"]),
+        db_path=db_path,
+        diagnostics=True,
+    )
+
+    assert payload["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert payload["diagnostics"]["context_read_reason"] == "stale_provenance"
+
+
+def test_offset_falls_back_when_pre_turn_carry_anchor_is_outside_window(
+    tmp_path: Path,
+) -> None:
+    session_id = "019f9000-0000-7000-8000-000000000033"
+    codex_home, _log_path = _write_context_source(
+        tmp_path,
+        session_id=session_id,
+        rows=[
+            _entry("session_meta", {"id": session_id}),
+            _entry("turn_context", {"turn_id": "before", "model": "gpt-5.5"}),
+            _token_event(100, 100),
+            _entry(
+                "compacted",
+                {
+                    "message": "",
+                    "replacement_history": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "Carry this summary"}],
+                        }
+                    ],
+                },
+            ),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "x" * 150_000}],
+                },
+            ),
+            _entry("turn_context", {"turn_id": "selected", "model": "gpt-5.5"}),
+            _token_event(300, 200),
+        ],
+    )
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    target = next(
+        row
+        for row in query_session_usage(db_path=db_path, session_id=session_id)
+        if row["turn_id"] == "selected"
+    )
+
+    payload = load_call_context(
+        str(target["record_id"]),
+        db_path=db_path,
+        include_compaction_history=True,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert payload["diagnostics"]["context_read_strategy"] == "sequential_fallback"
+    assert payload["diagnostics"]["context_read_reason"] == "context_anchor_outside_window"
+    assert any(entry["label"] == "Compaction detected" for entry in payload["entries"])
+
+
+def test_malformed_diagnostics_are_scoped_to_bounded_context_anchor(
+    tmp_path: Path,
+) -> None:
+    session_id = "019f9000-0000-7000-8000-000000000034"
+    codex_home, _log_path = _write_context_source(
+        tmp_path,
+        session_id=session_id,
+        rows=[
+            _entry("session_meta", {"id": session_id}),
+            "{malformed history",
+            _entry("turn_context", {"turn_id": "old", "model": "gpt-5.5"}),
+            _token_event(100, 100),
+            _entry(
+                "response_item",
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "x" * 150_000}],
+                },
+            ),
+            _entry("turn_context", {"turn_id": "anchor", "model": "gpt-5.5"}),
+            _token_event(200, 100),
+            _entry("turn_context", {"turn_id": "selected", "model": "gpt-5.5"}),
+            _token_event(400, 200),
+        ],
+    )
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    target = next(
+        row
+        for row in query_session_usage(db_path=db_path, session_id=session_id)
+        if row["turn_id"] == "selected"
+    )
+
+    offset_payload = load_call_context(
+        str(target["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE usage_events SET source_byte_offset = NULL WHERE record_id = ?",
+            (target["record_id"],),
+        )
+    sequential_payload = load_call_context(
+        str(target["record_id"]),
+        db_path=db_path,
+        max_chars=0,
+        max_entries=0,
+        diagnostics=True,
+    )
+
+    assert offset_payload["diagnostics"]["context_read_strategy"] == "offset_seek"
+    assert offset_payload["omitted"]["parse_errors"] == 0
+    assert _without_diagnostics(offset_payload) == _without_diagnostics(sequential_payload)

--- a/tests/store/test_context_offsets.py
+++ b/tests/store/test_context_offsets.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.parser.jsonl_v1 import parse_codex_jsonl_v1
+from codex_usage_tracker.store.api import query_session_usage, refresh_usage_index
+from codex_usage_tracker.store.context_offsets import resolve_context_offset
+from tests.store_dashboard_helpers import (
+    SESSION_ID,
+    _entry,
+    _make_codex_home,
+    _token_event,
+)
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r\n"])
+@pytest.mark.parametrize("cwd", ["/tmp/ascii", "/tmp/Résumé-雪"])
+def test_parser_records_exact_utf8_byte_offset(
+    tmp_path: Path,
+    newline: bytes,
+    cwd: str,
+) -> None:
+    session_id = "019f9000-0000-7000-8000-000000000001"
+    log_path = tmp_path / "rollout" / f"rollout-2026-07-24T00-00-00-{session_id}.jsonl"
+    lines = [
+        _entry("session_meta", {"id": session_id}),
+        _entry(
+            "turn_context",
+            {"turn_id": "turn-utf8", "model": "gpt-5.5", "cwd": cwd},
+        ),
+        _token_event(100, 100),
+    ]
+    encoded_lines = [
+        json.dumps(line, ensure_ascii=False, separators=(",", ":")).encode("utf-8") + newline
+        for line in lines
+    ]
+    log_path.parent.mkdir(parents=True)
+    log_path.write_bytes(b"".join(encoded_lines))
+
+    parsed = parse_codex_jsonl_v1(log_path)
+
+    assert len(parsed.events) == 1
+    assert parsed.events[0].source_byte_offset == sum(len(line) for line in encoded_lines[:2])
+
+
+def test_append_only_refresh_preserves_existing_offsets_and_adds_new_offset(
+    tmp_path: Path,
+) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    before = query_session_usage(db_path=db_path, session_id=SESSION_ID)
+    offsets_before = {str(row["record_id"]): int(row["source_byte_offset"]) for row in before}
+    source_path = Path(str(before[0]["source_file"]))
+
+    with source_path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(
+            json.dumps(
+                _entry(
+                    "turn_context",
+                    {"turn_id": "turn-appended", "model": "gpt-5.5", "effort": "high"},
+                ),
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+        handle.write(json.dumps(_token_event(500, 200), separators=(",", ":")) + "\n")
+
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    after = query_session_usage(db_path=db_path, session_id=SESSION_ID)
+    offsets_after = {str(row["record_id"]): int(row["source_byte_offset"]) for row in after}
+
+    assert offsets_after.items() >= offsets_before.items()
+    assert len(offsets_after) == len(offsets_before) + 1
+
+
+def test_context_offset_requires_current_source_provenance(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_path = Path(str(row["source_file"]))
+
+    current = resolve_context_offset(
+        db_path=db_path,
+        record_id=str(row["record_id"]),
+        source_file=source_path,
+    )
+    assert current.strategy == "offset_seek"
+    assert current.reason == "validated"
+    assert current.byte_offset == row["source_byte_offset"]
+
+    clone_path = tmp_path / "cloned.jsonl"
+    clone_path.write_bytes(source_path.read_bytes())
+    cloned = resolve_context_offset(
+        db_path=db_path,
+        record_id=str(row["record_id"]),
+        source_file=clone_path,
+    )
+    assert cloned.strategy == "sequential_fallback"
+    assert cloned.reason == "source_path_mismatch"
+
+    with source_path.open("ab") as handle:
+        handle.write(b'{"type":"synthetic-rewrite"}\n')
+    stale = resolve_context_offset(
+        db_path=db_path,
+        record_id=str(row["record_id"]),
+        source_file=source_path,
+    )
+    assert stale.strategy == "sequential_fallback"
+    assert stale.reason == "stale_provenance"
+
+
+def test_context_offset_rejects_rewritten_source(tmp_path: Path) -> None:
+    codex_home = _make_codex_home(tmp_path)
+    db_path = tmp_path / "usage.sqlite3"
+    refresh_usage_index(codex_home=codex_home, db_path=db_path)
+    row = query_session_usage(db_path=db_path, session_id=SESSION_ID)[0]
+    source_path = Path(str(row["source_file"]))
+    original_stat = source_path.stat()
+    original = source_path.read_bytes()
+    rewritten = original.replace(b"turn-a", b"turn-z", 1)
+    assert len(rewritten) == len(original)
+    source_path.write_bytes(rewritten)
+    os.utime(
+        source_path,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns + 1),
+    )
+
+    resolution = resolve_context_offset(
+        db_path=db_path,
+        record_id=str(row["record_id"]),
+        source_file=source_path,
+    )
+
+    assert resolution.strategy == "sequential_fallback"
+    assert resolution.reason == "stale_provenance"

--- a/tests/store/test_otel_schema.py
+++ b/tests/store/test_otel_schema.py
@@ -11,15 +11,13 @@ def test_schema_migration_creates_otel_sidecar_tables(tmp_path: Path) -> None:
     with connect(tmp_path / "usage.sqlite3") as conn:
         init_db(conn)
         source_columns = {
-            str(row["name"])
-            for row in conn.execute("PRAGMA table_info(otel_completion_sources)")
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(otel_completion_sources)")
         }
         event_columns = {
-            str(row["name"])
-            for row in conn.execute("PRAGMA table_info(otel_completion_events)")
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(otel_completion_events)")
         }
 
-    assert SCHEMA_VERSION == 34
+    assert SCHEMA_VERSION == 35
     assert {
         "source_path",
         "device",

--- a/tests/store/test_store_dashboard_mcp.py
+++ b/tests/store/test_store_dashboard_mcp.py
@@ -83,14 +83,14 @@ def test_refresh_is_idempotent_and_summary_works(tmp_path: Path) -> None:
     assert meta["parsed_source_files"] == "0"
     assert meta["skipped_source_files"] == "3"
     assert meta["parser_adapter"] == "codex-jsonl-v2"
-    assert meta["schema_version"] == "34"
+    assert meta["schema_version"] == "35"
     assert meta["parser_skipped_events"] == "0"
     assert allowance_cycle_count > 0
     assert allowance_source_state_count == 1
     state = schema_state(db_path)
-    assert state["schema_version"] == 34
+    assert state["schema_version"] == 35
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 35))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 36))
     with connect(db_path) as conn:
         init_db(conn)
         source_rows = [
@@ -717,7 +717,7 @@ def test_connect_sets_sqlite_concurrency_pragmas(tmp_path: Path) -> None:
 
     assert busy_timeout == 5000
     assert str(journal_mode).lower() == "wal"
-    assert user_version == 34
+    assert user_version == 35
 
 
 def test_current_schema_reads_succeed_while_writer_is_active(tmp_path: Path) -> None:
@@ -815,8 +815,8 @@ def test_init_db_repairs_version_zero_schema(tmp_path: Path) -> None:
     assert "used_percent" in allowance_columns
     assert "window_kind" in allowance_columns
     assert "idx_allowance_observations_window_time" in allowance_indexes
-    assert user_version == 34
-    assert [row["version"] for row in migrations] == list(range(1, 35))
+    assert user_version == 35
+    assert [row["version"] for row in migrations] == list(range(1, 36))
     assert "idx_usage_source_file_line" in indexes
 
 

--- a/tests/store/test_store_migrations.py
+++ b/tests/store/test_store_migrations.py
@@ -70,9 +70,9 @@ def test_init_db_migrates_legacy_aggregate_table_without_data_loss(tmp_path: Pat
     assert len(str(source_rows[0]["source_record_hash"])) == 64
     assert metadata["parsed_events"] == "legacy"
     assert metadata["parser_invalid_integer"] == "2"
-    assert state["schema_version"] == 34
+    assert state["schema_version"] == 35
     assert state["checksum_matches"] is True
-    assert [row["version"] for row in state["migrations"]] == list(range(1, 35))
+    assert [row["version"] for row in state["migrations"]] == list(range(1, 36))
     with connect(db_path) as conn:
         init_db(conn)
         facts = conn.execute("SELECT COUNT(*) AS count FROM call_diagnostic_facts").fetchone()
@@ -108,7 +108,7 @@ def test_refresh_is_idempotent_after_legacy_migration(tmp_path: Path) -> None:
     assert second_count == 2
     assert legacy_rows[0]["record_id"] == "legacy-record"
     assert new_rows[0]["thread_name"] == "Synthetic migration thread"
-    assert metadata["schema_version"] == "34"
+    assert metadata["schema_version"] == "35"
     assert metadata["parsed_events"] == "0"
     assert metadata["inserted_or_updated_events"] == "0"
     assert metadata["parsed_source_files"] == "0"
@@ -269,8 +269,8 @@ def test_init_db_records_all_schema_migrations_for_new_database(tmp_path: Path) 
             ).fetchall()
         ]
 
-    assert versions == list(range(1, 35))
-    assert user_version == 34
+    assert versions == list(range(1, 36))
+    assert user_version == 35
     assert "idx_usage_source_file_line" in usage_indexes
     assert {
         "idx_recommendation_facts_rank_active",
@@ -480,7 +480,7 @@ def test_init_db_upgrades_v25_database_without_changing_physical_rows(tmp_path: 
         conn.execute("DROP INDEX idx_allowance_observations_active_newest")
         conn.execute("DROP INDEX idx_allowance_observations_active_window_newest")
         conn.execute(
-            "DELETE FROM schema_migrations WHERE version IN (26, 27, 28, 29, 30, 31, 32, 33, 34)"
+            "DELETE FROM schema_migrations WHERE version IN (26, 27, 28, 29, 30, 31, 32, 33, 34, 35)"
         )
         conn.execute("PRAGMA user_version = 25")
         versions_before = [
@@ -507,7 +507,7 @@ def test_init_db_upgrades_v25_database_without_changing_physical_rows(tmp_path: 
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
 
     assert versions_before == list(range(1, 26))
-    assert user_version == 34
+    assert user_version == 35
     assert {
         "allowance_source_state",
         "allowance_cycles",
@@ -526,7 +526,7 @@ def test_init_db_upgrades_v27_allowance_indexes_to_v28(tmp_path: Path) -> None:
             """
             DROP INDEX idx_allowance_intervals_evidence_cohort;
             DROP INDEX idx_allowance_intervals_evidence_global;
-            DELETE FROM schema_migrations WHERE version IN (28, 29, 30, 31, 32, 33, 34);
+            DELETE FROM schema_migrations WHERE version IN (28, 29, 30, 31, 32, 33, 34, 35);
             PRAGMA user_version = 27;
             """
         )
@@ -539,8 +539,8 @@ def test_init_db_upgrades_v27_allowance_indexes_to_v28(tmp_path: Path) -> None:
         ]
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
 
-    assert user_version == 34
-    assert versions == list(range(1, 35))
+    assert user_version == 35
+    assert versions == list(range(1, 36))
     assert {
         "idx_allowance_intervals_evidence_cohort",
         "idx_allowance_intervals_evidence_global",
@@ -554,7 +554,7 @@ def test_init_db_upgrades_v28_with_allowance_plan_provenance(tmp_path: Path) -> 
         conn.executescript(
             """
             ALTER TABLE allowance_cycles DROP COLUMN plan_type;
-            DELETE FROM schema_migrations WHERE version IN (29, 30, 31, 32, 33, 34);
+            DELETE FROM schema_migrations WHERE version IN (29, 30, 31, 32, 33, 34, 35);
             PRAGMA user_version = 28;
             """
         )
@@ -568,8 +568,8 @@ def test_init_db_upgrades_v28_with_allowance_plan_provenance(tmp_path: Path) -> 
         ]
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
 
-    assert user_version == 34
-    assert versions == list(range(1, 35))
+    assert user_version == 35
+    assert versions == list(range(1, 36))
     assert "plan_type" in columns
 
 
@@ -578,7 +578,7 @@ def test_init_db_upgrades_v31_with_all_history_allowance_index(tmp_path: Path) -
     with connect(db_path) as conn:
         init_db(conn)
         conn.execute("DROP INDEX idx_allowance_observations_all_newest")
-        conn.execute("DELETE FROM schema_migrations WHERE version IN (32, 33, 34)")
+        conn.execute("DELETE FROM schema_migrations WHERE version IN (32, 33, 34, 35)")
         conn.execute("PRAGMA user_version = 31")
 
     with connect(db_path) as conn:
@@ -589,7 +589,7 @@ def test_init_db_upgrades_v31_with_all_history_allowance_index(tmp_path: Path) -
         }
         user_version = conn.execute("PRAGMA user_version").fetchone()[0]
 
-    assert user_version == 34
+    assert user_version == 35
     assert "idx_allowance_observations_all_newest" in indexes
 
 
@@ -620,7 +620,7 @@ def test_init_db_upgrades_v33_with_focused_call_indexes_without_data_loss(
     with connect(db_path) as conn:
         for index_name in expected_indexes:
             conn.execute(f"DROP INDEX IF EXISTS {index_name}")
-        conn.execute("DELETE FROM schema_migrations WHERE version = 34")
+        conn.execute("DELETE FROM schema_migrations WHERE version IN (34, 35)")
         conn.execute("PRAGMA user_version = 33")
 
     for _attempt in range(2):
@@ -633,13 +633,40 @@ def test_init_db_upgrades_v33_with_focused_call_indexes_without_data_loss(
                 ).fetchall()
             }
             assert expected_indexes <= actual_indexes
-            assert conn.execute("PRAGMA user_version").fetchone()[0] == 34
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 35
             assert (
                 conn.execute(
                     "SELECT COUNT(*) FROM usage_events WHERE record_id = 'migration-34-sentinel'"
                 ).fetchone()[0]
                 == 1
             )
+
+
+def test_init_db_upgrades_v34_with_nullable_source_byte_offsets(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    upsert_usage_events(
+        [_event("migration-35-sentinel", "/synthetic/migration-35.jsonl")],
+        db_path=db_path,
+    )
+    with connect(db_path) as conn:
+        conn.execute("ALTER TABLE usage_events DROP COLUMN source_byte_offset")
+        conn.execute("DELETE FROM schema_migrations WHERE version = 35")
+        conn.execute("PRAGMA user_version = 34")
+
+    with connect(db_path) as conn:
+        init_db(conn)
+        columns = {str(row["name"]) for row in conn.execute("PRAGMA table_info(usage_events)")}
+        stored_offset = conn.execute(
+            "SELECT source_byte_offset FROM usage_events WHERE record_id = ?",
+            ("migration-35-sentinel",),
+        ).fetchone()[0]
+        user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+
+    assert user_version == 35
+    assert "source_byte_offset" in columns
+    assert stored_offset is None
 
 
 def test_init_db_does_not_rerun_applied_migrations(


### PR DESCRIPTION
## Summary

- persist nullable UTF-8 JSONL byte offsets in schema v35 and record them during binary parsing
- validate source provenance, the opened descriptor, and exact token-event identity before bounded seeks
- preserve sequential fallback, compaction/diagnostic carry state, parse-error semantics, and quick/full payload equivalence
- add synthetic 100,000-line performance ratchets and migration/provenance/safety coverage

## Verification

- focused Task 32 suite: 60 passed
- full suite: 1998 passed
- coverage: 1998 passed, 88%
- ratchet: 1.4493% bytes inspected, 31.189x median speedup, payloads equivalent
- Ruff, MyPy, targeted Pyright, Tach, Deptry, Vulture, compileall, release checks, build/Twine, and installed-wheel smoke passed
- single final reviewer: 4 findings, 4 accepted and fixed; token attribution pending after one usage-index timeout

## Known repository-wide gate noise

Agent Maintainer still reports inherited repository-wide formatting, Pyright, Xenon, and file-length findings. Changed production files satisfy their ratchets; the roadmap-required legacy migration inventory remains above the generic file limit.