### PR TITLE
build: promote one verified release artifact

### DIFF
--- a/.agent-maintainer/change-plans/artifact-promotion.md
+++ b/.agent-maintainer/change-plans/artifact-promotion.md
@@ -1,0 +1,88 @@
++++
+id = "artifact-promotion"
+kind = "cohesive-release-hardening"
+status = "active"
+base_ref = "origin/main"
+expires = 2026-08-08
+allowed_paths = [
+  ".agent-maintainer/change-plans/artifact-promotion.md",
+  ".github/workflows/publish.yml",
+  "docs/architecture.md",
+  "docs/cli-json-schemas.md",
+  "docs/contracts.md",
+  "docs/development.md",
+  "docs/release-checklist.md",
+  "docs/roadmap/mcp-first-pivot-execution.md",
+  "scripts/check_release.py",
+  "scripts/release_promotion_quality.py",
+  "scripts/release_quality.py",
+  "scripts/smoke_installed_package.py",
+  "src/codex_usage_tracker/core/json_contracts.py",
+  "src/codex_usage_tracker/release/**",
+  "tests/release/**",
+  "tests/release_catalog.py",
+]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 23
+max_changed_lines = 3200
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = []
++++
+
+# Cohesive Change Plan: artifact-promotion
+
+## Why this change intentionally large
+
+Task 36 replaces the release graph as one fail-closed contract. The canonical
+manifest, TestPyPI qualification evidence, installed-wheel smoke, workflow job
+dependencies, offline release checks, schema inventory, tests, and operator
+documentation must agree on the same artifact identity. Splitting those pieces
+would permit an intermediate workflow to publish bytes that the local checker
+cannot reproduce or verify.
+
+## Why this should not be split smaller
+
+The production job is safe only when the build job emits the manifest, the
+qualification job proves published TestPyPI bytes, and the PyPI and GitHub jobs
+consume those exact qualified bytes. Landing any subset would either retain the
+old rebuild/manual-production path or make the release gate disagree with the
+executable workflow.
+
+## What allowed to change
+
+The release workflow, deterministic release modules, installed-artifact smoke,
+offline release checks, schema catalogs, focused tests, and the release
+architecture/operator documentation listed in `allowed_paths`.
+
+## What must not change
+
+This task does not change runtime usage accounting, user data, dashboard
+behavior, public MCP/CLI behavior, pricing, persistence, production credentials,
+or published package state. It must not relax Trusted Publishing, environment
+approval, immutable action pins, or existing release gates.
+
+## Verification plan
+
+- Focused manifest, promotion-evidence, packaging, workflow-policy, and
+  installed-artifact smoke tests.
+- Canonical wheel/sdist build, manifest create/verify, and
+  `scripts/check_release.py --dist`.
+- Ruff, mypy, actionlint, offline Zizmor, schema inventory, and whitespace
+  checks.
+- One CI-equivalent Agent Maintainer run after the diff is stable.
+- One read-only final reviewer after primary validation.
+
+## Rollback plan
+
+Before publication, revert the Task 36 commit and restore the previous workflow
+as one commit. After any TestPyPI or PyPI upload, do not reuse or replace the
+version; preserve the evidence, patch forward to the next version, and rerun the
+full promotion graph.
+
+## Follow-up ratchet work
+
+Task 37 will add package-size and public-surface budgets against artifacts
+produced by this manifest. Task 39 will consume the promotion evidence in the
+final 0.24 release gate.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,15 +2,6 @@ name: Publish Python package
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Publish target"
-        required: true
-        type: choice
-        options:
-          - testpypi
-          - pypi
-        default: testpypi
   release:
     types: [published]
 
@@ -23,21 +14,53 @@ concurrency:
 
 jobs:
   build:
-    name: Build distributions
+    name: Build one release artifact
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      manifest-sha256: ${{ steps.manifest-digest.outputs.sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
-      - name: Install build tooling
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          package-manager-cache: false
+      - name: Install release tooling
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]" twine
+          npm ci
+      - name: Verify exact release ref
+        run: |
+          echo "event=$GITHUB_EVENT_NAME"
+          echo "ref=$GITHUB_REF"
+          echo "sha=$GITHUB_SHA"
+          case "$GITHUB_REF" in
+            refs/heads/main|refs/tags/*)
+              ;;
+            *)
+              echo "Release candidates must run from main or an exact tag ref." >&2
+              exit 1
+              ;;
+          esac
+          if [ "$GITHUB_EVENT_NAME" = "release" ] && [[ "$GITHUB_REF" != refs/tags/* ]]; then
+            echo "Published releases must resolve to an exact tag ref." >&2
+            exit 1
+          fi
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+      - name: Pin reproducible build epoch
+        run: |
+          echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")" \
+            >> "$GITHUB_ENV"
+      - name: Verify deterministic Evidence Console assets
+        run: npm run dashboard:assets:check
       - name: Ruff
         run: python -m ruff check .
       - name: Type check
@@ -57,64 +80,79 @@ jobs:
         run: python scripts/check_release.py
       - name: Whitespace
         run: git diff --check
-      - name: Build wheel and sdist
+      - name: Build wheel and sdist once
         run: |
-          rm -rf dist build ./*.egg-info src/*.egg-info
+          rm -rf dist build release-bundle ./*.egg-info src/*.egg-info
           python -m build
+          python -m codex_usage_tracker.release.artifact_normalization \
+            --source dist \
+            --epoch "$SOURCE_DATE_EPOCH"
           python -m twine check dist/*
           python scripts/check_release.py --dist
-      - name: Show distribution files
+          mkdir -p release-bundle
+          cp -R dist release-bundle/dist
+          python -m codex_usage_tracker.release.artifact_manifest create \
+            --source release-bundle/dist \
+            --output release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+      - name: Verify the exact built artifact
         run: |
-          ls -la dist
-          python - <<'PY'
-          from pathlib import Path
-          import hashlib
-          for path in sorted(Path("dist").iterdir()):
-              digest = hashlib.sha256(path.read_bytes()).hexdigest()
-              print(f"{digest}  {path}")
-          PY
-      - name: Upload dist artifacts
+          python -m codex_usage_tracker.release.artifact_manifest verify \
+            --source release-bundle/dist \
+            --manifest release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            version="$(python -c \
+              'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+            expected_tag="v$version"
+            if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+              echo "Release tag $GITHUB_REF_NAME does not match package version $version." >&2
+              exit 1
+            fi
+          fi
+          python scripts/smoke_installed_package.py \
+            --artifact-dir release-bundle/dist
+      - name: Record manifest digest
+        id: manifest-digest
+        run: |
+          digest="$(python -m codex_usage_tracker.release.artifact_manifest digest \
+            --manifest release-bundle/release-manifest.json)"
+          echo "sha256=$digest" >> "$GITHUB_OUTPUT"
+          echo "$digest  release-bundle/release-manifest.json"
+      - name: Upload the sole build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-dist
-          path: dist/*
+          path: release-bundle/
           if-no-files-found: error
+          overwrite: true
 
   publish-testpypi:
-    name: Publish to TestPyPI
+    name: Publish unchanged bytes to TestPyPI
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     environment:
       name: testpypi
       url: https://test.pypi.org/project/codex-usage-tracking/
     permissions:
       id-token: write # Required for PyPI trusted publishing.
     steps:
-      - name: Verify PyPI publish ref
-        run: |
-          echo "event=$GITHUB_EVENT_NAME"
-          echo "ref=$GITHUB_REF"
-          echo "sha=$GITHUB_SHA"
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            case "$GITHUB_REF" in
-              refs/heads/main|refs/tags/*)
-                ;;
-              *)
-                echo "Manual PyPI publishing must run from main or a tag ref." >&2
-                exit 1
-                ;;
-            esac
-          fi
-      - name: Download dist artifacts
+      - name: Download the sole build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
-          path: dist
-      - name: Check target package version
+          path: release-bundle
+      - name: Verify manifest transfer
+        env:
+          EXPECTED_MANIFEST_SHA256: ${{ needs.build.outputs.manifest-sha256 }}
+        run: |
+          echo "$EXPECTED_MANIFEST_SHA256  release-bundle/release-manifest.json" \
+            | sha256sum --check --strict
+      - name: Check TestPyPI target version
         id: package-version
         env:
-          PACKAGE_INDEX_JSON_URL: https://test.pypi.org/pypi/codex-usage-tracking/json
+          PACKAGE_INDEX_BASE_URL: https://test.pypi.org/pypi/codex-usage-tracking
           PACKAGE_INDEX_NAME: TestPyPI
         run: |
           python - <<'PY'
@@ -124,81 +162,159 @@ jobs:
           import urllib.request
           from pathlib import Path
 
-          versions = set()
-          for path in Path("dist").iterdir():
-              name = path.name
-              if name.endswith(".tar.gz") and name.startswith("codex_usage_tracking-"):
-                  versions.add(name.removeprefix("codex_usage_tracking-").removesuffix(".tar.gz"))
-              elif name.endswith(".whl") and name.startswith("codex_usage_tracking-"):
-                  versions.add(name.split("-")[1])
-          if len(versions) != 1:
-              raise SystemExit(f"expected one distribution version, found {sorted(versions)}")
-          version = versions.pop()
-
-          url = os.environ["PACKAGE_INDEX_JSON_URL"]
-          index_name = os.environ["PACKAGE_INDEX_NAME"]
+          manifest = json.loads(Path("release-bundle/release-manifest.json").read_text())
+          version = manifest["version"]
+          url = f"{os.environ['PACKAGE_INDEX_BASE_URL']}/{version}/json"
           try:
-              with urllib.request.urlopen(url, timeout=30) as response:
-                  payload = json.load(response)
+              with urllib.request.urlopen(url, timeout=30):
+                  exists = True
           except urllib.error.HTTPError as exc:
               if exc.code == 404:
                   exists = False
               else:
                   raise
-          else:
-              exists = version in payload.get("releases", {})
-
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"version={version}\n")
               output.write(f"exists={str(exists).lower()}\n")
-          if exists:
-              print(f"codex-usage-tracking {version} already exists on {index_name}; skipping upload.")
-          else:
-              print(f"codex-usage-tracking {version} is not present on {index_name}; upload will run.")
+          index_name = os.environ["PACKAGE_INDEX_NAME"]
+          state = "already exists; qualification will verify it" if exists else "will upload"
+          print(f"codex-usage-tracking {version} on {index_name}: {state}")
           PY
       - name: Publish package distributions to TestPyPI
         if: steps.package-version.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
+          packages-dir: release-bundle/dist/
           repository-url: https://test.pypi.org/legacy/
           print-hash: true
 
-  publish-pypi:
-    name: Publish to PyPI
-    needs: build
+  qualify-testpypi:
+    name: Qualify TestPyPI artifact
+    needs: [build, publish-testpypi]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+      - name: Download the sole build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist
+          path: release-bundle
+      - name: Install qualification tooling from the exact wheel
+        run: python -m pip install release-bundle/dist/*.whl
+      - name: Verify build manifest
+        env:
+          EXPECTED_MANIFEST_SHA256: ${{ needs.build.outputs.manifest-sha256 }}
+        run: |
+          echo "$EXPECTED_MANIFEST_SHA256  release-bundle/release-manifest.json" \
+            | sha256sum --check --strict
+          python -m codex_usage_tracker.release.artifact_manifest verify \
+            --source release-bundle/dist \
+            --manifest release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+      - name: Download and verify TestPyPI bytes
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python -m codex_usage_tracker.release.promotion_evidence download-index \
+            --manifest release-bundle/release-manifest.json \
+            --index-json-url \
+              "https://test.pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --output qualified-dist
+          python -m codex_usage_tracker.release.artifact_manifest verify \
+            --source qualified-dist \
+            --manifest release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+      - name: Smoke exact TestPyPI artifact
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python scripts/smoke_installed_package.py \
+            --artifact-dir qualified-dist \
+            --version "$version"
+      - name: Record promotion evidence
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python -m codex_usage_tracker.release.promotion_evidence create \
+            --manifest release-bundle/release-manifest.json \
+            --output promotion-evidence.json \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --index-url \
+              "https://test.pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --installed-smoke passed
+      - name: Upload qualification evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: promotion-evidence
+          path: promotion-evidence.json
+          if-no-files-found: error
+          overwrite: true
+
+  publish-pypi:
+    name: Promote TestPyPI bytes to PyPI
+    needs: [build, qualify-testpypi]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     environment:
       name: pypi
       url: https://pypi.org/project/codex-usage-tracking/
     permissions:
       id-token: write # Required for PyPI trusted publishing.
+      contents: read
     steps:
-      - name: Verify PyPI publish ref
-        run: |
-          echo "event=$GITHUB_EVENT_NAME"
-          echo "ref=$GITHUB_REF"
-          echo "sha=$GITHUB_SHA"
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            case "$GITHUB_REF" in
-              refs/heads/main|refs/tags/*)
-                ;;
-              *)
-                echo "Manual PyPI publishing must run from main or a tag ref." >&2
-                exit 1
-                ;;
-            esac
-          fi
-      - name: Download dist artifacts
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+      - name: Download the sole build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-dist
-          path: dist
-      - name: Check target package version
-        id: package-version
+          path: release-bundle
+      - name: Install promotion tooling from the exact wheel
+        run: python -m pip install release-bundle/dist/*.whl
+      - name: Download qualification evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: promotion-evidence
+          path: release-evidence
+      - name: Verify qualification chain
         env:
-          PACKAGE_INDEX_JSON_URL: https://pypi.org/pypi/codex-usage-tracking/json
-          PACKAGE_INDEX_NAME: PyPI
+          EXPECTED_MANIFEST_SHA256: ${{ needs.build.outputs.manifest-sha256 }}
+        run: |
+          echo "$EXPECTED_MANIFEST_SHA256  release-bundle/release-manifest.json" \
+            | sha256sum --check --strict
+          python -m codex_usage_tracker.release.promotion_evidence verify \
+            --manifest release-bundle/release-manifest.json \
+            --evidence release-evidence/promotion-evidence.json \
+            --expected-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID"
+      - name: Download qualified TestPyPI bytes for promotion
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python -m codex_usage_tracker.release.promotion_evidence download-index \
+            --manifest release-bundle/release-manifest.json \
+            --index-json-url \
+              "https://test.pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --output promoted-dist
+          python -m codex_usage_tracker.release.artifact_manifest verify \
+            --source promoted-dist \
+            --manifest release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+      - name: Check PyPI target version
+        id: package-version
         run: |
           python - <<'PY'
           import json
@@ -207,40 +323,129 @@ jobs:
           import urllib.request
           from pathlib import Path
 
-          versions = set()
-          for path in Path("dist").iterdir():
-              name = path.name
-              if name.endswith(".tar.gz") and name.startswith("codex_usage_tracking-"):
-                  versions.add(name.removeprefix("codex_usage_tracking-").removesuffix(".tar.gz"))
-              elif name.endswith(".whl") and name.startswith("codex_usage_tracking-"):
-                  versions.add(name.split("-")[1])
-          if len(versions) != 1:
-              raise SystemExit(f"expected one distribution version, found {sorted(versions)}")
-          version = versions.pop()
-
-          url = os.environ["PACKAGE_INDEX_JSON_URL"]
-          index_name = os.environ["PACKAGE_INDEX_NAME"]
+          manifest = json.loads(Path("release-bundle/release-manifest.json").read_text())
+          version = manifest["version"]
+          url = f"https://pypi.org/pypi/codex-usage-tracking/{version}/json"
           try:
-              with urllib.request.urlopen(url, timeout=30) as response:
-                  payload = json.load(response)
+              with urllib.request.urlopen(url, timeout=30):
+                  exists = True
           except urllib.error.HTTPError as exc:
               if exc.code == 404:
                   exists = False
               else:
                   raise
-          else:
-              exists = version in payload.get("releases", {})
-
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"version={version}\n")
               output.write(f"exists={str(exists).lower()}\n")
-          if exists:
-              print(f"codex-usage-tracking {version} already exists on {index_name}; skipping upload.")
-          else:
-              print(f"codex-usage-tracking {version} is not present on {index_name}; upload will run.")
+          print(f"codex-usage-tracking {version} on PyPI: {'already exists' if exists else 'will upload'}")
           PY
-      - name: Publish package distributions to PyPI
+      - name: Publish qualified package distributions to PyPI
         if: steps.package-version.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
+          packages-dir: promoted-dist/
           print-hash: true
+
+  attach-github-release:
+    name: Attach verified PyPI bytes to GitHub Release
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+      - name: Download the sole build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist
+          path: release-bundle
+      - name: Install attachment tooling from the exact wheel
+        run: python -m pip install release-bundle/dist/*.whl
+      - name: Download qualification evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: promotion-evidence
+          path: release-evidence
+      - name: Download and verify PyPI bytes
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python -m codex_usage_tracker.release.promotion_evidence download-index \
+            --manifest release-bundle/release-manifest.json \
+            --index-json-url \
+              "https://pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --output release-assets
+          python -m codex_usage_tracker.release.artifact_manifest verify \
+            --source release-assets \
+            --manifest release-bundle/release-manifest.json \
+            --expected-sha "$GITHUB_SHA"
+          cp release-bundle/release-manifest.json release-assets/
+          cp release-evidence/promotion-evidence.json release-assets/
+      - name: Attach identical bytes and evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" release-assets/* \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
+  verify-public-release:
+    name: Verify TestPyPI, PyPI, and GitHub Release hashes
+    needs: attach-github-release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+      - name: Download the sole build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist
+          path: release-bundle
+      - name: Install verification tooling from the exact wheel
+        run: python -m pip install release-bundle/dist/*.whl
+      - name: Download qualification evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: promotion-evidence
+          path: release-evidence
+      - name: Verify every public location
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(python -c \
+            'import json; print(json.load(open("release-bundle/release-manifest.json"))["version"])')"
+          python -m codex_usage_tracker.release.promotion_evidence download-index \
+            --manifest release-bundle/release-manifest.json \
+            --index-json-url \
+              "https://test.pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --output public-testpypi
+          python -m codex_usage_tracker.release.promotion_evidence download-index \
+            --manifest release-bundle/release-manifest.json \
+            --index-json-url \
+              "https://pypi.org/pypi/codex-usage-tracking/$version/json" \
+            --output public-pypi
+          gh release download "$GITHUB_REF_NAME" \
+            --dir public-github \
+            --repo "$GITHUB_REPOSITORY"
+          for source in public-testpypi public-pypi public-github; do
+            python -m codex_usage_tracker.release.artifact_manifest verify \
+              --source "$source" \
+              --manifest release-bundle/release-manifest.json \
+              --expected-sha "$GITHUB_SHA"
+          done
+          cmp release-bundle/release-manifest.json public-github/release-manifest.json
+          cmp release-evidence/promotion-evidence.json public-github/promotion-evidence.json
+          sha256sum public-testpypi/* public-pypi/* public-github/*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,23 @@ Materialized facts may retain physical rows so source replacement and local evid
 
 Shareable outputs remain aggregate-first and must omit indexed/raw content unless an export is explicitly documented as a local raw/content export.
 
+### Release artifact promotion
+
+`release/artifact_manifest.py` is the build-once boundary for public packages. It
+accepts exactly one wheel and one sdist for one version, verifies their package
+metadata and Evidence Console files against the checked-out source, and records
+canonical SHA-256, source-commit, database-schema, JSON-schema, MCP-tool, and
+console-bundle inventories. Verification reconstructs that payload and rejects
+missing, changed, stale, multi-version, or non-canonical input.
+
+`release/promotion_evidence.py` binds a passed installed-artifact smoke and the
+GitHub Actions run identity to that manifest. The publication workflow sends the
+single uploaded `python-dist` build to TestPyPI, downloads and smokes those
+published bytes, then sends bytes downloaded from TestPyPI to PyPI. GitHub
+Release assets are downloaded from PyPI before attachment. The last job verifies
+the same manifest hashes at TestPyPI, PyPI, and GitHub; no production job may
+rebuild the distributions.
+
 ## Boundaries
 
 - `parser.py` converts local JSONL events into aggregate `UsageEvent` records. It also attaches metadata-only call-origin categories, diagnostic facts from `diagnostic_facts.py`, archived-session flags, conservative thread keys, source cursors, and parser diagnostics.
@@ -157,7 +174,7 @@ Shareable outputs remain aggregate-first and must omit indexed/raw content unles
 - `diagnostic_snapshots.py` owns persisted diagnostic snapshot refresh/load orchestration. Snapshot modules should stay synthetic-testable and avoid raw transcript persistence in aggregate diagnostic facts.
 - `dashboard.py` builds aggregate-first static dashboard payloads and writes HTML/assets. `server.py` adds localhost refresh, compatibility `/api/usage`, SQL-backed live API slices, and explicit lazy context loading.
 - `frontend/dashboard/` owns the React dashboard. The packaged React HTML embeds only a database-free boot payload (authentication, localization, and data-scope defaults), then hydrates aggregate data through the localhost APIs. It should render server/API payloads rather than becoming an independent source of usage calculations.
-- `plugin_installer.py`, `.mcp.json`, `skills/`, `src/codex_usage_tracker/plugin_data/skills/`, and `scripts/check_release.py` own install and packaging behavior.
+- `plugin_installer.py`, `.mcp.json`, `skills/`, `src/codex_usage_tracker/plugin_data/skills/`, `release/`, and `scripts/check_release.py` own install, packaging, and immutable artifact-promotion behavior.
 - `scripts/benchmark_synthetic_history.py` owns broad generated large-history query timing checks. `scripts/benchmark_dashboard_routes.py` owns deterministic cold/warm route budgets for the query pipeline. Both must stay synthetic-only and must not read real Codex logs.
 
 ## Extension Rules

--- a/docs/cli-json-schemas.md
+++ b/docs/cli-json-schemas.md
@@ -54,6 +54,8 @@ Tracked schema ids:
 | `codex-usage-tracker.job.v1` | HTTP `GET /api/v2/jobs/{job_id}` and asynchronous v2 starts; generic process-local job status |
 | `codex-usage-tracker.capabilities.v2` | HTTP `GET /api/v2/capabilities`; immutable analysis, query, allowance, and evidence allowlists |
 | `codex-usage-tracker.error.v1` | Stable HTTP v2 error envelope with machine-readable code and message |
+| `codex-usage-tracker.release-artifact-manifest.v1` | Canonical build-once wheel/sdist hashes, source identity, contract inventories, and Evidence Console bundle hashes |
+| `codex-usage-tracker.release-promotion-evidence.v1` | TestPyPI qualification, installed smoke, GitHub Actions run, and manifest binding required before PyPI promotion |
 | `codex-usage-tracker.query.v2` | Canonical bounded application query result with deterministic cursor continuation |
 | `codex-usage-tracker.analysis.v2` | Bounded evidence-backed analysis with strategy provenance, limitations, accounting, and dashboard destinations |
 | `codex-usage-tracker.analysis-job.v1` | Process-local semantic analysis job status; active and compatible completed work may be reused |

--- a/docs/development.md
+++ b/docs/development.md
@@ -449,9 +449,25 @@ Before publishing a future release, confirm Trusted Publishers are still configu
 
 TestPyPI and PyPI are separate services/accounts. Configure both before publishing to both, and keep the `pypi` GitHub environment behind manual approval.
 
-To publish to TestPyPI, run the `Publish Python package` workflow manually with `target` set to `testpypi`. The job builds once, checks the artifacts with `twine`, uploads them as workflow artifacts, then publishes the same artifacts to `https://test.pypi.org/project/codex-usage-tracking/`.
+To publish a TestPyPI dry run, use a distinct prerelease version and manually
+run the `Publish Python package` workflow from `main` or its exact prerelease
+tag. Manual dispatch is TestPyPI-only. Do not manually upload the final
+production version and then create its GitHub Release: package-index versions
+are immutable, and the release event owns the final version's complete
+TestPyPI-to-production promotion run. The workflow builds one wheel/sdist pair
+with a commit-derived `SOURCE_DATE_EPOCH`, records a canonical release
+manifest, publishes those exact files, downloads them from TestPyPI, verifies
+their hashes, and smokes the downloaded wheel.
 
-To publish to PyPI, either publish a GitHub Release for the tag or manually run the workflow with `target` set to `pypi`. The final project URL is `https://pypi.org/project/codex-usage-tracking/`.
+To publish to production PyPI, publish a GitHub Release whose exact annotated
+tag is `v<package-version>`. That release-event run builds once, publishes and
+qualifies TestPyPI, then waits for the protected `pypi` environment approval.
+The PyPI job publishes files downloaded from TestPyPI rather than rebuilding.
+The workflow then downloads those files from PyPI for GitHub Release attachment
+and verifies identical hashes at TestPyPI, PyPI, and GitHub. After TestPyPI
+publication, rerun failed jobs rather than every job; any rebuild must reproduce
+the commit-bound manifest or fail closed. The final project URL is
+`https://pypi.org/project/codex-usage-tracking/`.
 
 PyPI and TestPyPI filenames and versions cannot be reused after upload. If a bad artifact is uploaded, cut the next patch version instead of trying to replace it.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -22,10 +22,60 @@ dependency update.
 Local actions under `./` remain relative. Docker actions must use a
 `sha256` digest rather than a mutable image tag.
 
+## Promote one verified build
+
+1. Use the manual `Publish Python package` workflow only for a TestPyPI dry run
+   with a distinct prerelease version such as `0.24.0rc1`. Manual dispatch
+   cannot publish to production PyPI, and a manually uploaded final version
+   must not be reused by a later production run.
+2. For a production release, publish the exact annotated `v<package-version>`
+   tag as a GitHub Release without first manually uploading that final version.
+   The release-event workflow checks out that tag, derives `SOURCE_DATE_EPOCH`
+   from its commit, builds the wheel and sdist once, and performs TestPyPI
+   qualification and production promotion in that same run.
+3. Confirm the `python-dist` workflow artifact contains `dist/` and the
+   canonical `release-manifest.json`, and record the manifest SHA-256 from the
+   build job.
+4. Confirm TestPyPI qualification downloaded both files, matched the manifest,
+   and passed `smoke_installed_package.py --artifact-dir`.
+5. Approve the protected `pypi` environment only after the
+   `promotion-evidence.json` records the exact source SHA, Actions run, artifact
+   hashes, contract inventories, console bundle hashes, and passed smoke.
+6. Confirm the PyPI job publishes `promoted-dist/` downloaded from TestPyPI,
+   never a rebuild or an unqualified local directory.
+7. Confirm the GitHub Release receives bytes downloaded from PyPI plus the same
+   manifest and promotion evidence.
+8. Require the final public-location verification job to pass for TestPyPI,
+   PyPI, and GitHub Release before declaring the release complete.
+
+After TestPyPI accepts a final-version artifact, rerun failed jobs rather than
+rerunning every job. A full rerun still uses the commit-derived build epoch and
+must reproduce the manifest hashes or fail closed; never replace or work around
+an uploaded version.
+
+Local manifest verification:
+
+```bash
+export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+python -m build
+python -m codex_usage_tracker.release.artifact_normalization \
+  --source dist \
+  --epoch "$SOURCE_DATE_EPOCH"
+python -m codex_usage_tracker.release.artifact_manifest create \
+  --source dist \
+  --output /tmp/codex-usage-release-manifest.json \
+  --expected-sha "$(git rev-parse HEAD)"
+python -m codex_usage_tracker.release.artifact_manifest verify \
+  --source dist \
+  --manifest /tmp/codex-usage-release-manifest.json \
+  --expected-sha "$(git rev-parse HEAD)"
+python scripts/smoke_installed_package.py --artifact-dir dist
+```
+
 ## Verify
 
 ```bash
-python -m pytest tests/ci/test_immutable_action_pins.py tests/quality -q
+python -m pytest tests/ci/test_immutable_action_pins.py tests/release tests/quality -q
 actionlint .github/workflows/*.yml
 zizmor --offline --no-progress .github/workflows
 python scripts/check_release.py

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -1401,3 +1401,65 @@ complete without its named focused and full verification evidence.
 - Follow-up:
   - Task 36 owns build-once artifact promotion and will reuse these immutable
     workflow boundaries.
+
+## Task 36 - Promote One Verified Release Artifact
+
+- Status: complete locally on `pivot/36-artifact-promotion`; hosted CI and
+  merge remain.
+- Build-once contract:
+  - one wheel/sdist pair and one canonical manifest are uploaded as the sole
+    `python-dist` build artifact;
+  - the manifest binds exact hashes to the Git SHA, package version, database
+    schema, JSON schemas, MCP tool profiles, and Evidence Console bundles;
+  - missing, altered, multi-version, stale-asset, wrong-source, and
+    non-canonical inputs fail closed.
+- Promotion graph:
+  - TestPyPI receives the build bytes, then qualification downloads and smokes
+    those published bytes;
+  - protected PyPI publication consumes a fresh verified download from
+    TestPyPI and never rebuilds;
+  - GitHub Release attachment consumes verified PyPI bytes, and the last job
+    rechecks hashes at all three public locations.
+- Manual safety:
+  - workflow dispatch is TestPyPI-only; production publication requires an
+    exact `v<package-version>` release tag and the protected `pypi`
+    environment;
+  - manual TestPyPI dry runs use distinct prerelease versions, while a
+    production release performs TestPyPI qualification and PyPI promotion in
+    one release-event run.
+- Primary verification:
+  - the release, packaging, workflow-policy, and immutable-pin slice passes
+    `122` tests; the complete new release package passes `71` focused tests;
+  - changed-line coverage is `92%`, including `92.7%` for artifact manifests,
+    `85.7%` for artifact normalization, and `94.8%` for promotion evidence;
+  - Ruff, mypy, focused Pyright, Tach, Deptry, Bandit, actionlint, offline
+    Zizmor, schema inventory, suppression budget, change-plan budget, source
+    release readiness, and whitespace checks pass;
+  - a canonical wheel/sdist pair passed Twine, manifest create/verify, and an
+    isolated installed-wheel smoke covering the CLI, package data, MCP core
+    inventory, plugin installation, setup/doctor, dashboard generation, and a
+    strict-privacy support bundle;
+  - two independent final-source builds used the same commit-derived
+    `SOURCE_DATE_EPOCH`; the wheels and normalized sdists were byte-identical.
+- Broad verification:
+  - the full suite initially passed `2072` tests and exposed two Task 36
+    failures: missing Tach ownership and release schemas incorrectly listed in
+    the MCP-only contract document; both were fixed and their exact regressions
+    pass directly;
+  - the one broad Agent Maintainer run exposed those same Task 36 issues plus
+    file length, dependency, security, complexity, and coverage findings. All
+    Task 36 findings were repaired and bounded checks pass. Remaining
+    file-length and repository-format failures are inherited outside this
+    change.
+- Tooling note:
+  - GitNexus successfully supplied the base architecture/process orientation.
+    Its post-diff incremental refresh failed with an inconsistent `file_fts`
+    index, so final conclusions use the source, Tach, tests, and release
+    artifacts as authority rather than rebuilding the index and risking
+    generated guidance churn.
+- Final review:
+  - one read-only reviewer reported three findings and all three were accepted:
+    reproducible rerun/manual-candidate handling, release-tag/package-version
+    binding, and exact package-index artifact-set validation;
+  - all three fixes pass the bounded recheck above. Reviewer token attribution
+    is `pending` because the aggregate metrics helper timed out.

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -28,6 +28,7 @@ from release_quality import (  # noqa: E402
     check_publish_workflow,
     check_python_support_metadata,
     check_react_dashboard_privacy_artifacts,
+    check_release_artifact_contract,
     check_schema_inventory,
     check_skill_packaging,
     check_tracked_files_for_secrets,
@@ -339,6 +340,7 @@ def main() -> int:
     if args.dist:
         failures.extend(_check_sdist())
         failures.extend(_check_wheel())
+        failures.extend(check_release_artifact_contract(REPO_ROOT, _package_version()))
 
     if failures:
         for failure in failures:

--- a/scripts/release_promotion_quality.py
+++ b/scripts/release_promotion_quality.py
@@ -1,0 +1,205 @@
+"""Offline policy checks for build-once release artifact promotion."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def check_publish_workflow(repo_root: Path) -> list[str]:
+    """Require one build whose exact bytes are promoted through every release target."""
+    workflow_path = repo_root / ".github" / "workflows" / "publish.yml"
+    if not workflow_path.exists():
+        return ["missing publish workflow: .github/workflows/publish.yml"]
+    workflow = workflow_path.read_text(encoding="utf-8")
+    failures = _required_text_failures(workflow)
+    failures.extend(_event_policy_failures(workflow))
+    failures.extend(_promotion_job_failures(workflow))
+    return failures
+
+
+def check_release_artifact_contract(repo_root: Path, version: str) -> list[str]:
+    """Reconstruct the release manifest payload from a built dist directory."""
+    source_path = str(repo_root / "src")
+    if source_path not in sys.path:
+        sys.path.insert(0, source_path)
+    from codex_usage_tracker.release.artifact_manifest import (
+        ManifestError,
+        inspect_artifacts,
+    )
+
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ["release artifact contract could not resolve the source Git SHA"]
+    try:
+        inspect_artifacts(
+            repo_root / "dist",
+            expected_sha=result.stdout.strip(),
+            expected_version=version,
+            repository_root=repo_root,
+        )
+    except ManifestError as exc:
+        return [f"release artifact contract failed: {exc}"]
+    return []
+
+
+def _required_text_failures(workflow: str) -> list[str]:
+    required_text = [
+        "workflow_dispatch:",
+        "release:",
+        "pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1",
+        "id-token: write",
+        "repository-url: https://test.pypi.org/legacy/",
+        "python -m twine check dist/*",
+        "codex_usage_tracker.release.artifact_normalization",
+        "name: Build one release artifact",
+        "name: Pin reproducible build epoch",
+        'SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")',
+        "name: Publish unchanged bytes to TestPyPI",
+        "name: Qualify TestPyPI artifact",
+        "name: Promote TestPyPI bytes to PyPI",
+        "name: Attach verified PyPI bytes to GitHub Release",
+        "name: Verify TestPyPI, PyPI, and GitHub Release hashes",
+        "codex_usage_tracker.release.artifact_manifest create",
+        "codex_usage_tracker.release.artifact_manifest verify",
+        "codex_usage_tracker.release.promotion_evidence download-index",
+        "codex_usage_tracker.release.promotion_evidence create",
+        "codex_usage_tracker.release.promotion_evidence verify",
+        "--artifact-dir qualified-dist",
+        "manifest-sha256:",
+        'expected_tag="v$version"',
+        'if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then',
+        "name: python-dist",
+        "name: promotion-evidence",
+        "packages-dir: release-bundle/dist/",
+        "packages-dir: promoted-dist/",
+        "gh release upload",
+        "gh release download",
+        "cmp release-bundle/release-manifest.json public-github/release-manifest.json",
+        "name: testpypi",
+        "name: pypi",
+        "https://test.pypi.org/project/codex-usage-tracking/",
+        "https://pypi.org/project/codex-usage-tracking/",
+        "steps.package-version.outputs.exists != 'true'",
+    ]
+    return [
+        f"publish workflow is missing artifact-promotion text: {required}"
+        for required in required_text
+        if required not in workflow
+    ]
+
+
+def _event_policy_failures(workflow: str) -> list[str]:
+    failures: list[str] = []
+    if re.search(r"(?m)^\s*push\s*:", workflow):
+        failures.append("publish workflow must not publish on ordinary pushes")
+    if re.search(r"(?m)^\s*pull_request\s*:", workflow):
+        failures.append("publish workflow must not publish on pull requests")
+    if "secrets." in workflow or "api-token" in workflow or "password:" in workflow:
+        failures.append("publish workflow must not use token secrets or password-based publishing")
+    if "inputs.target" in workflow:
+        failures.append(
+            "publish workflow must not allow an unqualified manual PyPI target; "
+            "manual dispatch is TestPyPI-only"
+        )
+    if workflow.count("python -m build") != 1:
+        failures.append("publish workflow must build distributions exactly once")
+    if workflow.count("name: python-dist") != 6:
+        failures.append(
+            "publish workflow must upload python-dist once and download that named artifact "
+            "in every verification stage"
+        )
+    return failures
+
+
+def _promotion_job_failures(workflow: str) -> list[str]:
+    job_names = [
+        "build",
+        "publish-testpypi",
+        "qualify-testpypi",
+        "publish-pypi",
+        "attach-github-release",
+        "verify-public-release",
+    ]
+    failures: list[str] = []
+    positions = [workflow.find(f"\n  {job_name}:\n") for job_name in job_names]
+    if -1 in positions or positions != sorted(positions):
+        failures.append("publish workflow release jobs are missing or out of promotion order")
+    for job_name in job_names:
+        if _workflow_job_block(workflow, job_name) is None:
+            failures.append(f"publish workflow is missing job: {job_name}")
+    failures.extend(
+        _missing_job_text(
+            workflow,
+            "build",
+            "build-once proof",
+            [
+                "outputs:",
+                "manifest-sha256:",
+                "Build wheel and sdist once",
+                "Upload the sole build artifact",
+                "name: python-dist",
+            ],
+        )
+    )
+    failures.extend(
+        _missing_job_text(
+            workflow,
+            "qualify-testpypi",
+            "proof",
+            [
+                "needs: [build, publish-testpypi]",
+                "download-index",
+                "--output qualified-dist",
+                "--artifact-dir qualified-dist",
+                "promotion_evidence create",
+                "installed-smoke passed",
+            ],
+        )
+    )
+    failures.extend(
+        _missing_job_text(
+            workflow,
+            "publish-pypi",
+            "promotion proof",
+            [
+                "needs: [build, qualify-testpypi]",
+                "if: github.event_name == 'release'",
+                "--output promoted-dist",
+                "packages-dir: promoted-dist/",
+            ],
+        )
+    )
+    pypi = _workflow_job_block(workflow, "publish-pypi") or ""
+    if "python -m build" in pypi:
+        failures.append("publish workflow PyPI job must not rebuild distributions")
+    return failures
+
+
+def _missing_job_text(
+    workflow: str,
+    job_name: str,
+    label: str,
+    required_text: list[str],
+) -> list[str]:
+    job = _workflow_job_block(workflow, job_name) or ""
+    return [
+        f"publish workflow {job_name} job is missing {label}: {required}"
+        for required in required_text
+        if required not in job
+    ]
+
+
+def _workflow_job_block(workflow: str, job_name: str) -> str | None:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    return None if match is None else match.group("body")

--- a/scripts/release_quality.py
+++ b/scripts/release_quality.py
@@ -15,6 +15,14 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10.
     import tomli as tomllib
 
+if __package__:
+    import scripts.release_promotion_quality as _release_promotion_quality
+else:  # Direct script loading adds scripts/ rather than the repository root.
+    import release_promotion_quality as _release_promotion_quality
+
+check_publish_workflow = _release_promotion_quality.check_publish_workflow
+check_release_artifact_contract = _release_promotion_quality.check_release_artifact_contract
+
 REVIEWED_ACTION_PINS = {
     ("actions/cache", "v6.1.0"): "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
     ("actions/checkout", "v7.0.1"): "3d3c42e5aac5ba805825da76410c181273ba90b1",
@@ -148,65 +156,6 @@ def check_python_support_metadata(
         failures.append("docs/install.md should document CI support through Python 3.14")
 
     failures.extend(check_installed_smoke_docker_image(repo_root))
-    return failures
-
-
-def check_publish_workflow(repo_root: Path) -> list[str]:
-    workflow_path = repo_root / ".github" / "workflows" / "publish.yml"
-    if not workflow_path.exists():
-        return ["missing publish workflow: .github/workflows/publish.yml"]
-    workflow = workflow_path.read_text(encoding="utf-8")
-    failures: list[str] = []
-    for required in [
-        "workflow_dispatch:",
-        "release:",
-        "pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1",
-        "id-token: write",
-        "repository-url: https://test.pypi.org/legacy/",
-        "python -m twine check dist/*",
-        "if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'",
-        "if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')",
-        'echo "ref=$GITHUB_REF"',
-        'echo "sha=$GITHUB_SHA"',
-        "refs/heads/main|refs/tags/*",
-        "Manual PyPI publishing must run from main or a tag ref.",
-        "name: testpypi",
-        "name: pypi",
-        "https://test.pypi.org/project/codex-usage-tracking/",
-        "https://pypi.org/project/codex-usage-tracking/",
-        "steps.package-version.outputs.exists != 'true'",
-        "codex-usage-tracking {version} already exists on {index_name}; skipping upload.",
-    ]:
-        if required not in workflow:
-            failures.append(
-                f"publish workflow is missing required Trusted Publishing text: {required}"
-            )
-    if re.search(r"(?m)^\s*push\s*:", workflow):
-        failures.append("publish workflow must not publish on ordinary pushes")
-    if re.search(r"(?m)^\s*pull_request\s*:", workflow):
-        failures.append("publish workflow must not publish on pull requests")
-    if "secrets." in workflow or "api-token" in workflow or "password:" in workflow:
-        failures.append("publish workflow must not use token secrets or password-based publishing")
-    for job_name in ["publish-testpypi", "publish-pypi"]:
-        job_block = _workflow_job_block(workflow, job_name)
-        if job_block is None:
-            failures.append(f"publish workflow is missing job: {job_name}")
-            continue
-        for required in [
-            "Verify PyPI publish ref",
-            'echo "event=$GITHUB_EVENT_NAME"',
-            'echo "ref=$GITHUB_REF"',
-            'echo "sha=$GITHUB_SHA"',
-            "refs/heads/main|refs/tags/*",
-            "Manual PyPI publishing must run from main or a tag ref.",
-            "Check target package version",
-            "id: package-version",
-            "PACKAGE_INDEX_JSON_URL",
-            "PACKAGE_INDEX_NAME",
-            "steps.package-version.outputs.exists != 'true'",
-        ]:
-            if required not in job_block:
-                failures.append(f"publish workflow {job_name} job is missing preflight: {required}")
     return failures
 
 

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -3,8 +3,9 @@
 
 The default mode builds this checkout into a temporary dist directory, installs
 the wheel into a clean virtual environment, and verifies the installed CLI,
-package data, and plugin installer. Use ``--from-pypi`` to verify the public
-package instead, or ``--docker`` to run the same smoke in a clean Linux image.
+package data, and plugin installer. Use ``--artifact-dir`` to smoke an already
+built or downloaded wheel, ``--from-pypi`` to verify the public package, or
+``--docker`` to run the same smoke in a clean Linux image.
 """
 
 from __future__ import annotations
@@ -73,7 +74,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--version",
         default=None,
-        help="When used with --from-pypi, install this exact package version.",
+        help="Install this exact version with --from-pypi or --artifact-dir.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Install the sole matching wheel from an existing artifact directory.",
     )
     parser.add_argument(
         "--docker",
@@ -86,6 +93,8 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Docker image for --docker mode. Default: {DEFAULT_DOCKER_IMAGE}",
     )
     args = parser.parse_args(argv)
+    if args.from_pypi and args.artifact_dir is not None:
+        parser.error("--from-pypi and --artifact-dir cannot be used together")
 
     if args.docker:
         return _run_in_docker(args)
@@ -123,8 +132,13 @@ def _run_in_docker(args: argparse.Namespace) -> int:
         inner_args.append("--from-pypi")
     if args.version:
         inner_args.extend(["--version", args.version])
+    docker_mounts = ["-v", f"{REPO_ROOT}:/work"]
+    if args.artifact_dir is not None:
+        artifact_dir = args.artifact_dir.resolve()
+        inner_args.extend(["--artifact-dir", "/release-dist"])
+        docker_mounts.extend(["-v", f"{artifact_dir}:/release-dist:ro"])
     setup_commands = ["python -m pip install --upgrade pip >/dev/null"]
-    if not args.from_pypi:
+    if not args.from_pypi and args.artifact_dir is None:
         setup_commands.append("python -m pip install build >/dev/null")
     inner_command = " && ".join(
         setup_commands + ["python " + " ".join(shlex.quote(part) for part in inner_args)]
@@ -134,8 +148,7 @@ def _run_in_docker(args: argparse.Namespace) -> int:
             "docker",
             "run",
             "--rm",
-            "-v",
-            f"{REPO_ROOT}:/work",
+            *docker_mounts,
             "-w",
             "/work",
             args.docker_image,
@@ -149,6 +162,18 @@ def _run_in_docker(args: argparse.Namespace) -> int:
 def _resolve_install_target(args: argparse.Namespace, temp_dir: Path) -> str:
     if args.from_pypi:
         return f"{DISTRIBUTION_NAME}=={args.version}" if args.version else DISTRIBUTION_NAME
+    if args.artifact_dir is not None:
+        artifact_dir = args.artifact_dir.resolve()
+        if not artifact_dir.is_dir():
+            raise FileNotFoundError(f"artifact directory does not exist: {artifact_dir}")
+        version_pattern = args.version or "*"
+        wheels = sorted(artifact_dir.glob(f"{WHEEL_STEM}-{version_pattern}-*.whl"))
+        if len(wheels) != 1:
+            raise FileNotFoundError(
+                "expected exactly one matching wheel in artifact directory; "
+                f"found {[path.name for path in wheels]}"
+            )
+        return str(wheels[0])
 
     version = _project_version()
     dist_dir = temp_dir / "dist"

--- a/src/codex_usage_tracker/core/json_contracts.py
+++ b/src/codex_usage_tracker/core/json_contracts.py
@@ -40,6 +40,26 @@ AUXILIARY_JSON_PAYLOAD_CONTRACTS: dict[str, dict[str, Any]] = {
     "codex-usage-tracker-refresh-progress-v1": {
         "required": {"phase": str, "status": str, "message": str}
     },
+    "codex-usage-tracker.release-artifact-manifest.v1": {
+        "required": {
+            "artifacts": list,
+            "contract_inventory": dict,
+            "distribution": str,
+            "source": dict,
+            "version": str,
+        }
+    },
+    "codex-usage-tracker.release-promotion-evidence.v1": {
+        "required": {
+            "artifacts": list,
+            "contract_inventory": dict,
+            "github_actions": dict,
+            "manifest_sha256": str,
+            "qualification": dict,
+            "source_sha": str,
+            "version": str,
+        }
+    },
     "codex-usage-tracker-usage-drain-model-v1": {"required": {}},
     "codex-usage-tracker.analysis-result.v1": {"required": {}},
     "codex-usage-tracker.compression-profile.v1": {"required": {}},

--- a/src/codex_usage_tracker/release/__init__.py
+++ b/src/codex_usage_tracker/release/__init__.py
@@ -1,0 +1,3 @@
+"""Deterministic release-artifact promotion contracts."""
+
+from __future__ import annotations

--- a/src/codex_usage_tracker/release/artifact_manifest.py
+++ b/src/codex_usage_tracker/release/artifact_manifest.py
@@ -1,0 +1,456 @@
+"""Create and verify canonical manifests for one wheel/sdist release build."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tarfile
+import zipfile
+from email.parser import Parser
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from pathlib import Path
+from typing import Any
+
+MANIFEST_SCHEMA = "codex-usage-tracker.release-artifact-manifest.v1"
+DISTRIBUTION_NAME = "codex-usage-tracking"
+DIST_FILE_STEM = "codex_usage_tracking"
+IMPORT_PACKAGE = "codex_usage_tracker"
+_SOURCE_SHA = re.compile(r"[0-9a-f]{40}\Z")
+_WHEEL_NAME = re.compile(
+    rf"{DIST_FILE_STEM}-(?P<version>[^-]+)-[^/]+\.whl\Z",
+)
+_SDIST_NAME = re.compile(rf"{DIST_FILE_STEM}-(?P<version>.+)\.tar\.gz\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class ManifestError(ValueError):
+    """Raised when release files cannot prove one unchanged build."""
+
+
+def canonical_json_bytes(payload: object) -> bytes:
+    """Serialize a release record in its only accepted byte representation."""
+    return (
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True) + "\n"
+    ).encode()
+
+
+def sha256_file(path: Path) -> str:
+    """Return the lowercase SHA-256 digest for one file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def manifest_sha256(path: Path) -> str:
+    """Return the digest of a canonical manifest file."""
+    return sha256_file(path)
+
+
+def create_manifest(
+    source: Path,
+    output: Path,
+    *,
+    expected_sha: str,
+    expected_version: str | None = None,
+    repository_root: Path | None = None,
+) -> dict[str, Any]:
+    """Inspect one dist directory and write its canonical release manifest."""
+    repo_root = repository_root or _default_repository_root()
+    version = expected_version or _project_version(repo_root)
+    manifest = inspect_artifacts(
+        source,
+        expected_sha=expected_sha,
+        expected_version=version,
+        repository_root=repo_root,
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_json_bytes(manifest))
+    return manifest
+
+
+def inspect_artifacts(
+    source: Path,
+    *,
+    expected_sha: str,
+    expected_version: str,
+    repository_root: Path,
+) -> dict[str, Any]:
+    """Return the deterministic manifest payload without writing a file."""
+    return _build_manifest(
+        source,
+        expected_sha=expected_sha,
+        expected_version=expected_version,
+        repository_root=repository_root,
+    )
+
+
+def verify_manifest(
+    source: Path,
+    manifest_path: Path,
+    *,
+    expected_sha: str,
+    expected_version: str | None = None,
+    repository_root: Path | None = None,
+) -> dict[str, Any]:
+    """Verify manifest canonicalization, identity, contents, and source assets."""
+    if not manifest_path.is_file():
+        raise ManifestError(f"manifest file does not exist: {manifest_path}")
+    raw = manifest_path.read_bytes()
+    try:
+        manifest = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"manifest file is not valid UTF-8 JSON: {manifest_path}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError("manifest root must be an object")
+    if raw != canonical_json_bytes(manifest):
+        raise ManifestError("manifest is not in canonical JSON form")
+    _validate_manifest_payload(manifest)
+    _validate_source_sha(expected_sha)
+    source_record = manifest.get("source")
+    if not isinstance(source_record, dict) or source_record.get("git_sha") != expected_sha:
+        raise ManifestError("manifest source SHA does not match the expected Git commit")
+
+    repo_root = repository_root or _default_repository_root()
+    version = expected_version or _project_version(repo_root)
+    current = inspect_artifacts(
+        source,
+        expected_sha=expected_sha,
+        expected_version=version,
+        repository_root=repo_root,
+    )
+    if manifest != current:
+        raise ManifestError(
+            "release artifact manifest does not match the current distribution files"
+        )
+    return manifest
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load a canonical manifest without re-reading its distribution directory."""
+    if not path.is_file():
+        raise ManifestError(f"manifest file does not exist: {path}")
+    raw = path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"manifest file is not valid UTF-8 JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ManifestError("manifest root must be an object")
+    if raw != canonical_json_bytes(payload):
+        raise ManifestError("manifest is not in canonical JSON form")
+    _validate_manifest_payload(payload)
+    return payload
+
+
+def _build_manifest(
+    source: Path,
+    *,
+    expected_sha: str,
+    expected_version: str,
+    repository_root: Path,
+) -> dict[str, Any]:
+    _validate_source_sha(expected_sha)
+    wheel, sdist, version = _distribution_pair(source, expected_version)
+    wheel_members = _wheel_members(wheel)
+    sdist_members = _sdist_members(sdist)
+    _verify_metadata_version(wheel_members, ".dist-info/METADATA", version, wheel.name)
+    _verify_metadata_version(sdist_members, "/PKG-INFO", version, sdist.name)
+    bundles = _evidence_console_bundles(repository_root, wheel_members, sdist_members)
+    artifacts = [
+        {"path": path.name, "sha256": sha256_file(path), "size": path.stat().st_size}
+        for path in sorted((wheel, sdist), key=lambda item: item.name)
+    ]
+    return {
+        "artifacts": artifacts,
+        "contract_inventory": _contract_inventory(bundles),
+        "distribution": DISTRIBUTION_NAME,
+        "schema": MANIFEST_SCHEMA,
+        "source": {"git_sha": expected_sha},
+        "version": version,
+    }
+
+
+def _distribution_pair(source: Path, expected_version: str) -> tuple[Path, Path, str]:
+    if not source.is_dir():
+        raise ManifestError(f"distribution source directory does not exist: {source}")
+    wheels: list[tuple[Path, str]] = []
+    sdists: list[tuple[Path, str]] = []
+    for path in sorted(source.iterdir()):
+        wheel_match = _WHEEL_NAME.fullmatch(path.name)
+        sdist_match = _SDIST_NAME.fullmatch(path.name)
+        if wheel_match:
+            wheels.append((path, wheel_match.group("version")))
+        elif sdist_match:
+            sdists.append((path, sdist_match.group("version")))
+    versions = {version for _, version in (*wheels, *sdists)}
+    if len(versions) != 1:
+        raise ManifestError(
+            "expected exactly one distribution version across one wheel and one sdist; "
+            f"found {sorted(versions)}"
+        )
+    version = versions.pop()
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ManifestError(
+            "expected exactly one wheel and one source distribution; "
+            f"found wheels={len(wheels)}, sdists={len(sdists)}"
+        )
+    if version != expected_version:
+        raise ManifestError(
+            f"distribution expected version {expected_version!r}, found {version!r}"
+        )
+    return wheels[0][0], sdists[0][0], version
+
+
+def _wheel_members(path: Path) -> dict[str, bytes]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            return {name: archive.read(name) for name in archive.namelist()}
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ManifestError(f"could not read wheel distribution: {path.name}") from exc
+
+
+def _sdist_members(path: Path) -> dict[str, bytes]:
+    try:
+        with tarfile.open(path) as archive:
+            members: dict[str, bytes] = {}
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                extracted = archive.extractfile(member)
+                if extracted is not None:
+                    members[member.name] = extracted.read()
+            return members
+    except (OSError, tarfile.TarError) as exc:
+        raise ManifestError(f"could not read source distribution: {path.name}") from exc
+
+
+def _verify_metadata_version(
+    members: dict[str, bytes],
+    suffix: str,
+    expected_version: str,
+    archive_name: str,
+) -> None:
+    matches = [
+        payload
+        for name, payload in members.items()
+        if name.endswith(suffix) and (suffix != "/PKG-INFO" or name.count("/") == 1)
+    ]
+    if len(matches) != 1:
+        raise ManifestError(f"{archive_name} must contain exactly one {suffix}")
+    metadata = Parser().parsestr(matches[0].decode("utf-8"))
+    if metadata.get("Version") != expected_version:
+        raise ManifestError(
+            f"{archive_name} metadata version {metadata.get('Version')!r} "
+            f"does not match expected version {expected_version!r}"
+        )
+
+
+def _evidence_console_bundles(
+    repository_root: Path,
+    wheel_members: dict[str, bytes],
+    sdist_members: dict[str, bytes],
+) -> list[dict[str, object]]:
+    package_root = _package_root(repository_root)
+    console_root = package_root / "plugin_data" / "dashboard" / "react"
+    if not console_root.is_dir():
+        raise ManifestError(f"Evidence Console asset directory does not exist: {console_root}")
+    bundles: list[dict[str, object]] = []
+    for source_path in sorted(path for path in console_root.rglob("*") if path.is_file()):
+        relative = source_path.relative_to(package_root).as_posix()
+        expected = source_path.read_bytes()
+        wheel_name = f"{IMPORT_PACKAGE}/{relative}"
+        sdist_suffix = f"/src/{IMPORT_PACKAGE}/{relative}"
+        wheel_payload = wheel_members.get(wheel_name)
+        sdist_matches = [
+            payload for name, payload in sdist_members.items() if name.endswith(sdist_suffix)
+        ]
+        if wheel_payload != expected or sdist_matches != [expected]:
+            raise ManifestError(f"stale Evidence Console asset in distributions: {relative}")
+        bundles.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(expected).hexdigest(),
+                "size": len(expected),
+            }
+        )
+    return bundles
+
+
+def _contract_inventory(bundles: list[dict[str, object]]) -> dict[str, object]:
+    from codex_usage_tracker.core.json_contracts import known_json_schemas
+    from codex_usage_tracker.interfaces.mcp.profiles import tools_for_profile
+    from codex_usage_tracker.store.schema import SCHEMA_VERSION
+
+    profiles = {
+        profile: [spec.name for spec in tools_for_profile(profile)]
+        for profile in ("core", "full", "developer")
+    }
+    return {
+        "database_schema_version": SCHEMA_VERSION,
+        "evidence_console_bundles": bundles,
+        "json_schemas": list(known_json_schemas()),
+        "mcp_tools": profiles,
+    }
+
+
+def _package_root(repository_root: Path) -> Path:
+    source_root = repository_root / "src" / IMPORT_PACKAGE
+    if source_root.is_dir():
+        return source_root
+    return Path(__file__).resolve().parents[1]
+
+
+def _project_version(repository_root: Path) -> str:
+    pyproject = repository_root / "pyproject.toml"
+    if pyproject.is_file():
+        project_section = re.search(
+            r"(?ms)^\[project\]\s*$.*?^version\s*=\s*[\"'](?P<version>[^\"']+)[\"']",
+            pyproject.read_text(encoding="utf-8"),
+        )
+        if project_section is None:
+            raise ManifestError("pyproject.toml [project] is missing a string version")
+        return project_section.group("version")
+    try:
+        return installed_version(DISTRIBUTION_NAME)
+    except PackageNotFoundError as exc:
+        raise ManifestError("could not determine the expected distribution version") from exc
+
+
+def _default_repository_root() -> Path:
+    current = Path.cwd()
+    if (current / "pyproject.toml").is_file() and (current / "src" / IMPORT_PACKAGE).is_dir():
+        return current
+    return Path(__file__).resolve().parents[3]
+
+
+def _validate_source_sha(value: str) -> None:
+    if not _SOURCE_SHA.fullmatch(value):
+        raise ManifestError("expected source SHA must be a lowercase 40-character Git commit")
+
+
+def _validate_manifest_payload(payload: dict[str, Any]) -> None:
+    if payload.get("schema") != MANIFEST_SCHEMA:
+        raise ManifestError(f"unsupported manifest schema: {payload.get('schema')!r}")
+    if payload.get("distribution") != DISTRIBUTION_NAME:
+        raise ManifestError("manifest distribution name does not match")
+    version = _manifest_version(payload.get("version"))
+    _validate_manifest_source(payload.get("source"))
+    _validate_contract_inventory(payload.get("contract_inventory"))
+    names = _validate_artifact_entries(payload.get("artifacts"))
+    _validate_artifact_names(names, version)
+
+
+def _manifest_version(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ManifestError("manifest version must be a non-empty string")
+    return value
+
+
+def _validate_manifest_source(value: object) -> None:
+    if not isinstance(value, dict) or not isinstance(value.get("git_sha"), str):
+        raise ManifestError("manifest source must contain a Git SHA")
+    _validate_source_sha(value["git_sha"])
+
+
+def _validate_contract_inventory(value: object) -> None:
+    if not isinstance(value, dict):
+        raise ManifestError("manifest contract inventory must be an object")
+    required_types = (
+        ("database_schema_version", int),
+        ("evidence_console_bundles", list),
+        ("json_schemas", list),
+        ("mcp_tools", dict),
+    )
+    invalid = [key for key, expected in required_types if not isinstance(value.get(key), expected)]
+    if invalid:
+        raise ManifestError(f"manifest contract inventory has invalid {invalid[0]}")
+
+
+def _validate_artifact_entries(value: object) -> list[str]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise ManifestError("manifest must contain exactly one wheel and one sdist")
+    names = [_validate_artifact_entry(artifact) for artifact in value]
+    if len(set(names)) != len(names):
+        raise ManifestError("manifest artifact paths must be unique")
+    return names
+
+
+def _validate_artifact_entry(value: object) -> str:
+    if not isinstance(value, dict):
+        raise ManifestError("manifest artifact entry must be an object")
+    name = value.get("path")
+    digest = value.get("sha256")
+    size = value.get("size")
+    if not isinstance(name, str) or Path(name).name != name:
+        raise ManifestError("manifest artifact paths must be safe basenames")
+    if not isinstance(digest, str) or _SHA256.fullmatch(digest) is None:
+        raise ManifestError(f"manifest artifact has invalid SHA-256: {name}")
+    if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+        raise ManifestError(f"manifest artifact has invalid size: {name}")
+    return name
+
+
+def _validate_artifact_names(names: list[str], version: str) -> None:
+    if not _has_expected_wheel(names, version) or not _has_expected_sdist(names, version):
+        raise ManifestError("manifest artifact names do not match the manifest version")
+
+
+def _has_expected_wheel(names: list[str], version: str) -> bool:
+    matches = [match for name in names if (match := _WHEEL_NAME.fullmatch(name)) is not None]
+    return len(matches) == 1 and matches[0].group("version") == version
+
+
+def _has_expected_sdist(names: list[str], version: str) -> bool:
+    matches = [match for name in names if (match := _SDIST_NAME.fullmatch(name)) is not None]
+    return len(matches) == 1 and matches[0].group("version") == version
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("create", "verify"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--source", type=Path, required=True)
+        subparser.add_argument("--expected-sha", required=True)
+        subparser.add_argument("--expected-version")
+        if command == "create":
+            subparser.add_argument("--output", type=Path, required=True)
+        else:
+            subparser.add_argument("--manifest", type=Path, required=True)
+    digest = subparsers.add_parser("digest")
+    digest.add_argument("--manifest", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run shell-friendly manifest creation, verification, or digest output."""
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            manifest = create_manifest(
+                args.source,
+                args.output,
+                expected_sha=args.expected_sha,
+                expected_version=args.expected_version,
+            )
+            print(f"created {args.output} for {manifest['version']}")
+        elif args.command == "verify":
+            manifest = verify_manifest(
+                args.source,
+                args.manifest,
+                expected_sha=args.expected_sha,
+                expected_version=args.expected_version,
+            )
+            print(f"verified {len(manifest['artifacts'])} release artifacts")
+        else:
+            load_manifest(args.manifest)
+            print(manifest_sha256(args.manifest))
+    except ManifestError as exc:
+        print(f"release manifest error: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_usage_tracker/release/artifact_normalization.py
+++ b/src/codex_usage_tracker/release/artifact_normalization.py
@@ -8,6 +8,7 @@ import gzip
 import io
 import tarfile
 from pathlib import Path
+from typing import cast
 
 
 class ArtifactNormalizationError(ValueError):
@@ -71,7 +72,7 @@ def _normalized_member(member: tarfile.TarInfo, *, epoch: int) -> tarfile.TarInf
     normalized.gid = 0
     normalized.uname = ""
     normalized.gname = ""
-    normalized.pax_headers.clear()
+    cast(dict[str, str], normalized.pax_headers).clear()
     return normalized
 
 

--- a/src/codex_usage_tracker/release/artifact_normalization.py
+++ b/src/codex_usage_tracker/release/artifact_normalization.py
@@ -71,7 +71,7 @@ def _normalized_member(member: tarfile.TarInfo, *, epoch: int) -> tarfile.TarInf
     normalized.gid = 0
     normalized.uname = ""
     normalized.gname = ""
-    normalized.pax_headers = {}
+    normalized.pax_headers.clear()
     return normalized
 
 

--- a/src/codex_usage_tracker/release/artifact_normalization.py
+++ b/src/codex_usage_tracker/release/artifact_normalization.py
@@ -1,0 +1,108 @@
+"""Normalize the source distribution created by one release build."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gzip
+import io
+import tarfile
+from pathlib import Path
+
+
+class ArtifactNormalizationError(ValueError):
+    """Raised when a built source distribution cannot be normalized safely."""
+
+
+def normalize_sdist_directory(source: Path, *, epoch: int) -> Path:
+    """Normalize the sole sdist in a directory to a reproducible byte stream."""
+    if epoch < 0:
+        raise ArtifactNormalizationError("normalization epoch must not be negative")
+    if not source.is_dir():
+        raise ArtifactNormalizationError(f"distribution directory does not exist: {source}")
+    candidates = sorted(source.glob("codex_usage_tracking-*.tar.gz"))
+    if len(candidates) != 1:
+        raise ArtifactNormalizationError(
+            "expected exactly one source distribution to normalize; "
+            f"found {[path.name for path in candidates]}"
+        )
+    _normalize_sdist(candidates[0], epoch=epoch)
+    return candidates[0]
+
+
+def _normalize_sdist(path: Path, *, epoch: int) -> None:
+    try:
+        with tarfile.open(path, mode="r:gz") as archive:
+            entries = [
+                (_normalized_member(member, epoch=epoch), _member_payload(archive, member))
+                for member in sorted(archive.getmembers(), key=lambda item: item.name)
+            ]
+    except (OSError, tarfile.TarError) as exc:
+        raise ArtifactNormalizationError(
+            f"could not read source distribution: {path.name}"
+        ) from exc
+
+    temporary = path.with_name(f".{path.name}.normalized")
+    try:
+        with (
+            temporary.open("wb") as raw,
+            gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=epoch) as compressed,
+            tarfile.open(
+                fileobj=compressed,
+                mode="w",
+                format=tarfile.PAX_FORMAT,
+            ) as archive,
+        ):
+            for member, payload in entries:
+                archive.addfile(member, payload)
+        temporary.replace(path)
+    except OSError as exc:
+        raise ArtifactNormalizationError(
+            f"could not write normalized source distribution: {path.name}"
+        ) from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _normalized_member(member: tarfile.TarInfo, *, epoch: int) -> tarfile.TarInfo:
+    normalized = copy.copy(member)
+    normalized.mtime = epoch
+    normalized.uid = 0
+    normalized.gid = 0
+    normalized.uname = ""
+    normalized.gname = ""
+    normalized.pax_headers = {}
+    return normalized
+
+
+def _member_payload(
+    archive: tarfile.TarFile,
+    member: tarfile.TarInfo,
+) -> io.BytesIO | None:
+    if not member.isfile():
+        return None
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise ArtifactNormalizationError(
+            f"source distribution member has no payload: {member.name}"
+        )
+    return io.BytesIO(extracted.read())
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run shell-friendly source-distribution normalization."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--epoch", type=int, required=True)
+    args = parser.parse_args(argv)
+    try:
+        path = normalize_sdist_directory(args.source, epoch=args.epoch)
+    except ArtifactNormalizationError as exc:
+        print(f"release artifact normalization error: {exc}")
+        return 1
+    print(f"normalized {path.name} at epoch {args.epoch}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_usage_tracker/release/promotion_evidence.py
+++ b/src/codex_usage_tracker/release/promotion_evidence.py
@@ -1,0 +1,356 @@
+"""Qualify release bytes from package indexes and record promotion evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.release.artifact_manifest import (
+    ManifestError,
+    canonical_json_bytes,
+    load_manifest,
+    manifest_sha256,
+)
+
+PROMOTION_SCHEMA = "codex-usage-tracker.release-promotion-evidence.v1"
+
+
+class PromotionError(ValueError):
+    """Raised when published artifacts are not safe to promote."""
+
+
+def create_promotion_evidence(
+    manifest_path: Path,
+    output: Path,
+    *,
+    run_id: str,
+    run_attempt: str,
+    index_url: str,
+    installed_smoke: str,
+) -> dict[str, Any]:
+    """Write canonical evidence for a successful TestPyPI qualification."""
+    manifest = _load_release_manifest(manifest_path)
+    if installed_smoke != "passed":
+        raise PromotionError("installed smoke must be recorded as passed")
+    if not run_id.isdigit() or not run_attempt.isdigit():
+        raise PromotionError("GitHub Actions run id and attempt must be numeric")
+    _validate_https_url(index_url, label="package index")
+    evidence = {
+        "artifacts": manifest["artifacts"],
+        "contract_inventory": manifest["contract_inventory"],
+        "github_actions": {"run_attempt": run_attempt, "run_id": run_id},
+        "manifest_sha256": manifest_sha256(manifest_path),
+        "qualification": {
+            "index_url": index_url,
+            "installed_smoke": installed_smoke,
+        },
+        "schema": PROMOTION_SCHEMA,
+        "source_sha": manifest["source"]["git_sha"],
+        "version": manifest["version"],
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_json_bytes(evidence))
+    return evidence
+
+
+def verify_promotion_evidence(
+    manifest_path: Path,
+    evidence_path: Path,
+    *,
+    expected_sha: str,
+    expected_run_id: str | None = None,
+) -> dict[str, Any]:
+    """Verify qualification evidence remains bound to one canonical manifest."""
+    manifest = _load_release_manifest(manifest_path)
+    evidence = _load_canonical_evidence(evidence_path)
+    _verify_evidence_identity(evidence, manifest, manifest_path, expected_sha)
+    _verify_run_identity(evidence, expected_run_id)
+    _verify_qualification(evidence)
+    _verify_manifest_fields(evidence, manifest)
+    return evidence
+
+
+def _verify_evidence_identity(
+    evidence: dict[str, Any],
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    expected_sha: str,
+) -> None:
+    if evidence.get("manifest_sha256") != manifest_sha256(manifest_path):
+        raise PromotionError("promotion evidence manifest SHA-256 does not match")
+    if evidence.get("source_sha") != expected_sha:
+        raise PromotionError("promotion evidence source SHA does not match")
+    if manifest["source"]["git_sha"] != expected_sha:
+        raise PromotionError("release manifest source SHA does not match")
+
+
+def _verify_run_identity(evidence: dict[str, Any], expected_run_id: str | None) -> None:
+    if expected_run_id is None:
+        return
+    actions = evidence.get("github_actions")
+    if not isinstance(actions, dict) or actions.get("run_id") != expected_run_id:
+        raise PromotionError("promotion evidence GitHub Actions run id does not match")
+
+
+def _verify_qualification(evidence: dict[str, Any]) -> None:
+    qualification = evidence.get("qualification")
+    if not isinstance(qualification, dict) or qualification.get("installed_smoke") != "passed":
+        raise PromotionError("promotion evidence does not record a passed installed smoke")
+
+
+def _verify_manifest_fields(
+    evidence: dict[str, Any],
+    manifest: dict[str, Any],
+) -> None:
+    for key in ("version", "artifacts", "contract_inventory"):
+        if evidence.get(key) != manifest.get(key):
+            raise PromotionError(f"promotion evidence {key} does not match the manifest")
+
+
+def validate_index_payload(
+    manifest: dict[str, Any],
+    payload: dict[str, Any],
+) -> list[str]:
+    """Return mismatches between an index version payload and the manifest."""
+    failures = _index_version_failures(manifest, payload)
+    urls = payload.get("urls")
+    if not isinstance(urls, list):
+        return [*failures, "index payload urls must be a list"]
+    published, entry_failures = _published_artifacts(urls)
+    failures.extend(entry_failures)
+    expected_names = {artifact["path"] for artifact in manifest["artifacts"]}
+    unexpected = sorted(set(published).difference(expected_names))
+    if unexpected:
+        failures.append(f"index has unexpected release artifacts: {unexpected}")
+    for artifact in manifest["artifacts"]:
+        failures.extend(_artifact_index_failures(artifact, published))
+    return failures
+
+
+def _index_version_failures(
+    manifest: dict[str, Any],
+    payload: dict[str, Any],
+) -> list[str]:
+    info = payload.get("info")
+    version = info.get("version") if isinstance(info, dict) else None
+    if version != manifest.get("version"):
+        return [
+            f"index version {version!r} does not match manifest version {manifest.get('version')!r}"
+        ]
+    return []
+
+
+def _published_artifacts(
+    urls: list[object],
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    published: dict[str, dict[str, Any]] = {}
+    failures: list[str] = []
+    for item in urls:
+        if not isinstance(item, dict):
+            failures.append("index artifact entries must be objects with string filenames")
+            continue
+        filename = item.get("filename")
+        if not isinstance(filename, str):
+            failures.append("index artifact entries must be objects with string filenames")
+        elif filename in published:
+            failures.append(f"index has duplicate release artifact: {filename}")
+        else:
+            published[filename] = item
+    return published, failures
+
+
+def _artifact_index_failures(
+    artifact: dict[str, Any],
+    published: dict[str, dict[str, Any]],
+) -> list[str]:
+    filename = artifact["path"]
+    item = published.get(filename)
+    if item is None:
+        return [f"index is missing release artifact: {filename}"]
+    failures: list[str] = []
+    digests = item.get("digests")
+    sha256 = digests.get("sha256") if isinstance(digests, dict) else None
+    if sha256 != artifact["sha256"]:
+        failures.append(f"index SHA-256 does not match manifest for {filename}")
+    if item.get("size") != artifact["size"]:
+        failures.append(f"index size does not match manifest for {filename}")
+    return failures
+
+
+def download_index_artifacts(
+    manifest_path: Path,
+    index_json_url: str,
+    destination: Path,
+    *,
+    attempts: int = 12,
+    delay_seconds: float = 10.0,
+) -> list[Path]:
+    """Download and verify every manifest artifact from one package index."""
+    if attempts < 1:
+        raise PromotionError("download attempts must be at least one")
+    if delay_seconds < 0:
+        raise PromotionError("download delay must not be negative")
+    _validate_https_url(index_json_url, label="package index")
+    manifest = _load_release_manifest(manifest_path)
+    last_error = "index did not return release metadata"
+    for attempt in range(1, attempts + 1):
+        try:
+            payload = _read_json_url(index_json_url)
+            failures = validate_index_payload(manifest, payload)
+            if failures:
+                raise PromotionError("; ".join(failures))
+            return _download_payload_files(manifest, payload, destination)
+        except (PromotionError, urllib.error.URLError) as exc:
+            last_error = str(exc)
+            if attempt < attempts:
+                time.sleep(delay_seconds)
+    raise PromotionError(
+        f"package index artifacts were not ready after {attempts} attempts: {last_error}"
+    )
+
+
+def _download_payload_files(
+    manifest: dict[str, Any],
+    payload: dict[str, Any],
+    destination: Path,
+) -> list[Path]:
+    urls = {
+        item["filename"]: item
+        for item in payload["urls"]
+        if isinstance(item, dict) and isinstance(item.get("filename"), str)
+    }
+    destination.mkdir(parents=True, exist_ok=True)
+    downloaded: list[Path] = []
+    for artifact in manifest["artifacts"]:
+        filename = artifact["path"]
+        url = urls[filename].get("url")
+        if not isinstance(url, str):
+            raise PromotionError(f"index artifact has no download URL: {filename}")
+        _validate_https_url(url, label=f"artifact {filename}")
+        with _open_https_url(url, timeout=60) as response:
+            payload_bytes = response.read()
+        digest = hashlib.sha256(payload_bytes).hexdigest()
+        if digest != artifact["sha256"] or len(payload_bytes) != artifact["size"]:
+            raise PromotionError(f"downloaded artifact bytes do not match manifest: {filename}")
+        output = destination / filename
+        partial = destination / f".{filename}.part"
+        partial.write_bytes(payload_bytes)
+        partial.replace(output)
+        downloaded.append(output)
+    return downloaded
+
+
+def _read_json_url(url: str) -> dict[str, Any]:
+    with _open_https_url(url, timeout=30) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise PromotionError("package index response must be a JSON object")
+    return payload
+
+
+def _load_release_manifest(path: Path) -> dict[str, Any]:
+    try:
+        return load_manifest(path)
+    except ManifestError as exc:
+        raise PromotionError(str(exc)) from exc
+
+
+def _load_canonical_evidence(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise PromotionError(f"promotion evidence file does not exist: {path}")
+    raw = path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PromotionError("promotion evidence is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise PromotionError("promotion evidence root must be an object")
+    if raw != canonical_json_bytes(payload):
+        raise PromotionError("promotion evidence is not in canonical JSON form")
+    if payload.get("schema") != PROMOTION_SCHEMA:
+        raise PromotionError(f"unsupported promotion evidence schema: {payload.get('schema')!r}")
+    return payload
+
+
+def _validate_https_url(url: str, *, label: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+        raise PromotionError(f"{label} URL must be credential-free HTTPS")
+
+
+def _open_https_url(url: str, *, timeout: int) -> Any:
+    _validate_https_url(url, label="network")
+    # The immediately preceding validator permits only credential-free HTTPS.
+    return urllib.request.urlopen(url, timeout=timeout)  # nosec B310
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create = subparsers.add_parser("create")
+    create.add_argument("--manifest", type=Path, required=True)
+    create.add_argument("--output", type=Path, required=True)
+    create.add_argument("--run-id", required=True)
+    create.add_argument("--run-attempt", required=True)
+    create.add_argument("--index-url", required=True)
+    create.add_argument("--installed-smoke", choices=("passed", "failed"), required=True)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--manifest", type=Path, required=True)
+    verify.add_argument("--evidence", type=Path, required=True)
+    verify.add_argument("--expected-sha", required=True)
+    verify.add_argument("--run-id")
+    download = subparsers.add_parser("download-index")
+    download.add_argument("--manifest", type=Path, required=True)
+    download.add_argument("--index-json-url", required=True)
+    download.add_argument("--output", type=Path, required=True)
+    download.add_argument("--attempts", type=int, default=12)
+    download.add_argument("--delay-seconds", type=float, default=10.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run promotion evidence and index-download commands."""
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            evidence = create_promotion_evidence(
+                args.manifest,
+                args.output,
+                run_id=args.run_id,
+                run_attempt=args.run_attempt,
+                index_url=args.index_url,
+                installed_smoke=args.installed_smoke,
+            )
+            print(f"recorded promotion evidence for {evidence['version']}")
+        elif args.command == "verify":
+            evidence = verify_promotion_evidence(
+                args.manifest,
+                args.evidence,
+                expected_sha=args.expected_sha,
+                expected_run_id=args.run_id,
+            )
+            print(f"verified promotion evidence for {evidence['version']}")
+        else:
+            downloaded = download_index_artifacts(
+                args.manifest,
+                args.index_json_url,
+                args.output,
+                attempts=args.attempts,
+                delay_seconds=args.delay_seconds,
+            )
+            print(f"downloaded and verified {len(downloaded)} release artifacts")
+    except PromotionError as exc:
+        print(f"promotion evidence error: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_usage_tracker/release/tach.domain.toml
+++ b/src/codex_usage_tracker/release/tach.domain.toml
@@ -1,0 +1,6 @@
+[root]
+depends_on = [
+    "//codex_usage_tracker.core",
+    "//codex_usage_tracker.interfaces.mcp",
+    "//codex_usage_tracker.store",
+]

--- a/tests/release/__init__.py
+++ b/tests/release/__init__.py
@@ -1,0 +1,1 @@
+"""Release-promotion contract tests."""

--- a/tests/release/conftest.py
+++ b/tests/release/conftest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+PACKAGE_STEM = "codex_usage_tracking"
+IMPORT_PACKAGE = "codex_usage_tracker"
+ASSET_PATH = "plugin_data/dashboard/react/assets/dashboard-react.js"
+INDEX_PATH = "plugin_data/dashboard/react/index.html"
+
+
+class ReleaseFixture:
+    def __init__(self, root: Path, *, version: str = "0.23.0") -> None:
+        self.root = root
+        self.version = version
+        self.repo_root = root / "repo"
+        self.dist_dir = root / "dist"
+        self.manifest_path = root / "release-manifest.json"
+        self.asset_bytes = b"console.log('current');\n"
+        self.index_bytes = b'<script src="./assets/dashboard-react.js"></script>\n'
+
+    @property
+    def wheel_path(self) -> Path:
+        return self.dist_dir / f"{PACKAGE_STEM}-{self.version}-py3-none-any.whl"
+
+    @property
+    def sdist_path(self) -> Path:
+        return self.dist_dir / f"{PACKAGE_STEM}-{self.version}.tar.gz"
+
+    def write_source_assets(
+        self,
+        *,
+        asset_bytes: bytes | None = None,
+        index_bytes: bytes | None = None,
+    ) -> None:
+        package_root = self.repo_root / "src" / IMPORT_PACKAGE
+        asset_path = package_root / ASSET_PATH
+        index_path = package_root / INDEX_PATH
+        asset_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        asset_path.write_bytes(asset_bytes or self.asset_bytes)
+        index_path.write_bytes(index_bytes or self.index_bytes)
+
+    def write_distributions(
+        self,
+        *,
+        version: str | None = None,
+        wheel_asset: bytes | None = None,
+        sdist_asset: bytes | None = None,
+    ) -> tuple[Path, Path]:
+        selected_version = version or self.version
+        self.dist_dir.mkdir(parents=True, exist_ok=True)
+        wheel_path = self.dist_dir / f"{PACKAGE_STEM}-{selected_version}-py3-none-any.whl"
+        sdist_path = self.dist_dir / f"{PACKAGE_STEM}-{selected_version}.tar.gz"
+        wheel_members = {
+            f"{IMPORT_PACKAGE}/{INDEX_PATH}": self.index_bytes,
+            f"{IMPORT_PACKAGE}/{ASSET_PATH}": wheel_asset or self.asset_bytes,
+            (f"{PACKAGE_STEM}-{selected_version}.dist-info/METADATA"): _metadata(selected_version),
+        }
+        with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as wheel:
+            for name, payload in wheel_members.items():
+                wheel.writestr(name, payload)
+
+        root = f"{PACKAGE_STEM}-{selected_version}"
+        sdist_members = {
+            f"{root}/PKG-INFO": _metadata(selected_version),
+            f"{root}/src/{IMPORT_PACKAGE}/{INDEX_PATH}": self.index_bytes,
+            f"{root}/src/{IMPORT_PACKAGE}/{ASSET_PATH}": sdist_asset or self.asset_bytes,
+        }
+        with tarfile.open(sdist_path, "w:gz") as sdist:
+            for name, payload in sdist_members.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                info.mtime = 0
+                sdist.addfile(info, io.BytesIO(payload))
+        return wheel_path, sdist_path
+
+
+@pytest.fixture
+def release_fixture(tmp_path: Path) -> ReleaseFixture:
+    fixture = ReleaseFixture(tmp_path)
+    fixture.write_source_assets()
+    fixture.write_distributions()
+    return fixture
+
+
+def _metadata(version: str) -> bytes:
+    return (f"Metadata-Version: 2.4\nName: codex-usage-tracking\nVersion: {version}\n\n").encode()

--- a/tests/release/test_artifact_manifest.py
+++ b/tests/release/test_artifact_manifest.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import zipfile
+from argparse import Namespace
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_usage_tracker.release.artifact_manifest import (
+    ManifestError,
+    canonical_json_bytes,
+    create_manifest,
+    load_manifest,
+    main,
+    verify_manifest,
+)
+from codex_usage_tracker.release.artifact_normalization import (
+    ArtifactNormalizationError,
+    normalize_sdist_directory,
+)
+from codex_usage_tracker.release.artifact_normalization import (
+    main as normalization_main,
+)
+from scripts.smoke_installed_package import _resolve_install_target
+from tests.release.conftest import ReleaseFixture
+
+SOURCE_SHA = "a" * 40
+
+
+def _write_sdist(path: Path, *, mtime: int) -> None:
+    with tarfile.open(path, mode="w:gz") as archive:
+        for name, payload in (
+            ("package/", None),
+            ("package/PKG-INFO", b"Version: 0.23.0\n"),
+        ):
+            member = tarfile.TarInfo(name)
+            member.mtime = mtime
+            member.uid = mtime
+            member.gid = mtime
+            if payload is None:
+                member.type = tarfile.DIRTYPE
+                archive.addfile(member)
+            else:
+                member.size = len(payload)
+                archive.addfile(member, io.BytesIO(payload))
+
+
+def test_sdist_normalization_is_byte_reproducible(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    first_sdist = first / "codex_usage_tracking-0.23.0.tar.gz"
+    second_sdist = second / "codex_usage_tracking-0.23.0.tar.gz"
+    _write_sdist(first_sdist, mtime=1)
+    _write_sdist(second_sdist, mtime=2)
+
+    normalize_sdist_directory(first, epoch=123456)
+    normalize_sdist_directory(second, epoch=123456)
+
+    assert first_sdist.read_bytes() == second_sdist.read_bytes()
+    with tarfile.open(first_sdist, mode="r:gz") as archive:
+        assert all(
+            (member.mtime, member.uid, member.gid, member.uname, member.gname)
+            == (123456, 0, 0, "", "")
+            for member in archive.getmembers()
+        )
+
+
+def test_sdist_normalization_cli_fails_closed(tmp_path: Path) -> None:
+    assert normalization_main(["--source", str(tmp_path), "--epoch", "1"]) == 1
+    with pytest.raises(ArtifactNormalizationError, match="must not be negative"):
+        normalize_sdist_directory(tmp_path, epoch=-1)
+
+
+def _create(fixture: ReleaseFixture) -> dict[str, Any]:
+    return create_manifest(
+        fixture.dist_dir,
+        fixture.manifest_path,
+        expected_sha=SOURCE_SHA,
+        expected_version=fixture.version,
+        repository_root=fixture.repo_root,
+    )
+
+
+def _verify(fixture: ReleaseFixture, *, expected_sha: str = SOURCE_SHA) -> dict[str, Any]:
+    return verify_manifest(
+        fixture.dist_dir,
+        fixture.manifest_path,
+        expected_sha=expected_sha,
+        expected_version=fixture.version,
+        repository_root=fixture.repo_root,
+    )
+
+
+def test_manifest_is_canonical_and_deterministic(release_fixture: ReleaseFixture) -> None:
+    first = _create(release_fixture)
+    first_bytes = release_fixture.manifest_path.read_bytes()
+
+    second = _create(release_fixture)
+
+    assert first == second
+    assert release_fixture.manifest_path.read_bytes() == first_bytes
+    assert first["source"]["git_sha"] == SOURCE_SHA
+    assert [item["path"] for item in first["artifacts"]] == sorted(
+        item["path"] for item in first["artifacts"]
+    )
+    assert _verify(release_fixture) == first
+
+
+def test_verify_rejects_noncanonical_manifest(release_fixture: ReleaseFixture) -> None:
+    manifest = _create(release_fixture)
+    release_fixture.manifest_path.write_text(
+        json.dumps(manifest, indent=4) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ManifestError, match="canonical"):
+        _verify(release_fixture)
+
+
+def test_verify_rejects_unsafe_artifact_path(release_fixture: ReleaseFixture) -> None:
+    manifest = _create(release_fixture)
+    manifest["artifacts"][0]["path"] = "../unexpected.whl"
+    release_fixture.manifest_path.write_bytes(canonical_json_bytes(manifest))
+
+    with pytest.raises(ManifestError, match="safe basenames"):
+        _verify(release_fixture)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        (lambda payload: payload.update(schema="unknown"), "unsupported manifest schema"),
+        (lambda payload: payload.update(distribution="other"), "distribution name"),
+        (lambda payload: payload.update(version=""), "version must"),
+        (lambda payload: payload.update(source={}), "must contain a Git SHA"),
+        (lambda payload: payload.update(contract_inventory=[]), "inventory must be an object"),
+        (
+            lambda payload: payload["contract_inventory"].update(json_schemas={}),
+            "invalid json_schemas",
+        ),
+        (lambda payload: payload.update(artifacts=[]), "exactly one wheel"),
+        (
+            lambda payload: payload["artifacts"][0].update(sha256="bad"),
+            "invalid SHA-256",
+        ),
+        (
+            lambda payload: payload["artifacts"][0].update(size=-1),
+            "invalid size",
+        ),
+        (
+            lambda payload: payload["artifacts"][1].update(path=payload["artifacts"][0]["path"]),
+            "paths must be unique",
+        ),
+        (
+            lambda payload: payload["artifacts"][0].update(path="unexpected.whl"),
+            "names do not match",
+        ),
+    ],
+    ids=[
+        "schema",
+        "distribution",
+        "version",
+        "source",
+        "inventory-root",
+        "inventory-field",
+        "artifact-count",
+        "artifact-hash",
+        "artifact-size",
+        "duplicate-name",
+        "unexpected-name",
+    ],
+)
+def test_load_rejects_invalid_manifest_shape(
+    release_fixture: ReleaseFixture,
+    mutation: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    manifest = deepcopy(_create(release_fixture))
+    mutation(manifest)
+    release_fixture.manifest_path.write_bytes(canonical_json_bytes(manifest))
+
+    with pytest.raises(ManifestError, match=expected):
+        load_manifest(release_fixture.manifest_path)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [b"not-json\n", canonical_json_bytes([])],
+    ids=["invalid-json", "non-object"],
+)
+def test_load_rejects_invalid_json_root(
+    release_fixture: ReleaseFixture,
+    payload: bytes,
+) -> None:
+    release_fixture.manifest_path.write_bytes(payload)
+
+    with pytest.raises(ManifestError):
+        load_manifest(release_fixture.manifest_path)
+
+
+def test_verify_rejects_missing_artifact(release_fixture: ReleaseFixture) -> None:
+    _create(release_fixture)
+    release_fixture.wheel_path.unlink()
+
+    with pytest.raises(ManifestError, match="distribution"):
+        _verify(release_fixture)
+
+
+def test_verify_rejects_altered_artifact(release_fixture: ReleaseFixture) -> None:
+    _create(release_fixture)
+    with zipfile.ZipFile(release_fixture.wheel_path, "a") as wheel:
+        wheel.writestr("unexpected.txt", b"altered after manifest creation\n")
+
+    with pytest.raises(ManifestError, match="manifest does not match"):
+        _verify(release_fixture)
+
+
+def test_verify_rejects_wrong_source_sha(release_fixture: ReleaseFixture) -> None:
+    _create(release_fixture)
+
+    with pytest.raises(ManifestError, match="source SHA"):
+        _verify(release_fixture, expected_sha="b" * 40)
+
+
+def test_create_rejects_wrong_version(release_fixture: ReleaseFixture) -> None:
+    with pytest.raises(ManifestError, match="expected version"):
+        create_manifest(
+            release_fixture.dist_dir,
+            release_fixture.manifest_path,
+            expected_sha=SOURCE_SHA,
+            expected_version="0.24.0",
+            repository_root=release_fixture.repo_root,
+        )
+
+
+def test_create_rejects_multiple_versions(release_fixture: ReleaseFixture) -> None:
+    release_fixture.write_distributions(version="0.24.0")
+
+    with pytest.raises(ManifestError, match="one distribution version"):
+        _create(release_fixture)
+
+
+def test_create_rejects_stale_frontend_asset(release_fixture: ReleaseFixture) -> None:
+    release_fixture.write_distributions(wheel_asset=b"console.log('stale');\n")
+
+    with pytest.raises(ManifestError, match="stale Evidence Console asset"):
+        _create(release_fixture)
+
+
+@pytest.mark.parametrize("archive", ["wheel", "sdist"])
+def test_create_rejects_unreadable_distribution(
+    release_fixture: ReleaseFixture,
+    archive: str,
+) -> None:
+    path = release_fixture.wheel_path if archive == "wheel" else release_fixture.sdist_path
+    path.write_bytes(b"not an archive")
+
+    with pytest.raises(ManifestError, match="could not read"):
+        _create(release_fixture)
+
+
+def test_create_rejects_missing_console_source(release_fixture: ReleaseFixture) -> None:
+    empty_repo = release_fixture.root / "empty-repo"
+    (empty_repo / "src" / "codex_usage_tracker").mkdir(parents=True)
+
+    with pytest.raises(ManifestError, match="asset directory"):
+        create_manifest(
+            release_fixture.dist_dir,
+            release_fixture.manifest_path,
+            expected_sha=SOURCE_SHA,
+            expected_version=release_fixture.version,
+            repository_root=empty_repo,
+        )
+
+
+def test_create_rejects_duplicate_wheel(release_fixture: ReleaseFixture) -> None:
+    duplicate = release_fixture.dist_dir / (
+        f"codex_usage_tracking-{release_fixture.version}-py2-none-any.whl"
+    )
+    duplicate.write_bytes(release_fixture.wheel_path.read_bytes())
+
+    with pytest.raises(ManifestError, match="exactly one wheel"):
+        _create(release_fixture)
+
+
+def test_verify_rejects_missing_manifest_file(release_fixture: ReleaseFixture) -> None:
+    missing = Path(release_fixture.root / "missing.json")
+
+    with pytest.raises(ManifestError, match="manifest file"):
+        verify_manifest(
+            release_fixture.dist_dir,
+            missing,
+            expected_sha=SOURCE_SHA,
+            expected_version=release_fixture.version,
+            repository_root=release_fixture.repo_root,
+        )
+
+
+def test_installed_smoke_selects_exact_existing_wheel(
+    release_fixture: ReleaseFixture,
+) -> None:
+    args = Namespace(
+        artifact_dir=release_fixture.dist_dir,
+        from_pypi=False,
+        version=release_fixture.version,
+    )
+
+    assert _resolve_install_target(args, release_fixture.root) == str(
+        release_fixture.wheel_path.resolve()
+    )
+
+
+def test_installed_smoke_rejects_ambiguous_artifact_directory(
+    release_fixture: ReleaseFixture,
+) -> None:
+    release_fixture.write_distributions(version="0.24.0")
+    args = Namespace(
+        artifact_dir=release_fixture.dist_dir,
+        from_pypi=False,
+        version=None,
+    )
+
+    with pytest.raises(FileNotFoundError, match="exactly one matching wheel"):
+        _resolve_install_target(args, release_fixture.root)
+
+
+def test_manifest_cli_create_verify_and_digest(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (release_fixture.repo_root / "pyproject.toml").write_text(
+        f'[project]\nname = "codex-usage-tracking"\nversion = "{release_fixture.version}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(release_fixture.repo_root)
+
+    assert (
+        main(
+            [
+                "create",
+                "--source",
+                str(release_fixture.dist_dir),
+                "--output",
+                str(release_fixture.manifest_path),
+                "--expected-sha",
+                SOURCE_SHA,
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "verify",
+                "--source",
+                str(release_fixture.dist_dir),
+                "--manifest",
+                str(release_fixture.manifest_path),
+                "--expected-sha",
+                SOURCE_SHA,
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "digest",
+                "--manifest",
+                str(release_fixture.manifest_path),
+            ]
+        )
+        == 0
+    )
+    assert "created" in capsys.readouterr().out
+
+
+def test_manifest_cli_reports_contract_error(release_fixture: ReleaseFixture) -> None:
+    assert (
+        main(
+            [
+                "verify",
+                "--source",
+                str(release_fixture.dist_dir),
+                "--manifest",
+                str(release_fixture.root / "missing.json"),
+                "--expected-sha",
+                SOURCE_SHA,
+                "--expected-version",
+                release_fixture.version,
+            ]
+        )
+        == 1
+    )

--- a/tests/release/test_promotion_evidence.py
+++ b/tests/release/test_promotion_evidence.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import io
+import shutil
+import urllib.error
+from collections.abc import Callable
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from codex_usage_tracker.release import promotion_evidence as promotion_module
+from codex_usage_tracker.release.artifact_manifest import create_manifest
+from codex_usage_tracker.release.promotion_evidence import (
+    PromotionError,
+    create_promotion_evidence,
+    download_index_artifacts,
+    main,
+    validate_index_payload,
+    verify_promotion_evidence,
+)
+from scripts import release_promotion_quality
+from scripts.release_quality import check_publish_workflow
+from tests.release.conftest import ReleaseFixture
+
+SOURCE_SHA = "a" * 40
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _manifest(fixture: ReleaseFixture) -> dict[str, Any]:
+    return create_manifest(
+        fixture.dist_dir,
+        fixture.manifest_path,
+        expected_sha=SOURCE_SHA,
+        expected_version=fixture.version,
+        repository_root=fixture.repo_root,
+    )
+
+
+def test_evidence_records_exact_release_identity(release_fixture: ReleaseFixture) -> None:
+    manifest = _manifest(release_fixture)
+    evidence_path = release_fixture.root / "promotion-evidence.json"
+
+    evidence = create_promotion_evidence(
+        release_fixture.manifest_path,
+        evidence_path,
+        run_id="123456",
+        run_attempt="2",
+        index_url="https://test.pypi.org/pypi/codex-usage-tracking/0.23.0/json",
+        installed_smoke="passed",
+    )
+
+    assert evidence["source_sha"] == SOURCE_SHA
+    assert evidence["github_actions"] == {"run_attempt": "2", "run_id": "123456"}
+    assert evidence["qualification"]["installed_smoke"] == "passed"
+    assert evidence["artifacts"] == manifest["artifacts"]
+    assert evidence["contract_inventory"] == manifest["contract_inventory"]
+    assert (
+        verify_promotion_evidence(
+            release_fixture.manifest_path,
+            evidence_path,
+            expected_sha=SOURCE_SHA,
+            expected_run_id="123456",
+        )
+        == evidence
+    )
+
+
+def test_evidence_rejects_failed_smoke(release_fixture: ReleaseFixture) -> None:
+    _manifest(release_fixture)
+
+    with pytest.raises(PromotionError, match="installed smoke"):
+        create_promotion_evidence(
+            release_fixture.manifest_path,
+            release_fixture.root / "promotion-evidence.json",
+            run_id="123456",
+            run_attempt="1",
+            index_url="https://test.pypi.org/pypi/codex-usage-tracking/0.23.0/json",
+            installed_smoke="failed",
+        )
+
+
+def test_evidence_rejects_manifest_substitution(release_fixture: ReleaseFixture) -> None:
+    _manifest(release_fixture)
+    evidence_path = release_fixture.root / "promotion-evidence.json"
+    create_promotion_evidence(
+        release_fixture.manifest_path,
+        evidence_path,
+        run_id="123456",
+        run_attempt="1",
+        index_url="https://test.pypi.org/pypi/codex-usage-tracking/0.23.0/json",
+        installed_smoke="passed",
+    )
+    release_fixture.manifest_path.write_bytes(
+        release_fixture.manifest_path.read_bytes().replace(SOURCE_SHA.encode(), ("b" * 40).encode())
+    )
+
+    with pytest.raises(PromotionError, match="manifest SHA-256"):
+        verify_promotion_evidence(
+            release_fixture.manifest_path,
+            evidence_path,
+            expected_sha=SOURCE_SHA,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        (
+            lambda payload: payload["github_actions"].update(run_id="other"),
+            "run id",
+        ),
+        (
+            lambda payload: payload.update(source_sha="b" * 40),
+            "source SHA",
+        ),
+        (
+            lambda payload: payload["qualification"].update(installed_smoke="failed"),
+            "passed installed smoke",
+        ),
+        (
+            lambda payload: payload.update(version="0.24.0"),
+            "version does not match",
+        ),
+    ],
+    ids=["run-id", "source-sha", "smoke", "version"],
+)
+def test_evidence_verify_rejects_changed_qualification(
+    release_fixture: ReleaseFixture,
+    mutation: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    _manifest(release_fixture)
+    evidence_path = release_fixture.root / "promotion-evidence.json"
+    evidence = create_promotion_evidence(
+        release_fixture.manifest_path,
+        evidence_path,
+        run_id="123456",
+        run_attempt="1",
+        index_url="https://test.pypi.org/pypi/codex-usage-tracking/0.23.0/json",
+        installed_smoke="passed",
+    )
+    mutation(evidence)
+    evidence_path.write_bytes(promotion_module.canonical_json_bytes(evidence))
+
+    with pytest.raises(PromotionError, match=expected):
+        verify_promotion_evidence(
+            release_fixture.manifest_path,
+            evidence_path,
+            expected_sha=SOURCE_SHA,
+            expected_run_id="123456",
+        )
+
+
+@pytest.mark.parametrize(
+    ("run_id", "run_attempt", "index_url", "expected"),
+    [
+        ("not-numeric", "1", "https://test.pypi.org/project", "numeric"),
+        ("1", "nope", "https://test.pypi.org/project", "numeric"),
+        ("1", "1", "http://test.pypi.org/project", "credential-free HTTPS"),
+        ("1", "1", "https://user@example.com/project", "credential-free HTTPS"),
+    ],
+)
+def test_evidence_create_rejects_invalid_identity(
+    release_fixture: ReleaseFixture,
+    run_id: str,
+    run_attempt: str,
+    index_url: str,
+    expected: str,
+) -> None:
+    _manifest(release_fixture)
+
+    with pytest.raises(PromotionError, match=expected):
+        create_promotion_evidence(
+            release_fixture.manifest_path,
+            release_fixture.root / "promotion-evidence.json",
+            run_id=run_id,
+            run_attempt=run_attempt,
+            index_url=index_url,
+            installed_smoke="passed",
+        )
+
+
+def test_index_payload_must_match_every_artifact_hash(
+    release_fixture: ReleaseFixture,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+
+    assert validate_index_payload(manifest, payload) == []
+
+    altered = deepcopy(payload)
+    altered["urls"][0]["digests"]["sha256"] = "0" * 64
+    failures = validate_index_payload(manifest, altered)
+
+    assert any("SHA-256" in failure for failure in failures)
+
+
+def test_index_payload_rejects_missing_file(release_fixture: ReleaseFixture) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    payload["urls"].pop()
+
+    failures = validate_index_payload(manifest, payload)
+
+    assert any("missing release artifact" in failure for failure in failures)
+
+
+def test_index_payload_rejects_wrong_version_size_and_shape(
+    release_fixture: ReleaseFixture,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    payload["info"] = {"version": "0.24.0"}
+    payload["urls"][0]["size"] = -1
+
+    failures = validate_index_payload(manifest, payload)
+
+    assert any("index version" in failure for failure in failures)
+    assert any("index size" in failure for failure in failures)
+    assert validate_index_payload(manifest, {"info": payload["info"], "urls": None})[-1] == (
+        "index payload urls must be a list"
+    )
+
+
+def test_download_index_artifacts_writes_exact_bytes(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    source_by_name = {
+        path.name: path.read_bytes()
+        for path in (release_fixture.wheel_path, release_fixture.sdist_path)
+    }
+    monkeypatch.setattr(promotion_module, "_read_json_url", lambda _url: payload)
+    monkeypatch.setattr(
+        promotion_module,
+        "_open_https_url",
+        lambda url, *, timeout: io.BytesIO(source_by_name[Path(url).name]),
+    )
+    output = release_fixture.root / "downloaded"
+
+    downloaded = download_index_artifacts(
+        release_fixture.manifest_path,
+        "https://test.pypi.org/project/version/json",
+        output,
+        attempts=1,
+    )
+
+    assert [path.name for path in downloaded] == [item["path"] for item in manifest["artifacts"]]
+    assert all(path.read_bytes() == source_by_name[path.name] for path in downloaded)
+
+
+def test_download_index_retries_then_succeeds(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(release_fixture)
+    valid = _index_payload(manifest)
+    invalid = deepcopy(valid)
+    invalid["info"] = {"version": "pending"}
+    payloads = iter((invalid, valid))
+    sleeps: list[float] = []
+    source_by_name = {
+        path.name: path.read_bytes()
+        for path in (release_fixture.wheel_path, release_fixture.sdist_path)
+    }
+    monkeypatch.setattr(promotion_module, "_read_json_url", lambda _url: next(payloads))
+    monkeypatch.setattr(promotion_module.time, "sleep", sleeps.append)
+    monkeypatch.setattr(
+        promotion_module,
+        "_open_https_url",
+        lambda url, *, timeout: io.BytesIO(source_by_name[Path(url).name]),
+    )
+
+    download_index_artifacts(
+        release_fixture.manifest_path,
+        "https://test.pypi.org/project/version/json",
+        release_fixture.root / "retried",
+        attempts=2,
+        delay_seconds=0.25,
+    )
+
+    assert sleeps == [0.25]
+
+
+@pytest.mark.parametrize(
+    ("attempts", "delay", "url", "expected"),
+    [
+        (0, 0.0, "https://example.com", "at least one"),
+        (1, -1.0, "https://example.com", "must not be negative"),
+        (1, 0.0, "file:///tmp/index.json", "credential-free HTTPS"),
+    ],
+)
+def test_download_index_rejects_invalid_options(
+    release_fixture: ReleaseFixture,
+    attempts: int,
+    delay: float,
+    url: str,
+    expected: str,
+) -> None:
+    _manifest(release_fixture)
+
+    with pytest.raises(PromotionError, match=expected):
+        download_index_artifacts(
+            release_fixture.manifest_path,
+            url,
+            release_fixture.root / "downloaded",
+            attempts=attempts,
+            delay_seconds=delay,
+        )
+
+
+def test_download_index_reports_unready_release(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    payload["urls"].pop()
+    monkeypatch.setattr(promotion_module, "_read_json_url", lambda _url: payload)
+
+    with pytest.raises(PromotionError, match="not ready"):
+        download_index_artifacts(
+            release_fixture.manifest_path,
+            "https://test.pypi.org/project/version/json",
+            release_fixture.root / "downloaded",
+            attempts=1,
+            delay_seconds=0,
+        )
+
+
+def test_read_json_url_rejects_non_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        promotion_module,
+        "_open_https_url",
+        lambda _url, *, timeout: io.BytesIO(b"[]"),
+    )
+
+    with pytest.raises(PromotionError, match="JSON object"):
+        promotion_module._read_json_url("https://example.com/project.json")
+
+
+def test_open_https_url_rejects_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        promotion_module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.URLError("offline")),
+    )
+
+    with pytest.raises(urllib.error.URLError):
+        promotion_module._open_https_url("https://example.com", timeout=1)
+
+
+def test_repository_publish_workflow_promotes_one_build() -> None:
+    assert check_publish_workflow(ROOT) == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    [
+        ("\n      - run: python -m build\n", "exactly once"),
+        ("\n# inputs.target\n", "manual PyPI target"),
+    ],
+    ids=["second-build", "manual-pypi-dispatch"],
+)
+def test_release_check_rejects_unsafe_promotion_workflow(
+    tmp_path: Path,
+    mutation: str,
+    expected: str,
+) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    (workflow_dir / "publish.yml").write_text(workflow + mutation, encoding="utf-8")
+
+    failures = check_publish_workflow(tmp_path)
+
+    assert any(expected in failure for failure in failures)
+
+
+def test_release_check_rejects_forbidden_events_and_secrets(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    workflow += "\npush:\npull_request:\n# secrets.PYPI api-token password:\n"
+    (workflow_dir / "publish.yml").write_text(workflow, encoding="utf-8")
+
+    failures = check_publish_workflow(tmp_path)
+
+    assert any("ordinary pushes" in failure for failure in failures)
+    assert any("pull requests" in failure for failure in failures)
+    assert any("token secrets" in failure for failure in failures)
+
+
+def test_release_check_reports_missing_workflow(tmp_path: Path) -> None:
+    assert check_publish_workflow(tmp_path) == [
+        "missing publish workflow: .github/workflows/publish.yml"
+    ]
+
+
+def test_release_artifact_contract_handles_git_and_manifest_failures(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        release_promotion_quality.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout=""),
+    )
+    assert (
+        "source Git SHA"
+        in release_promotion_quality.check_release_artifact_contract(
+            release_fixture.repo_root,
+            release_fixture.version,
+        )[0]
+    )
+
+    monkeypatch.setattr(
+        release_promotion_quality.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout=SOURCE_SHA),
+    )
+    repo_dist = release_fixture.repo_root / "dist"
+    repo_dist.mkdir()
+    shutil.copy2(release_fixture.wheel_path, repo_dist)
+    shutil.copy2(release_fixture.sdist_path, repo_dist)
+    assert (
+        release_promotion_quality.check_release_artifact_contract(
+            release_fixture.repo_root,
+            release_fixture.version,
+        )
+        == []
+    )
+
+
+def test_promotion_cli_create_verify_and_download(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _manifest(release_fixture)
+    evidence = release_fixture.root / "promotion-evidence.json"
+    assert (
+        main(
+            [
+                "create",
+                "--manifest",
+                str(release_fixture.manifest_path),
+                "--output",
+                str(evidence),
+                "--run-id",
+                "123",
+                "--run-attempt",
+                "1",
+                "--index-url",
+                "https://test.pypi.org/project/version/json",
+                "--installed-smoke",
+                "passed",
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "verify",
+                "--manifest",
+                str(release_fixture.manifest_path),
+                "--evidence",
+                str(evidence),
+                "--expected-sha",
+                SOURCE_SHA,
+                "--run-id",
+                "123",
+            ]
+        )
+        == 0
+    )
+    monkeypatch.setattr(
+        promotion_module,
+        "download_index_artifacts",
+        lambda *_args, **_kwargs: [release_fixture.wheel_path, release_fixture.sdist_path],
+    )
+    assert (
+        main(
+            [
+                "download-index",
+                "--manifest",
+                str(release_fixture.manifest_path),
+                "--index-json-url",
+                "https://test.pypi.org/project/version/json",
+                "--output",
+                str(release_fixture.root / "downloaded"),
+            ]
+        )
+        == 0
+    )
+
+
+def _index_payload(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "info": {"version": manifest["version"]},
+        "urls": [
+            {
+                "filename": item["path"],
+                "digests": {"sha256": item["sha256"]},
+                "size": item["size"],
+                "url": f"https://files.pythonhosted.org/{item['path']}",
+            }
+            for item in manifest["artifacts"]
+        ],
+    }

--- a/tests/release/test_promotion_evidence_fail_closed.py
+++ b/tests/release/test_promotion_evidence_fail_closed.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_usage_tracker.release import promotion_evidence as promotion_module
+from codex_usage_tracker.release.artifact_manifest import create_manifest
+from codex_usage_tracker.release.promotion_evidence import (
+    PromotionError,
+    create_promotion_evidence,
+    download_index_artifacts,
+    verify_promotion_evidence,
+)
+from scripts.release_quality import check_publish_workflow
+from tests.release.conftest import ReleaseFixture
+
+SOURCE_SHA = "a" * 40
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _manifest(fixture: ReleaseFixture) -> dict[str, Any]:
+    return create_manifest(
+        fixture.dist_dir,
+        fixture.manifest_path,
+        expected_sha=SOURCE_SHA,
+        expected_version=fixture.version,
+        repository_root=fixture.repo_root,
+    )
+
+
+def _index_payload(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "info": {"version": manifest["version"]},
+        "urls": [
+            {
+                "filename": item["path"],
+                "digests": {"sha256": item["sha256"]},
+                "size": item["size"],
+                "url": f"https://files.pythonhosted.org/{item['path']}",
+            }
+            for item in manifest["artifacts"]
+        ],
+    }
+
+
+def test_evidence_loader_rejects_noncanonical_or_malformed_files(
+    release_fixture: ReleaseFixture,
+) -> None:
+    _manifest(release_fixture)
+    evidence_path = release_fixture.root / "promotion-evidence.json"
+    verification = {
+        "manifest_path": release_fixture.manifest_path,
+        "evidence_path": evidence_path,
+        "expected_sha": SOURCE_SHA,
+    }
+
+    with pytest.raises(PromotionError, match="does not exist"):
+        verify_promotion_evidence(**verification)
+
+    evidence_path.write_bytes(b"{")
+    with pytest.raises(PromotionError, match="valid UTF-8 JSON"):
+        verify_promotion_evidence(**verification)
+
+    evidence_path.write_bytes(b"[]\n")
+    with pytest.raises(PromotionError, match="root must be an object"):
+        verify_promotion_evidence(**verification)
+
+    evidence = create_promotion_evidence(
+        release_fixture.manifest_path,
+        evidence_path,
+        run_id="123",
+        run_attempt="1",
+        index_url="https://test.pypi.org/project/version/json",
+        installed_smoke="passed",
+    )
+    evidence_path.write_text(json.dumps(evidence, indent=2), encoding="utf-8")
+    with pytest.raises(PromotionError, match="canonical JSON"):
+        verify_promotion_evidence(**verification)
+
+    evidence["schema"] = "unsupported"
+    evidence_path.write_bytes(promotion_module.canonical_json_bytes(evidence))
+    with pytest.raises(PromotionError, match="unsupported promotion evidence schema"):
+        verify_promotion_evidence(**verification)
+
+
+@pytest.mark.parametrize("failure", ("missing-url", "altered-bytes"))
+def test_download_rejects_unusable_index_artifacts(
+    release_fixture: ReleaseFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    source_by_name = {
+        path.name: path.read_bytes()
+        for path in (release_fixture.wheel_path, release_fixture.sdist_path)
+    }
+    expected = "download URL"
+    if failure == "missing-url":
+        payload["urls"][0].pop("url")
+    else:
+        first_name = manifest["artifacts"][0]["path"]
+        source_by_name[first_name] += b"altered"
+        expected = "bytes do not match"
+
+    monkeypatch.setattr(promotion_module, "_read_json_url", lambda _url: payload)
+    monkeypatch.setattr(
+        promotion_module,
+        "_open_https_url",
+        lambda url, *, timeout: io.BytesIO(source_by_name[Path(url).name]),
+    )
+
+    with pytest.raises(PromotionError, match=expected):
+        download_index_artifacts(
+            release_fixture.manifest_path,
+            "https://test.pypi.org/project/version/json",
+            release_fixture.root / "downloaded",
+            attempts=1,
+        )
+
+
+@pytest.mark.parametrize("failure", ("unexpected", "duplicate", "malformed"))
+def test_index_payload_requires_exact_artifact_set(
+    release_fixture: ReleaseFixture,
+    failure: str,
+) -> None:
+    manifest = _manifest(release_fixture)
+    payload = _index_payload(manifest)
+    if failure == "unexpected":
+        extra = dict(payload["urls"][0])
+        extra["filename"] = "codex_usage_tracking-0.23.0-py3-none-macos.whl"
+        payload["urls"].append(extra)
+    elif failure == "duplicate":
+        payload["urls"].append(dict(payload["urls"][0]))
+    else:
+        payload["urls"].append({"filename": 42})
+
+    failures = promotion_module.validate_index_payload(manifest, payload)
+
+    assert any(failure in message or "string filenames" in message for message in failures)
+
+
+@pytest.mark.parametrize(
+    "required",
+    [
+        'SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")',
+        'expected_tag="v$version"',
+        'if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then',
+    ],
+    ids=["reproducible-epoch", "versioned-tag", "tag-comparison"],
+)
+def test_release_check_requires_reproducible_version_bound_release(
+    tmp_path: Path,
+    required: str,
+) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    (workflow_dir / "publish.yml").write_text(
+        workflow.replace(required, "removed-release-proof", 1),
+        encoding="utf-8",
+    )
+
+    failures = check_publish_workflow(tmp_path)
+
+    assert any(required in failure for failure in failures)

--- a/tests/release_catalog.py
+++ b/tests/release_catalog.py
@@ -288,6 +288,8 @@ RELEASE_SCHEMA_IDS = {
     "codex-usage-tracker.recommendation.v1",
     "codex-usage-tracker.refresh.v2",
     "codex-usage-tracker.refresh-result.v1",
+    "codex-usage-tracker.release-artifact-manifest.v1",
+    "codex-usage-tracker.release-promotion-evidence.v1",
     "codex-usage-tracker.scope.v1",
     "codex-usage-tracker.status.v2",
     "codex-usage-tracker.subagent-usage.v1",


### PR DESCRIPTION
## Summary

- build one wheel/sdist pair and bind it to a canonical release manifest
- qualify exact TestPyPI bytes before protected PyPI promotion
- attach verified PyPI bytes and promotion evidence to the GitHub Release
- enforce reproducible sdists, `v<package-version>` tag identity, and exact index artifact sets
- extend installed-artifact smoke, offline policy checks, schema inventory, tests, and operator docs

## Why

The previous workflow rebuilt or independently selected artifacts at publication boundaries. Task 36 makes release identity fail closed across the source commit, TestPyPI, PyPI, and GitHub Release.

## Validation

- 122 release, packaging, workflow-policy, and immutable-pin tests
- 71 focused release-contract tests
- 92% changed-line coverage
- byte-identical wheel and normalized-sdist double build with a commit-derived epoch
- Ruff, mypy, focused Pyright, Tach, Deptry, Bandit, actionlint, offline Zizmor
- Twine, canonical manifest create/verify, exact installed-wheel smoke
- staged Gitleaks scan
- one read-only final review; all three findings accepted and fixed

## Known inherited gates

The broad Agent Maintainer run still reports pre-existing repository-wide file-length and formatting debt outside this diff. All Task 36 findings from that run were repaired and rechecked directly.
