### PR TITLE
test: budget product and package complexity

### DIFF
--- a/.agent-maintainer/change-plans/artifact-promotion.md
+++ b/.agent-maintainer/change-plans/artifact-promotion.md
@@ -1,7 +1,7 @@
 +++
 id = "artifact-promotion"
 kind = "cohesive-release-hardening"
-status = "active"
+status = "complete"
 base_ref = "origin/main"
 expires = 2026-08-08
 allowed_paths = [

--- a/.agent-maintainer/change-plans/product-complexity-budget.md
+++ b/.agent-maintainer/change-plans/product-complexity-budget.md
@@ -1,0 +1,80 @@
++++
+id = "product-complexity-budget"
+kind = "cohesive-quality-gate"
+status = "complete"
+base_ref = "origin/main"
+expires = 2026-08-08
+allowed_paths = [
+  ".agent-maintainer/change-plans/artifact-promotion.md",
+  ".agent-maintainer/change-plans/product-complexity-budget.md",
+  ".github/workflows/ci.yml",
+  "MANIFEST.in",
+  "config/product-complexity-budget.json",
+  "docs/architecture.md",
+  "docs/development.md",
+  "docs/roadmap/mcp-first-pivot-execution.md",
+  "pyproject.toml",
+  "scripts/check-dashboard-bundles.mjs",
+  "scripts/check_product_complexity.py",
+  "scripts/check_release.py",
+  "tests/cli/test_cli_release.py",
+  "tests/quality/test_product_complexity_budget.py",
+]
+forbidden_paths = ["config/prod/**", ".env", ".env.*"]
+max_changed_files = 14
+max_changed_lines = 1800
+allow_source_without_test_change = false
+requires_tests = true
+requires_full_verify = true
+ratchet_targets = ["scripts/check_product_complexity.py"]
++++
+
+# Cohesive Change Plan: product-complexity-budget
+
+## Why this change intentionally large
+
+Task 37 adds one deterministic policy surface for product complexity. The
+measurement script, committed ceilings, focused fail-closed tests, dashboard
+bundle integration, release integration, CI steps, and operator documentation
+must agree on the same metric names and authoritative registries.
+
+## Why this should not be split smaller
+
+Landing the checker without its measured ceilings would create an undefined
+policy. Landing ceilings without CI, release, bundle, and test integration
+would create a false-green policy. The source and built-artifact halves share
+one schema so later releases can ratchet them together.
+
+## What allowed to change
+
+Only the Task 37 budget, checker, focused tests, CI and release wiring,
+dashboard bundle gate, project configuration, architecture/development
+documentation, execution ledger, and Task 36 plan closure listed in
+`allowed_paths`.
+
+## What must not change
+
+This task does not alter runtime accounting, dashboard behavior, MCP/CLI
+contracts, persistence schemas, package publication, production data, or
+credentials. It must not raise a ceiling without an explicit architecture
+decision recorded beside the changed fixture.
+
+## Verification plan
+
+- Focused tests that lower every ceiling and prove each metric blocks.
+- Deterministic source-only measurement and JSON report comparison.
+- Dashboard bundle report plus the dedicated product-complexity gate.
+- Canonical wheel/sdist build followed by artifact-size checks.
+- Existing release, lint, type, workflow, and repository quality gates.
+- One read-only final reviewer after the diff is stable.
+
+## Rollback plan
+
+Revert the Task 37 commit. The new checker is additive and does not migrate
+data or change public behavior, so rollback removes only the additional gate.
+
+## Follow-up ratchet work
+
+Task 38 removes legacy workbench route imports and should reduce the initial
+React bundle. Tasks 40/41 in the next release ratchet removed compatibility
+surfaces downward.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,11 @@ jobs:
       - name: Dependency hygiene
         run: deptry .
       - name: Dead code
-        run: vulture src tests config/vulture-whitelist.py
+        run: >-
+          vulture src tests
+          scripts/check_product_complexity.py
+          scripts/check_release.py
+          config/vulture-whitelist.py
       - name: Python security
         run: python -m agent_maintainer.runners.bandit
 
@@ -247,6 +251,11 @@ jobs:
       - name: Type check
         if: matrix.python-version == '3.14'
         run: python -m mypy
+      - name: Product complexity budget
+        if: matrix.python-version == '3.14'
+        run: >-
+          python scripts/check_product_complexity.py
+          --config config/product-complexity-budget.json
       - name: Test
         if: matrix.python-version != '3.14'
         run: python -m pytest
@@ -300,6 +309,11 @@ jobs:
           python -m pip install ".[dev]" twine
       - name: Build wheel and sdist
         run: python -m build
+      - name: Product complexity distribution budget
+        run: >-
+          python scripts/check_product_complexity.py
+          --config config/product-complexity-budget.json
+          --dist dist
       - name: Check distributions
         run: python -m twine check dist/*
       - name: Verify built wheel

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ exclude docs/usage-drain-research-white-paper.md
 prune output
 recursive-include skills *.md *.py
 recursive-include scripts *.py
+include config/product-complexity-budget.json
 recursive-include src/codex_usage_tracker/plugin_data/assets *
 recursive-include src/codex_usage_tracker/plugin_data/dashboard *
 recursive-include src/codex_usage_tracker/plugin_data/docs *

--- a/config/product-complexity-budget.json
+++ b/config/product-complexity-budget.json
@@ -1,0 +1,146 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "release": "0.23.0",
+    "commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+    "measurement_command": "python scripts/check_product_complexity.py --config config/product-complexity-budget.json [--dist dist]",
+    "rationale": "0.24 adopts a blocking ratchet from the immutable 0.23.0 release artifacts and the post-Task-36 source state."
+  },
+  "increase_policy": "A ceiling increase requires a documented architecture decision, an updated baseline fixture, and focused tests that prove the changed ceiling still fails closed.",
+  "metrics": {
+    "default_mcp_tools": {
+      "maximum": 7,
+      "baseline": 7,
+      "baseline_commit": "c75babd9fc6d1b4e4cb6efa8a1661b90ce55b2ee",
+      "rationale": "The default conversational surface remains the seven-tool 0.22 core."
+    },
+    "full_profile_mcp_tools": {
+      "maximum": 59,
+      "baseline": 59,
+      "baseline_commit": "c75babd9fc6d1b4e4cb6efa8a1661b90ce55b2ee",
+      "rationale": "The 0.22 full-profile catalog is a hard ceiling and may ratchet only downward without an architecture decision."
+    },
+    "stable_cli_top_level_commands": {
+      "maximum": 11,
+      "baseline": 11,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "The 0.24 grouped CLI exposes eleven stable top-level command families."
+    },
+    "primary_dashboard_routes": {
+      "maximum": 3,
+      "baseline": 3,
+      "baseline_commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+      "rationale": "Home, Explore, and Limits are the complete primary Evidence Console."
+    },
+    "shell_utility_dashboard_routes": {
+      "maximum": 1,
+      "baseline": 1,
+      "baseline_commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+      "rationale": "Settings is the only shell utility route."
+    },
+    "contextual_dashboard_routes": {
+      "maximum": 1,
+      "baseline": 1,
+      "baseline_commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+      "rationale": "Evidence is the only contextual supporting route."
+    },
+    "unbudgeted_python_files_over_600": {
+      "maximum": 0,
+      "baseline": 0,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "No new runtime Python file may exceed 600 physical lines and grandfathered debt may not grow."
+    },
+    "unbudgeted_frontend_source_files_over_500": {
+      "maximum": 0,
+      "baseline": 0,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "No new authored frontend source may exceed 500 physical lines and grandfathered debt may not grow."
+    },
+    "wheel_bytes": {
+      "maximum": 7368106,
+      "baseline": 7017243,
+      "baseline_commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+      "rationale": "Immutable PyPI 0.23.0 wheel size plus exactly five percent headroom, rounded up."
+    },
+    "sdist_bytes": {
+      "maximum": 33622880,
+      "baseline": 32021790,
+      "baseline_commit": "53483690ce4bda9f692a74d8c584472bdec34ff0",
+      "rationale": "Immutable PyPI 0.23.0 source distribution size plus exactly five percent headroom, rounded up."
+    },
+    "main_initial_react_js_gzip_bytes": {
+      "maximum": 67603,
+      "baseline": 61457,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "Post-constellation-removal initial React JavaScript plus exactly ten percent headroom, rounded up."
+    },
+    "stable_json_schemas": {
+      "maximum": 114,
+      "baseline": 114,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "The 95 schemas in 0.23.0 plus nineteen explicitly approved 0.24 contract additions form the adoption ceiling."
+    },
+    "sqlite_schema_increments": {
+      "maximum": 1,
+      "baseline": 0,
+      "baseline_commit": "a52338d510b731288819c169dbbd2ba412fa56ad",
+      "rationale": "The prospective release ratchet starts at schema 37; the already-approved pre-adoption 0.24 migrations from 34 to 37 are documented architecture history."
+    }
+  },
+  "source_files": {
+    "python": {
+      "roots": [
+        "src/codex_usage_tracker"
+      ],
+      "extensions": [
+        ".py"
+      ],
+      "exclude_globs": [
+        "src/codex_usage_tracker/plugin_data/**"
+      ],
+      "maximum_physical_lines": 600,
+      "grandfathered": {
+        "src/codex_usage_tracker/reports/agentic_dogfood.py": 803,
+        "src/codex_usage_tracker/store/api.py": 824,
+        "src/codex_usage_tracker/store/dashboard_queries.py": 949,
+        "src/codex_usage_tracker/store/schema.py": 750
+      }
+    },
+    "frontend": {
+      "roots": [
+        "frontend/dashboard/src"
+      ],
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".css"
+      ],
+      "exclude_globs": [
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
+      "maximum_physical_lines": 500,
+      "grandfathered": {
+        "frontend/dashboard/src/App.tsx": 744,
+        "frontend/dashboard/src/api/client.ts": 829,
+        "frontend/dashboard/src/app/zh-Hans/corePages.ts": 730,
+        "frontend/dashboard/src/app/zh-Hans/diagnosticsReports.ts": 773,
+        "frontend/dashboard/src/features/call-investigator/CallInvestigatorPage.tsx": 807,
+        "frontend/dashboard/src/features/diagnostics/DiagnosticFactsPanels.tsx": 537,
+        "frontend/dashboard/src/features/diagnostics/DiagnosticsPage.tsx": 510,
+        "frontend/dashboard/src/features/limits/LimitsPage.tsx": 658
+      }
+    }
+  },
+  "dashboard_routes": {
+    "catalog": "frontend/dashboard/src/routes/evidenceConsoleRoutes.ts",
+    "const": "evidenceConsoleRoutes"
+  },
+  "dashboard_bundle": {
+    "output_dir": "src/codex_usage_tracker/plugin_data/dashboard/react"
+  },
+  "sqlite_schema": {
+    "release_023_version": 34,
+    "budget_adoption_version": 37
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,32 @@ Release assets are downloaded from PyPI before attachment. The last job verifies
 the same manifest hashes at TestPyPI, PyPI, and GitHub; no production job may
 rebuild the distributions.
 
+### Product-complexity budget decision
+
+`config/product-complexity-budget.json` is the versioned architecture boundary
+for public-surface counts, authored-source size, package bytes, the initial
+React JavaScript payload, stable JSON schemas, and SQLite schema growth.
+`scripts/check_product_complexity.py` measures the actual MCP registry, CLI
+parser inventory, Evidence Console route catalog, JSON contract registry, and
+SQLite schema constant. It reads built artifacts only when `--dist` is
+provided. The dashboard bundle checker reads the same committed initial-JS
+ceiling instead of maintaining a second number.
+
+The 0.24 budget adopts two explicit historical exceptions without hiding them:
+
+- Existing runtime Python files above 600 physical lines and authored frontend
+  files above 500 are enumerated at their exact adoption sizes. They may shrink
+  or be removed, but no grandfathered file may grow and no new oversized file
+  may appear.
+- Release 0.23.0 used SQLite schema 34. Approved Tasks 29 and 33 reached schema
+  37 before this gate was introduced. The blocking one-increment ceiling is
+  therefore prospective from adoption version 37; the 34-to-37 history remains
+  recorded in the budget rather than being rewritten or collapsed.
+
+A ceiling increase requires an architecture decision, a changed baseline
+fixture, and focused fail-closed tests. Ordinary feature work may ratchet a
+ceiling downward without a new decision.
+
 ## Boundaries
 
 - `parser.py` converts local JSONL events into aggregate `UsageEvent` records. It also attaches metadata-only call-origin categories, diagnostic facts from `diagnostic_facts.py`, archived-session flags, conservative thread keys, source cursors, and parser diagnostics.
@@ -222,11 +248,13 @@ Use the narrowest useful check first, then the release suite before committing s
 python -m pytest
 python -m compileall src
 python -m mypy
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json
 for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
   node --check "$file"
 done
 python scripts/check_release.py
 python -m build
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json --dist dist
 python scripts/check_release.py --dist
 git diff --check
 python scripts/benchmark_dashboard_routes.py --sizes 100000 --iterations 3 --skip-compression --enforce-thresholds --output-dir /tmp/dashboard-route-budget

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,6 +124,7 @@ vulture src tests config/vulture-whitelist.py
 pip-audit -r requirements/audit.txt
 python -m agent_maintainer.runners.bandit
 zizmor --offline --no-progress .github/workflows
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json
 python -m compileall src
 for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
   node --check "$file"
@@ -133,6 +134,7 @@ git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info
 python -m build
 python -m twine check dist/*
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json --dist dist
 python scripts/check_release.py --dist
 ```
 
@@ -151,6 +153,36 @@ The quality inventory tests are also release blockers:
 - `tests/quality/test_compatibility_inventory.py` keeps every deprecated MCP
   alias synchronized with the normative deprecation ledger and migration
   metadata.
+- `tests/quality/test_product_complexity_budget.py` proves every public-surface,
+  source-size, artifact-size, bundle-size, schema-count, and migration metric
+  fails above its committed ceiling.
+
+### Product-complexity budgets
+
+Run the source-only budget during normal development:
+
+```bash
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json
+```
+
+After building exactly one wheel and one sdist, include immutable artifact
+sizes:
+
+```bash
+python scripts/check_product_complexity.py \
+  --config config/product-complexity-budget.json \
+  --dist dist
+```
+
+The checker reads authoritative registries and the named Evidence Console route
+catalog; it does not infer public surfaces from repository-wide text matches.
+Inherited oversized authored files are frozen at their adoption line counts.
+If one shrinks below its threshold or is removed, remove its grandfathered
+entry in the same change so the ratchet cannot grow back.
+
+Do not raise a ceiling to make CI green. A ceiling increase requires a
+documented architecture decision, updated baseline and rationale fields, and a
+focused fixture that still proves the new maximum fails closed.
 
 Regenerate the universal runtime audit input after changing production
 dependencies:
@@ -392,6 +424,7 @@ git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info
 python -m build
 python -m twine check dist/*
+python scripts/check_product_complexity.py --config config/product-complexity-budget.json --dist dist
 python scripts/check_release.py --dist
 ```
 

--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -1404,8 +1404,8 @@ complete without its named focused and full verification evidence.
 
 ## Task 36 - Promote One Verified Release Artifact
 
-- Status: complete locally on `pivot/36-artifact-promotion`; hosted CI and
-  merge remain.
+- Status: merged by PR #304 as `a52338d510b731288819c169dbbd2ba412fa56ad`;
+  the complete hosted CI matrix passed.
 - Build-once contract:
   - one wheel/sdist pair and one canonical manifest are uploaded as the sole
     `python-dist` build artifact;
@@ -1463,3 +1463,51 @@ complete without its named focused and full verification evidence.
     binding, and exact package-index artifact-set validation;
   - all three fixes pass the bounded recheck above. Reviewer token attribution
     is `pending` because the aggregate metrics helper timed out.
+
+## Task 37 - Budget Product and Package Complexity
+
+- Status: complete locally on `pivot/37-product-complexity-budget`; reviewed
+  PR remains.
+- Graph-guided scope:
+  - a fresh GitNexus index at `a52338d` routed measurement to the MCP
+    `tool_specs` catalog, CLI `build_parser` inventory, Evidence Console route
+    catalog, stable JSON schema registry, SQLite schema constant, and release
+    artifact boundary;
+  - Serena verified the exact symbols before implementation. Source and focused
+    tests remain authoritative.
+- Budget decisions:
+  - default/full MCP ceilings are 7/59, stable CLI families are 11, and
+    Evidence Console placements remain 3 primary, 1 contextual, and 1 utility;
+  - immutable PyPI 0.23.0 artifacts establish 7,017,243-byte wheel and
+    32,021,790-byte sdist baselines with exactly 5% rounded-up headroom;
+  - post-constellation initial React JavaScript is 61,457 deterministic gzip
+    bytes with exactly 10% rounded-up headroom;
+  - existing oversized authored files are explicitly frozen while new or
+    growing violations remain zero;
+  - 0.23 schema 34 to pre-adoption schema 37 is recorded as architecture
+    history, and the one-increment blocking ratchet starts prospectively at 37.
+- Focused verification so far:
+  - all 31 budget tests plus the focused CLI bundle-contract test pass,
+    including a reduced ceiling for every metric, strict literal route-catalog
+    parsing, recursive source exclusions, line-debt growth, and duplicate
+    distributions;
+  - source measurement, release readiness, MyPy, Ruff, format, and the
+    config-backed dashboard bundle gate pass.
+- Broad verification:
+  - one Agent Maintainer `ci` run
+    `20260724T111442082155Z-ci-c9b951763d69` passed all 2,146 tests and
+    reported only inherited repository-wide file-length, formatting, Pyright
+    test, Xenon, Pylint, Tach/config, optional TypeScript-tooling, and
+    Zizmor findings; its launch-snapshot change-plan failure was corrected and
+    the direct plan check passes;
+  - final wheel/sdist measurements are 7,077,471 and 32,160,218 bytes, both
+    under their immutable-0.23-derived ceilings.
+- Final review:
+  - the single read-only reviewer reported four findings (two medium, two
+    low); all four were accepted;
+  - the route catalog now rejects comments, nested decoys, spreads, computed
+    keys, calls, and non-object entries; critical policy values are pinned;
+    recursive exclusions are normalized; and the checker itself now satisfies
+    the Task 37 Xenon A/B complexity gate;
+  - reviewer token attribution is `pending` in the aggregate-only metrics
+    ledger.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,13 @@ structure_ignore_paths = [
   "venv/**",
   "**/__pycache__/**",
 ]
-vulture_paths = ["src", "tests", "config/vulture-whitelist.py"]
+vulture_paths = [
+  "src",
+  "tests",
+  "scripts/check_product_complexity.py",
+  "scripts/check_release.py",
+  "config/vulture-whitelist.py",
+]
 require_tests = true
 coverage_fail_under = 85
 diff_cover_fail_under = 90
@@ -300,6 +306,7 @@ log_dir = ".verify-logs"
 python_version = "3.10"
 warn_unused_configs = true
 files = [
+  "scripts/check_product_complexity.py",
   "src/codex_usage_tracker/core/json_contracts.py",
   "src/codex_usage_tracker/core/models.py",
   "src/codex_usage_tracker/reports/recommendations.py",

--- a/scripts/check-dashboard-bundles.mjs
+++ b/scripts/check-dashboard-bundles.mjs
@@ -2,9 +2,20 @@ import { gzipSync } from 'node:zlib';
 import { readFile, readdir } from 'node:fs/promises';
 
 const outputDir = new URL('../src/codex_usage_tracker/plugin_data/dashboard/react/', import.meta.url);
+const productBudget = JSON.parse(
+  await readFile(
+    new URL('../config/product-complexity-budget.json', import.meta.url),
+    'utf8',
+  ),
+);
+const productInitialJsBudget =
+  productBudget?.metrics?.main_initial_react_js_gzip_bytes?.maximum;
+if (!Number.isSafeInteger(productInitialJsBudget) || productInitialJsBudget < 0) {
+  throw new Error('product complexity budget must declare a non-negative initial React JS maximum');
+}
 const budgets = {
   // Equivalent bundles vary slightly across zlib builds; retain bounded platform headroom.
-  currentInitialJs: 67 * 1024,
+  currentInitialJs: productInitialJsBudget,
   currentInitialCss: 10 * 1024,
   targetInitialJs: 85 * 1024,
   targetInitialCss: 12 * 1024,

--- a/scripts/check_product_complexity.py
+++ b/scripts/check_product_complexity.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Measure and enforce deterministic product-complexity budgets."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import sys
+from collections import Counter
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any
+
+SCRIPT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_ROOT.parent
+
+METRIC_NAMES = (
+    "default_mcp_tools",
+    "full_profile_mcp_tools",
+    "stable_cli_top_level_commands",
+    "primary_dashboard_routes",
+    "shell_utility_dashboard_routes",
+    "contextual_dashboard_routes",
+    "unbudgeted_python_files_over_600",
+    "unbudgeted_frontend_source_files_over_500",
+    "wheel_bytes",
+    "sdist_bytes",
+    "main_initial_react_js_gzip_bytes",
+    "stable_json_schemas",
+    "sqlite_schema_increments",
+)
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_SCRIPT_REFERENCE_PATTERN = re.compile(r'(?:src|href)="[^"]*/(assets/[^"?]+)(?:\?[^"\s]*)?"')
+
+
+class BudgetError(ValueError):
+    """Raised when a budget or measurement source is incomplete or ambiguous."""
+
+
+def load_budget(path: Path) -> dict[str, Any]:
+    """Load and validate one versioned product-complexity budget."""
+    payload = _read_budget_object(path)
+    _validate_budget_header(payload)
+    _validate_metrics(payload.get("metrics"))
+    _validate_measurement_config(payload)
+    return payload
+
+
+def _read_budget_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BudgetError(f"could not load budget {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BudgetError("budget root must be an object")
+    return payload
+
+
+def _validate_budget_header(payload: dict[str, Any]) -> None:
+    if payload.get("schema_version") != 1:
+        raise BudgetError("budget schema_version must equal 1")
+    _validate_baseline(payload.get("baseline"))
+    if not isinstance(payload.get("increase_policy"), str) or not payload["increase_policy"]:
+        raise BudgetError("budget increase_policy must be a non-empty string")
+
+
+def _validate_metrics(metrics: object) -> None:
+    if not isinstance(metrics, dict):
+        raise BudgetError("budget metrics must be an object")
+    missing = [name for name in METRIC_NAMES if name not in metrics]
+    extras = sorted(set(metrics) - set(METRIC_NAMES))
+    if missing:
+        raise BudgetError(f"budget is missing metric {missing[0]}")
+    if extras:
+        raise BudgetError(f"budget has unknown metrics: {', '.join(extras)}")
+    for name in METRIC_NAMES:
+        _validate_metric(name, metrics[name])
+
+
+def _validate_baseline(value: object) -> None:
+    if not isinstance(value, dict):
+        raise BudgetError("budget baseline must be an object")
+    for key in ("release", "measurement_command", "rationale"):
+        if not isinstance(value.get(key), str) or not value[key]:
+            raise BudgetError(f"budget baseline {key} must be a non-empty string")
+    if not isinstance(value.get("commit"), str) or not _SHA_PATTERN.fullmatch(value["commit"]):
+        raise BudgetError("budget baseline commit must be a full lowercase Git SHA")
+
+
+def _validate_metric(name: str, value: object) -> None:
+    if not isinstance(value, dict):
+        raise BudgetError(f"{name} budget must be an object")
+    for key in ("maximum", "baseline"):
+        if not isinstance(value.get(key), int) or value[key] < 0:
+            raise BudgetError(f"{name} {key} must be a non-negative integer")
+    commit = value.get("baseline_commit")
+    if not isinstance(commit, str) or not _SHA_PATTERN.fullmatch(commit):
+        raise BudgetError(f"{name} baseline_commit must be a full lowercase Git SHA")
+    if not isinstance(value.get("rationale"), str) or not value["rationale"]:
+        raise BudgetError(f"{name} rationale must be a non-empty string")
+
+
+def _validate_measurement_config(payload: dict[str, Any]) -> None:
+    _validate_source_files(payload.get("source_files"))
+    _validate_dashboard_routes(payload.get("dashboard_routes"))
+    _validate_dashboard_bundle(payload.get("dashboard_bundle"))
+    _validate_sqlite_schema(payload.get("sqlite_schema"))
+
+
+def _validate_source_files(value: object) -> None:
+    if not isinstance(value, dict):
+        raise BudgetError("source_files must be an object")
+    for name in ("python", "frontend"):
+        config = value.get(name)
+        if not isinstance(config, dict):
+            raise BudgetError(f"source_files.{name} must be an object")
+        _validate_source_file(name, config)
+
+
+def _validate_source_file(name: str, config: dict[str, Any]) -> None:
+    context = f"source_files.{name}"
+    _require_string_list(config, "roots", context)
+    _require_string_list(config, "extensions", context)
+    _require_string_list(config, "exclude_globs", context, allow_empty=True)
+    _require_non_negative_integer(
+        config.get("maximum_physical_lines"),
+        f"{context}.maximum_physical_lines",
+    )
+    _validate_grandfathered(config.get("grandfathered"), context)
+
+
+def _require_non_negative_integer(value: object, context: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise BudgetError(f"{context} must be a non-negative integer")
+
+
+def _validate_grandfathered(grandfathered: object, context: str) -> None:
+    if not isinstance(grandfathered, dict):
+        raise BudgetError(f"{context}.grandfathered must map paths to lines")
+    invalid = [
+        path
+        for path, lines in grandfathered.items()
+        if not isinstance(path, str)
+        or not isinstance(lines, int)
+        or isinstance(lines, bool)
+        or lines <= 0
+    ]
+    if invalid:
+        raise BudgetError(f"{context}.grandfathered must map paths to lines")
+
+
+def _validate_dashboard_routes(value: object) -> None:
+    if not isinstance(value, dict) or not all(
+        isinstance(value.get(key), str) and value[key] for key in ("catalog", "const")
+    ):
+        raise BudgetError("dashboard_routes must declare catalog and const")
+
+
+def _validate_dashboard_bundle(value: object) -> None:
+    if (
+        not isinstance(value, dict)
+        or not isinstance(value.get("output_dir"), str)
+        or not value["output_dir"]
+    ):
+        raise BudgetError("dashboard_bundle must declare output_dir")
+
+
+def _validate_sqlite_schema(value: object) -> None:
+    if not isinstance(value, dict) or not all(
+        isinstance(value.get(key), int) and not isinstance(value[key], bool) and value[key] >= 0
+        for key in ("release_023_version", "budget_adoption_version")
+    ):
+        raise BudgetError(
+            "sqlite_schema must declare non-negative integer release and adoption versions"
+        )
+    if value["budget_adoption_version"] < value["release_023_version"]:
+        raise BudgetError("SQLite budget adoption version predates the release baseline")
+
+
+def _require_string_list(
+    config: dict[str, Any],
+    key: str,
+    context: str,
+    *,
+    allow_empty: bool = False,
+) -> None:
+    value = config.get(key)
+    if (
+        not isinstance(value, list)
+        or (not allow_empty and not value)
+        or not all(isinstance(item, str) and item for item in value)
+    ):
+        raise BudgetError(f"{context}.{key} must be a list of non-empty strings")
+
+
+def evaluate_budget(
+    budget: dict[str, Any],
+    measurements: dict[str, int],
+) -> list[str]:
+    """Return stable failure messages for measurements above their ceilings."""
+    metrics = budget["metrics"]
+    failures: list[str] = []
+    for name in METRIC_NAMES:
+        if name not in measurements:
+            continue
+        value = measurements[name]
+        if not isinstance(value, int) or value < 0:
+            raise BudgetError(f"{name} measurement must be a non-negative integer")
+        maximum = metrics[name]["maximum"]
+        if value > maximum:
+            failures.append(f"{name}={value} exceeds maximum {maximum}")
+    return failures
+
+
+def parse_route_placements(source: str, const_name: str) -> dict[str, int]:
+    """Count placements from one named TypeScript route-catalog array."""
+    array_source = _extract_typescript_array(source, const_name)
+    objects = _top_level_typescript_objects(array_source, const_name)
+    if not objects:
+        raise BudgetError(f"{const_name} contains no route objects")
+    placements: Counter[str] = Counter()
+    route_ids: set[str] = set()
+    for route in objects:
+        if any(marker in route for marker in ("//", "/*", "*/", "...")):
+            raise BudgetError(f"{const_name} route entries must not use comments or spreads")
+        route_ids_found = re.findall(
+            r"^    id: '([^'\n]+)',$",
+            route,
+            flags=re.MULTILINE,
+        )
+        placements_found = re.findall(
+            r"^    placement: '(primary|contextual|utility)',$",
+            route,
+            flags=re.MULTILINE,
+        )
+        if len(route_ids_found) != 1:
+            raise BudgetError(f"{const_name} route must have exactly one literal id")
+        if len(placements_found) != 1:
+            raise BudgetError(
+                f"{const_name} route {route_ids_found[0]} "
+                "must have exactly one literal known placement"
+            )
+        route_id = route_ids_found[0]
+        if route_id in route_ids:
+            raise BudgetError(f"{const_name} contains duplicate route id {route_id}")
+        route_ids.add(route_id)
+        placements[placements_found[0]] += 1
+    return {
+        "primary": placements["primary"],
+        "contextual": placements["contextual"],
+        "utility": placements["utility"],
+    }
+
+
+def _extract_typescript_array(source: str, const_name: str) -> str:
+    declaration_pattern = re.compile(
+        rf"^[ \t]*(?:export[ \t]+)?const[ \t]+{re.escape(const_name)}"
+        rf"[ \t]*=[ \t]*\[(?P<body>.*?)^[ \t]*\][ \t]+as[ \t]+const"
+        rf"(?:[ \t]+satisfies[^\n;]+)?[ \t]*;",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    declarations = list(declaration_pattern.finditer(source))
+    if len(declarations) != 1:
+        raise BudgetError(f"expected exactly one literal TypeScript array const {const_name}")
+    return declarations[0].group("body")
+
+
+def _top_level_typescript_objects(
+    array_source: str,
+    const_name: str,
+) -> list[str]:
+    objects: list[str] = []
+    current: list[str] | None = None
+    for line_number, line in enumerate(array_source.splitlines(), start=1):
+        if not line.strip():
+            continue
+        if current is None:
+            if line != "  {":
+                raise BudgetError(
+                    f"{const_name} array entry at line {line_number} is not a literal route object"
+                )
+            current = []
+            continue
+        if line in {"  },", "  }"}:
+            objects.append("\n".join(current))
+            current = None
+            continue
+        current.append(line)
+    if current is not None:
+        raise BudgetError(f"{const_name} contains an unterminated route object")
+    return objects
+
+
+def _matches_exclusion(relative: str, pattern: str) -> bool:
+    """Match normalized repository paths, including recursive directory globs."""
+    if pattern.endswith("/**"):
+        prefix = pattern.removesuffix("/**").rstrip("/")
+        return relative == prefix or relative.startswith(f"{prefix}/")
+    return fnmatchcase(relative, pattern)
+
+
+def _iter_source_files(
+    root: Path,
+    configured_roots: list[str],
+    extensions: set[str],
+) -> list[Path]:
+    paths: list[Path] = []
+    for item in configured_roots:
+        source_root = root / item
+        if not source_root.is_dir():
+            raise BudgetError(f"source root does not exist: {source_root}")
+        paths.extend(
+            path for path in source_root.rglob("*") if path.is_file() and path.suffix in extensions
+        )
+    return sorted(paths)
+
+
+def _stale_grandfathered_paths(
+    seen: dict[str, int],
+    grandfathered: dict[str, int],
+    maximum: int,
+) -> list[str]:
+    return sorted(
+        path
+        for path, frozen_lines in grandfathered.items()
+        if path not in seen or seen[path] <= maximum or seen[path] < frozen_lines
+    )
+
+
+def measure_line_budget(root: Path, config: dict[str, Any]) -> list[str]:
+    """Return sorted source paths that are new or have grown beyond frozen debt."""
+    extensions = set(config["extensions"])
+    excludes = tuple(config["exclude_globs"])
+    maximum = int(config["maximum_physical_lines"])
+    grandfathered = dict(config["grandfathered"])
+    seen: dict[str, int] = {}
+    violations: list[str] = []
+    paths = _iter_source_files(root, config["roots"], extensions)
+    for path in paths:
+        relative = path.relative_to(root).as_posix()
+        if any(_matches_exclusion(relative, pattern) for pattern in excludes):
+            continue
+        lines = len(path.read_bytes().splitlines())
+        seen[relative] = lines
+        frozen_limit = grandfathered.get(relative)
+        if lines > maximum and (frozen_limit is None or lines > frozen_limit):
+            violations.append(relative)
+    stale = _stale_grandfathered_paths(seen, grandfathered, maximum)
+    if stale:
+        raise BudgetError("grandfathered source baseline is stale: " + ", ".join(stale))
+    return sorted(violations)
+
+
+def measure_distribution_sizes(dist_dir: Path) -> dict[str, int]:
+    """Measure exactly one built wheel and one built source distribution."""
+    if not dist_dir.is_dir():
+        raise BudgetError(f"distribution directory does not exist: {dist_dir}")
+    wheels = sorted(dist_dir.glob("*.whl"))
+    sdists = sorted(dist_dir.glob("*.tar.gz"))
+    if len(wheels) != 1:
+        raise BudgetError(f"expected exactly one wheel in {dist_dir}, found {len(wheels)}")
+    if len(sdists) != 1:
+        raise BudgetError(f"expected exactly one sdist in {dist_dir}, found {len(sdists)}")
+    return {
+        "wheel_bytes": wheels[0].stat().st_size,
+        "sdist_bytes": sdists[0].stat().st_size,
+    }
+
+
+def measure_initial_javascript(output_dir: Path) -> int:
+    """Return deterministic gzip bytes for JavaScript loaded by dashboard HTML."""
+    try:
+        html = (output_dir / "index.html").read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BudgetError(f"could not read dashboard index: {exc}") from exc
+    references = sorted(
+        {
+            match.group(1)
+            for match in _SCRIPT_REFERENCE_PATTERN.finditer(html)
+            if match.group(1).endswith(".js")
+        }
+    )
+    if not references:
+        raise BudgetError("dashboard index contains no initial JavaScript assets")
+    total = 0
+    for reference in references:
+        path = (output_dir / reference).resolve()
+        try:
+            path.relative_to(output_dir.resolve())
+        except ValueError as exc:
+            raise BudgetError(f"dashboard asset escapes output directory: {reference}") from exc
+        try:
+            total += len(gzip.compress(path.read_bytes(), compresslevel=9, mtime=0))
+        except OSError as exc:
+            raise BudgetError(f"could not read dashboard asset {reference}: {exc}") from exc
+    return total
+
+
+def measure_product_complexity(
+    root: Path,
+    budget: dict[str, Any],
+    *,
+    dist_dir: Path | None = None,
+) -> dict[str, int]:
+    """Measure authoritative registries, authored source, bundles, and artifacts."""
+    source_root = root / "src"
+    if str(source_root) not in sys.path:
+        sys.path.insert(0, str(source_root))
+
+    from codex_usage_tracker.core.json_contracts import known_json_schemas
+    from codex_usage_tracker.interfaces.cli.parser import STABLE_TOP_LEVEL_COMMANDS
+    from codex_usage_tracker.interfaces.mcp.profiles import tools_for_profile
+    from codex_usage_tracker.store.schema import SCHEMA_VERSION
+
+    route_config = budget["dashboard_routes"]
+    route_source = (root / route_config["catalog"]).read_text(encoding="utf-8")
+    placements = parse_route_placements(route_source, route_config["const"])
+    python_debt = measure_line_budget(root, budget["source_files"]["python"])
+    frontend_debt = measure_line_budget(root, budget["source_files"]["frontend"])
+    adoption_version = budget["sqlite_schema"]["budget_adoption_version"]
+    increments = SCHEMA_VERSION - adoption_version
+    if increments < 0:
+        raise BudgetError(
+            f"SQLite schema version {SCHEMA_VERSION} predates budget adoption "
+            f"version {adoption_version}"
+        )
+    measurements = {
+        "default_mcp_tools": len(tools_for_profile("core")),
+        "full_profile_mcp_tools": len(tools_for_profile("full")),
+        "stable_cli_top_level_commands": len(STABLE_TOP_LEVEL_COMMANDS),
+        "primary_dashboard_routes": placements["primary"],
+        "shell_utility_dashboard_routes": placements["utility"],
+        "contextual_dashboard_routes": placements["contextual"],
+        "unbudgeted_python_files_over_600": len(python_debt),
+        "unbudgeted_frontend_source_files_over_500": len(frontend_debt),
+        "main_initial_react_js_gzip_bytes": measure_initial_javascript(
+            root / budget["dashboard_bundle"]["output_dir"]
+        ),
+        "stable_json_schemas": len(known_json_schemas()),
+        "sqlite_schema_increments": increments,
+    }
+    if dist_dir is not None:
+        measurements.update(measure_distribution_sizes(dist_dir))
+    return measurements
+
+
+def check_product_complexity_budget(
+    root: Path,
+    config_path: Path,
+    *,
+    dist_dir: Path | None = None,
+) -> list[str]:
+    """Return release-checker-ready failures without hiding measurement errors."""
+    try:
+        budget = load_budget(config_path)
+        measurements = measure_product_complexity(root, budget, dist_dir=dist_dir)
+        return evaluate_budget(budget, measurements)
+    except (BudgetError, OSError) as exc:
+        return [f"could not be measured: {exc}"]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config/product-complexity-budget.json"),
+    )
+    parser.add_argument("--dist", type=Path)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _resolve_repo_path(path: Path | None) -> Path | None:
+    if path is None or path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def _print_report(
+    measurements: dict[str, int],
+    failures: list[str],
+    *,
+    as_json: bool,
+) -> None:
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "status": "failed" if failures else "passed",
+                    "measurements": measurements,
+                    "failures": failures,
+                },
+                sort_keys=True,
+            )
+        )
+        return
+    for name in METRIC_NAMES:
+        if name in measurements:
+            print(f"{name}: {measurements[name]}")
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    if not failures:
+        print("Product complexity budget passed.")
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        config_path = _resolve_repo_path(args.config)
+        if config_path is None:
+            raise BudgetError("budget config path is required")
+        budget = load_budget(config_path)
+        dist_dir = _resolve_repo_path(args.dist)
+        measurements = measure_product_complexity(REPO_ROOT, budget, dist_dir=dist_dir)
+        failures = evaluate_budget(budget, measurements)
+    except (BudgetError, OSError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    _print_report(measurements, failures, as_json=args.json)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_product_complexity.py
+++ b/scripts/check_product_complexity.py
@@ -10,6 +10,7 @@ import re
 import sys
 from collections import Counter
 from fnmatch import fnmatchcase
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -410,10 +411,12 @@ def measure_product_complexity(
     if str(source_root) not in sys.path:
         sys.path.insert(0, str(source_root))
 
-    from codex_usage_tracker.core.json_contracts import known_json_schemas
-    from codex_usage_tracker.interfaces.cli.parser import STABLE_TOP_LEVEL_COMMANDS
-    from codex_usage_tracker.interfaces.mcp.profiles import tools_for_profile
-    from codex_usage_tracker.store.schema import SCHEMA_VERSION
+    # Keep the release checker as its own typed boundary instead of making its
+    # focused MyPy target recursively analyze the complete runtime package.
+    json_contracts = import_module("codex_usage_tracker.core.json_contracts")
+    cli_parser = import_module("codex_usage_tracker.interfaces.cli.parser")
+    mcp_profiles = import_module("codex_usage_tracker.interfaces.mcp.profiles")
+    store_schema = import_module("codex_usage_tracker.store.schema")
 
     route_config = budget["dashboard_routes"]
     route_source = (root / route_config["catalog"]).read_text(encoding="utf-8")
@@ -421,16 +424,17 @@ def measure_product_complexity(
     python_debt = measure_line_budget(root, budget["source_files"]["python"])
     frontend_debt = measure_line_budget(root, budget["source_files"]["frontend"])
     adoption_version = budget["sqlite_schema"]["budget_adoption_version"]
-    increments = SCHEMA_VERSION - adoption_version
+    schema_version = store_schema.SCHEMA_VERSION
+    increments = schema_version - adoption_version
     if increments < 0:
         raise BudgetError(
-            f"SQLite schema version {SCHEMA_VERSION} predates budget adoption "
+            f"SQLite schema version {schema_version} predates budget adoption "
             f"version {adoption_version}"
         )
     measurements = {
-        "default_mcp_tools": len(tools_for_profile("core")),
-        "full_profile_mcp_tools": len(tools_for_profile("full")),
-        "stable_cli_top_level_commands": len(STABLE_TOP_LEVEL_COMMANDS),
+        "default_mcp_tools": len(mcp_profiles.tools_for_profile("core")),
+        "full_profile_mcp_tools": len(mcp_profiles.tools_for_profile("full")),
+        "stable_cli_top_level_commands": len(cli_parser.STABLE_TOP_LEVEL_COMMANDS),
         "primary_dashboard_routes": placements["primary"],
         "shell_utility_dashboard_routes": placements["utility"],
         "contextual_dashboard_routes": placements["contextual"],
@@ -439,7 +443,7 @@ def measure_product_complexity(
         "main_initial_react_js_gzip_bytes": measure_initial_javascript(
             root / budget["dashboard_bundle"]["output_dir"]
         ),
-        "stable_json_schemas": len(known_json_schemas()),
+        "stable_json_schemas": len(json_contracts.known_json_schemas()),
         "sqlite_schema_increments": increments,
     }
     if dist_dir is not None:

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -21,6 +21,7 @@ SCRIPT_ROOT = Path(__file__).resolve().parent
 if str(SCRIPT_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPT_ROOT))
 
+from check_product_complexity import check_product_complexity_budget  # noqa: E402
 from release_quality import (  # noqa: E402
     check_ci_workflow,
     check_compatibility_inventory,
@@ -289,6 +290,7 @@ WHEEL_REQUIRED_MEMBERS = {
     "codex_usage_tracker/plugin_data/skills/codex-usage-tracker/scripts/run_mcp.py",
 }
 SDIST_REQUIRED_MEMBERS = {
+    *("config/product-complexity-budget.json", "scripts/check_product_complexity.py"),
     "docs/cli-json-schemas.md",
     "docs/releases/0.22.0.md",
     "docs/upgrading-to-0.22.0.md",
@@ -337,6 +339,14 @@ def main() -> int:
     failures.extend(_check_tracked_files_for_secrets())
     failures.extend(_check_react_dashboard_privacy_artifacts())
     failures.extend(_check_removed_dashboard_visualization())
+    failures.extend(
+        f"product complexity budget: {failure}"
+        for failure in check_product_complexity_budget(
+            REPO_ROOT,
+            REPO_ROOT / "config/product-complexity-budget.json",
+            dist_dir=REPO_ROOT / "dist" if args.dist else None,
+        )
+    )
     if args.dist:
         failures.extend(_check_sdist())
         failures.extend(_check_wheel())

--- a/tests/cli/test_cli_release.py
+++ b/tests/cli/test_cli_release.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import re
 import shlex
 import subprocess
 import sys
@@ -88,12 +87,15 @@ def test_dashboard_release_excludes_three_and_constellation_artifacts() -> None:
 
 
 def test_dashboard_main_bundle_budget_is_ratcheted_after_constellation_removal() -> None:
-    script = (
-        Path(__file__).resolve().parents[2] / "scripts" / "check-dashboard-bundles.mjs"
-    ).read_text(encoding="utf-8")
-    match = re.search(r"currentInitialJs:\s*(\d+)\s*\*\s*1024", script)
-    assert match is not None
-    assert int(match.group(1)) <= MAX_INITIAL_DASHBOARD_JS_KIB
+    root = Path(__file__).resolve().parents[2]
+    script = (root / "scripts" / "check-dashboard-bundles.mjs").read_text(encoding="utf-8")
+    budget = json.loads(
+        (root / "config" / "product-complexity-budget.json").read_text(encoding="utf-8")
+    )
+    maximum = budget["metrics"]["main_initial_react_js_gzip_bytes"]["maximum"]
+
+    assert "main_initial_react_js_gzip_bytes" in script
+    assert maximum <= MAX_INITIAL_DASHBOARD_JS_KIB * 1024
 
 
 def test_release_check_rejects_stale_public_package_version_claims(tmp_path: Path) -> None:
@@ -286,10 +288,7 @@ def test_release_pipeline_rebuilds_dashboard_assets_and_smokes_installed_wheel()
     workflow = (repo_root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     package_job = workflow.split("\n  package:\n", maxsplit=1)[1]
     required_in_order = [
-        (
-            "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 "
-            "# v7.0.0",
-        ),
+        ("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",),
         ('node-version: "22"',),
         ("run: npm ci",),
         ("run: npm run dashboard:assets:check",),

--- a/tests/quality/test_product_complexity_budget.py
+++ b/tests/quality/test_product_complexity_budget.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.check_product_complexity import (
+    METRIC_NAMES,
+    BudgetError,
+    evaluate_budget,
+    load_budget,
+    measure_distribution_sizes,
+    measure_line_budget,
+    measure_product_complexity,
+    parse_route_placements,
+)
+
+
+def _budget_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "baseline": {
+            "release": "0.23.0",
+            "commit": "a" * 40,
+            "measurement_command": "python scripts/check_product_complexity.py",
+            "rationale": "Synthetic focused-test baseline.",
+        },
+        "increase_policy": "Architecture decision and changed test fixture required.",
+        "metrics": {
+            name: {
+                "maximum": 1,
+                "baseline": 1,
+                "baseline_commit": "a" * 40,
+                "rationale": f"Synthetic {name} ceiling.",
+            }
+            for name in METRIC_NAMES
+        },
+        "source_files": {
+            "python": {
+                "roots": ["src"],
+                "extensions": [".py"],
+                "exclude_globs": [],
+                "maximum_physical_lines": 600,
+                "grandfathered": {},
+            },
+            "frontend": {
+                "roots": ["frontend"],
+                "extensions": [".ts", ".tsx", ".css"],
+                "exclude_globs": ["**/*.test.ts", "**/*.test.tsx"],
+                "maximum_physical_lines": 500,
+                "grandfathered": {},
+            },
+        },
+        "dashboard_routes": {
+            "catalog": "frontend/routes.ts",
+            "const": "evidenceConsoleRoutes",
+        },
+        "dashboard_bundle": {
+            "output_dir": "built-dashboard",
+        },
+        "sqlite_schema": {
+            "release_023_version": 34,
+            "budget_adoption_version": 37,
+        },
+    }
+
+
+@pytest.mark.parametrize("metric", METRIC_NAMES)
+def test_every_product_complexity_metric_blocks_above_its_ceiling(metric: str) -> None:
+    payload = _budget_payload()
+    measurements = dict.fromkeys(METRIC_NAMES, 1)
+    measurements[metric] = 2
+
+    failures = evaluate_budget(payload, measurements)
+
+    assert failures == [f"{metric}=2 exceeds maximum 1"]
+
+
+def test_budget_loader_requires_provenance_and_every_metric(tmp_path: Path) -> None:
+    path = tmp_path / "budget.json"
+    payload = _budget_payload()
+    del payload["baseline"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(BudgetError, match="baseline"):
+        load_budget(path)
+
+    payload = _budget_payload()
+    del payload["metrics"][METRIC_NAMES[0]]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(BudgetError, match=METRIC_NAMES[0]):
+        load_budget(path)
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "key"),
+    [
+        ("python", "roots"),
+        ("python", "extensions"),
+        ("frontend", "roots"),
+        ("frontend", "extensions"),
+    ],
+)
+def test_budget_loader_rejects_empty_required_source_lists(
+    tmp_path: Path,
+    source_kind: str,
+    key: str,
+) -> None:
+    payload = _budget_payload()
+    payload["source_files"][source_kind][key] = []
+    path = tmp_path / "budget.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(BudgetError, match=key):
+        load_budget(path)
+
+
+def test_route_catalog_parser_counts_only_the_named_structured_catalog() -> None:
+    source = """
+export const evidenceConsoleRoutes = [
+  {
+    id: 'home',
+    placement: 'primary',
+  },
+  {
+    id: 'evidence',
+    placement: 'contextual',
+  },
+  {
+    id: 'settings',
+    placement: 'utility',
+  },
+] as const;
+const unrelated = { placement: 'primary' };
+"""
+
+    assert parse_route_placements(source, "evidenceConsoleRoutes") == {
+        "primary": 1,
+        "contextual": 1,
+        "utility": 1,
+    }
+
+
+def test_route_catalog_parser_fails_closed_on_missing_placement() -> None:
+    source = """
+export const evidenceConsoleRoutes = [
+  {
+    id: 'home',
+  },
+] as const;
+"""
+
+    with pytest.raises(BudgetError, match="placement"):
+        parse_route_placements(source, "evidenceConsoleRoutes")
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        """  {
+    id: 'home',
+    // placement: 'primary',
+  },""",
+        """  {
+    id: 'home',
+    metadata: {
+      placement: 'primary',
+    },
+  },""",
+        """  {
+    id: 'home',
+    ...routeDefaults,
+    placement: 'primary',
+  },""",
+        """  createRoute({
+    id: 'home',
+    placement: 'primary',
+  }),""",
+        """  {
+    ['id']: 'home',
+    placement: 'primary',
+  },""",
+    ],
+)
+def test_route_catalog_parser_rejects_nonliteral_or_decoy_entries(entry: str) -> None:
+    source = f"""
+export const evidenceConsoleRoutes = [
+{entry}
+] as const;
+"""
+
+    with pytest.raises(BudgetError, match="literal|comments|spreads"):
+        parse_route_placements(source, "evidenceConsoleRoutes")
+
+
+def test_line_budget_allows_frozen_debt_but_blocks_growth_and_new_debt(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    frozen = root / "frozen.py"
+    frozen.write_text("x = 1\n" * 4, encoding="utf-8")
+    fresh = root / "fresh.py"
+    fresh.write_text("x = 1\n" * 3, encoding="utf-8")
+    config = {
+        "roots": ["src"],
+        "extensions": [".py"],
+        "exclude_globs": [],
+        "maximum_physical_lines": 3,
+        "grandfathered": {"src/frozen.py": 4},
+    }
+
+    assert measure_line_budget(tmp_path, config) == []
+
+    frozen.write_text("x = 1\n" * 5, encoding="utf-8")
+    fresh.write_text("x = 1\n" * 4, encoding="utf-8")
+
+    assert measure_line_budget(tmp_path, config) == [
+        "src/fresh.py",
+        "src/frozen.py",
+    ]
+
+
+def test_line_budget_excludes_nested_files_with_recursive_glob(tmp_path: Path) -> None:
+    nested = tmp_path / "src" / "plugin_data" / "nested" / "deeper"
+    nested.mkdir(parents=True)
+    (nested / "generated.py").write_text("x = 1\n" * 4, encoding="utf-8")
+    config = {
+        "roots": ["src"],
+        "extensions": [".py"],
+        "exclude_globs": ["src/plugin_data/**"],
+        "maximum_physical_lines": 3,
+        "grandfathered": {},
+    }
+
+    assert measure_line_budget(tmp_path, config) == []
+
+
+def test_line_budget_requires_a_downward_ratchet_after_debt_shrinks(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    frozen = root / "frozen.py"
+    frozen.write_text("x = 1\n" * 4, encoding="utf-8")
+    config = {
+        "roots": ["src"],
+        "extensions": [".py"],
+        "exclude_globs": [],
+        "maximum_physical_lines": 3,
+        "grandfathered": {"src/frozen.py": 5},
+    }
+
+    with pytest.raises(BudgetError, match="baseline is stale"):
+        measure_line_budget(tmp_path, config)
+
+
+def test_distribution_measurement_requires_exactly_one_wheel_and_sdist(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "package-0.24.0-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "package-0.24.0.tar.gz").write_bytes(b"source")
+
+    assert measure_distribution_sizes(tmp_path) == {
+        "wheel_bytes": 5,
+        "sdist_bytes": 6,
+    }
+
+    (tmp_path / "duplicate-0.24.0-py3-none-any.whl").write_bytes(b"other")
+    with pytest.raises(BudgetError, match="exactly one wheel"):
+        measure_distribution_sizes(tmp_path)
+
+
+def test_committed_product_complexity_budget_passes_source_measurement() -> None:
+    root = Path(__file__).resolve().parents[2]
+    budget = load_budget(root / "config/product-complexity-budget.json")
+    measurements = measure_product_complexity(root, budget)
+
+    assert set(measurements) == set(METRIC_NAMES) - {"wheel_bytes", "sdist_bytes"}
+    assert evaluate_budget(budget, measurements) == []
+
+
+def test_committed_budget_preserves_reviewed_baselines_and_exact_headroom() -> None:
+    root = Path(__file__).resolve().parents[2]
+    budget = load_budget(root / "config/product-complexity-budget.json")
+    metrics = budget["metrics"]
+
+    assert metrics["default_mcp_tools"]["maximum"] == 7
+    assert metrics["full_profile_mcp_tools"]["maximum"] == 59
+    assert metrics["stable_cli_top_level_commands"]["maximum"] == 11
+    assert metrics["primary_dashboard_routes"]["maximum"] == 3
+    assert metrics["shell_utility_dashboard_routes"]["maximum"] == 1
+    assert metrics["contextual_dashboard_routes"]["maximum"] == 1
+    assert metrics["unbudgeted_python_files_over_600"]["maximum"] == 0
+    assert metrics["unbudgeted_frontend_source_files_over_500"]["maximum"] == 0
+    assert metrics["wheel_bytes"]["baseline"] == 7_017_243
+    assert metrics["wheel_bytes"]["maximum"] == math.ceil(7_017_243 * 1.05)
+    assert metrics["sdist_bytes"]["baseline"] == 32_021_790
+    assert metrics["sdist_bytes"]["maximum"] == math.ceil(32_021_790 * 1.05)
+    assert metrics["main_initial_react_js_gzip_bytes"]["baseline"] == 61_457
+    assert metrics["main_initial_react_js_gzip_bytes"]["maximum"] == math.ceil(61_457 * 1.10)
+    assert metrics["stable_json_schemas"]["maximum"] == 114
+    assert metrics["sqlite_schema_increments"]["maximum"] == 1
+    assert budget["source_files"]["python"]["roots"] == ["src/codex_usage_tracker"]
+    assert budget["source_files"]["python"]["extensions"] == [".py"]
+    assert budget["source_files"]["python"]["exclude_globs"] == [
+        "src/codex_usage_tracker/plugin_data/**"
+    ]
+    assert budget["source_files"]["python"]["maximum_physical_lines"] == 600
+    assert budget["source_files"]["frontend"]["roots"] == ["frontend/dashboard/src"]
+    assert budget["source_files"]["frontend"]["extensions"] == [".ts", ".tsx", ".css"]
+    assert budget["source_files"]["frontend"]["exclude_globs"] == [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+    ]
+    assert budget["source_files"]["frontend"]["maximum_physical_lines"] == 500
+    assert budget["dashboard_routes"] == {
+        "catalog": "frontend/dashboard/src/routes/evidenceConsoleRoutes.ts",
+        "const": "evidenceConsoleRoutes",
+    }
+    assert budget["dashboard_bundle"] == {
+        "output_dir": "src/codex_usage_tracker/plugin_data/dashboard/react"
+    }
+    assert budget["sqlite_schema"] == {
+        "release_023_version": 34,
+        "budget_adoption_version": 37,
+    }


### PR DESCRIPTION
## What changed

- adds one versioned product-complexity budget for MCP/CLI surface counts, Evidence Console routes, authored-source debt, package artifacts, initial React JavaScript, stable JSON schemas, and SQLite growth
- measures authoritative registries and built artifacts with a fail-closed checker wired into CI and release readiness
- makes the dashboard bundle gate read the same committed JavaScript ceiling
- documents the ratchet policy, historical exceptions, and release commands

## Why

Task 37 makes product and package complexity a blocking 0.24 release contract. Existing oversized files are frozen at their adoption sizes, immutable 0.23 artifacts establish package baselines, and future ceiling increases require an explicit architecture decision.

## Validation

- 32 focused budget and release-contract tests
- complete 2,146-test suite in the single Agent Maintainer CI run
- source and built wheel/sdist budget checks
- release readiness with and without `--dist`
- MyPy, Pyright, Ruff, Vulture, Bandit, Xenon, actionlint, Zizmor, compileall, and change-plan validation
- one read-only final review; all four findings accepted and fixed
