### PR TITLE
ci: pin workflow actions immutably

### DIFF
--- a/.agent-maintainer/change-plans/immutable-action-pins.md
+++ b/.agent-maintainer/change-plans/immutable-action-pins.md
@@ -1,0 +1,79 @@
++++
+id = "immutable-action-pins"
+kind = "cohesive-release-hardening"
+status = "complete"
+base_ref = "origin/main"
+expires = 2026-08-08
+allowed_paths = [
+  ".agent-maintainer/change-plans/immutable-action-pins.md",
+  ".github/dependabot.yml",
+  ".github/workflows/allowance-statistical-calibration.yml",
+  ".github/workflows/ci.yml",
+  ".github/workflows/pricing-compat.yml",
+  ".github/workflows/publish.yml",
+  "docs/development.md",
+  "docs/install.md",
+  "docs/one-dot-oh-readiness.md",
+  "docs/release-checklist.md",
+  "docs/roadmap/mcp-first-pivot-execution.md",
+  "scripts/check_release.py",
+  "scripts/release_quality.py",
+  "scripts/smoke_installed_package.py",
+  "tests/ci/test_immutable_action_pins.py",
+  "tests/cli/test_cli_release.py",
+  "tests/quality/test_release_quality_gates.py",
+]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 20
+max_changed_lines = 1000
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+
+# Cohesive Change Plan: immutable-action-pins
+
+## Why this change intentionally large
+
+Task 35 makes workflow supply-chain integrity one release-wide contract.
+Four workflows, Dependabot policy, the installed-package Docker smoke, the
+offline release checker, tests, and operator documentation must agree on the
+same reviewed immutable revisions. Splitting those surfaces would leave a
+window where mutable references or mismatched release comments can pass.
+
+## Why this should not be split smaller
+
+The workflow edits and offline validator are one fail-closed migration. Landing
+either side alone would make release readiness disagree with the executable
+workflows. The documentation, Dependabot policy, and tests describe and prove
+that same tuple contract rather than adding independent product behavior.
+
+## What allowed to change
+
+- Third-party action references and reviewed release comments.
+- The installed-package Docker smoke default digest.
+- Offline release validation, focused tests, and release operator guidance.
+
+## What must not change
+
+- Runtime package, dashboard, MCP, CLI, privacy, schema, or data behavior.
+- Trusted Publishing environments, permissions, package identity, or secrets.
+- Release artifact construction or promotion topology owned by Task 36.
+
+## Verification plan
+
+- Focused immutable-pin, release-quality, and release CLI tests.
+- `actionlint` and offline `zizmor` for every workflow.
+- Source release readiness and installed-package smoke checks.
+- One CI-equivalent Agent Maintainer profile after the diff is stable.
+
+## Rollback plan
+
+Revert the Task 35 commit. No runtime data or public JSON/MCP contract changes
+are involved; rollback restores the prior mutable workflow and Docker tags.
+
+## Follow-up ratchet work
+
+Task 36 will promote one verified artifact bundle through TestPyPI, PyPI, and
+the GitHub Release without rebuilding it.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+    # Before merge, review the upstream release and update the workflow's
+    # trailing release tag plus REVIEWED_ACTION_PINS in scripts/release_quality.py.

--- a/.github/workflows/allowance-statistical-calibration.yml
+++ b/.github/workflows/allowance-statistical-calibration.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
           cache: pip
@@ -51,7 +51,7 @@ jobs:
             --json | tee allowance-statistical-calibration.json
       - name: Upload calibration evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: allowance-statistical-calibration
           path: allowance-statistical-calibration.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     name: Hardening / Dashboard quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -48,10 +48,10 @@ jobs:
     name: Hardening / Dashboard route budget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
           cache: pip
@@ -73,10 +73,10 @@ jobs:
     name: Hardening / Python quality and security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
           cache: pip
@@ -106,25 +106,25 @@ jobs:
     name: Hardening / Repository policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: package-lock.json
-      - uses: actions/setup-go@v6.5.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.25"
       - name: Restore pinned policy tools
         id: policy-tools-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/go/bin/actionlint
@@ -195,10 +195,10 @@ jobs:
     name: Dashboard visualization contracts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
       - name: Install dashboard tooling
@@ -211,7 +211,7 @@ jobs:
         run: npm run dashboard:visualization-smoke
       - name: Upload visualization evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dashboard-visualization-evidence
           path: test-results/**/*.png
@@ -226,18 +226,18 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: matrix.python-version == '3.14'
         with:
           node-version: "22"
@@ -279,13 +279,13 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/pricing-compat.yml
+++ b/.github/workflows/pricing-compat.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
       - name: Install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
       - name: Install build tooling
@@ -74,7 +74,7 @@ jobs:
               print(f"{digest}  {path}")
           PY
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-dist
           path: dist/*
@@ -107,7 +107,7 @@ jobs:
             esac
           fi
       - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist
@@ -158,7 +158,7 @@ jobs:
           PY
       - name: Publish package distributions to TestPyPI
         if: steps.package-version.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           print-hash: true
@@ -190,7 +190,7 @@ jobs:
             esac
           fi
       - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
           path: dist
@@ -241,6 +241,6 @@ jobs:
           PY
       - name: Publish package distributions to PyPI
         if: steps.package-version.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           print-hash: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -402,7 +402,9 @@ python scripts/smoke_installed_package.py
 python scripts/smoke_installed_package.py --docker
 ```
 
-The Docker smoke uses `python:3.14-slim` by default so release prep verifies installed-package behavior on the newest supported runtime.
+The Docker smoke uses a reviewed digest for the `python:3.14-slim` image by
+default so release prep verifies installed-package behavior on the newest
+supported runtime without a mutable image reference.
 
 The release checker verifies version alignment, required public docs, packaged plugin assets, wheel contents, and obvious tracked secret patterns. It does not publish anything.
 
@@ -420,6 +422,16 @@ Do not create or push release tags without maintainer approval.
 ## Publishing
 
 Publishing uses GitHub Actions Trusted Publishing through `.github/workflows/publish.yml`; do not upload from a local machine and do not add PyPI or TestPyPI API tokens.
+
+All third-party workflow actions are pinned to a reviewed 40-character commit
+SHA with the reviewed release tag in a trailing comment. The matching
+SHA/tag catalog is `REVIEWED_ACTION_PINS` in `scripts/release_quality.py`.
+Resolve changes from the action's official GitHub release and commit records;
+never infer or abbreviate the commit. A Dependabot action update is incomplete
+until its workflow comment and the reviewed-pin catalog are updated together.
+Run the immutable-pin tests, `actionlint`, `zizmor`, and
+`python scripts/check_release.py` before merging an action update. The complete
+operator sequence is in [the release checklist](release-checklist.md).
 
 The first public package release, `0.3.0`, was published on June 8, 2026. Patch releases `0.3.1` and `0.3.2` stabilized live-dashboard launch and context loading. Minor releases `0.4.0` through `0.13.1` added Python 3.14 support, localization, SQL-backed dashboard loading, observed usage snapshots, diagnostics, usage-drain reports, maintainability refactors, onboarding hardening, and guided usage-summary diagnostics. Minor release `0.14.0` ships the React dashboard transition with legacy parity fixes, local-only safeguards, and weekly-first usage remaining displays.
 
@@ -457,7 +469,7 @@ gh run view <run-id> --log-failed
 
 Fix the branch or workflow, rerun the workflow, and keep the same version only if the failed run did not upload artifacts to TestPyPI or PyPI. If upload succeeded anywhere, cut the next patch version for follow-up validation.
 
-If Trusted Publishing or environment approval breaks, inspect `.github/workflows/publish.yml` first. The publish jobs should use `permissions: id-token: write`, `pypa/gh-action-pypi-publish@release/v1`, environment `testpypi` for TestPyPI, and environment `pypi` for PyPI. Confirm the Trusted Publisher entries in TestPyPI and PyPI still point to owner `douglasmonsky`, repository `codex-usage-tracker`, workflow `publish.yml`, and the matching environment. Do not work around a Trusted Publishing failure by adding API tokens.
+If Trusted Publishing or environment approval breaks, inspect `.github/workflows/publish.yml` first. The publish jobs should use `permissions: id-token: write`, the reviewed immutable `pypa/gh-action-pypi-publish` pin, environment `testpypi` for TestPyPI, and environment `pypi` for PyPI. Confirm the Trusted Publisher entries in TestPyPI and PyPI still point to owner `douglasmonsky`, repository `codex-usage-tracker`, workflow `publish.yml`, and the matching environment. Do not work around a Trusted Publishing failure by adding API tokens.
 
 If PyPI or TestPyPI appears stale, verify with the JSON API and simple index before assuming the upload failed:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,10 @@ Restart Codex after plugin registration if you want Codex to discover the MCP to
 
 The CLI, SQLite index, dashboard generator, and localhost server are Python-based and are not macOS-only. CI runs the package on Ubuntu with Python 3.10, 3.11, 3.12, 3.13, and 3.14.
 
-The installed-package Docker smoke path uses `python:3.14-slim` by default, which exercises the built wheel, package data, CLI entry point, and plugin installer on the newest supported runtime.
+The installed-package Docker smoke path uses a reviewed digest for
+`python:3.14-slim` by default, which exercises the built wheel, package data,
+CLI entry point, and plugin installer on the newest supported runtime without
+a mutable image reference.
 
 By default the tracker looks for Codex JSONL logs under `~/.codex`, stores its own database/config under `~/.codex-usage-tracker`, and writes the local plugin wrapper under `~/plugins/codex-usage-tracker`. Override paths with `--codex-home`, `--db`, `--plugin-dir`, or `--marketplace` if your platform or Codex installation uses a different layout.
 

--- a/docs/one-dot-oh-readiness.md
+++ b/docs/one-dot-oh-readiness.md
@@ -31,7 +31,10 @@ Not guaranteed:
 - [x] Verify installed package resources in Linux Docker: `python scripts/smoke_installed_package.py --docker`.
 - [x] Verify public PyPI package in Docker: `python scripts/smoke_installed_package.py --docker --from-pypi --version 0.21.0`.
 - [x] Verify PyPI metadata names remain unchanged: `python scripts/check_release.py`.
-- [x] Add Python 3.14 as an official support target after CI, package classifiers, docs, and installed-package smoke coverage were added. Docker smoke coverage uses `python:3.14-slim` by default. Track this in issue #12.
+- [x] Add Python 3.14 as an official support target after CI, package
+  classifiers, docs, and installed-package smoke coverage were added. Docker
+  smoke coverage uses a reviewed `python:3.14-slim` digest by default. Track
+  this in issue #12.
 
 ## 2. Upgrade And Migration
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,37 @@
+# Release checklist
+
+Use this checklist for release preparation and for every GitHub Actions
+dependency update.
+
+## Review workflow dependencies
+
+1. Read the release notes in the action's official GitHub repository.
+2. Resolve the release tag to its full 40-character commit SHA from the
+   official commit or tag record.
+3. Update the workflow reference and trailing reviewed tag together:
+
+   ```yaml
+   uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1.2.3
+   ```
+
+4. Update the same `(action, tag) -> SHA` tuple in
+   `REVIEWED_ACTION_PINS` in `scripts/release_quality.py`.
+5. Review major-version changes for runtime, input, permission, and
+   Node-version changes. Do not merge a Dependabot SHA-only update.
+
+Local actions under `./` remain relative. Docker actions must use a
+`sha256` digest rather than a mutable image tag.
+
+## Verify
+
+```bash
+python -m pytest tests/ci/test_immutable_action_pins.py tests/quality -q
+actionlint .github/workflows/*.yml
+zizmor --offline --no-progress .github/workflows
+python scripts/check_release.py
+git diff --check
+```
+
+Before publishing, also complete the build, distribution, installed-package,
+TestPyPI, PyPI, and GitHub Release checks documented in
+[Development](development.md#publishing).

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -1210,9 +1210,9 @@ commit as each roadmap task.
 
 ## Remaining Planned Tasks
 
-Tasks 27.5 through 33 are merged. Task 34 is complete locally on
-`pivot/34-blocking-quality-gates` and awaiting its final review and PR; Tasks 35
-through 45 remain planned in the approved implementation roadmap. Add a full
+Tasks 27.5 through 34 are merged. Task 35 is active on
+`pivot/35-immutable-action-pins`; Tasks 36 through 45 remain planned in the
+approved implementation roadmap. Add a full
 entry using the format above when each task becomes active; do not mark a task
 complete without its named focused and full verification evidence.
 
@@ -1292,8 +1292,7 @@ complete without its named focused and full verification evidence.
 
 ## Task 34 - Make Quality and Work-Proof Gates Directly Blocking
 
-- Status: complete locally on `pivot/34-blocking-quality-gates`; final review
-  and reviewed PR remain.
+- Status: merged through PR #301 as `0a4818e`.
 - Blocking coverage:
   - aggregate branch coverage now fails below 85% in both Coverage.py and Agent
     Maintainer configuration;
@@ -1356,3 +1355,49 @@ complete without its named focused and full verification evidence.
   - auxiliary schemas with intentionally flexible payloads are inventoried with
     empty required-field maps; future stabilization may tighten those shapes
     without changing their IDs when the change is additive.
+
+## Task 35 - Pin Workflow and Release Dependencies Immutably
+
+- Status: complete locally on `pivot/35-immutable-action-pins`; final review
+  complete and reviewed PR remains.
+- Immutable workflow contract:
+  - every third-party workflow action uses an official 40-character commit
+    SHA and a trailing reviewed release-tag comment;
+  - `REVIEWED_ACTION_PINS` validates the action, tag, and SHA as one offline
+    tuple, so mutable, abbreviated, missing-comment, and mismatched-comment
+    references fail release readiness;
+  - local actions remain relative, while Docker action references require a
+    `sha256` digest.
+- Reviewed dependency sources:
+  - action tags and commits were resolved from the official GitHub release and
+    commit APIs;
+  - the installed-package `python:3.14-slim` smoke image is pinned to the
+    reviewed multi-platform manifest digest.
+- Dependabot and operator policy:
+  - Dependabot action PRs carry CI/dependency metadata and require a human to
+    update the release comment and reviewed-pin catalog together;
+  - development and release-checklist docs record the review and verification
+    sequence for action updates.
+- Focused verification:
+  - CI policy, immutable-pin, release-quality, release CLI, and packaging slice:
+    `74 passed`;
+  - `actionlint`, offline `zizmor`, Ruff, source release readiness, and
+    `git diff --check` pass.
+- Broad verification:
+  - CI-equivalent Agent Maintainer run
+    `20260724T090631521509Z-ci-313859a133e4` completed the full suite and
+    surfaced inherited repository-wide file-length, formatting, type,
+    complexity, and boundary debt;
+  - its only task-local failure was the cohesive change-plan template, which
+    was repaired and passes the direct staged plan check.
+- Final review:
+  - the single read-only reviewer reported two medium false-green findings and
+    both were accepted;
+  - noncanonical-but-valid YAML `uses` keys are now rejected and covered;
+  - Docker smoke validation parses the actual `DEFAULT_DOCKER_IMAGE`
+    assignment, so a decoy digest cannot satisfy the gate;
+  - reviewer token attribution remains `pending` after the permitted aggregate
+    metrics helper timed out; no retry was attempted.
+- Follow-up:
+  - Task 36 owns build-once artifact promotion and will reuse these immutable
+    workflow boundaries.

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -24,6 +24,7 @@ if str(SCRIPT_ROOT) not in sys.path:
 from release_quality import (  # noqa: E402
     check_ci_workflow,
     check_compatibility_inventory,
+    check_immutable_action_pins,
     check_publish_workflow,
     check_python_support_metadata,
     check_react_dashboard_privacy_artifacts,
@@ -42,8 +43,7 @@ CONSOLE_SCRIPT = "codex-usage-tracker"
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 SUPPORTED_SETUP_NODE_ACTIONS = (
-    "actions/setup-node@v6.4.0",
-    "actions/setup-node@v7.0.0",
+    "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
 )
 OLD_PYPI_DISTRIBUTION_NAME = "codex-usage-tracker"
 DASHBOARD_LOCALE_CODES = [
@@ -152,6 +152,7 @@ REQUIRED_FILES = [
     "MANIFEST.in",
     "AGENTS.md",
     "docs/architecture.md",
+    "docs/release-checklist.md",
     "docs/dashboard-guide.md",
     "docs/cli-json-schemas.md",
     "docs/one-dot-oh-readiness.md",
@@ -633,6 +634,7 @@ def _check_packaging_metadata() -> list[str]:
             "MCP runtime launcher should invalidate cached runtimes when package spec changes"
         )
     failures.extend(_check_python_support_metadata(project))
+    failures.extend(check_immutable_action_pins(REPO_ROOT))
     failures.extend(_check_ci_workflow())
     failures.extend(_check_publish_workflow())
     return failures

--- a/scripts/release_quality.py
+++ b/scripts/release_quality.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import subprocess
@@ -13,6 +14,110 @@ try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10.
     import tomli as tomllib
+
+REVIEWED_ACTION_PINS = {
+    ("actions/cache", "v6.1.0"): "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+    ("actions/checkout", "v7.0.1"): "3d3c42e5aac5ba805825da76410c181273ba90b1",
+    ("actions/download-artifact", "v8.0.1"): ("3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"),
+    ("actions/setup-go", "v6.5.0"): "924ae3a1cded613372ab5595356fb5720e22ba16",
+    ("actions/setup-node", "v7.0.0"): "820762786026740c76f36085b0efc47a31fe5020",
+    ("actions/setup-python", "v6.3.0"): ("ece7cb06caefa5fff74198d8649806c4678c61a1"),
+    ("actions/upload-artifact", "v7.0.1"): ("043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"),
+    ("pypa/gh-action-pypi-publish", "v1.14.1"): ("ba38be9e461d3875417946c167d0b5f3d385a247"),
+}
+REVIEWED_PYTHON_SMOKE_IMAGE = (
+    "python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6"
+)
+_USES_KEY_PATTERN = re.compile(r"""^\s*(?:-\s*)?(?:"uses"|'uses'|uses)\s*:""")
+_USES_LINE_PATTERN = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<reference>\S+)"
+    r"(?:\s+#\s*(?P<release_tag>\S+))?\s*$"
+)
+_FULL_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_DOCKER_DIGEST_PATTERN = re.compile(r"^docker://[^@\s]+@sha256:[0-9a-f]{64}$")
+
+
+def check_immutable_action_pins(repo_root: Path) -> list[str]:
+    """Reject mutable or unreviewed third-party workflow action references."""
+    workflow_dir = repo_root / ".github" / "workflows"
+    workflow_paths = sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
+    failures: list[str] = []
+    for workflow_path in workflow_paths:
+        relative_path = workflow_path.relative_to(repo_root)
+        for line_number, line in enumerate(
+            workflow_path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if _USES_KEY_PATTERN.match(line) is None:
+                continue
+            match = _USES_LINE_PATTERN.match(line)
+            location = f"{relative_path}:{line_number}"
+            if match is None:
+                failures.append(f"{location} has an unsupported uses reference")
+                continue
+            reference = match.group("reference")
+            release_tag = match.group("release_tag")
+            if reference.startswith("./"):
+                continue
+            if reference.startswith("docker://"):
+                if _DOCKER_DIGEST_PATTERN.fullmatch(reference) is None:
+                    failures.append(f"{location} Docker action must use an immutable sha256 digest")
+                continue
+            if "@" not in reference:
+                failures.append(
+                    f"{location} third-party action must use a full 40-character commit SHA"
+                )
+                continue
+            action, revision = reference.rsplit("@", 1)
+            if _FULL_COMMIT_PATTERN.fullmatch(revision) is None:
+                failures.append(
+                    f"{location} third-party action must use a full 40-character commit SHA"
+                )
+                continue
+            if release_tag is None:
+                failures.append(
+                    f"{location} third-party action is missing a reviewed release comment"
+                )
+                continue
+            expected_revision = REVIEWED_ACTION_PINS.get((action, release_tag))
+            if expected_revision != revision:
+                failures.append(
+                    f"{location} does not match a reviewed action pin: "
+                    f"{action}@{revision} # {release_tag}"
+                )
+    return failures
+
+
+def check_installed_smoke_docker_image(repo_root: Path) -> list[str]:
+    """Require the smoke script's actual default assignment to use the reviewed digest."""
+    smoke_path = repo_root / "scripts" / "smoke_installed_package.py"
+    if not smoke_path.exists():
+        return ["missing installed-package smoke script"]
+    try:
+        module = ast.parse(smoke_path.read_text(encoding="utf-8"), filename=str(smoke_path))
+    except SyntaxError:
+        return ["installed-package smoke script is not valid Python"]
+    default_image: str | None = None
+    for statement in module.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+        if not any(
+            isinstance(target, ast.Name) and target.id == "DEFAULT_DOCKER_IMAGE"
+            for target in targets
+        ):
+            continue
+        try:
+            value = ast.literal_eval(statement.value)
+        except (ValueError, TypeError):
+            value = None
+        default_image = value if isinstance(value, str) else None
+        break
+    if default_image != REVIEWED_PYTHON_SMOKE_IMAGE:
+        return [
+            "installed-package Docker smoke default should use the reviewed python:3.14-slim digest"
+        ]
+    return []
 
 
 def check_python_support_metadata(
@@ -42,11 +147,7 @@ def check_python_support_metadata(
     if "Python 3.10, 3.11, 3.12, 3.13, and 3.14" not in install_doc:
         failures.append("docs/install.md should document CI support through Python 3.14")
 
-    smoke_script = (repo_root / "scripts" / "smoke_installed_package.py").read_text(
-        encoding="utf-8"
-    )
-    if 'DEFAULT_DOCKER_IMAGE = "python:3.14-slim"' not in smoke_script:
-        failures.append("installed-package Docker smoke default should use python:3.14-slim")
+    failures.extend(check_installed_smoke_docker_image(repo_root))
     return failures
 
 
@@ -59,7 +160,7 @@ def check_publish_workflow(repo_root: Path) -> list[str]:
     for required in [
         "workflow_dispatch:",
         "release:",
-        "pypa/gh-action-pypi-publish@release/v1",
+        "pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1",
         "id-token: write",
         "repository-url: https://test.pypi.org/legacy/",
         "python -m twine check dist/*",

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -40,7 +40,9 @@ DISTRIBUTION_NAME = "codex-usage-tracking"
 WHEEL_STEM = "codex_usage_tracking"
 IMPORT_PACKAGE = "codex_usage_tracker"
 CONSOLE_SCRIPT = "codex-usage-tracker"
-DEFAULT_DOCKER_IMAGE = "python:3.14-slim"
+DEFAULT_DOCKER_IMAGE = (
+    "python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6"
+)
 REACT_ASSET_PATTERN = re.compile(
     r"""(?:src|href)=["'](?P<path>/codex-usage-tracker-assets/react/[^"']+)["']"""
 )

--- a/tests/ci/test_immutable_action_pins.py
+++ b/tests/ci/test_immutable_action_pins.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.release_quality import (
+    REVIEWED_PYTHON_SMOKE_IMAGE,
+    check_immutable_action_pins,
+    check_installed_smoke_docker_image,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKOUT_SHA = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+
+def _write_workflow(tmp_path: Path, uses_line: str) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        f"""name: CI
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - {uses_line}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_accepts_reviewed_full_sha_and_local_action(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        f"uses: actions/checkout@{CHECKOUT_SHA} # v7.0.1\n"
+        "      - uses: ./github/actions/local-check",
+    )
+
+    assert check_immutable_action_pins(tmp_path) == []
+
+
+def test_repository_workflows_are_immutably_pinned() -> None:
+    assert check_immutable_action_pins(ROOT) == []
+
+
+@pytest.mark.parametrize(
+    "uses_line",
+    [
+        f'"uses": actions/checkout@{CHECKOUT_SHA} # v7.0.1',
+        f"uses : actions/checkout@{CHECKOUT_SHA} # v7.0.1",
+    ],
+    ids=["quoted-key", "space-before-colon"],
+)
+def test_rejects_noncanonical_uses_keys(tmp_path: Path, uses_line: str) -> None:
+    _write_workflow(tmp_path, uses_line)
+
+    failures = check_immutable_action_pins(tmp_path)
+
+    assert any("unsupported uses reference" in failure for failure in failures)
+
+
+@pytest.mark.parametrize(
+    ("reference", "expected"),
+    [
+        ("actions/checkout@v7 # v7.0.1", "full 40-character commit SHA"),
+        ("actions/checkout@main # v7.0.1", "full 40-character commit SHA"),
+        ("actions/checkout@3d3c42e # v7.0.1", "full 40-character commit SHA"),
+        (f"actions/checkout@{CHECKOUT_SHA}", "reviewed release comment"),
+        (f"actions/checkout@{CHECKOUT_SHA} # v7.0.0", "reviewed action pin"),
+    ],
+    ids=["tag", "branch", "abbreviated-sha", "missing-comment", "mismatched-comment"],
+)
+def test_rejects_mutable_or_unreviewed_action_reference(
+    tmp_path: Path,
+    reference: str,
+    expected: str,
+) -> None:
+    _write_workflow(tmp_path, f"uses: {reference}")
+
+    failures = check_immutable_action_pins(tmp_path)
+
+    assert any(expected in failure for failure in failures)
+
+
+@pytest.mark.parametrize(
+    ("reference", "expected_failures"),
+    [
+        ("docker://python:3.14-slim", 1),
+        ("docker://python@sha256:" + "a" * 64, 0),
+    ],
+    ids=["mutable-docker-tag", "immutable-docker-digest"],
+)
+def test_requires_immutable_docker_action_references(
+    tmp_path: Path,
+    reference: str,
+    expected_failures: int,
+) -> None:
+    _write_workflow(tmp_path, f"uses: {reference}")
+
+    assert len(check_immutable_action_pins(tmp_path)) == expected_failures
+
+
+@pytest.mark.parametrize(
+    ("default_image", "expected_failures"),
+    [
+        (REVIEWED_PYTHON_SMOKE_IMAGE, 0),
+        ("python:3.14-slim", 1),
+    ],
+    ids=["reviewed-digest", "mutable-default-with-decoy"],
+)
+def test_validates_actual_smoke_default_assignment(
+    tmp_path: Path,
+    default_image: str,
+    expected_failures: int,
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "smoke_installed_package.py").write_text(
+        f'# Decoy: {REVIEWED_PYTHON_SMOKE_IMAGE}\nDEFAULT_DOCKER_IMAGE = "{default_image}"\n',
+        encoding="utf-8",
+    )
+
+    assert len(check_installed_smoke_docker_image(tmp_path)) == expected_failures

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -286,7 +286,10 @@ def test_release_pipeline_rebuilds_dashboard_assets_and_smokes_installed_wheel()
     workflow = (repo_root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     package_job = workflow.split("\n  package:\n", maxsplit=1)[1]
     required_in_order = [
-        ("actions/setup-node@v6.4.0", "actions/setup-node@v7.0.0"),
+        (
+            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 "
+            "# v7.0.0",
+        ),
         ('node-version: "22"',),
         ("run: npm ci",),
         ("run: npm run dashboard:assets:check",),

--- a/tests/quality/test_release_quality_gates.py
+++ b/tests/quality/test_release_quality_gates.py
@@ -13,6 +13,9 @@ _COVERAGE_STEP = """      - name: Changed-line coverage
           BASE_REF: ${{ github.base_ref }}
         run: diff-cover coverage.xml --compare-branch="origin/$BASE_REF" --fail-under=90
 """
+_SETUP_NODE_PIN = (
+    "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+)
 
 
 def _write_release_fixture(tmp_path: Path, coverage_step: str = _COVERAGE_STEP) -> None:
@@ -25,7 +28,7 @@ jobs:
   package:
     name: Build package
     steps:
-      - uses: actions/setup-node@v7.0.0
+      - uses: {_SETUP_NODE_PIN}
         with:
           node-version: "22"
       - run: npm ci
@@ -72,7 +75,7 @@ diff_cover_fail_under = 90
 def test_release_check_accepts_blocking_coverage_and_setup_node_v7(tmp_path: Path) -> None:
     _write_release_fixture(tmp_path)
 
-    assert check_ci_workflow(tmp_path, ("actions/setup-node@v7.0.0",)) == []
+    assert check_ci_workflow(tmp_path, (_SETUP_NODE_PIN,)) == []
 
 
 @pytest.mark.parametrize(
@@ -95,6 +98,6 @@ def test_release_check_rejects_non_blocking_changed_coverage(
 ) -> None:
     _write_release_fixture(tmp_path, coverage_step)
 
-    failures = check_ci_workflow(tmp_path, ("actions/setup-node@v7.0.0",))
+    failures = check_ci_workflow(tmp_path, (_SETUP_NODE_PIN,))
 
     assert any("coverage step" in failure for failure in failures)


### PR DESCRIPTION
## Summary
- pin every third-party workflow action to an official 40-character commit with its reviewed release tag
- add an offline action/tag/SHA catalog that blocks mutable, abbreviated, missing-comment, mismatched, and noncanonical YAML references
- pin the installed-package Python Docker smoke to a reviewed multi-platform digest
- document Dependabot and release review procedure

## Validation
- 74 focused CI policy, quality, release CLI, and packaging tests
- `actionlint .github/workflows/*.yml`
- `zizmor --offline --no-progress .github/workflows`
- Ruff check and format validation on changed Python
- `python scripts/check_release.py`
- Markdown lint, change-plan validation, and `git diff --check`
- staged gitleaks scan: no findings
- GitNexus staged impact: 17 files, 22 symbols, 0 runtime processes, low risk

## Review
The single final reviewer reported two medium false-green gaps. Both were accepted and fixed: noncanonical valid YAML `uses` keys are rejected, and Docker validation now parses the actual `DEFAULT_DOCKER_IMAGE` assignment rather than searching for a digest substring.

The CI-equivalent Agent Maintainer run completed the full test pass and reported inherited repository-wide debt plus one task-local change-plan template issue; the template was repaired and directly revalidated.
