### PR TITLE
chore: add Scalene development profiler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,14 @@ Use patch releases for public blockers such as broken PyPI installs, missing pac
 
 Use the `agent-perf` skill and CLI when optimizing localhost API endpoints, dashboard refreshes, report generation, content indexing, parser or SQLite hot paths, or other latency- or CPU-sensitive code, and when investigating a performance regression or making a speedup claim.
 
-Install the repository's pinned profiling tools with `uv sync --group performance`. Profile the smallest repeatable workload with synthetic or anonymized inputs; never profile production, live private databases, arbitrary processes, or real Codex session content. Record the identical workload without a profiler before making a performance claim. Change one suspected cause at a time, rerun the unprofiled workload, and use `agent-perf compare` only to compare attribution evidence rather than as proof of a speedup.
+Install the repository's pinned profiling tools with
+`.venv/bin/python -m pip install -e ".[dev]"`. Profile the smallest repeatable
+workload with synthetic or anonymized inputs; never profile production, live
+private databases, arbitrary processes, or real Codex session content. Record
+the identical workload without a profiler before making a performance claim.
+Change one suspected cause at a time, rerun the unprofiled workload, and use
+`agent-perf compare` only to compare attribution evidence rather than as proof
+of a speedup.
 
 ### Code intelligence tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
   "pytest>=8.0",
   "pyright>=1.1.405",
   "ruff>=0.8",
+  "scalene==2.3.0",
   "tomli>=2.0; python_version < '3.11'",
   "xenon>=0.9.3",
 ]


### PR DESCRIPTION
## Summary

- pin Scalene 2.3.0 in the existing development extra
- align profiling setup guidance with the repository standard editable dev install
- keep runtime dependencies and product behavior unchanged

## Validation

- `PATH="$PWD/.venv/bin:$PATH" just v` (340 Python tests and 7 Console tests passed; Ruff, MyPy, Pyright, frontend, scope, manifest, maintainability, and release checks passed)
- `.venv/bin/python -m build`
- `.venv/bin/python scripts/check_release.py --dist`
- `.venv/bin/python scripts/smoke_installed_package.py --artifact-dir dist --version 0.28.0`
- verified installed Scalene version is exactly 2.3.0