### PR TITLE
docs: adopt Product Recovery roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,11 @@
 
 ## Project Purpose
 
-This repository builds the lean local usage-data kernel. Version 0.28 is
-publishable only from merged `main` or its exact release tag through the
-protected build-once workflow.
+This repository builds the lean local usage-data kernel. The active
+`0.29.0` Product Recovery program makes the installed agent outcome fast,
+accurate, useful, and evidence-grounded before the next public package.
+Publication remains restricted to merged `main` or its exact release tag
+through the protected build-once workflow.
 
 ## Tech Stack
 
@@ -40,48 +42,33 @@ just v
 
 This project is now a published PyPI package with user-facing docs, JSON/MCP contracts, a release workflow, and privacy guarantees. Treat `main` as always releasable.
 
-### Product Kernel Reset Execution
+### Product Recovery Execution
 
-All post-0.25 product work must follow
-`docs/roadmap/product-kernel-reset.md`, its approved
-`docs/superpowers/specs/2026-07-26-product-kernel-reset-design.md`, and the
-code-quarantine amendment at
-`docs/superpowers/specs/2026-07-26-kernel-code-quarantine-design.md`.
-Use one focused
-`kernel/<task-id>-<slug>` branch per task, implement only the task's declared
-contract, and update `docs/roadmap/product-kernel-reset-execution.md` in the
-same changeset with branch, commits, verification, measurements, deviations,
-review metrics, and residual risk.
+All post-0.28 product work must follow
+`docs/roadmap/product-recovery.md`, its
+`docs/roadmap/product-recovery-tasks/README.md` task packets, and
+`docs/roadmap/product-recovery-execution.md`.
 
-K1 starts from current `main` and freezes both the public-surface inventory and
-the full tracked-tree code-disposition manifest. Its resolver input is exactly
-`git ls-files` at the K1 commit; workflows, root metadata, configuration, and
-agent instructions are not exempt. After K1, create a detached,
-policy-read-only v0.25.1 reference worktree and the temporary,
-non-publishable `kernel/0.26-integration` branch. K1A–K9 used short-lived task
-branches based on, and merged back into, that integration branch. K10 creates
-`release/0.26.0` from the audited current-`main` SHA, incorporates the qualified
-integration head once, and opens `release/0.26.0` to `main`. The release branch
-remains blocked from publication; only merged `main` or its exact tag may enter
-the protected flow.
+Use one focused branch per task, implement only the packet's declared contract,
+and update the Product Recovery execution ledger in the same changeset with
+branch, commits, verification, measurements, deviations, review metrics, and
+residual risk. Start each task from the exact base named in its packet and use
+the ordinary branch prefixes below. Do not reopen the historical
+`kernel/0.26-integration` flow or create new K-series work.
 
-Before each K1A–K9 task and K10, audit tracked-path deltas from the frozen K1
-main SHA. An unrepresented path fails closed. Port required blocker behavior on
-`kernel/k<owner>-mainline-port-<issue>`, based on and targeting integration,
-with manifest, oracle, ledger, and affected phase-gate updates. Never merge the
-legacy main line into integration. If `main` moves after the K10 audit, restart
-the cutover audit rather than resolving an unclassified delta.
+Task packets identify work that could be parallelized, but they never authorize
+parallel agents. Parallel writing lanes are allowed only when the user or
+maintainer explicitly authorizes subagents for the current task. A coordinating
+agent cannot self-authorize them. After authorization, record each lane's owner,
+worktree, base, and disjoint file allowlist before work begins. The coordinating
+agent alone owns shared contracts and the execution ledger. Schema files, public
+JSON, generated Console assets, and package manifests each have one writer at a
+time. Integrate parallel branches only at the checkpoint named in the packet.
 
-After K1A, activate only the integration worktree in Serena, GitNexus, and
-ordinary agent search. Read retired or transplant source from the v0.25.1 tag
-only through a bounded path named in `config/kernel-code-disposition-v1.json`;
-do not add the reference worktree to the normal project scope. Never delete an
-old worktree or branch without explicit maintainer permission.
-
-The branch/ref publication guard must reject integration and every K1A–K9 task
-ref. K9 may remove disposable skeleton metadata but not that guard. Only K10
-sets the final version on `release/0.26.0`; publication still occurs only from
-merged `main` through the protected release workflow.
+The Product Kernel Reset roadmap, design, code-quarantine amendment, and K0–K16
+execution ledger are historical evidence for the 0.26–0.28 rewrite. They do not
+authorize new implementation. Never delete an old worktree or branch without
+explicit maintainer permission.
 
 The tracker owns exact facts, deterministic calculations, freshness, and
 evidence. The consuming model owns inference, explanation, and recommendations.
@@ -148,18 +135,15 @@ remains available for doctor, guidance, change-plan, context, and host-side wait
 workflows.
 
 - Do not commit directly to `main`.
-- Start ordinary work and K1 from current `main` with a short-lived branch.
-  For the approved reset only, start K1A–K9 from
-  `kernel/0.26-integration`; K10 creates `release/0.26.0` from audited current
-  `main`, incorporates qualified integration once, and targets `main`.
-- Use branch prefixes `feature/`, `fix/`, `docs/`, `chore/`, `test/`, `release/`, `hotfix/`, or `kernel/`. Reserve `kernel/` for tasks in the approved Product Kernel Reset roadmap.
+- Start ordinary work from current `main`, unless the active Product Recovery
+  task packet names a different exact integration checkpoint.
+- Use branch prefixes `feature/`, `fix/`, `docs/`, `chore/`, `test/`,
+  `release/`, or `hotfix/`. `kernel/` is historical and reserved for the
+  completed Product Kernel Reset.
 - Keep each branch focused on one issue, one reviewable task, or one release.
-- Do not create a long-lived `develop` branch. The non-publishable
-  `kernel/0.26-integration` branch is the sole temporary exception and exists
-  only for K1A–K10.
+- Do not create a long-lived `develop` or integration branch.
 - Do not mix release prep with unrelated feature work.
-- Push task branches and open a PR for all changes headed to `main` or
-  `kernel/0.26-integration`.
+- Push task branches and open a PR for all changes headed to `main`.
 - Prefer squash merge for ordinary task PRs so `main` stays readable.
 - Use the PR as the review artifact even when there is only one maintainer.
 
@@ -173,9 +157,8 @@ chore/<issue-number>-short-description
 test/<issue-number>-short-description
 release/0.4.0
 hotfix/0.3.3
-kernel/0.26-integration
-kernel/k1a-legacy-quarantine
-kernel/k3-ingest-tail
+feature/r3-ingest-tail
+feature/r4-fast-query
 ```
 
 Before starting a task branch:

--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -10,6 +10,6 @@
   "http_routes": 7,
   "cli_commands": 11,
   "wheel_bytes": 130000,
-  "sdist_bytes": 382000,
+  "sdist_bytes": 414000,
   "plugin_bundle_bytes": 3900
 }

--- a/docs/roadmap/product-kernel-reset-execution.md
+++ b/docs/roadmap/product-kernel-reset-execution.md
@@ -1,5 +1,11 @@
 # Product Kernel Reset Execution Ledger
 
+> **Historical ledger:** K0–K15 are complete. K16 created the `v0.28.0` source
+> tag and GitHub release, but PyPI publication and GitHub package assets were
+> not completed. The [Product Recovery Roadmap](product-recovery.md)
+> supersedes the remaining release work; do not late-publish stale `0.28.0`
+> package bytes.
+
 This is the durable execution record for the
 [Product Kernel Reset](product-kernel-reset.md). The approved
 [design](../superpowers/specs/2026-07-26-product-kernel-reset-design.md) and
@@ -76,7 +82,7 @@ progress.
 | K13 | 0.27.0 | Complete | K11 | Read-only overlay boundary |
 | K14 | 0.27.0 | Complete | K12, K13 | Release qualification |
 | K15 | 0.28.0 | Complete | K14 | Fault, recovery, and scale |
-| K16 | 0.28.0 | In progress | K15 | Contract freeze and release |
+| K16 | 0.28.0 | Superseded | K15 | Source/tag complete; public package publication incomplete |
 
 ## Baseline Evidence
 
@@ -1959,8 +1965,8 @@ focused repository contract rejects removal of `--upgrade-from 0.26.0`.
 
 ## K16 — Freeze Contracts And Publish 0.28.0
 
-**State:** In progress — local qualification complete; final review, CI, and
-protected publication pending
+**State:** Superseded — local qualification and source release completed;
+public package publication did not complete
 **Branch:** `release/0.28.0`
 **Base:** `b44a767d41434ff1ee3ec3c1293b8194f10a99a4`
 **Commits:** pending
@@ -2027,15 +2033,13 @@ protected publication pending
 - The single final reviewer reported one finding and it was accepted: the
   frozen two-version upgrade promise needed both 0.26.0 and 0.27.0 to remain
   blocking CI smokes. Both now run exactly once.
-- Reviewer token attribution is pending after the single metrics finish call;
-  it was not retried.
-- Complete the bounded post-review recheck.
-- Protected publication run 30264962387 stopped in artifact verification
-  before TestPyPI upload because the normalized sdist made the first ceiling
-  too loose. No public package bytes were created.
-- Merge the release PR through maintained CI, tag the exact merged-main SHA,
-  publish only through protected Trusted Publishing, and verify TestPyPI,
-  PyPI, and GitHub artifacts byte-for-byte.
+- Reviewer token attribution remained pending after the single metrics finish
+  call; it was not retried.
+- Tag `v0.28.0` and its GitHub release now exist, but the release has no package
+  assets and public PyPI still serves `0.27.0` as latest.
+- K16 is closed as superseded rather than falsely recorded as published. R0 of
+  the Product Recovery Roadmap owns the next release decision, and the project
+  will not late-publish the stale `0.28.0` candidate.
 
 ## Task Entry Template
 

--- a/docs/roadmap/product-kernel-reset.md
+++ b/docs/roadmap/product-kernel-reset.md
@@ -1,6 +1,12 @@
 # Product Kernel Reset
 
-This document is the normative product and release sequence for Codex Usage
+> **Historical program:** K0–K15 are complete. K16 produced the `v0.28.0`
+> source tag and GitHub release, but public package publication and GitHub
+> assets were not completed. Remaining work is superseded by the
+> [Product Recovery Roadmap](product-recovery.md); do not late-publish stale
+> `0.28.0` package bytes.
+
+This document was the normative product and release sequence for Codex Usage
 Tracker after Release 0.25.1. The approved
 [design](../superpowers/specs/2026-07-26-product-kernel-reset-design.md) and
 [implementation plan](../superpowers/plans/2026-07-26-product-kernel-reset.md)

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -148,7 +148,7 @@ disjoint file sets.
 **Commits:** pending
 **Owned files:** `AGENTS.md`; Product Recovery roadmap, ledger, and task
 packets; historical notices in the Product Kernel Reset roadmap and ledger;
-scope checker and focused scope test
+scope checker, focused scope test, and measured source-distribution budget
 **Parallel lane:** none; R0 is coordinator-owned
 
 ### Contract added first
@@ -175,6 +175,10 @@ scope checker and focused scope test
 - Pointed `AGENTS.md` to the new active authority.
 - Preserved Product Kernel Reset documents as historical evidence and recorded
   K16 as superseded.
+- CI and the matching local build measured source-complete sdists at
+  402,327–402,593 bytes after adding the roadmap source. The sdist ceiling was
+  ratcheted from 382,000 to 414,000 bytes, 2.83–2.90 percent headroom. Wheel,
+  runtime source, Console, plugin, and catalog ceilings are unchanged.
 
 ### Agent outcome
 
@@ -188,6 +192,7 @@ creates the executable installed-agent scorecard.
 | Focused | Pass | `pytest tests/kernel/test_kernel_scope.py -q`: 14 passed |
 | Scope | Pass | `python scripts/check_kernel_scope.py`: integration scope passed |
 | Release safety | Pass | `python scripts/check_release.py`: release-safety checks passed |
+| Distribution | Pass | local wheel/sdist build plus `python scripts/check_release.py --dist`; 402,593-byte sdist under 414,000-byte ceiling |
 | Broad | Pass | `just v`: 340 Python tests, 7 frontend tests, Ruff, MyPy, Pyright, maintainability, manifest, deterministic asset, scope, and release checks passed |
 | Diff | Pass | `git diff --check` |
 | Performance | N/A | no runtime behavior changed |
@@ -212,6 +217,10 @@ supports the metrics helper's `strict` command. It was not retried.
   plan was written directly into the repository's established roadmap format.
 - Public `0.28.0` package publication is not resumed. The next qualified target
   is `0.29.0`.
+- Initial PR CI correctly failed both distribution-building jobs because the
+  new source documents exceeded the frozen 382,000-byte sdist ceiling. The
+  measured ratchet is a source-package accounting correction, not a runtime or
+  compatibility expansion.
 
 ### Residual risk and next task
 

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -1,0 +1,220 @@
+# Product Recovery Execution Ledger
+
+This ledger records execution of the
+[Product Recovery Roadmap](product-recovery.md) and its
+[task packets](product-recovery-tasks/README.md).
+
+Do not mark a task complete for intent, partial implementation, an unreviewed
+benchmark, a source-only tag, or an unpublished package.
+
+## Program Status
+
+| Task | State | Depends on | Branch | Outcome |
+| --- | --- | --- | --- | --- |
+| R0 | In progress | — | `docs/product-recovery-roadmap` | Adopt recovery authority |
+| R1 | Pending | R0 | — | Agent outcome and performance baseline |
+| R2 | Pending | R1 | — | Schema v3 and compact storage contract |
+| R3 | Pending | R2 | — | Cold build and incremental refresh acceleration |
+| R4 | Pending | R2 | — | Persisted rollups and fast API/MCP |
+| R5 | Pending | R3, R4 | — | Analytical primitives and human semantics |
+| R6 | Pending | R4, R5 | — | Console usability |
+| R7 | Pending | R1; completes after R3–R6 | — | Installed fresh-task qualification |
+| R8 | Pending | R0; completes after R6, R7 | — | Public documentation |
+| R9 | Pending | R7, R8 | — | Public `0.29.0` release |
+
+## Adoption Baseline
+
+- Roadmap base: `origin/main` at
+  `0f1483509a837857efaa42aa3b1be6487ea7ada4`.
+- Repository version: `0.28.0`.
+- Git tag: `v0.28.0` at
+  `b23648e`.
+- GitHub release: published, no package assets.
+- Public PyPI latest: `0.27.0`.
+- Active analytical schema: version 2.
+- Product Kernel Reset K0–K15: complete.
+- Product Kernel Reset K16: incomplete publication, superseded by R0.
+- Paused public README and synthetic screenshot draft remains isolated on
+  `docs/public-product-docs`.
+- Paused thread-label investigation remains isolated on
+  `fix/human-readable-thread-labels`.
+
+## Measured Recovery Baseline
+
+| Metric | Baseline | R1 authority |
+| --- | ---: | --- |
+| Cold production-shaped build | 1,096.357 s | pending reproducibility gate |
+| Source history | 14.955 GiB | aggregate-only measurement |
+| Stored fact rows | about 2.40 million | pending exact fixture manifest |
+| Analytical database | about 1.17 GB | pending deterministic reproduction |
+| Tables | 615.02 MiB | SQLite `dbstat` aggregate |
+| Indexes | 501.21 MiB | SQLite `dbstat` aggregate |
+| Allowance observations | 1,051,496 | schema-v2 aggregate |
+| Same-timestamp allowance repeats | 518,900 | schema-v2 aggregate |
+| Measured state-change rows | 133,587 | schema-v2 aggregate |
+| Top-threads agent outcome | 5m45s | user-observed dogfood |
+
+No raw prompt, response, reasoning, command, tool-output, or private path was
+read to produce these measurements.
+
+## Fresh-Task Agent Scorecard
+
+R1 freezes the exact rubric and fixtures. Every subsequent task records:
+
+| Dimension | Evidence |
+| --- | --- |
+| Readiness | package, plugin, MCP, skill, cached bundle, revision coherence |
+| Exposure | fresh task exposes the expected six tools and no retired tools |
+| Success | task returns a terminal useful answer |
+| Accuracy | deterministic oracle comparison |
+| Traceability | valid evidence selectors and destinations |
+| Latency | end-to-end and tracker-tool wall time |
+| Efficiency | MCP calls, batches, polls, retries, refresh jobs, response bytes |
+| Usefulness | human labels, relevant metrics, explicit fact/estimate/inference |
+| Freshness | correct committed generation and moving-tail behavior |
+
+## Parallel Work Ledger
+
+No parallel lane is active until its row names owners, worktrees, bases, and
+disjoint file sets.
+
+| Wave | Lane | Owner | Base | Files | State |
+| --- | --- | --- | --- | --- | --- |
+| 1 | R1 baseline | primary | R0 merge | task packet allowlist | Pending |
+| 2 | R3 ingestion | unassigned | R2 contract | ingest-owned files | Blocked |
+| 2 | R4 query | unassigned | R2 contract | query-owned files | Blocked |
+| 2 | R7 harness | unassigned | R1 harness | test/runner-owned files | Blocked |
+| 2 | R8 copy audit | unassigned | R0 merge | docs-only files | Blocked |
+
+## Task Entry Template
+
+```markdown
+## RX — Title
+
+**State:** In progress | Blocked | Complete
+**Branch:** `<branch>`
+**Base:** `<sha>`
+**Commits:** `<sha subject>`
+**Owned files:** `<exact paths or directories>`
+**Parallel lane:** `<none or named lane and integration checkpoint>`
+
+### Contract added first
+
+- `<failing test, benchmark, invariant, or task artifact>`
+
+### Implementation
+
+- `<behavior implemented>`
+
+### Agent outcome
+
+| Prompt | Success | End to end | Tool time | MCP calls | Accuracy | Usefulness |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| `<prompt>` | Pass/Fail | `<time>` | `<time>` | `<count>` | `<grade>` | `<grade>` |
+
+### Verification
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Focused | Pass/Fail | `<command and summary>` |
+| Broad | Pass/Fail | `<command and summary>` |
+| Performance | Pass/Fail/N/A | `<identical before/after workload>` |
+| Privacy | Pass/Fail | `synthetic fixtures; no private content` |
+| Installed | Pass/Fail/N/A | `<wheel/plugin/skill/fresh-task evidence>` |
+
+### Review metrics
+
+- Total findings: `<n>`
+- Accepted findings: `<n>`
+- Accepted IDs: `<ids or none>`
+- Reviewer tokens: `<n or pending>`
+- Tokens per accepted finding: `<value, N/A, or pending>`
+
+### Deviations and decisions
+
+- `<none or approved decision>`
+
+### Residual risk and next task
+
+- `<remaining risk>`
+- `<exact task unblocked>`
+```
+
+## R0 — Roadmap Adoption
+
+**State:** In progress
+**Branch:** `docs/product-recovery-roadmap`
+**Base:** `0f1483509a837857efaa42aa3b1be6487ea7ada4`
+**Commits:** pending
+**Owned files:** `AGENTS.md`; Product Recovery roadmap, ledger, and task
+packets; historical notices in the Product Kernel Reset roadmap and ledger;
+scope checker and focused scope test
+**Parallel lane:** none; R0 is coordinator-owned
+
+### Contract added first
+
+- The focused scope test failed at collection because
+  `RECOVERY_ROADMAP_ADDITIONS` did not exist.
+- The implemented contract now asserts the exact thirteen-file Product
+  Recovery documentation inventory and its inclusion in the fail-closed active
+  tree.
+
+### Implementation
+
+- Added the Product Recovery roadmap, execution ledger, and R0–R9 task
+  packets.
+- Made the installed fresh-task agent outcome the product north star.
+- Recorded performance, storage, privacy, and incomplete-publication evidence.
+- Defined the dependency graph, task ownership, acceptance gates, and safe
+  parallel-subagent lanes.
+- Made every parallel lane planning-only until explicitly authorized by the
+  user or maintainer for the current task.
+- Removed the R4/R5 dependency cycle, froze the R3/R4 rollup integration
+  checkpoint, required supported local CLI/Desktop qualification, and made
+  post-merge exact artifacts the only promotable release bytes.
+- Pointed `AGENTS.md` to the new active authority.
+- Preserved Product Kernel Reset documents as historical evidence and recorded
+  K16 as superseded.
+
+### Agent outcome
+
+Not applicable: R0 changes documentation and repository governance only. R1
+creates the executable installed-agent scorecard.
+
+### Verification
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Focused | Pass | `pytest tests/kernel/test_kernel_scope.py -q`: 14 passed |
+| Scope | Pass | `python scripts/check_kernel_scope.py`: integration scope passed |
+| Release safety | Pass | `python scripts/check_release.py`: release-safety checks passed |
+| Broad | Pass | `just v`: 340 Python tests, 7 frontend tests, Ruff, MyPy, Pyright, maintainability, manifest, deterministic asset, scope, and release checks passed |
+| Diff | Pass | `git diff --check` |
+| Performance | N/A | no runtime behavior changed |
+| Privacy | Pass | documentation uses aggregate measurements and synthetic-only future fixtures; no private content or paths |
+| Installed | N/A | no package, plugin, MCP, or skill bytes changed |
+
+### Review metrics
+
+- Total findings: 5
+- Accepted findings: 5
+- Accepted IDs: `PRR-1`, `PRR-2`, `PRR-3`, `PRR-4`, `PRR-5`
+- Reviewer tokens: pending
+- Tokens per accepted finding: pending
+
+The metrics tool completed once with aggregate-only privacy, but reviewer-token
+attribution was unavailable because the installed Usage Tracker CLI no longer
+supports the metrics helper's `strict` command. It was not retried.
+
+### Deviations and decisions
+
+- The optional `agent_os` planning module was unavailable, so the approved
+  plan was written directly into the repository's established roadmap format.
+- Public `0.28.0` package publication is not resumed. The next qualified target
+  is `0.29.0`.
+
+### Residual risk and next task
+
+- The single final read-only review is resolved. R0 remains in progress only
+  until the reviewed branch merges and its merge SHA can be recorded.
+- R1 is unblocked after that merge.

--- a/docs/roadmap/product-recovery-tasks/README.md
+++ b/docs/roadmap/product-recovery-tasks/README.md
@@ -1,0 +1,51 @@
+# Product Recovery Task Packets
+
+These packets implement the
+[Product Recovery Roadmap](../product-recovery.md). The
+[execution ledger](../product-recovery-execution.md) is the durable progress
+record.
+
+Every task packet is an instruction set, not a completion claim. The task owner
+must:
+
+1. Start from the dependency commit recorded in the ledger.
+2. Re-read `AGENTS.md` and this packet.
+3. Confirm a clean, task-specific worktree.
+4. Add one observable failing contract or benchmark before implementation.
+5. Run GitNexus impact before editing existing symbols.
+6. Use synthetic fixtures only.
+7. Update the execution ledger in the same changeset.
+8. Complete focused and required broad validation.
+9. Stabilize the diff before one final read-only reviewer.
+10. Record accepted findings, reviewer metrics, deviations, and residual risk.
+
+## Packets
+
+- [R0 — Adopt the recovery roadmap](r0-adopt-recovery-roadmap.md)
+- [R1 — Freeze agent outcome and performance baselines](r1-agent-outcome-baseline.md)
+- [R2 — Define schema v3 and compact storage](r2-schema-v3-storage.md)
+- [R3 — Accelerate cold build and incremental refresh](r3-build-refresh-performance.md)
+- [R4 — Build persisted rollups and fast MCP/API paths](r4-fast-query-mcp.md)
+- [R5 — Restore analytical primitives and human semantics](r5-analytical-primitives.md)
+- [R6 — Rebuild Console usability](r6-console-usability.md)
+- [R7 — Qualify the installed fresh-task agent outcome](r7-installed-agent-qualification.md)
+- [R8 — Publish public product documentation](r8-public-docs.md)
+- [R9 — Qualify and release 0.29.0](r9-release-0.29.0.md)
+
+## Parallel Work Rule
+
+Potential parallel lanes in these packets are planning information, not
+authorization. They may run only when the user or maintainer explicitly
+authorizes subagents for the current task. A coordinator cannot self-authorize
+them, and no packet permits agents to edit one worktree concurrently.
+
+The coordinator assigns:
+
+- branch and base SHA;
+- owned files;
+- shared-contract version;
+- integration checkpoint;
+- expected handoff artifact.
+
+When two tasks share a file, they are sequential regardless of conceptual
+independence.

--- a/docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md
+++ b/docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md
@@ -1,0 +1,71 @@
+# R0 — Adopt The Product Recovery Roadmap
+
+## Objective
+
+Replace the completed Product Kernel Reset as active authority with the
+`0.29.0` Product Recovery Roadmap. Preserve the reset as historical evidence
+and record the incomplete `0.28.0` publication truthfully.
+
+## Depends On
+
+None.
+
+## Owned Files
+
+- `AGENTS.md`
+- `docs/roadmap/product-recovery.md`
+- `docs/roadmap/product-recovery-execution.md`
+- `docs/roadmap/product-recovery-tasks/**`
+- status notices in:
+  - `docs/roadmap/product-kernel-reset.md`
+  - `docs/roadmap/product-kernel-reset-execution.md`
+- `scripts/check_kernel_scope.py`
+- `tests/kernel/test_kernel_scope.py`
+
+## Contract Added First
+
+Add a fail-closed scope contract listing every recovery roadmap file before
+creating those files. The focused scope test must fail because the new
+allowlist is absent, then pass after the exact inventory is added.
+
+## Required Work
+
+1. Verify `origin/main`, repository version, schema version, `v0.28.0`, GitHub
+   release state, and public PyPI latest.
+2. Record that K0–K15 completed.
+3. Record K16 as superseded with a GitHub source release but no public PyPI
+   `0.28.0` package.
+4. Add the active roadmap, execution ledger, and R0–R9 packets.
+5. Point `AGENTS.md` to the new authority.
+6. Preserve the reset roadmap in place to avoid breaking historical links.
+7. Preserve the paused public-doc and thread-label worktrees.
+8. Run documentation, scope, release, and diff checks.
+9. Complete one final read-only review after the diff is stable.
+
+## Non-Goals
+
+- No product code.
+- No schema or contract change.
+- No package version bump.
+- No late `0.28.0` publication.
+- No deletion of branches, worktrees, databases, or historical roadmaps.
+
+## Parallel Execution
+
+R0 is coordinator-owned and should not use parallel writing agents. A
+read-only reviewer runs only after primary validation. Later task packets may
+name parallel lanes once R0 merges.
+
+## Acceptance
+
+- One active roadmap authority is unambiguous.
+- Every task has scope, ownership, dependencies, validation, and parallel
+  boundaries.
+- Existing reset links remain valid.
+- Scope inventory fails closed for unlisted recovery files.
+- Public release state is accurate.
+- Documentation-only gates pass.
+
+## Handoff
+
+Record the R0 merge SHA in the execution ledger. R1 must base from that SHA.

--- a/docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md
+++ b/docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md
@@ -19,6 +19,7 @@ None.
 - status notices in:
   - `docs/roadmap/product-kernel-reset.md`
   - `docs/roadmap/product-kernel-reset-execution.md`
+- `config/kernel-release-candidate-budget.json`
 - `scripts/check_kernel_scope.py`
 - `tests/kernel/test_kernel_scope.py`
 
@@ -39,8 +40,11 @@ allowlist is absent, then pass after the exact inventory is added.
 5. Point `AGENTS.md` to the new authority.
 6. Preserve the reset roadmap in place to avoid breaking historical links.
 7. Preserve the paused public-doc and thread-label worktrees.
-8. Run documentation, scope, release, and diff checks.
-9. Complete one final read-only review after the diff is stable.
+8. Measure and ratchet the source-distribution budget when the new source
+   documents change the archive size; retain no more than three percent
+   headroom and do not change runtime, wheel, Console, or plugin budgets.
+9. Run documentation, scope, release, distribution, and diff checks.
+10. Complete one final read-only review after the diff is stable.
 
 ## Non-Goals
 

--- a/docs/roadmap/product-recovery-tasks/r1-agent-outcome-baseline.md
+++ b/docs/roadmap/product-recovery-tasks/r1-agent-outcome-baseline.md
@@ -1,0 +1,136 @@
+# R1 — Freeze Agent Outcome And Performance Baselines
+
+## Objective
+
+Make the installed fresh-task agent outcome the primary product benchmark.
+Freeze deterministic workloads, prompts, timing boundaries, usefulness rubric,
+and production-shaped storage/build evidence before optimization.
+
+## Depends On
+
+R0.
+
+## Owned Areas
+
+- recovery benchmark configuration under `config/`
+- synthetic workload generators and benchmark runners under `scripts/`
+- agent-outcome and performance tests under `tests/kernel/` and `tests/e2e/`
+- plugin/skill coherence smoke support
+- R1 execution-ledger entry
+
+R1 does not edit kernel behavior.
+
+## Contract Added First
+
+Add a benchmark contract that fails until it can:
+
+1. identify one candidate wheel, plugin manifest, MCP server, skill, cached
+   bundle, version, and source revision;
+2. generate deterministic small-CI and production-shaped synthetic histories;
+3. run the fixed prompt suite from genuinely fresh tasks in every advertised
+   supported local host, including Codex CLI and Codex Desktop;
+4. emit a bounded machine-readable scorecard without prompt or response text.
+
+Record host name, host version or build, launch method, and candidate
+registration. Background-created or generic orchestration tasks do not count as
+fresh local-host qualification.
+
+## Fixed Prompt Suite
+
+- List my top threads by usage.
+- What drove my usage this week?
+- Compare this week with the previous week.
+- Which models and reasoning efforts cost the most?
+- Show my four token classes.
+- How quickly is my allowance draining?
+- Which tools added the most context?
+- Open the evidence timeline for this thread.
+- Show the most expensive calls in this thread.
+- What changed after the latest incremental refresh?
+
+Store prompt IDs and expected intent, not private transcripts.
+
+## Scenarios
+
+- no index;
+- compatible warm committed generation;
+- no-change refresh;
+- small append-safe tail;
+- larger bounded tail;
+- JSONL appended while refresh runs;
+- refresh already in progress;
+- browser close and reopen;
+- package/plugin upgrade;
+- fresh Codex CLI and Codex Desktop tasks after install, where supported;
+- current task with intentionally stale catalog.
+
+## Measurements
+
+- task start to final answer;
+- first tool call and total tracker-tool time;
+- MCP calls and query batches;
+- response bytes;
+- refresh starts, joins, polls, retries, and terminal state;
+- committed generation used;
+- deterministic oracle accuracy;
+- evidence-selector resolution;
+- human-label presence;
+- fact/estimate/inference separation;
+- usefulness rubric.
+
+Do not store model chain of thought, raw prompts from private tasks, tool
+arguments, raw Usage Tracker results, or local paths.
+
+## Initial Gates
+
+- warm top-threads tracker time: ≤1 second;
+- warm top-threads final answer: ≤15 seconds;
+- warm status: ≤100 ms;
+- Console useful committed render: ≤500 ms;
+- ordinary tail refresh: ≤500 ms;
+- cold production-shaped build: ≤240 seconds;
+- database: <700 MiB;
+- deterministic answer correctness and selector validity: 100%.
+
+R1 records failures as the baseline. It does not weaken targets to make the
+current build pass.
+
+## Parallel Execution
+
+The R1 owner controls the scorecard contract and runner. Explicitly authorized
+read-only subagents may independently audit:
+
+- correctness fixtures;
+- latency-boundary definitions;
+- usefulness rubric;
+- privacy of recorded artifacts.
+
+They may not edit the runner or benchmark configuration concurrently. A
+separate R8 documentation audit may begin after R0 because it owns disjoint
+files, but it cannot publish product claims.
+
+## Validation
+
+- deterministic fixture regeneration;
+- benchmark schema validation;
+- small-CI run twice with identical structural results;
+- one production-shaped unprofiled baseline;
+- installed candidate coherence check;
+- at least two genuinely fresh local-host task runs, covering every advertised
+  CLI/Desktop host;
+- separate proofs for installation, registration, handshake, supported-host
+  catalog exposure, and fresh-task exposure;
+- privacy scan of every persisted artifact.
+
+## Acceptance
+
+- Baseline results are reproducible.
+- Fresh-task exposure is distinguished from installation and handshake.
+- End-to-end time is separated from tracker-tool time.
+- Scorecards can compare candidates without retaining private content.
+- R2–R8 can reuse the same gates.
+
+## Handoff
+
+R2 receives the frozen data-volume and correctness oracle. R7 receives the
+installed-task runner and scorecard.

--- a/docs/roadmap/product-recovery-tasks/r2-schema-v3-storage.md
+++ b/docs/roadmap/product-recovery-tasks/r2-schema-v3-storage.md
@@ -1,0 +1,129 @@
+# R2 — Define Schema V3 And Compact Storage
+
+## Objective
+
+Approve a compact metadata-first analytical schema that preserves exact
+accounting and evidence while removing per-call allowance amplification,
+wide-key index amplification, and landing-page scans.
+
+## Depends On
+
+R1.
+
+## Ownership
+
+R2 is the sole owner of:
+
+- analytical and operational schema definitions;
+- stable identity and internal-key policy;
+- upgrade and rollback state machine;
+- allowance interval semantics;
+- rollup table contracts;
+- schema fixtures, migration tests, and storage budgets.
+
+No parallel task may edit schema files until R2 merges.
+
+## Contract Added First
+
+Add failing schema-v3 contracts for:
+
+- integer internal foreign keys plus stable external selectors;
+- four token classes;
+- exact copied-row exclusion;
+- compact allowance state observations and intervals;
+- observation trigger distinct from causal attribution;
+- persisted generation-scoped rollups;
+- human thread label plus opaque logical selector;
+- metadata-only privacy;
+- side-by-side build, atomic promotion, and rollback;
+- measured database-size ceiling.
+
+## Schema Decisions
+
+- Use analytical schema version 3.
+- Build under a new side-by-side cache generation; never mutate the validated
+  schema-v2 database in place.
+- Keep stable logical selectors as external evidence identities.
+- Use compact internal row keys and foreign keys for joins and indexes.
+- Keep the optional content store separate and disabled by default.
+- Store tool operation and bounded safe target metadata, never raw arguments or
+  output.
+- Store allowance state only when the exact timestamp snapshot or ordered state
+  changes according to the approved interval algorithm.
+- Preserve reset boundaries, first and last observations, periodic freshness
+  checkpoints, and source provenance.
+- Replace causal `source_call` wording with observation-trigger semantics.
+
+## Required Rollups
+
+Generation-scoped persisted rollups cover:
+
+- global four-token and call totals;
+- thread and call ranking facts;
+- model × effort;
+- hour and day token bands;
+- configured cost and credit totals with coverage;
+- allowance interval facts;
+- tool operation summaries.
+
+Rollups are disposable and exactly reproducible from foundational facts. Their
+publication is atomic with the generation they summarize.
+
+## Upgrade Contract
+
+- First explicit refresh builds schema v3 beside schema v2.
+- Existing readers stay on the validated schema-v2 generation.
+- New lines appended during build are caught before promotion.
+- Foreign-key, accounting, rollup, privacy, and size checks pass before
+  promotion.
+- Failed promotion leaves schema v2 active.
+- The previous database remains recoverable until explicit maintainer
+  deletion.
+- No runtime compatibility adapter reads both schemas.
+
+## Performance And Size Proof
+
+Use the R1 production-shaped generator to measure:
+
+- table, index, and total bytes;
+- row counts by fact and rollup;
+- allowance snapshot and interval reduction;
+- join and common-query plans;
+- rebuild and rollback cost.
+
+Required: <700 MiB. Stretch: <500 MiB.
+
+## Parallel Execution
+
+R2 is sequential because schema, identity, and migration are shared contracts.
+Read-only subagents may audit SQLite layout, allowance semantics, or privacy.
+They return recommendations to the R2 owner; they do not edit schema files.
+
+After R2 merges, R3, R4, and the R7 harness lane may work in parallel from the
+same recorded schema-contract SHA.
+
+## Validation
+
+- schema and foreign-key tests;
+- accounting oracle;
+- copied-source reconciliation;
+- allowance interval golden tests;
+- exact rollup recomputation comparison;
+- side-by-side promotion and rollback;
+- interrupted migration recovery;
+- storage budget;
+- privacy scan.
+
+## Acceptance
+
+- No foundational information required by the roadmap is lost.
+- Allowance deltas belong to intervals, not final calls.
+- Stable selectors survive a clean rebuild.
+- Common rollups are generation-consistent.
+- The measured size gate passes.
+- R3 and R4 have disjoint implementation ownership.
+
+## Handoff
+
+Record the schema-contract SHA, table inventory, index inventory, and approved
+upgrade behavior in the ledger. R3 and R4 must use that exact base.

--- a/docs/roadmap/product-recovery-tasks/r3-build-refresh-performance.md
+++ b/docs/roadmap/product-recovery-tasks/r3-build-refresh-performance.md
@@ -1,0 +1,115 @@
+# R3 — Accelerate Cold Build And Incremental Refresh
+
+## Objective
+
+Reduce the production-shaped cold build from about 18 minutes to at most four
+minutes while making ordinary append-only refresh sub-second and keeping reads
+available.
+
+## Depends On
+
+R2.
+
+## Owned Areas
+
+- source discovery and cursor planning;
+- parser and normalizer hot paths;
+- ingestion orchestration;
+- writer and index-build strategy;
+- refresh lease, progress, recovery, and moving-tail tests;
+- R3 benchmarks.
+
+R3 does not edit schema contracts, query plans, MCP schemas, or Console files.
+
+## Contract Added First
+
+Add failing unprofiled benchmarks and lifecycle tests for:
+
+- complete production-shaped build ≤240 seconds;
+- ordinary append-safe tail ≤500 ms;
+- bounded larger tail ≤2 seconds;
+- no-change refresh performs no fact or rollup writes;
+- browser or query cannot trigger refresh;
+- one active compatible worker is joined;
+- lines appended during build are included before promotion;
+- readers stay available on the committed generation.
+
+## Implementation Order
+
+1. Remove repeated cumulative counts from every parser batch.
+2. Stop opening thousands of short writer transactions for an unpublished
+   database.
+3. Batch inserts and metadata updates.
+4. Defer secondary index construction until bulk fact load completes.
+5. Avoid repeated thread, turn, source, and stable-ID work within one stream.
+6. Skip full JSON materialization where bounded structural extraction proves
+   equivalent.
+7. Make progress reflect parse, normalize, write, index, validate, and promote
+   work truthfully.
+8. Add bounded process parallelism only after global repeated work is removed.
+9. Evaluate content-addressed per-source fact shards only if the required cold
+   build still misses its gate.
+
+Every optimization changes one suspected cause, reruns the identical
+unprofiled workload, and records before/after evidence. Profiler shares do not
+count as speedup proof.
+
+## Refresh Invariants
+
+- Complete-line parsing only.
+- Source replacement and truncation reconcile bounded rows.
+- One durable owner and recoverable lease.
+- No long `BEGIN IMMEDIATE` across parsing or derived-state work.
+- After the R4 rollup-interface checkpoint, the fact-writing transaction
+  invokes that frozen updater contract so appended facts and rollups publish
+  atomically.
+- A failed refresh never invalidates the active generation.
+- No duplicate refresh is started by MCP, Console, or agent orchestration.
+
+## Parallel Execution
+
+R3 may run in parallel with R4 and the R7 harness after R2.
+
+R3 owns:
+
+- `discovery`, `parser`, `normalize`, `ingest`, `writer`, `lease`, and watcher
+  implementation and tests.
+
+R4 owns query, rollup read plans, application, and MCP files. R7 owns runners
+and installed qualification. If a required change crosses ownership, pause and
+integrate through the coordinator rather than editing the other lane.
+
+R3 may use the frozen R4 interface fixture before the implementation checkpoint.
+R3 owns the ingestion call site; it must not edit the R4 updater module. The
+coordinator verifies the integrated transaction after R4 publishes that module.
+
+Within R3, multiple writing subagents are not recommended because parser,
+normalizer, writer, and ingestion share the same transaction contract.
+Read-only profiling or SQLite-plan audits may run in parallel.
+
+## Validation
+
+- focused parser/writer/ingest tests;
+- accounting oracle;
+- fault and recovery suite;
+- synthetic scale matrix;
+- production-shaped unprofiled cold run;
+- warm no-change and tail distributions;
+- concurrent read test;
+- database and lock-duration measurements;
+- privacy checks;
+- broader repository gate.
+
+## Acceptance
+
+- Required cold and warm targets pass.
+- Progress never appears stuck while work advances.
+- Refresh does not block committed reads.
+- Reopen and query never rebuild.
+- Moving-tail correctness remains exact.
+- R1 agent scenarios no longer spend minutes in refresh orchestration.
+
+## Handoff
+
+R5 receives stable refreshed facts. R7 records installed cold, warm, tail, and
+concurrent-write outcomes.

--- a/docs/roadmap/product-recovery-tasks/r4-fast-query-mcp.md
+++ b/docs/roadmap/product-recovery-tasks/r4-fast-query-mcp.md
@@ -1,0 +1,120 @@
+# R4 — Build Persisted Rollups And Fast MCP/API Paths
+
+## Objective
+
+Make routine agent and Console questions read small generation-scoped rollups
+or bounded indexes instead of scanning hundreds of thousands of foundational
+facts.
+
+## Depends On
+
+R2.
+
+## Owned Areas
+
+- rollup algorithms, frozen updater interface, and generation publication
+  validation;
+- query catalog, plans, contracts, and service;
+- application-level generation/request result cache;
+- MCP, HTTP, and CLI query adapters;
+- common-query performance tests;
+- response-size and selector contracts.
+
+R4 does not edit ingestion-owned files or frontend assets.
+
+## Contract Added First
+
+Add failing contracts for:
+
+- global Live summary;
+- top threads;
+- top calls;
+- Threads and Calls listings;
+- model × effort;
+- hourly and daily token bands;
+- allowance interval reads;
+- one-thread evidence first page;
+- stable generation/request cache reuse.
+
+Each contract asserts a scanned-row or query-plan budget in addition to wall
+time and result correctness.
+
+## Required Behavior
+
+- Keep exactly six MCP tools.
+- Preserve bounded `usage_query` for composition.
+- Provide curated query plans inside the existing tool contract.
+- Preserve typed extension points for the human labels, costs, and credits that
+  R5 will populate; R4 does not claim those values as an acceptance gate.
+- Cache normalized responses by active generation and request hash.
+- Invalidate only when a new generation publishes or relevant configuration
+  changes.
+- Never start refresh from query execution.
+- Batch compatible questions against one committed generation.
+- Return one structured representation; do not duplicate the payload in a
+  second textual form.
+- Keep selectors concise and resolve evidence only when requested.
+
+## Common Warm Path
+
+“List my top threads by usage” must require:
+
+1. one fresh-task tool call;
+2. one bounded query batch;
+3. no refresh when the generation is current;
+4. no polling;
+5. four token classes and stable selectors.
+
+Tracker time must be ≤1 second, stretch ≤500 ms.
+
+R5 adds human labels and cost/credit coverage to this same bounded path. R7
+owns the final end-to-end gate that requires those populated values.
+
+## Parallel Execution
+
+R4 may run in parallel with R3 and the R7 harness from the R2 schema SHA.
+
+R4 exclusively owns query, application, MCP, and query-performance files.
+R3 owns ingest and writer. R7 may invoke public interfaces but may not patch
+them. Early R6 frontend prototyping may use frozen fixtures only after R4
+publishes its response contract; it cannot modify generated assets concurrently
+with R4 interface changes.
+
+R4 first publishes a tested rollup-updater interface and fixture checkpoint.
+R4 owns that updater module; R3 later owns the ingestion call site that invokes
+it inside the fact-writing transaction. Neither lane edits the other's files,
+and the coordinator validates atomic fact-and-rollup publication after
+integration.
+
+One R4 implementation owner should integrate the updater and query reads to
+avoid cache-coherence races. Read-only SQL-plan and response-budget audits may
+run as parallel subagents.
+
+## Validation
+
+- exact query oracle;
+- generation consistency;
+- result-cache invalidation;
+- response-byte ceilings;
+- evidence selector resolution;
+- SQL plan and scanned-row budgets;
+- latency distributions on production-shaped synthetic data;
+- MCP/HTTP/CLI parity;
+- concurrent refresh read behavior;
+- no implicit refresh assertion;
+- broader interface and release gates.
+
+## Acceptance
+
+- All common warm routes pass required latency.
+- Top threads is one bounded tool call.
+- No common landing query scans all calls.
+- Cache reuse is observable and generation-safe.
+- Response payloads remain concise.
+- R5 receives frozen extension points for labels, costs, and credits; R6
+  receives the core bounded-query contract after R5 populates those fields.
+
+## Handoff
+
+Record every curated plan, cache key, invalidation event, scan budget, and
+latency in the ledger. R5 extends values without changing the six-tool surface.

--- a/docs/roadmap/product-recovery-tasks/r5-analytical-primitives.md
+++ b/docs/roadmap/product-recovery-tasks/r5-analytical-primitives.md
@@ -1,0 +1,125 @@
+# R5 — Restore Analytical Primitives And Human Semantics
+
+## Objective
+
+Restore the facts people need to make useful inferences while preserving the
+kernel rule that Codex—not the server—does the interpretation.
+
+## Depends On
+
+R3 and R4.
+
+## Owned Areas
+
+- allowance interval calculations and service;
+- rate-card cost and credit calculations;
+- human thread-label metadata boundary;
+- tool operation and bounded target classification;
+- turn and tool-impact facts;
+- evidence and query fields required by these primitives;
+- focused correctness, privacy, and performance tests.
+
+## Contract Added First
+
+Add failing golden contracts for:
+
+- total tokens with uncached input, cached input, reasoning, and output;
+- configured dollar cost and estimated credits with coverage;
+- allowance drain assigned to intervals, never the revealing call;
+- local tokens, calls, and turns within each allowance interval;
+- time-first recent token and allowance bands;
+- thread label plus stable selector;
+- turn ordinal and completion basis;
+- tool operation, target label, duration, output bytes, and impact grade;
+- copied-row exclusion across every aggregate.
+
+## Cost And Credit Semantics
+
+Keep three concepts separate:
+
+1. **Configured token cost:** deterministic when a dated rate card covers the
+   model and token classes.
+2. **Estimated Codex credits:** calculated from an explicit local credit rate
+   card with source, date, confidence, and coverage.
+3. **Observed allowance drain:** upstream cumulative state measured over an
+   interval, with possible out-of-band activity.
+
+No view may label one as another. Unpriced usage remains visible.
+
+## Thread Labels
+
+- Read bounded thread-name metadata from Codex's session index.
+- Return `thread_label` alongside the stable `thread` selector to MCP and
+  Console consumers.
+- Bound length, collapse controls and whitespace, and treat the label as
+  untrusted display data.
+- Keep selectors exact and copyable.
+- Disclose that agent-facing thread names are prompt-derived metadata.
+- Do not store message bodies to obtain a label.
+
+## Tool Semantics
+
+Extract only bounded structural meaning:
+
+- operation such as read, write, search, patch, test, browser, or MCP;
+- safe project-relative target label when available;
+- tool and server name;
+- start, end, duration, status;
+- output bytes;
+- turn and nearest model call;
+- observation confidence.
+
+Do not persist commands, raw arguments, file contents, tool output, secrets, or
+full local paths.
+
+Tool token impact must distinguish:
+
+- exact tool-output bytes;
+- exact adjacent model-call token classes;
+- deterministic interval totals;
+- estimated tool/context attribution;
+- consuming-model inference.
+
+## Parallel Execution
+
+R5 begins only after R3 and R4 integrate because it touches both fact
+production and query/evidence contracts.
+
+After the R5 field contract is frozen, explicitly authorized subagents may
+implement disjoint lanes:
+
+- allowance and rate-card calculations;
+- thread-label metadata;
+- tool classification and impact.
+
+Each lane must have separate files and tests. The R5 coordinator alone changes
+shared query/evidence schemas and integrates the lanes. If ownership overlaps,
+run sequentially.
+
+## Validation
+
+- four-token accounting oracle;
+- cost and credit coverage matrix;
+- allowance interval and reset golden tests;
+- out-of-band and concurrent-call caveats;
+- thread-label sanitation and selector preservation;
+- tool classification fixtures;
+- no raw-content persistence assertions;
+- aggregate deduplication;
+- common-query latency after adding fields;
+- response-byte ceilings.
+
+## Acceptance
+
+- Agent and Console results use human names.
+- Total tokens always expose their breakdown.
+- Dollar cost and credits return with explicit coverage.
+- Limits can render a truthful usage-over-time graph.
+- Tool and turn facts support useful model inference.
+- No estimate is promoted to exact.
+- Warm query gates remain green.
+
+## Handoff
+
+R6 receives frozen presentation fields and fixtures. R7 adds analytical prompts
+to the installed fresh-task suite.

--- a/docs/roadmap/product-recovery-tasks/r6-console-usability.md
+++ b/docs/roadmap/product-recovery-tasks/r6-console-usability.md
@@ -1,0 +1,131 @@
+# R6 — Rebuild Console Usability
+
+## Objective
+
+Make the Evidence Console fast and understandable when a person opens it
+directly or follows a link from Codex.
+
+## Depends On
+
+R4 and R5.
+
+## Owned Areas
+
+- `frontend/kernel-console/**`
+- deterministic generated Console assets
+- Console contract and browser tests
+- localhost Console smoke
+- synthetic screenshot fixtures
+
+R6 does not change analytical semantics or MCP contracts.
+
+## Contract Added First
+
+Add failing browser and presentation contracts for:
+
+- committed-generation Live render ≤500 ms;
+- useful default Threads and Calls Explore views;
+- every visible table heading sortable when the field supports ordering;
+- pagination and filtering;
+- human-first column ordering;
+- exact evidence navigation;
+- responsive layout and keyboard access;
+- Limits usage-over-time graph;
+- no rebuild or refresh on navigation or reopen.
+
+## Live
+
+Show:
+
+- calls;
+- total tokens with four-class breakdown;
+- cache reuse;
+- configured cost and estimated credits;
+- recent token/allowance graph;
+- freshness and refresh action without making freshness the main product.
+
+Remove:
+
+- “Snapshot truth”;
+- “Tool-independent facts”;
+- raw selector columns from the primary view.
+
+## Explore
+
+- Open on curated Threads and Calls views.
+- Make switching datasets return a valid result or an actionable explanation.
+- Put time, human label, and meaningful totals before internal fields.
+- Keep the generic typed-query composer available but secondary.
+- Support sortable headers, pagination, filters, and saved local views.
+- Preserve one-generation consistency across a view.
+
+## Evidence
+
+Default order:
+
+1. time;
+2. turn number;
+3. event or tool;
+4. four-token or tool-impact facts;
+5. cost or credits;
+6. duration;
+7. evidence action.
+
+Long event IDs, selectors, generation IDs, and provenance details belong in an
+expandable detail area or copy control. Timeline rows distinguish model calls,
+tools, activities, and allowance observations without redundant category
+columns.
+
+## Limits
+
+- Render compact interval data.
+- Restore the usage-over-time graph.
+- Show observed drain, local tokens, estimated credits, credits per usage
+  point, reset boundaries, and coverage.
+- Put time first.
+- Do not synchronously scan foundational calls.
+
+## Parallel Execution
+
+After R5 freezes fixtures, R6 may run in parallel with:
+
+- final R7 installed-runner work;
+- R8 documentation copy.
+
+Within R6, explicitly authorized subagents may own disjoint areas:
+
+- Live and shared cards;
+- Explore and reusable table interactions;
+- Evidence and Limits;
+- browser accessibility and responsive qualification.
+
+Only the R6 coordinator edits shared model utilities, styles, generated assets,
+and the deterministic asset manifest. Subagents work in separate worktrees and
+return commits at named fixture checkpoints.
+
+## Validation
+
+- frontend unit, lint, type, and bundle checks;
+- deterministic generated assets;
+- Chromium desktop and mobile flows;
+- keyboard sorting and pagination;
+- direct evidence deep links;
+- cached reopen with request-count assertion;
+- page-level latency on production-shaped synthetic data;
+- no implicit refresh;
+- localhost installed-wheel Console smoke;
+- synthetic screenshot inspection.
+
+## Acceptance
+
+- A person can understand every primary table without reading internal IDs.
+- Sort, filter, paginate, and evidence actions work.
+- Live and Limits pass latency gates.
+- Explore never silently returns an empty broken view.
+- Cost, credits, four tokens, turn order, and tool impact are visible.
+- Final screenshots are ready for R8.
+
+## Handoff
+
+Record route-level timings, request counts, screenshots, accessibility results,
+and final asset hashes. R8 may then publish the qualified visuals.

--- a/docs/roadmap/product-recovery-tasks/r7-installed-agent-qualification.md
+++ b/docs/roadmap/product-recovery-tasks/r7-installed-agent-qualification.md
@@ -1,0 +1,147 @@
+# R7 — Qualify The Installed Fresh-Task Agent Outcome
+
+## Objective
+
+Prove the actual product: an installed wheel, plugin, MCP server, and skill used
+from genuinely fresh Codex tasks to produce fast, accurate, useful answers.
+
+## Depends On
+
+R1 creates the harness. R7 runs continuously and completes only after R3–R6.
+
+## Owned Areas
+
+- installed-package and plugin smoke runners;
+- isolated Codex-home fixtures;
+- fresh-task prompt orchestration;
+- scorecard aggregation;
+- installed browser and MCP qualification;
+- candidate comparison reports.
+
+R7 invokes public behavior. It does not patch product behavior.
+
+## Contract Added First
+
+Add a failing installed-candidate contract that verifies:
+
+- wheel version;
+- plugin manifest version;
+- MCP server version and source revision;
+- bundled skill version or content hash;
+- cached plugin bundle identity;
+- local Codex host name and version or build;
+- fresh-task callable catalog;
+- exactly six expected tools and no retired tools;
+- terminal answer scorecard for the fixed prompt suite.
+
+Installation, registration, server handshake, supported-host catalog exposure,
+and current-task exposure are separate states and must be reported separately.
+
+Qualifying tasks must be launched through every local Codex CLI and Codex
+Desktop host that the product advertises as supported. Background-created,
+generic orchestration, or unrelated-host tasks may be negative diagnostics, but
+they do not count as release qualification.
+
+## Required Runs
+
+### Synthetic automated
+
+- deterministic small fixture in CI;
+- production-shaped scale outside normal CI;
+- fresh local CLI/Desktop task on current generation;
+- fresh task after small tail;
+- concurrent JSONL append;
+- refresh already active;
+- browser close and reopen;
+- upgrade from public `0.27.0`;
+- failed build and recovery;
+- two consecutive identical prompts for cache reuse.
+
+### Maintainer dogfood
+
+Run the same fixed prompts against the maintainer-owned aggregate index using
+only structured MCP results. Do not read raw JSONL or persist private result
+rows, labels, paths, or transcripts in repository artifacts.
+
+## Scorecard
+
+Every run records:
+
+- candidate revision and coherent component identities;
+- tool exposure;
+- success or terminal failure;
+- end-to-end time;
+- tracker-tool time;
+- MCP calls, batches, polls, retries, and refresh jobs;
+- response bytes;
+- generation and freshness;
+- oracle correctness;
+- evidence validity;
+- human readability;
+- usefulness;
+- fact/estimate/inference quality.
+
+The report may persist prompt IDs, scores, counts, durations, error codes, and
+synthetic selectors. It must not persist private prompt or response text.
+
+## Parallel Execution
+
+After an exact candidate artifact exists, explicitly authorized qualification
+subagents may run isolated lanes:
+
+- warm common-query prompts;
+- refresh, tail, and concurrency prompts;
+- Console and evidence browser flows;
+- upgrade, plugin cache, skill, and fresh-task exposure.
+
+Each lane uses its own worktree, isolated state, ports, and task IDs. No lane
+installs over another lane's environment. The R7 coordinator owns candidate
+installation, scorecard schema, result aggregation, and termination.
+
+Use host-side waits for long refreshes. Models never run status-poll loops.
+
+## Release Gates
+
+For warm top threads:
+
+- tracker time ≤1 second;
+- final answer ≤15 seconds;
+- one query batch;
+- no refresh when current;
+- correct ranking;
+- human names;
+- four-token and cost/credit context;
+- exact selectors.
+
+For every deterministic synthetic prompt:
+
+- answer correctness: 100%;
+- selector validity: 100%;
+- no duplicate refresh;
+- no raw-content exposure;
+- no missing or retired tools.
+
+## Validation
+
+- runner unit tests;
+- isolated installation twice;
+- fresh-task catalog proof;
+- complete fixed prompt suite;
+- production-shaped candidate comparison;
+- browser qualification;
+- privacy review of scorecard artifacts;
+- failure-injection run;
+- repeated exact candidate run.
+
+## Acceptance
+
+- Installed behavior matches source behavior.
+- No old wheel, plugin cache, or skill can masquerade as the candidate.
+- Common questions are fast and useful end to end.
+- Failures are terminal and actionable.
+- The scorecard improves or records an approved tradeoff against R1.
+
+## Handoff
+
+R8 receives approved facts and example outcomes. R9 receives the exact candidate
+identity and blocking scorecard.

--- a/docs/roadmap/product-recovery-tasks/r8-public-docs.md
+++ b/docs/roadmap/product-recovery-tasks/r8-public-docs.md
@@ -1,0 +1,119 @@
+# R8 — Publish Public Product Documentation
+
+## Objective
+
+Turn the repository front door into an inviting, accurate explanation of a
+mature community product, using only claims and visuals proven by R6 and R7.
+
+## Depends On
+
+R0 starts the durable copy audit. R8 completes only after R6 and R7.
+
+## Owned Areas
+
+- `README.md`
+- user documentation home and getting-started guide;
+- copy-paste questions and conversation examples;
+- Console, CLI, MCP, and query references;
+- troubleshooting and privacy documentation;
+- `SECURITY.md`, `CONTRIBUTING.md`, issue templates, and public metadata;
+- final synthetic screenshots.
+
+The paused `docs/public-product-docs` draft is input, not an automatic merge.
+
+## Contract Added First
+
+Add failing public-document checks for:
+
+- current installable version and source;
+- agent-install prompt;
+- six-tool surface;
+- fresh-task requirement;
+- performance and refresh semantics;
+- metadata-only privacy;
+- exact/estimated/inference wording;
+- valid local links;
+- synthetic screenshot provenance;
+- no retired commands or product surfaces.
+
+## Required Front Door
+
+The README leads with:
+
+- what the product helps a person understand;
+- one strong Console visual;
+- “Want your agent to set it up for you?” copy-paste prompt;
+- manual installation;
+- first useful question;
+- realistic conversation examples;
+- local-first trust boundary;
+- community and contribution paths.
+
+It must not lead with internal roadmap mechanics, frozen contracts, or
+repository architecture.
+
+## Required Guides
+
+- documentation home;
+- install and first run;
+- what to ask Codex;
+- worked conversations;
+- Console guide;
+- MCP reference;
+- CLI reference;
+- query and evidence reference;
+- cost, credits, allowance, and coverage;
+- performance and troubleshooting;
+- privacy and safe issue reporting;
+- upgrade to `0.29.0`.
+
+## Screenshots And Conversations
+
+- Capture the final shipped Console through deterministic synthetic fixtures.
+- Show Live, Explore, Evidence, and Limits.
+- Use human thread names and qualified metrics.
+- Do not include local paths, real usage, prompts, tools, projects, or labels.
+- Conversation examples use R7 synthetic outcomes and are edited for clarity
+  without inventing capability or timing.
+
+## Parallel Execution
+
+An explicitly authorized documentation subagent may audit stale public claims
+after R0 while R3–R7 continue. It owns documentation-only files and produces a
+replacement list, not final performance claims or screenshots.
+
+After R6 and R7, separate subagents may draft:
+
+- installation and troubleshooting;
+- conversation examples and product recipes;
+- reference documentation.
+
+The R8 coordinator owns README voice, cross-document consistency, screenshots,
+version wording, and final integration. No two agents edit README or the same
+guide concurrently.
+
+## Validation
+
+- public-doc contract tests;
+- Markdown and local-link checks;
+- release metadata checks;
+- screenshot visual inspection;
+- synthetic-data provenance;
+- install command verification;
+- fresh-task example replay;
+- stale-surface search;
+- build and installed-package docs smoke.
+
+## Acceptance
+
+- A new user understands value before architecture.
+- Agent and manual installation are copy-pastable and current.
+- Examples match qualified behavior.
+- Screenshots show the final product.
+- Privacy and estimation caveats are clear without overwhelming the pitch.
+- No unshipped or retired surface is advertised.
+
+## Handoff
+
+R9 receives release-ready docs with version placeholders resolved only on the
+release branch.

--- a/docs/roadmap/product-recovery-tasks/r9-release-0.29.0.md
+++ b/docs/roadmap/product-recovery-tasks/r9-release-0.29.0.md
@@ -1,0 +1,118 @@
+# R9 — Qualify And Release 0.29.0
+
+## Objective
+
+Merge the release source through maintained CI, build one exact `0.29.0`
+candidate from the resulting merged-main SHA, qualify those bytes through every
+product surface, and publish only those verified artifacts.
+
+## Depends On
+
+R7 and R8.
+
+## Owned Areas
+
+- version and changelog;
+- release qualification, stable contract, and artifact budgets;
+- wheel and sdist;
+- protected publication workflow evidence;
+- final execution-ledger closure.
+
+R9 contains no unrelated feature or refactor.
+
+## Contract Added First
+
+Add failing release contracts for:
+
+- repository, package, plugin, MCP, skill, and docs version agreement;
+- schema-v3 upgrade and rollback;
+- exact six-tool catalog;
+- required pre-merge R7 source scorecard and post-build exact-artifact
+  scorecard;
+- R6 browser qualification;
+- R8 public docs;
+- measured artifact budgets;
+- build-once exact-byte promotion.
+
+## Release Decision
+
+- Do not publish stale `0.28.0` bytes to PyPI.
+- Prepare `0.29.0` from the qualified recovery head.
+- Preserve the historical `v0.28.0` source-release evidence.
+- Only merged `main` or its exact tag may enter protected publication.
+- Pre-merge local distributions are disposable previews and can never be
+  promoted as release artifacts.
+- Tags and production publishing require explicit maintainer approval.
+
+## Required Sequence
+
+1. Audit current `origin/main`.
+2. Create `release/0.29.0`.
+3. Apply only version, changelog, qualification, budget, and release wording.
+4. Run the complete source, Console/browser, schema upgrade, rollback, privacy,
+   release, and pre-merge R7 qualification gates. Any local distributions are
+   non-promotable previews.
+5. Complete one final stable-diff review.
+6. Open the release PR, wait for maintained CI, and merge it.
+7. Invoke the protected build-once workflow against the exact merged-main SHA.
+   It creates wheel, sdist, release manifest, and durable workflow artifacts,
+   then stops before registry or GitHub release upload.
+8. Download those workflow artifacts, verify exact members, source bytes,
+   hashes, sizes, manifest identity, and budgets, then install that exact wheel
+   and its plugin locally.
+9. Run the complete R7 fresh-task suite plus installed Console/browser,
+   schema-upgrade, rollback, privacy, and package smokes against those exact
+   bytes.
+10. If any check fails, do not overwrite or rebuild the candidate. Fix through
+    a new PR and merged-main SHA, then restart at the protected build step; the
+    failed artifacts are never promoted.
+11. After explicit approval, tag the exact qualified merged-main SHA and
+    promote the stored artifacts by recorded hash through protected Trusted
+    Publishing to TestPyPI, PyPI, and the GitHub release without rebuilding.
+12. Verify TestPyPI, PyPI, GitHub, and a clean local download are byte-identical.
+13. Run a clean public-installed fresh-task and Console smoke.
+14. Close the ledger with public URLs, hashes, sizes, workflow, and scorecard.
+
+## Parallel Execution
+
+One release coordinator owns artifacts, Git state, versioning, PR, tags, and
+publication.
+
+After the exact candidate is immutable, explicitly authorized qualification
+subagents may run isolated read-only lanes:
+
+- Python and schema qualification;
+- frontend and browser qualification;
+- installed plugin/MCP/skill fresh-task qualification;
+- artifact and public-document audit.
+
+They may not rebuild artifacts, change the candidate, publish, tag, or modify
+external state. Any accepted fix invalidates the candidate and restarts the
+build-once sequence.
+
+## Validation
+
+- focused release contracts;
+- complete `just vc`;
+- deterministic assets;
+- wheel and sdist exact checks;
+- isolated upgrade from public `0.27.0`;
+- schema-v3 rollback;
+- R7 fixed prompt suite;
+- installed browser smoke;
+- privacy and secret scan;
+- maintained CI;
+- protected publication and public byte verification.
+
+## Acceptance
+
+- Exact qualified bytes are public.
+- Public installation exposes the same plugin, MCP, and skill tested locally.
+- Fresh-task outcomes meet release gates.
+- PyPI, GitHub, and downloaded artifacts match.
+- The roadmap and ledger close with no hidden remaining publication step.
+
+## Handoff
+
+The next roadmap begins from public `0.29.0` dogfood evidence. No post-release
+feature is bundled into R9.

--- a/docs/roadmap/product-recovery.md
+++ b/docs/roadmap/product-recovery.md
@@ -1,0 +1,315 @@
+# Product Recovery Roadmap
+
+**Status:** Approved direction; active when this roadmap merges
+
+**Target:** `0.29.0`
+
+**Authority:** This document, its [task packets](product-recovery-tasks/README.md),
+and the [execution ledger](product-recovery-execution.md) govern post-`0.28`
+product work.
+
+The [Product Kernel Reset](product-kernel-reset.md) remains historical evidence
+for the `0.26`–`0.28` rewrite. It no longer governs new implementation.
+
+## Executive Decision
+
+Codex Usage Tracker will optimize for one outcome:
+
+> A fresh Codex task returns a fast, accurate, useful, evidence-grounded answer
+> about the user's usage through the installed plugin, MCP server, and skill.
+
+The kernel rewrite established the correct product boundary: local structural
+facts below model inference. Dogfood then exposed that the current
+implementation is not yet a good product experience at production scale.
+Common queries can be slow, persisted facts and indexes are larger than
+necessary, Console tables are database-shaped, useful cost and allowance views
+regressed, and installed agent workflows can take minutes.
+
+`0.29.0` is therefore a recovery release, not a feature expansion. It will:
+
+- make reopen and common warm queries immediate;
+- make refresh genuinely append-oriented and observable;
+- compact the metadata store without weakening accounting;
+- restore the high-value token, cost, credit, allowance, turn, and tool facts;
+- make MCP results and Console views understandable to humans;
+- qualify the complete installed agent outcome, not only isolated endpoints;
+- publish public documentation only after the experience is proven.
+
+## Current Release Boundary
+
+As of 2026-07-27:
+
+- repository and plugin metadata identify `0.28.0`;
+- tag `v0.28.0` and a GitHub release exist;
+- that GitHub release has no attached package assets;
+- public PyPI still serves `0.27.0` as latest;
+- at the adoption base, the old execution ledger still left K16 in progress.
+
+R0 records this accurately and supersedes the incomplete K16 publication path.
+The project will not quietly promote stale `0.28.0` package bytes after the
+recovery program begins. The next fully qualified public package is `0.29.0`
+unless the maintainer approves a different release decision.
+
+## Evidence Behind the Recovery
+
+The aggregate production-shaped audit read no prompts, responses, commands,
+tool output, or private paths. It measured:
+
+| Measure | Observed |
+| --- | ---: |
+| Source history | 14.955 GiB |
+| Cold build | 1,096.357 seconds |
+| Parsed JSONL lines | 3,806,301 |
+| Stored fact rows | about 2.40 million |
+| Analytical database | about 1.17 GB |
+| Table storage | 615.02 MiB |
+| Index storage | 501.21 MiB |
+| Model-call rows | 608,694 |
+| Tool-call rows | 589,568 |
+| Allowance rows | 1,051,496 |
+| Exact same-timestamp allowance repeats | 518,900 |
+| Allowance state-change rows in measured sequence | 133,587 |
+
+The active database is metadata-only. Its size is caused by row and index
+amplification, especially per-call allowance snapshots and repeated text
+identifiers. No legacy cache is configured, no optional content database is
+present, the SQLite freelist is empty, and rebuilding the same schema would
+recreate approximately the same cost.
+
+User-facing evidence adds the more important product failures:
+
+- reopening Live feels like a rebuild instead of a cached read;
+- common warm API and MCP questions feel slower than the retired product;
+- “list my top threads by usage” took 5 minutes 45 seconds end to end;
+- Explore can return no rows for apparently valid selections;
+- Limits is slow and lost the useful usage-over-time graph;
+- cost and credits are absent from core views;
+- thread selectors and internal IDs appear where human names belong;
+- Evidence lacks turn order and useful tool-impact context;
+- table columns are poorly ordered and cannot be sorted;
+- low-value “Snapshot truth” and “Tool-independent facts” displace useful data.
+
+## Product Contract
+
+### North-star outcome
+
+Every milestone is evaluated through fresh installed Codex tasks. Unit tests,
+SQL benchmarks, and browser tests are necessary supporting evidence, but they
+do not replace the agent outcome.
+
+The north-star scorecard records:
+
+- successful useful answers;
+- end-to-end wall time;
+- tracker-tool time;
+- MCP call and query-batch count;
+- refresh jobs, joins, polls, retries, and duplicate work;
+- response bytes and agent context cost;
+- accuracy against deterministic synthetic truth;
+- evidence-selector validity;
+- human readability;
+- correct separation of fact, estimate, and model inference.
+
+### Facts below inference
+
+The tracker owns deterministic facts, calculations, provenance, coverage,
+freshness, and evidence. Codex owns explanation, hypotheses, and
+recommendations.
+
+The tracker will not restore server-authored narrative diagnostics,
+OpenTelemetry ingestion, Compression Lab, or another MCP tool.
+
+### Metadata-first storage
+
+The default analytical store may retain:
+
+- source cursors and generations;
+- threads and human display labels;
+- turns;
+- model calls and four token classes;
+- tool operation, bounded target label, duration, output bytes, and status;
+- structured lifecycle activity;
+- allowance state observations and intervals;
+- cost and credit calculations with rate-card provenance;
+- compact persisted rollups.
+
+It must not retain prompts, responses, reasoning text, raw tool arguments, raw
+tool output, full shell commands, secrets, or full local paths.
+
+### Allowance attribution
+
+An allowance state observed after a call is not attributed to that call. The
+delta belongs to the interval since the preceding observation and can include
+multiple local calls or out-of-band activity.
+
+The schema must distinguish:
+
+- observation trigger from causal attribution;
+- exact upstream allowance state from local interval calculations;
+- deterministic token-rate cost from estimated allowance/credit allocation;
+- unchanged state from proof of zero consumption.
+
+### One cache, one append path
+
+- Opening the Console never starts refresh.
+- A compatible committed generation renders immediately.
+- Query execution never starts refresh implicitly.
+- No-change refresh performs no fact or rollup writes.
+- Ordinary refresh parses only complete appended lines.
+- Moving-tail catch-up includes lines appended during refresh.
+- One durable worker owns refresh; compatible callers join it.
+- Readers stay on the prior committed generation until atomic promotion.
+
+## Performance Gates
+
+All timings use identical unprofiled synthetic workloads. CPU profiles
+attribute work but do not prove speedup.
+
+| Scenario | Required | Stretch |
+| --- | ---: | ---: |
+| Console useful render from committed generation | ≤500 ms | ≤250 ms |
+| Live, Explore defaults, Limits, Evidence first page | ≤1 s | ≤500 ms |
+| Warm top-threads tracker response | ≤1 s | ≤500 ms |
+| Warm top-threads fresh-task final answer | ≤15 s | ≤10 s |
+| Warm status | ≤100 ms | ≤50 ms |
+| Ordinary moving-tail refresh | ≤500 ms | ≤250 ms |
+| Larger bounded tail | ≤2 s | ≤1 s |
+| Complete production-shaped cold build | ≤240 s | ≤180 s |
+| Production-shaped database | <700 MiB | <500 MiB |
+
+Common warm routes must read bounded indexes or persisted rollups. They may not
+scan every foundational fact to render a landing page or answer a routine
+question.
+
+## Restored Analytical Value
+
+`0.29.0` restores or completes:
+
+- total calls and total tokens with four-class breakdown;
+- cache reuse and context pressure with explicit coverage;
+- configured dollar cost and Codex credit estimates;
+- observed allowance drain and usage-over-time graphs;
+- time-first token and allowance bands;
+- thread and call rankings with human labels;
+- turn ordinal, elapsed time, and completion basis;
+- tool read/write/search/test operation and bounded target label;
+- tool duration, output bytes, and provenance-graded context impact;
+- exact evidence selectors that remain copyable but do not dominate tables.
+
+Per-call dollar cost may be deterministic when configured token rates cover the
+model. Per-call allowance consumption remains estimated unless upstream data
+provides causal attribution.
+
+## Console Contract
+
+### Live
+
+Render persisted committed summaries immediately. Show calls, four token
+classes, cache reuse, cost, credits, and a recent usage/allowance graph. Remove
+“Snapshot truth” and “Tool-independent facts.”
+
+### Explore
+
+Open on useful Threads and Calls views. Every selectable default must return a
+valid bounded result or a specific actionable explanation. Keep the generic
+query composer secondary to curated views.
+
+### Evidence
+
+Default columns begin with time, turn, event or tool, token impact, cost or
+credits, and duration. Human labels precede selectors. Long IDs live in
+expandable details or copy actions. Tables support sorting, pagination,
+filtering, and stable evidence navigation.
+
+### Limits
+
+Read compact allowance intervals. Restore the usage-over-time graph and expose
+observed drain, local tokens, estimated credits, credits per usage unit,
+coverage, and reset boundaries.
+
+## Program Tasks
+
+| Task | Depends on | Outcome |
+| --- | --- | --- |
+| [R0](product-recovery-tasks/r0-adopt-recovery-roadmap.md) | — | Adopt recovery authority and close the incomplete reset program accurately |
+| [R1](product-recovery-tasks/r1-agent-outcome-baseline.md) | R0 | Freeze fresh-task agent scorecard and production-shaped baselines |
+| [R2](product-recovery-tasks/r2-schema-v3-storage.md) | R1 | Approve compact schema v3, allowance intervals, rollups, and side-by-side upgrade |
+| [R3](product-recovery-tasks/r3-build-refresh-performance.md) | R2 | Accelerate cold build and prove incremental moving-tail refresh |
+| [R4](product-recovery-tasks/r4-fast-query-mcp.md) | R2 | Persist rollups and make common API/MCP questions bounded and fast |
+| [R5](product-recovery-tasks/r5-analytical-primitives.md) | R3, R4 | Restore human labels, costs, credits, allowance, turns, and tool impact |
+| [R6](product-recovery-tasks/r6-console-usability.md) | R4, R5 | Rebuild all Console areas around fast human workflows |
+| [R7](product-recovery-tasks/r7-installed-agent-qualification.md) | R1; final gate after R3–R6 | Qualify installed wheel, plugin, MCP, skill, browser, and fresh-task outcomes |
+| [R8](product-recovery-tasks/r8-public-docs.md) | R0; final gate after R6, R7 | Publish benefit-led docs, conversations, and final synthetic screenshots |
+| [R9](product-recovery-tasks/r9-release-0.29.0.md) | R7, R8 | Release exact qualified `0.29.0` bytes |
+
+## Dependency And Parallelization Map
+
+```text
+R0 → R1 → R2 ─┬→ R3 ─┐
+              └→ R4 ─┼→ R5 → R6 ─┐
+R1 ─────────────────────→ R7 ─────┼→ R9
+R0 ─────────────────────→ R8 ─────┘
+```
+
+R7 begins as a harness after R1 and continuously measures each candidate. It
+cannot complete until R3–R6 pass. R8 may draft durable copy after R0 but cannot
+finalize claims or screenshots until R6 and R7 pass.
+
+After R2 freezes schema and ownership, the following lanes are technically safe
+to parallelize if the user or maintainer explicitly authorizes subagents for
+that current task:
+
+- R3 ingestion work in `ingest`, `writer`, `discovery`, and refresh tests;
+- R4 rollup/query work in query, application, MCP, and query tests;
+- the R7 harness in isolated synthetic fixtures and installed-task runners;
+- early R8 copy audit in documentation-only files.
+
+R3 and R4 must not both edit schema files. R7 must not patch product behavior.
+R8 must not publish screenshots or performance claims from an unqualified
+candidate.
+
+R4 publishes the frozen rollup-updater interface before R3 connects it to the
+fact-writing transaction. R4 owns the updater implementation; R3 owns its
+ingestion call site. That named checkpoint is sequential even while the
+remaining ingestion and query work proceeds in parallel.
+
+Parallel execution follows these rules:
+
+1. Task packets and coordinators identify candidates but do not grant
+   authorization; only an explicit current-task user or maintainer instruction
+   can activate subagents.
+2. One writing agent owns one branch and worktree.
+3. Every writing task has an explicit file allowlist.
+4. The coordinator alone updates the execution ledger and shared contracts.
+5. Schema, public JSON, generated Console assets, and package manifests each
+   have one owner at a time.
+6. Subagents do not rebase, force-push, delete worktrees, or modify another
+   agent's files.
+7. Each task finishes primary validation before one final read-only review.
+8. Parallel branches integrate only at named contract checkpoints.
+
+## Non-Goals
+
+- No new MCP tool.
+- No automatic narrative-analysis service.
+- No OpenTelemetry or legacy dashboard revival.
+- No default raw-content database.
+- No attribution of cumulative allowance drain to one call.
+- No compatibility adapter for retired beta databases.
+- No public documentation claim that has not passed installed qualification.
+- No destructive deletion of the old cache during side-by-side validation.
+
+## Program Completion
+
+The recovery program completes only when:
+
+- R0–R9 have terminal ledger entries;
+- the production-shaped cold build and database-size gates pass;
+- common warm API and Console routes pass without broad fact scans;
+- the fixed fresh-task prompt suite passes correctness and latency gates;
+- package, plugin, MCP, skill, and cached bundle identities agree;
+- human labels and exact selectors coexist across agent and Console surfaces;
+- cost, credits, allowance, four-token, turn, and tool-impact views pass;
+- reopen and ordinary refresh never rebuild compatible history;
+- final public screenshots use only deterministic synthetic fixtures;
+- exact wheel and sdist bytes pass protected publication and public verification.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -218,6 +218,24 @@ K16_ADDITIONS = frozenset(
     }
 )
 
+RECOVERY_ROADMAP_ADDITIONS = frozenset(
+    {
+        "docs/roadmap/product-recovery.md",
+        "docs/roadmap/product-recovery-execution.md",
+        "docs/roadmap/product-recovery-tasks/README.md",
+        "docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md",
+        "docs/roadmap/product-recovery-tasks/r1-agent-outcome-baseline.md",
+        "docs/roadmap/product-recovery-tasks/r2-schema-v3-storage.md",
+        "docs/roadmap/product-recovery-tasks/r3-build-refresh-performance.md",
+        "docs/roadmap/product-recovery-tasks/r4-fast-query-mcp.md",
+        "docs/roadmap/product-recovery-tasks/r5-analytical-primitives.md",
+        "docs/roadmap/product-recovery-tasks/r6-console-usability.md",
+        "docs/roadmap/product-recovery-tasks/r7-installed-agent-qualification.md",
+        "docs/roadmap/product-recovery-tasks/r8-public-docs.md",
+        "docs/roadmap/product-recovery-tasks/r9-release-0.29.0.md",
+    }
+)
+
 INTEGRATION_ADDITIONS = (
     K1A_ADDITIONS
     | K2_ADDITIONS
@@ -234,6 +252,7 @@ INTEGRATION_ADDITIONS = (
     | K14_ADDITIONS
     | K15_ADDITIONS
     | K16_ADDITIONS
+    | RECOVERY_ROADMAP_ADDITIONS
 )
 _BLOCKED_TASK_REF = re.compile(
     r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))"

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -21,6 +21,7 @@ from scripts.check_kernel_scope import (
     K14_ADDITIONS,
     K15_ADDITIONS,
     K16_ADDITIONS,
+    RECOVERY_ROADMAP_ADDITIONS,
     active_paths,
     load_disposition_manifest,
     publication_ref_failure,
@@ -212,6 +213,21 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/kernel/test_release_028_qualification.py",
         "tests/kernel/test_stable_contract_028.py",
     } == K16_ADDITIONS
+    assert {
+        "docs/roadmap/product-recovery.md",
+        "docs/roadmap/product-recovery-execution.md",
+        "docs/roadmap/product-recovery-tasks/README.md",
+        "docs/roadmap/product-recovery-tasks/r0-adopt-recovery-roadmap.md",
+        "docs/roadmap/product-recovery-tasks/r1-agent-outcome-baseline.md",
+        "docs/roadmap/product-recovery-tasks/r2-schema-v3-storage.md",
+        "docs/roadmap/product-recovery-tasks/r3-build-refresh-performance.md",
+        "docs/roadmap/product-recovery-tasks/r4-fast-query-mcp.md",
+        "docs/roadmap/product-recovery-tasks/r5-analytical-primitives.md",
+        "docs/roadmap/product-recovery-tasks/r6-console-usability.md",
+        "docs/roadmap/product-recovery-tasks/r7-installed-agent-qualification.md",
+        "docs/roadmap/product-recovery-tasks/r8-public-docs.md",
+        "docs/roadmap/product-recovery-tasks/r9-release-0.29.0.md",
+    } == RECOVERY_ROADMAP_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -228,6 +244,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | K14_ADDITIONS
         | K15_ADDITIONS
         | K16_ADDITIONS
+        | RECOVERY_ROADMAP_ADDITIONS
     )
 
 


### PR DESCRIPTION
## Summary

- replace Product Kernel Reset as the active post-0.28 authority
- add the Product Recovery roadmap, execution ledger, and R0-R9 task packets
- define performance, storage, Console, analytical, installed-agent, documentation, and exact-byte release gates
- preserve K0-K16 as historical evidence and record incomplete 0.28 publication accurately
- add fail-closed scope coverage for every new roadmap file

## Parallel execution

Task packets identify technically safe parallel lanes, but only explicit current-task user or maintainer authorization can activate subagents. Shared contracts, schemas, generated assets, and package manifests retain single-writer ownership.

## Validation

- `just v` (340 Python tests, 7 frontend tests, Ruff, MyPy, Pyright, maintainability, manifests, deterministic assets, scope, and release checks)
- `pytest tests/kernel/test_kernel_scope.py -q` (14 passed)
- `python scripts/check_kernel_scope.py`
- `python scripts/check_release.py`
- Product Recovery relative-link validation (13 documents)
- `git diff --check`

## Review

One final read-only review reported five findings; all five were accepted and resolved. Reviewer token attribution remains pending because the installed Usage Tracker CLI no longer supports the metrics helper command.