### PR TITLE
fix: keep compression status reads query only

### DIFF
--- a/docs/roadmap/mcp-first-pivot-execution.md
+++ b/docs/roadmap/mcp-first-pivot-execution.md
@@ -1466,8 +1466,8 @@ complete without its named focused and full verification evidence.
 
 ## Task 37 - Budget Product and Package Complexity
 
-- Status: complete locally on `pivot/37-product-complexity-budget`; reviewed
-  PR remains.
+- Status: complete; PR #305 merged to `main` at
+  `f5cb45ac64653f29c8712a0a1ea09ddfd0674ac9`.
 - Graph-guided scope:
   - a fresh GitNexus index at `a52338d` routed measurement to the MCP
     `tool_specs` catalog, CLI `build_parser` inventory, Evidence Console route
@@ -1511,3 +1511,39 @@ complete without its named focused and full verification evidence.
     the Task 37 Xenon A/B complexity gate;
   - reviewer token attribution is `pending` in the aggregate-only metrics
     ledger.
+
+## 0.24 Release Blocker - Read-only Compression Status Polling
+
+- Status: fixed locally on `fix/compression-status-read-only`; release gate
+  remains in progress.
+- Root cause:
+  - `get_compression_run(..., touch=False)` still opened the writable
+    connection and initialized the schema while the dashboard polled job status;
+  - `read_compression_source_generation()` also performed schema setup during
+    the background evidence fold;
+  - those redundant writes could overlap and fail the compression job with
+    `sqlite3.OperationalError`.
+- Fix:
+  - non-touching status reads now use `connect_read_only`;
+  - source-generation reads require the caller's already initialized schema and
+    perform only the query.
+- Verification:
+  - deterministic regressions prove both paths work without initialization or
+    writes;
+  - two accepted reviewer findings restore missing-database status semantics
+    and fresh-database query initialization without reintroducing writes on the
+    normal initialized read path;
+  - the focused application/compression/store/dashboard slice passes 56 tests;
+  - the previously flaky end-to-end dashboard compression test passes 100
+    consecutive runs;
+  - the full Python suite passes 2,158 tests with 88.1% coverage; its broad gate
+    also exposed and hardened one frontend retry assertion whose default
+    one-second wait was unreliable under full-suite contention; ESLint,
+    TypeScript, and all 621 frontend tests then pass;
+  - Ruff lint, configured MyPy, focused Pyright, release readiness,
+    product-complexity budget, and whitespace checks pass.
+- Final review:
+  - the single read-only reviewer reported two medium findings; both were
+    accepted and pass bounded regression checks;
+  - review metrics: 2 findings, 2 accepted; reviewer tokens `pending`; tokens
+    per accepted finding `pending`.

--- a/frontend/dashboard/src/App.threads-live.test.tsx
+++ b/frontend/dashboard/src/App.threads-live.test.tsx
@@ -295,7 +295,13 @@ describe('React dashboard threads live queries', () => {
 
     expect(await screen.findByText('Stored snapshot')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Open investigator for thread call/i })).toBeInTheDocument();
-    fireEvent.click(await screen.findByRole('button', { name: 'Retry loading thread calls' }));
+    fireEvent.click(
+      await screen.findByRole(
+        'button',
+        { name: 'Retry loading thread calls' },
+        { timeout: 5_000 },
+      ),
+    );
     await waitFor(() => expect(callAttempts).toBe(3));
     expect(await screen.findByText('No aggregate calls are available for this thread.')).toBeInTheDocument();
     expect(screen.queryByText('Stored snapshot')).not.toBeInTheDocument();

--- a/src/codex_usage_tracker/application/query.py
+++ b/src/codex_usage_tracker/application/query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import sqlite3
 from dataclasses import asdict
 from pathlib import Path
 
@@ -26,7 +27,8 @@ from codex_usage_tracker.pricing.config import PricingConfig, load_pricing_confi
 from codex_usage_tracker.pricing.costing import estimate_cost_usd
 from codex_usage_tracker.store.api import query_canonical_usage_v2
 from codex_usage_tracker.store.compression_schema import read_compression_source_generation
-from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.connection import connect, connect_read_only
+from codex_usage_tracker.store.schema import init_db
 
 
 def query_usage(
@@ -135,8 +137,16 @@ def _query_fingerprint(request: QueryRequest) -> str:
 
 
 def _source_revision(db_path: Path) -> str:
-    with connect(db_path) as connection:
-        generation = read_compression_source_generation(connection)
+    try:
+        with connect_read_only(db_path) as connection:
+            generation = read_compression_source_generation(connection)
+    except sqlite3.OperationalError as exc:
+        missing_generation_table = "no such table: compression_source_state"
+        if db_path.exists() and missing_generation_table not in str(exc):
+            raise
+        with connect(db_path) as connection:
+            init_db(connection)
+            generation = read_compression_source_generation(connection)
     return f"generation:{generation}"
 
 

--- a/src/codex_usage_tracker/store/compression_runs.py
+++ b/src/codex_usage_tracker/store/compression_runs.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from codex_usage_tracker.core.paths import DEFAULT_DB_PATH
-from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.connection import connect, connect_read_only
 from codex_usage_tracker.store.schema import init_db
 
 _CACHEABLE_STATUSES = ("completed", "completed_with_warnings")
@@ -261,11 +261,17 @@ def get_compression_run(
     run_id: str,
     touch: bool = True,
 ) -> dict[str, Any] | None:
-    """Return one decoded run, optionally marking it recently accessed."""
+    """Return one decoded run; non-touching status reads stay query-only."""
+    if not touch:
+        if not db_path.is_file():
+            return None
+        with connect_read_only(db_path) as conn:
+            row = _select_run(conn, run_id)
+        return _decode_run(row) if row is not None else None
     with connect(db_path) as conn:
         init_db(conn)
         row = _select_run(conn, run_id)
-        if row is not None and touch:
+        if row is not None:
             conn.execute(
                 "UPDATE compression_runs SET last_accessed_at = ? WHERE run_id = ?",
                 (_utc_now(), run_id),

--- a/src/codex_usage_tracker/store/compression_schema.py
+++ b/src/codex_usage_tracker/store/compression_schema.py
@@ -348,7 +348,7 @@ def create_compression_revision_tables(conn: sqlite3.Connection) -> None:
 
 
 def read_compression_source_generation(conn: sqlite3.Connection) -> int:
-    _ensure_compression_storage(conn)
+    """Read generation from an already initialized compression schema."""
     row = conn.execute(
         "SELECT generation FROM compression_source_state WHERE singleton = 1"
     ).fetchone()

--- a/tests/application/test_query.py
+++ b/tests/application/test_query.py
@@ -34,6 +34,22 @@ def _seed(db_path: Path) -> None:
         )
 
 
+def test_query_usage_initializes_fresh_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "fresh.sqlite3"
+
+    result = query_usage(
+        QueryRequest(
+            entity="call",
+            measures=("tokens",),
+            filters=QueryFilters(),
+        ),
+        db_path=db_path,
+    )
+
+    assert result.rows == ()
+    assert db_path.is_file()
+
+
 def test_query_uses_canonical_rows_and_explicit_history(tmp_path: Path) -> None:
     db_path = tmp_path / "usage.sqlite3"
     _seed(db_path)

--- a/tests/compression/test_jobs.py
+++ b/tests/compression/test_jobs.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from codex_usage_tracker.compression import run_builder
+from codex_usage_tracker.compression.api import compression_status
 from codex_usage_tracker.compression.jobs import CompressionJobRegistry
 from codex_usage_tracker.compression.models import CompressionScope
 from codex_usage_tracker.compression.request import prepare_compression_request
@@ -22,6 +23,21 @@ from codex_usage_tracker.store.compression_runs import (
     update_compression_run,
 )
 from tests.compression.compression_helpers import call, snapshot
+
+
+def test_status_missing_database_returns_not_found_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "missing.sqlite3"
+
+    payload = compression_status(
+        db_path,
+        run_id="missing-run",
+        registry=CompressionJobRegistry(),
+    )
+
+    error = payload["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "compression_run_not_found"
+    assert not db_path.exists()
 
 
 def test_start_returns_immediately_and_deduplicates_active_request(tmp_path: Path) -> None:

--- a/tests/store/test_compression_facts.py
+++ b/tests/store/test_compression_facts.py
@@ -11,7 +11,8 @@ from codex_usage_tracker.store.compression_facts import backfill_compression_det
 from codex_usage_tracker.store.compression_schema import (
     read_compression_source_generation,
 )
-from codex_usage_tracker.store.connection import connect
+from codex_usage_tracker.store.connection import connect, connect_read_only
+from codex_usage_tracker.store.schema import init_db
 from tests.store_dashboard_helpers import (
     _entry,
     _make_codex_home,
@@ -41,6 +42,17 @@ def test_content_refresh_updates_detector_fact_exposure(tmp_path: Path) -> None:
     assert fact_row["content_exposure_tokens"] > 0
     assert fact_state is not None
     assert fact_state["source_generation"] == source_generation
+
+
+def test_source_generation_read_works_on_query_only_connection(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    with connect(db_path) as conn:
+        init_db(conn)
+
+    with connect_read_only(db_path) as conn:
+        source_generation = read_compression_source_generation(conn)
+
+    assert source_generation == 0
 
 
 def test_direct_ingestion_facts_match_legacy_backfill(tmp_path: Path) -> None:

--- a/tests/store/test_compression_runs.py
+++ b/tests/store/test_compression_runs.py
@@ -15,6 +15,7 @@ from codex_usage_tracker.compression.models import (
     EstimateRange,
 )
 from codex_usage_tracker.store import compression_candidates as candidate_store
+from codex_usage_tracker.store import compression_runs as run_store
 from codex_usage_tracker.store.compression_candidates import (
     get_compression_candidate,
     list_compression_candidates,
@@ -83,6 +84,35 @@ def test_run_updates_preserve_monotonic_progress(tmp_path: Path) -> None:
     assert run is not None
     assert run["progress_percent"] == 60
     assert run["stage"] == "stale-update"
+
+
+def test_status_read_without_touch_does_not_initialize_or_write_schema(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite3"
+    create_compression_run(db_path, run_id="run-1", **cache_key("rev-1"))
+
+    def fail_if_initialized(_connection: sqlite3.Connection) -> None:
+        raise AssertionError("status read attempted schema initialization")
+
+    monkeypatch.setattr(run_store, "init_db", fail_if_initialized)
+
+    run = run_store.get_compression_run(db_path, run_id="run-1", touch=False)
+
+    assert run is not None
+    assert run["run_id"] == "run-1"
+
+
+def test_status_read_without_touch_returns_none_for_missing_database(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "missing.sqlite3"
+
+    run = run_store.get_compression_run(db_path, run_id="run-1", touch=False)
+
+    assert run is None
+    assert not db_path.exists()
 
 
 def test_candidate_replace_lists_compact_rows_and_reconstructs_detail(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make non-touching compression status polling use a read-only SQLite connection
- remove write-capable schema setup from source-generation reads while preserving explicit fresh-database initialization
- harden the frontend retry assertion discovered by the full release gate
- record the reproduced 0.24 release blocker and verification evidence

## Verification
- 56 focused application/compression/store/dashboard tests
- former compression race: 100 consecutive end-to-end passes
- full Python suite: 2,158 passed, 88.1% coverage
- frontend: ESLint, TypeScript, 621 tests
- Ruff, configured MyPy, focused Pyright
- release readiness and product-complexity budget
- markdownlint and diff whitespace

## Review
- one read-only final reviewer: 2 findings, 2 accepted and fixed
- reviewer token attribution: pending