### PR TITLE
chore: release 0.25.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "codex-usage-tracker",
-  "version": "0.25.0.dev0",
+  "version": "0.25.0",
   "bundle": {
     "schema": "codex-usage-tracker.plugin-bundle.v1",
-    "digest": "sha256:651d9d34b7dc923e6d7d82de11f7ea8aee2001b420c206114b465fd2f5bdf90f",
-    "runtime_version": "0.25.0.dev0"
+    "digest": "sha256:b84df0e09d57b420744efa079e8681915a0485718fd96bdc34918d61d9dc2b72",
+    "runtime_version": "0.25.0"
   },
   "description": "Unofficial local, evidence-backed Codex usage analyst with MCP tools and an Evidence Console.",
   "author": {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,9 +73,8 @@ jobs:
         run: python -m compileall src
       - name: Dashboard JavaScript syntax
         run: |
-          for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-            node --check "$file"
-          done
+          find src/codex_usage_tracker/plugin_data/dashboard \
+            -type f -name '*.js' -exec node --check '{}' ';'
       - name: Release readiness
         run: python scripts/check_release.py
       - name: Whitespace

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,8 +6,8 @@
       "cwd": ".",
       "env": {
         "CODEX_USAGE_TRACKER_MCP_PROFILE": "core",
-        "CODEX_USAGE_TRACKER_PLUGIN_VERSION": "0.25.0.dev0",
-        "CODEX_USAGE_TRACKER_PLUGIN_BUNDLE_DIGEST": "sha256:651d9d34b7dc923e6d7d82de11f7ea8aee2001b420c206114b465fd2f5bdf90f"
+        "CODEX_USAGE_TRACKER_PLUGIN_VERSION": "0.25.0",
+        "CODEX_USAGE_TRACKER_PLUGIN_BUNDLE_DIGEST": "sha256:b84df0e09d57b420744efa079e8681915a0485718fd96bdc34918d61d9dc2b72"
       },
       "startup_timeout_sec": 120
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,9 +215,8 @@ python -m mypy
 python -m pytest
 python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info
@@ -231,9 +230,8 @@ Additional smoke checks for touched CLI surfaces:
 ```bash
 python -m pytest
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python -m build
 python scripts/check_release.py --dist
 git diff --check
@@ -289,9 +287,8 @@ python -m mypy
 python -m pytest
 python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.25.0.dev0 - 2026-07-25
+## 0.25.0 - 2026-07-25
 
 - Prioritize central-product reliability before compatibility removal, moving
   the existing removal and stabilization roadmap stages to 0.26 and 0.27.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -252,9 +252,8 @@ python -m pytest
 python -m compileall src
 python -m mypy
 python scripts/check_product_complexity.py --config config/product-complexity-budget.json
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 python -m build
 python scripts/check_product_complexity.py --config config/product-complexity-budget.json --dist dist

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,9 +126,8 @@ python -m agent_maintainer.runners.bandit
 zizmor --offline --no-progress .github/workflows
 python scripts/check_product_complexity.py --config config/product-complexity-budget.json
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info
@@ -223,8 +222,8 @@ python scripts/smoke_installed_package.py --docker
 To verify the public PyPI package instead of the local checkout:
 
 ```bash
-python scripts/smoke_installed_package.py --from-pypi --version 0.25.0.dev0
-python scripts/smoke_installed_package.py --docker --from-pypi --version 0.25.0.dev0
+python scripts/smoke_installed_package.py --from-pypi --version 0.25.0
+python scripts/smoke_installed_package.py --docker --from-pypi --version 0.25.0
 ```
 
 `scripts/check_release.py` treats these public-package smoke commands as release-state claims. Keep their `--version` and `codex-usage-tracking==...` values aligned with `pyproject.toml`; the release gate fails when the docs claim a different public version. It also checks that install docs point at the real PyPI distribution, `codex-usage-tracking`, and keep the warning that `codex-usage-tracker` is a different PyPI package.
@@ -410,9 +409,8 @@ python -m mypy
 python -m pytest
 python -m pytest --cov=codex_usage_tracker --cov-report=term-missing
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do
-  node --check "$file"
-done
+find src/codex_usage_tracker/plugin_data/dashboard \
+  -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 git diff --check
 rm -rf dist build src/codex_usage_tracker.egg-info src/codex_usage_tracking.egg-info

--- a/docs/maintainability-roadmap.md
+++ b/docs/maintainability-roadmap.md
@@ -46,7 +46,7 @@ python -m ruff check .
 python -m mypy
 python -m pytest
 python -m compileall src
-for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do node --check "$file"; done
+find src/codex_usage_tracker/plugin_data/dashboard -type f -name '*.js' -exec node --check '{}' ';'
 python scripts/check_release.py
 git diff --check
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codex-usage-tracking"
-version = "0.25.0.dev0"
+version = "0.25.0"
 description = "Local, evidence-backed Codex usage analyst with MCP tools and an Evidence Console."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/release_promotion_quality.py
+++ b/scripts/release_promotion_quality.py
@@ -16,6 +16,7 @@ def check_publish_workflow(repo_root: Path) -> list[str]:
     workflow = workflow_path.read_text(encoding="utf-8")
     failures = _required_text_failures(workflow)
     failures.extend(_event_policy_failures(workflow))
+    failures.extend(_dashboard_syntax_failures(workflow))
     failures.extend(_promotion_job_failures(workflow))
     return failures
 
@@ -117,6 +118,17 @@ def _event_policy_failures(workflow: str) -> list[str]:
             "in every verification stage"
         )
     return failures
+
+
+def _dashboard_syntax_failures(workflow: str) -> list[str]:
+    packaged_javascript_check = "-type f -name '*.js' -exec node --check '{}' ';'"
+    static_dashboard_glob = "plugin_data/dashboard/dashboard*.js"
+    if packaged_javascript_check not in workflow or static_dashboard_glob in workflow:
+        return [
+            "publish workflow must syntax-check all packaged JavaScript "
+            "without relying on removed static-dashboard filenames"
+        ]
+    return []
 
 
 def _promotion_job_failures(workflow: str) -> list[str]:

--- a/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "codex-usage-tracking==0.25.0.dev0",
+    "codex-usage-tracking==0.25.0",
 )
-RUNTIME_VERSION = "0.25.0.dev0"
+RUNTIME_VERSION = "0.25.0"
 PACKAGE_SPEC_MARKER = ".codex-usage-tracker-package-spec"
 MODULE_CHECK = (
     "import importlib.metadata; "

--- a/src/codex_usage_tracker/__init__.py
+++ b/src/codex_usage_tracker/__init__.py
@@ -2,6 +2,6 @@
 
 from codex_usage_tracker.core.models import UsageEvent
 
-__version__ = "0.25.0.dev0"
+__version__ = "0.25.0"
 
 __all__ = ["UsageEvent", "__version__"]

--- a/src/codex_usage_tracker/core/version.py
+++ b/src/codex_usage_tracker/core/version.py
@@ -1,3 +1,3 @@
 """Package version owned by the dependency-free core layer."""
 
-__version__ = "0.25.0.dev0"
+__version__ = "0.25.0"

--- a/src/codex_usage_tracker/plugin_data/skills/codex-usage-tracker/scripts/run_mcp.py
+++ b/src/codex_usage_tracker/plugin_data/skills/codex-usage-tracker/scripts/run_mcp.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 PACKAGE_SPEC = os.environ.get(
     "CODEX_USAGE_TRACKER_PACKAGE_SPEC",
-    "codex-usage-tracking==0.25.0.dev0",
+    "codex-usage-tracking==0.25.0",
 )
-RUNTIME_VERSION = "0.25.0.dev0"
+RUNTIME_VERSION = "0.25.0"
 PACKAGE_SPEC_MARKER = ".codex-usage-tracker-package-spec"
 MODULE_CHECK = (
     "import importlib.metadata; "

--- a/tests/release/test_publish_workflow_javascript.py
+++ b/tests/release/test_publish_workflow_javascript.py
@@ -1,0 +1,28 @@
+"""Release-policy coverage for packaged JavaScript validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.release_quality import check_publish_workflow
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_release_check_rejects_static_dashboard_only_javascript_glob(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    workflow = workflow.replace(
+        "find src/codex_usage_tracker/plugin_data/dashboard \\\n"
+        "            -type f -name '*.js' -exec node --check '{}' ';'",
+        "for file in src/codex_usage_tracker/plugin_data/dashboard/dashboard*.js; do\n"
+        '            node --check "$file"\n'
+        "          done",
+        1,
+    )
+    (workflow_dir / "publish.yml").write_text(workflow, encoding="utf-8")
+
+    failures = check_publish_workflow(tmp_path)
+
+    assert any("all packaged JavaScript" in failure for failure in failures)


### PR DESCRIPTION
## Summary
- promote package, plugin, launcher, and MCP bundle versions to 0.25.0
- update the deterministic plugin bundle identity and public smoke commands
- make production publishing syntax-check every packaged JavaScript asset after the static dashboard sunset
- add fail-closed release-policy coverage for the removed static-only glob

## Validation
- 2,092 Python tests passed
- 599 frontend tests passed with lint, type checks, boundaries, budgets, and deterministic assets
- 152 focused release/packaging/plugin/CLI tests passed
- release readiness, Twine, package/complexity budgets, wheel and sdist checks passed
- installed-wheel smoke passed locally and in clean Linux Docker
- installed MCP two-task probe passed with moving-tail hydration and durable analysis reuse

## Known local verifier baseline
The CI-equivalent Agent Maintainer profile continues to report pre-existing whole-repository debt in historic plan validation, file-length baselines, embedded Markdown code formatting, Pyright, Tach, Xenon, and Pylint. The release-scoped checks and GitHub-required gates remain authoritative; thresholds were not relaxed.
