### PR TITLE
feat: add fast generation-scoped query rollups

### DIFF
--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -1,7 +1,7 @@
 {
   "schema": "codex-usage-tracker.kernel-rc-budget.v1",
   "headroom_percent": 3,
-  "kernel_source_bytes": 495474,
+  "kernel_source_bytes": 541436,
   "console_asset_bytes": 48811,
   "analytical_tables": 17,
   "analytical_indexes": 14,
@@ -9,7 +9,14 @@
   "mcp_tools": 6,
   "http_routes": 7,
   "cli_commands": 11,
-  "wheel_bytes": 143000,
-  "sdist_bytes": 440000,
-  "plugin_bundle_bytes": 3900
+  "wheel_bytes": 151960,
+  "sdist_bytes": 461160,
+  "plugin_bundle_bytes": 3900,
+  "mcp_golden_prompt": {
+    "mcp_calls": 3,
+    "measured_response_bytes": [889, 10517, 906],
+    "response_byte_ceilings": [915, 10832, 933],
+    "measured_total_bytes": 12312,
+    "total_byte_ceiling": 12681
+  }
 }

--- a/config/kernel-stable-contract-v1.json
+++ b/config/kernel-stable-contract-v1.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "usage_refresh",
-      "input_schema_sha256": "01ae972862e38edb771a88e742a5f3d8b966335a206bbedb98c73d33504309da"
+      "input_schema_sha256": "d4142c076615f64709570c5e60927c4bf942a362e148b51fe68d65d3de619c17"
     },
     {
       "name": "usage_query",

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -639,8 +639,8 @@ query, recovery, and performance contracts, scope allowlist, and this ledger
 | Performance | Pass | 100,000-call query distributions and active-writer 50 ms gate |
 | Ruff, MyPy, Pyright | Pass | active kernel, kernel tests, and scope script |
 | Agent Perf | Pass with one compatibility caveat | one complete Scalene run; direct pytest capture incomplete |
-| Full repository | Pass | 386 Python tests; frontend build/lint/typecheck/tests; Ruff, MyPy, Pyright, maintainability, scope, manifests, and release safety |
-| Distribution and installed | Pass | exact 148,013-byte wheel and 449,670-byte sdist; two-fresh-task installed smoke and installed Console/allowance smoke; warm Console p95 0.853 ms |
+| Full repository | Pass | 387 Python tests; frontend build/lint/typecheck/tests; Ruff, MyPy, Pyright, maintainability, scope, manifests, and release safety |
+| Distribution and installed | Pass | exact 148,034-byte wheel and 449,942-byte sdist; clean and supported 0.26/0.27 upgrade smokes, two fresh MCP tasks each, and installed Console/allowance smoke; observed warm Console p95 no worse than 0.853 ms |
 | Final review | Pass after remediation | one read-only reviewer reported five findings; R1–R5 accepted and fixed; reviewer token attribution pending because the installed tracker CLI lacks the metrics helper's legacy `strict` command |
 
 ### Residual risk and next action
@@ -651,3 +651,8 @@ query, recovery, and performance contracts, scope allowlist, and this ledger
   synthetic allowance fixture relied on the former complete-history default.
   The smoke now explicitly requests `complete`; the local installed
   Console/allowance smoke passes without changing product behavior.
+- The next Python 3.14 attempt exposed a pre-refresh upgrade boundary:
+  read-only status queried schema-v3 coverage before a 0.26/0.27 sidecar had
+  migrated. Publication snapshots now report conservative empty coverage for
+  pre-v3 sidecars without writing. The v2-to-v3 migration creates the exact
+  active/staged coverage schemas, and both published upgrade paths pass locally.

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -13,9 +13,9 @@ benchmark, a source-only tag, or an unpublished package.
 | --- | --- | --- | --- | --- |
 | R0 | Complete | — | `docs/product-recovery-roadmap` | Recovery authority merged as `117fff8` |
 | R1 | Complete | R0 | `feature/r1-agent-outcome-baseline` | PR #342 merged as `aefb216`; frozen benchmark and measured failures |
-| R2 | In progress | R1 | `feature/r2-schema-v3-compact-storage` | Schema v3 implementation complete; final review/merge pending |
-| R3 | In progress | R2 | `feature/r3-build-refresh-performance` | Cold and incremental gates pass; final review/merge pending |
-| R4 | Pending | R2 | — | Persisted rollups and fast API/MCP |
+| R2 | Complete | R1 | `feature/r2-schema-v3-compact-storage` | PR #344 merged as `f740939`; compact schema v3 published to `main` |
+| R3 | Complete | R2 | `feature/r3-build-refresh-performance` | PR #344 merged as `f740939`; selective hydration and refresh gates pass |
+| R4 | In progress | R2 | `feature/r4-fast-query-mcp` | Rollup/query contracts pass; final review and merge pending |
 | R5 | Pending | R3, R4 | — | Analytical primitives and human semantics |
 | R6 | Pending | R4, R5 | — | Console usability |
 | R7 | Pending | R1; completes after R3–R6 | — | Installed fresh-task qualification |
@@ -81,8 +81,8 @@ disjoint file sets.
 | Wave | Lane | Owner | Base | Files | State |
 | --- | --- | --- | --- | --- | --- |
 | 1 | R1 baseline | primary | `96c6335` | task packet allowlist | In progress |
-| 2 | R3 ingestion | primary | `1f241f9` | ingest-owned files | In progress |
-| 2 | R4 query | unassigned | R2 contract | query-owned files | Blocked |
+| 2 | R3 ingestion | primary | `1f241f9` | ingest-owned files | Complete |
+| 2 | R4 query | primary | `f740939` | R4 packet plus integrated rollup publication hook | In progress |
 | 2 | R7 harness | unassigned | R1 harness | test/runner-owned files | Blocked |
 | 2 | R8 copy audit | unassigned | R0 merge | docs-only files | Blocked |
 
@@ -548,3 +548,102 @@ reparsing the first 52 sources.
   byte. R8/R9 must either freeze a broader deterministic artifact-integrity
   contract or explicitly document why SQLite integrity, foreign-key checks,
   accounting oracles, and exact release hashes remain the chosen layers.
+
+## R4 — Build Persisted Rollups And Fast MCP/API Paths
+
+**State:** In progress
+**Branch:** `feature/r4-fast-query-mcp`
+**Base:** `f740939a58f1a1bbba60d3fd19016e14b154ba89`
+**Commits:** pending
+**Owned files:** rollup updater, query catalog/plans/contracts/service,
+application cache, refresh preset adapters and schemas, focused interface,
+query, recovery, and performance contracts, scope allowlist, and this ledger
+**Parallel lane:** none
+
+### Contract added first
+
+- Four initial R4 contracts failed because status/query omitted history
+  coverage, partial all-history reads did not fail closed, query execution did
+  not prove refresh absence, and refresh had no hydration-preset transport.
+- A production-shaped append contract then exposed a critical integration
+  defect: rebuilding every rollup from 100,000 prior calls held the active
+  writer lock for 229.652 ms against the 50 ms ceiling.
+- The current contracts cover generation/request cache reuse and invalidation,
+  exact partial-history opt-in, new-install `recent_30d` default, monotonic
+  explicit expansion, atomic rollup recovery, no-change upgrade backfill,
+  HTTP/MCP preset transport, bounded time-band/tool-operation plans, and
+  exact incremental-rollup parity.
+- Final review added deterministic coverage for publication/coverage
+  interleaving, cross-preset interrupted append recovery, regrouping stored
+  model/tool dimensions, nullable tool-measure fallback, and immutable
+  historical release evidence.
+
+### Implementation checkpoint
+
+- `usage_refresh` retains the six-tool surface and accepts `recent_30d`,
+  `recent_90d`, or `complete` through MCP, HTTP, CLI, and the background
+  worker. New installs default to 30 days; an existing or explicitly expanded
+  complete generation never silently narrows.
+- Status and query envelopes expose the committed preset, cutoff,
+  completeness, source/byte coverage, and coverage revision. Partial
+  all-history queries fail closed unless `allow_partial=true`; bounded queries
+  never launch refresh or deferred hydration.
+- Query cache lookup, partial-history validation, execution, and response
+  coverage bind to one operational SQLite publication snapshot. Interrupted
+  valid generations publish before a different-preset retry continues, while
+  retaining prior conservative coverage until the retry publishes its own.
+- Common global, thread, model/effort/tier, daily/hourly, and tool-operation
+  aggregates read generation-scoped persisted rollups. Subset dimensions are
+  regrouped exactly; nullable tool duration/output measures retain the generic
+  exact path instead of converting missing values to zero. Query responses are
+  cached by publication, generation, normalized request, coverage revision,
+  and optional-content status, with observable hit/miss metadata and bounded
+  deep-copy isolation.
+- Append-safe refreshes seed compact prior-generation rollups and apply only
+  the new generation delta. Replacement, expansion, and one-time upgrade
+  backfill rebuild on unpublished clones. The atomic global rollup row is the
+  publication marker; interrupted post-fact updates recover the rollups before
+  promotion, while readers remain on the prior generation.
+- R4 integrated the updater call site after R3 merged. This is an intentional
+  deviation from the packet's earlier parallel ownership wording; there was no
+  concurrent R3 writer and no ingestion file was edited by another lane.
+
+### Unprofiled performance evidence
+
+| Workload | Before | Current | Result |
+| --- | ---: | ---: | --- |
+| 100,000-call model/effort query | generic fact scan | 4.744 ms p95; 4 rollup rows | passes 500 ms stretch |
+| 100,000-call thread concentration | generic fact scan | 2.157 ms p95; 250 rollup rows | passes 1 s gate |
+| 100,000-call daily bands | generic fact scan | 2.258 ms p95; 28 rollup rows | passes 500 ms stretch |
+| 100,000-call week comparison | unchanged generic path | 145.575 ms p95 | passes 1 s gate |
+| 2,000-call append over 100,000 active calls | 229.652 ms writer p95 | 35.565 ms writer p95 | 84.5% lower; passes 50 ms gate |
+| Synthetic 100,000-call kernel benchmark | — | 5.00 s unprofiled | attribution baseline |
+
+### Profiling evidence
+
+- Unprofiled timings above are the only speedup evidence.
+- `agent-perf` run `20260727T235119Z-a3ca6bb7` was incomplete because Scalene
+  did not emit JSON for the direct pytest workload.
+- `agent-perf` run `20260727T235209Z-3f902139` completed the identical
+  100,000-call synthetic kernel workload in 6.113 seconds under Scalene 2.3.0.
+  Its ranked application hotspots were existing writer insertion/deletion and
+  selector mapping; the rollup updater did not appear among the ranked
+  hotspots. This is attribution evidence only.
+
+### Verification checkpoint
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| R4 query/coverage/recovery focus | Pass | 21 final rollup/query/coverage tests plus focused interruption, upgrade-backfill, and preset contracts |
+| Broad touched surface | Pass | 144 query, interface, Console, content, live, allowance, ingestion, fault, and concurrency tests |
+| Performance | Pass | 100,000-call query distributions and active-writer 50 ms gate |
+| Ruff, MyPy, Pyright | Pass | active kernel, kernel tests, and scope script |
+| Agent Perf | Pass with one compatibility caveat | one complete Scalene run; direct pytest capture incomplete |
+| Full repository | Pass | 386 Python tests; frontend build/lint/typecheck/tests; Ruff, MyPy, Pyright, maintainability, scope, manifests, and release safety |
+| Distribution and installed | Pass | exact 148,013-byte wheel and 449,325-byte sdist; two-fresh-task installed smoke; warm Console p95 0.853 ms |
+| Final review | Pass after remediation | one read-only reviewer reported five findings; R1–R5 accepted and fixed; reviewer token attribution pending because the installed tracker CLI lacks the metrics helper's legacy `strict` command |
+
+### Residual risk and next action
+
+- Commit and open the R4 pull request, require green CI, and merge before
+  starting R5. No second reviewer is permitted.

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -640,10 +640,14 @@ query, recovery, and performance contracts, scope allowlist, and this ledger
 | Ruff, MyPy, Pyright | Pass | active kernel, kernel tests, and scope script |
 | Agent Perf | Pass with one compatibility caveat | one complete Scalene run; direct pytest capture incomplete |
 | Full repository | Pass | 386 Python tests; frontend build/lint/typecheck/tests; Ruff, MyPy, Pyright, maintainability, scope, manifests, and release safety |
-| Distribution and installed | Pass | exact 148,013-byte wheel and 449,325-byte sdist; two-fresh-task installed smoke; warm Console p95 0.853 ms |
+| Distribution and installed | Pass | exact 148,013-byte wheel and 449,670-byte sdist; two-fresh-task installed smoke and installed Console/allowance smoke; warm Console p95 0.853 ms |
 | Final review | Pass after remediation | one read-only reviewer reported five findings; R1–R5 accepted and fixed; reviewer token attribution pending because the installed tracker CLI lacks the metrics helper's legacy `strict` command |
 
 ### Residual risk and next action
 
 - Commit and open the R4 pull request, require green CI, and merge before
   starting R5. No second reviewer is permitted.
+- The first PR CI attempt exposed one stale installed-Console assumption: its
+  synthetic allowance fixture relied on the former complete-history default.
+  The smoke now explicitly requests `complete`; the local installed
+  Console/allowance smoke passes without changing product behavior.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -252,6 +252,13 @@ R3_ADDITIONS = frozenset(
         "tests/kernel/test_hydration_policy.py",
     }
 )
+R4_ADDITIONS = frozenset(
+    {
+        "src/codex_usage_tracker/kernel/rollups.py",
+        "tests/kernel/interfaces/test_r4_coverage_contract.py",
+        "tests/kernel/query/test_r4_rollups.py",
+    }
+)
 
 INTEGRATION_ADDITIONS = (
     K1A_ADDITIONS
@@ -273,6 +280,7 @@ INTEGRATION_ADDITIONS = (
     | R1_ADDITIONS
     | R2_ADDITIONS
     | R3_ADDITIONS
+    | R4_ADDITIONS
 )
 _BLOCKED_TASK_REF = re.compile(
     r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))"

--- a/scripts/smoke_installed_console.py
+++ b/scripts/smoke_installed_console.py
@@ -91,7 +91,7 @@ def smoke_current(wheel: Path) -> None:
                 raise RuntimeError(f"installed CLI is missing {command_name}")
         _smoke_mcp_catalog(_python(root / "venv"), environment)
         subprocess.run(
-            [command, "refresh", "--wait", "30"],
+            [command, "refresh", "--preset", "complete", "--wait", "30"],
             check=True,
             capture_output=True,
             env=environment,

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -643,7 +643,7 @@ def smoke_install(
         if version is not None and package.get("version") != version:
             raise RuntimeError(f"installed version differs: {package}")
         _run_json(
-            [command, "refresh", "--wait", "30"],
+            [command, "refresh", "--wait", "30", "--preset", "complete"],
             environment=environment,
             timeout=40,
         )

--- a/src/codex_usage_tracker/kernel/application/codec.py
+++ b/src/codex_usage_tracker/kernel/application/codec.py
@@ -38,6 +38,10 @@ def query_request(payload: dict[str, Any]) -> QueryRequest:
         limit=_integer(payload.get("limit", 100), "limit"),
         cursor=_optional_text(payload.get("cursor"), "cursor"),
         comparison=comparison,
+        allow_partial=_boolean(
+            payload.get("allow_partial", False),
+            "allow_partial",
+        ),
     )
 
 

--- a/src/codex_usage_tracker/kernel/application/service.py
+++ b/src/codex_usage_tracker/kernel/application/service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
 import os
 import subprocess
@@ -9,6 +11,7 @@ import sys
 import threading
 import time
 import uuid
+from collections import OrderedDict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,11 +22,15 @@ from ..allowance import AllowanceService
 from ..allowance.rates import rate_card_status
 from ..content import content_status
 from ..evidence import EvidenceService
+from ..hydration import HydrationPreset
 from ..ingest import KernelIngestor, RefreshTrigger, refresh_request_hash
 from ..live import GenerationJournal, LiveStream
+from ..models import CutoverControl
 from ..operational import (
     initialize_operational_database,
     load_cutover_control,
+    load_hydration_coverage,
+    load_publication_snapshot,
 )
 from ..query import QueryService, exploration_guidance
 from ..query.contracts import MAX_QUERY_RESPONSE_BYTES
@@ -37,8 +44,9 @@ from .runtime import (
     discover_sources,
 )
 
-WorkerLauncher = Callable[[RuntimePaths], None]
+WorkerLauncher = Callable[[RuntimePaths, HydrationPreset], None]
 WORKER_START_TIMEOUT_SECONDS = 5.0
+HYDRATION_PRESET_ENV = "CODEX_USAGE_TRACKER_HYDRATION_PRESET"
 _THREAD_LAUNCH_GUARD = threading.Lock()
 
 
@@ -55,12 +63,15 @@ class KernelApplication:
         self.paths = paths
         self._launch_worker = worker_launcher
         self._sources = source_provider
+        self._query_cache: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+        self._query_cache_lock = threading.Lock()
 
     def dispatch(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         handlers = {
             "usage_status": lambda: self.status(),
             "usage_refresh": lambda: self.refresh(
-                wait_seconds=_number(arguments.get("wait_seconds", 0))
+                wait_seconds=_number(arguments.get("wait_seconds", 0)),
+                hydration_preset=_hydration_preset(arguments.get("preset")),
             ),
             "usage_query": lambda: self.query(arguments),
             "usage_evidence": lambda: self.evidence(arguments),
@@ -87,10 +98,11 @@ class KernelApplication:
                 "generation": None,
                 "publication_id": None,
                 "refresh": None,
+                "history_coverage": _empty_history_coverage(),
                 "rate_card": rates,
                 "content": content_status(self.paths.content),
             }
-        control = load_cutover_control(operational)
+        control, history_coverage = load_publication_snapshot(operational)
         active = JobReader(operational).active()
         return {
             "version": __version__,
@@ -98,6 +110,7 @@ class KernelApplication:
             "generation": control.active_generation,
             "publication_id": control.integrity_digest,
             "refresh": json_value(active),
+            "history_coverage": history_coverage,
             "rate_card": rates,
             "content": content_status(self.paths.content),
         }
@@ -107,24 +120,47 @@ class KernelApplication:
         if not isinstance(raw_requests, list):
             raise ValueError("requests must be an array")
         include_guidance = _bool(payload.get("include_guidance", False))
-        requests = tuple(
-            query_request(item)
-            for item in raw_requests
-            if isinstance(item, dict)
-        )
+        requests = tuple(query_request(item) for item in raw_requests if isinstance(item, dict))
         if len(requests) != len(raw_requests):
             raise ValueError("every query request must be an object")
         if not requests and not include_guidance:
             raise ValueError("query requires a query request or guidance")
-        results = (
-            QueryService(
-                self.paths.kernel.operational,
-                content_path=self.paths.content,
-            ).execute_batch(requests)
-            if requests
-            else ()
+        publication = load_publication_snapshot(self.paths.kernel.operational) if requests else None
+        history_coverage = (
+            publication[1]
+            if publication is not None
+            else _history_coverage(self.paths.kernel.operational)
         )
-        response = {"results": json_value(results)}
+        cache_key = None
+        if requests:
+            assert publication is not None
+            cache_key = _query_cache_key(
+                publication[0],
+                requests,
+                history_coverage=history_coverage,
+                content=self.paths.content,
+            )
+        cached = self._cached_query(cache_key) if cache_key is not None else None
+        cache_hit = cached is not None
+        if cached is None:
+            results = (
+                QueryService(
+                    self.paths.kernel.operational,
+                    content_path=self.paths.content,
+                    publication=publication,
+                ).execute_batch(requests)
+                if requests
+                else ()
+            )
+            serialized_results = json_value(results)
+            if cache_key is not None:
+                self._store_query(cache_key, serialized_results)
+        else:
+            serialized_results = cached
+        response = {"results": serialized_results}
+        response["history_coverage"] = history_coverage
+        if cache_key is not None:
+            response["cache"] = {"hit": cache_hit, "key": cache_key}
         if include_guidance:
             response["guidance"] = exploration_guidance()
         response_size = len(
@@ -135,15 +171,26 @@ class KernelApplication:
             ).encode()
         )
         if response_size > MAX_QUERY_RESPONSE_BYTES:
-            raise ValueError(
-                "query response exceeds byte budget; lower request limits"
-            )
+            raise ValueError("query response exceeds byte budget; lower request limits")
         return response
 
+    def _cached_query(self, key: str) -> list[dict[str, Any]] | None:
+        with self._query_cache_lock:
+            cached = self._query_cache.get(key)
+            if cached is None:
+                return None
+            self._query_cache.move_to_end(key)
+            return copy.deepcopy(cached)
+
+    def _store_query(self, key: str, results: list[dict[str, Any]]) -> None:
+        with self._query_cache_lock:
+            self._query_cache[key] = copy.deepcopy(results)
+            self._query_cache.move_to_end(key)
+            while len(self._query_cache) > 32:
+                self._query_cache.popitem(last=False)
+
     def evidence(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = EvidenceService(
-            self.paths.kernel.operational
-        ).read(evidence_request(payload))
+        result = EvidenceService(self.paths.kernel.operational).read(evidence_request(payload))
         return json_value(result)
 
     def allowance(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -157,10 +204,22 @@ class KernelApplication:
             cursor=cursor,
         )
 
-    def refresh(self, *, wait_seconds: float = 0) -> dict[str, Any]:
+    def refresh(
+        self,
+        *,
+        wait_seconds: float = 0,
+        hydration_preset: HydrationPreset | None = None,
+    ) -> dict[str, Any]:
         operational = self.paths.kernel.operational
+        selected_preset = _selected_hydration_preset(
+            operational,
+            requested=hydration_preset,
+        )
         sources = self._sources(self.paths.codex_home)
-        request_hash = refresh_request_hash(list(sources))
+        request_hash = refresh_request_hash(
+            list(sources),
+            hydration_preset=selected_preset,
+        )
         with _launch_guard(self.paths.cache_root):
             initialize_operational_database(operational)
             reader = JobReader(operational)
@@ -168,15 +227,13 @@ class KernelApplication:
             disposition = "started"
             if active is None:
                 latest = reader.latest()
-                self._launch_worker(self.paths)
+                self._launch_worker(self.paths, selected_preset)
                 active = _await_worker_start(
                     reader,
                     previous_job_id=latest.job_id if latest else None,
                 )
             else:
-                disposition = (
-                    "joined" if active.request_hash == request_hash else "busy"
-                )
+                disposition = "joined" if active.request_hash == request_hash else "busy"
         reader = JobReader(operational)
         snapshot = reader.get(
             active.job_id,
@@ -214,9 +271,7 @@ class KernelApplication:
 
         validate_loopback_origin(origin)
         control = load_cutover_control(self.paths.kernel.operational)
-        batch = LiveStream(
-            GenerationJournal(self.paths.kernel.operational)
-        ).read(
+        batch = LiveStream(GenerationJournal(self.paths.kernel.operational)).read(
             last_event_id=last_event_id,
             limit=limit,
             active_generation=control.active_generation or 0,
@@ -236,10 +291,14 @@ def build_application(
     )
 
 
-def launch_refresh_worker(paths: RuntimePaths) -> None:
+def launch_refresh_worker(
+    paths: RuntimePaths,
+    hydration_preset: HydrationPreset,
+) -> None:
     environment = os.environ.copy()
     environment[CODEX_HOME_ENV] = str(paths.codex_home)
     environment[CACHE_ROOT_ENV] = str(paths.cache_root)
+    environment[HYDRATION_PRESET_ENV] = hydration_preset.value
     package_root = str(Path(__file__).resolve().parents[3])
     inherited_path = environment.get("PYTHONPATH")
     environment["PYTHONPATH"] = os.pathsep.join(
@@ -260,8 +319,16 @@ def launch_refresh_worker(paths: RuntimePaths) -> None:
     )
 
 
-def run_refresh_worker(paths: RuntimePaths | None = None) -> dict[str, Any]:
+def run_refresh_worker(
+    paths: RuntimePaths | None = None,
+    *,
+    hydration_preset: HydrationPreset | None = None,
+) -> dict[str, Any]:
     runtime = paths or default_runtime_paths()
+    selected_preset = hydration_preset or _selected_hydration_preset(
+        runtime.kernel.operational,
+        requested=_hydration_preset(os.environ.get(HYDRATION_PRESET_ENV)),
+    )
     sources = list(discover_sources(runtime.codex_home))
     result = KernelIngestor(
         runtime.kernel.analytical,
@@ -271,6 +338,7 @@ def run_refresh_worker(paths: RuntimePaths | None = None) -> dict[str, Any]:
         sources,
         trigger=RefreshTrigger.MCP_USAGE_REFRESH,
         owner_id=f"interface-worker-{uuid.uuid4().hex}",
+        hydration_preset=selected_preset,
     )
     return json_value(result)
 
@@ -320,6 +388,77 @@ def _number(value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError("wait_seconds must be numeric")
     return float(value)
+
+
+def _hydration_preset(value: Any) -> HydrationPreset | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("preset must be a string")
+    try:
+        return HydrationPreset(value)
+    except ValueError as exc:
+        raise ValueError("preset must be recent_30d, recent_90d, or complete") from exc
+
+
+def _selected_hydration_preset(
+    operational: Path,
+    *,
+    requested: HydrationPreset | None,
+) -> HydrationPreset:
+    if requested is not None:
+        return requested
+    if operational.is_file():
+        active = load_hydration_coverage(operational)["preset"]
+        if isinstance(active, str):
+            return HydrationPreset(active)
+    return HydrationPreset.RECENT_30D
+
+
+def _empty_history_coverage() -> dict[str, object]:
+    return {
+        "preset": None,
+        "captured_at": None,
+        "cutoff_at": None,
+        "complete_history": False,
+        "coverage_revision": None,
+        "cataloged_source_count": 0,
+        "hydrated_source_count": 0,
+        "deferred_source_count": 0,
+        "cataloged_bytes": 0,
+        "hydrated_bytes": 0,
+        "deferred_bytes": 0,
+        "uncertain_source_count": 0,
+    }
+
+
+def _history_coverage(operational: Path) -> dict[str, object]:
+    if not operational.is_file():
+        return _empty_history_coverage()
+    return load_hydration_coverage(operational)
+
+
+def _query_cache_key(
+    control: CutoverControl,
+    requests: tuple[Any, ...],
+    *,
+    history_coverage: dict[str, object],
+    content: Path,
+) -> str:
+    payload = {
+        "generation": control.active_generation,
+        "publication_id": control.integrity_digest,
+        "active_kernel_path": str(control.active_kernel_path),
+        "coverage_revision": history_coverage["coverage_revision"],
+        "requests": [json_value(request.normalized()) for request in requests],
+        "content": content_status(content),
+    }
+    return (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        ).hexdigest()
+    )
 
 
 def _int(value: Any, label: str) -> int:

--- a/src/codex_usage_tracker/kernel/ingest.py
+++ b/src/codex_usage_tracker/kernel/ingest.py
@@ -41,7 +41,6 @@ from .operational import (
     hydrated_source_ids,
     hydrated_source_locations,
     hydration_catalog_checkpoints,
-    hydration_selection_revision,
     initialize_operational_database,
     load_cutover_control,
     load_staged_hydration,
@@ -55,6 +54,7 @@ from .operational import (
     transition_cutover,
 )
 from .parser import ParsedBatch, iter_jsonl_batches, parse_jsonl
+from .rollups import generation_rollups_ready, rebuild_generation_rollups
 from .schema import SCHEMA_VERSION
 from .writer import (
     WriteResult,
@@ -137,17 +137,13 @@ class KernelIngestor:
                 joined=not lease.busy,
             )
         try:
-            was_failed = (
-                load_cutover_control(self.operational_path).state
-                is CutoverState.FAILED
-            )
+            was_failed = load_cutover_control(self.operational_path).state is CutoverState.FAILED
             recovered_generation = self._recover_or_active_generation(
                 selection,
             )
             if (
                 was_failed
-                and load_cutover_control(self.operational_path).state
-                is CutoverState.ACTIVE
+                and load_cutover_control(self.operational_path).state is CutoverState.ACTIVE
             ):
                 self._register_observations(observations)
             active_path = self._active_path()
@@ -202,9 +198,7 @@ class KernelIngestor:
             hydrated_source_ids=hydrated_source_ids(self.operational_path),
             hydrated_paths=hydrated_source_locations(self.operational_path),
         )
-        observations = tuple(
-            item.observation for item in selection.hydrate
-        )
+        observations = tuple(item.observation for item in selection.hydrate)
         return (
             selection,
             observations,
@@ -237,6 +231,27 @@ class KernelIngestor:
         leases: RefreshLeaseRepository,
     ) -> RefreshResult:
         if recovered_generation > 0:
+            if not generation_rollups_ready(active_path, recovered_generation):
+                with leases.maintain(refresh_run_id, owner_id) as guard:
+                    staging_path, _isolated = self._write_path(
+                        active_path,
+                        (),
+                        (),
+                        recovered_generation,
+                        refresh_run_id,
+                        force_isolation=True,
+                    )
+                    self._begin_cutover(refresh_run_id, staging_path)
+                    rebuild_generation_rollups(
+                        staging_path,
+                        recovered_generation,
+                    )
+                    guard.check()
+                    self._promote(
+                        staging_path,
+                        recovered_generation,
+                        hydration_selection=selection,
+                    )
             result = _empty_result(
                 refresh_run_id,
                 recovered_generation,
@@ -290,6 +305,11 @@ class KernelIngestor:
                 guard.check,
                 selection,
             )
+            rollup_ms = rebuild_generation_rollups(active_path, generation)
+            written = replace(
+                written,
+                transaction_ms=(*written.transaction_ms, rollup_ms),
+            )
             self._promote(
                 active_path,
                 generation,
@@ -335,10 +355,7 @@ class KernelIngestor:
                 owner_id,
                 stage="writing",
                 percent=45,
-                high_water={
-                    plan.observation.source_id: plan.end_byte
-                    for plan in plans
-                },
+                high_water={plan.observation.source_id: plan.end_byte for plan in plans},
                 changed_sources=len(plans),
                 timings=timings,
             )
@@ -360,6 +377,10 @@ class KernelIngestor:
                     timings=timings,
                 )
 
+            active_generation = self._active_generation()
+            requires_rollup_backfill = active_generation > 0 and not generation_rollups_ready(
+                active_path, active_generation
+            )
             write_path, isolated = self._write_path(
                 active_path,
                 plans,
@@ -367,7 +388,7 @@ class KernelIngestor:
                 generation,
                 refresh_run_id,
                 force_isolation=(
-                    streamed_bulk and self._active_generation() > 0
+                    (streamed_bulk and active_generation > 0) or requires_rollup_backfill
                 ),
             )
             self._begin_cutover(refresh_run_id, write_path)
@@ -400,6 +421,17 @@ class KernelIngestor:
                 guard.check,
                 selection,
             )
+            rollup_ms = rebuild_generation_rollups(
+                write_path,
+                generation,
+                incremental_from=(
+                    active_generation if active_generation > 0 and not isolated else None
+                ),
+            )
+            written = replace(
+                written,
+                transaction_ms=(*written.transaction_ms, rollup_ms),
+            )
             guard.check()
             leases.progress(
                 refresh_run_id,
@@ -416,19 +448,14 @@ class KernelIngestor:
                 generation,
                 hydration_selection=selection,
             )
-        self._register_observations(
-            tuple(plan.observation for plan in plans)
-        )
+        self._register_observations(tuple(plan.observation for plan in plans))
         result = _write_result(
             refresh_run_id,
             plans,
             generation,
             written,
             changed_sources=len(
-                {
-                    plan.observation.source_id for plan in plans
-                }
-                | catch_up_source_ids
+                {plan.observation.source_id for plan in plans} | catch_up_source_ids
             ),
         )
         result = self._publish_generation(result)
@@ -443,40 +470,29 @@ class KernelIngestor:
         self,
         plans: tuple[SourcePlan, ...],
     ) -> bool:
-        new_plans = tuple(
-            plan for plan in plans if plan.prior_source_id is None
-        )
+        new_plans = tuple(plan for plan in plans if plan.prior_source_id is None)
         if self._active_generation() == 0:
             return len(new_plans) == len(plans)
         large_new_source_set = (
             len(new_plans) >= _BULK_EXPANSION_MIN_SOURCES
-            or sum(
-                plan.end_byte - plan.start_byte
-                for plan in new_plans
-            )
+            or sum(plan.end_byte - plan.start_byte for plan in new_plans)
             >= _BULK_EXPANSION_MIN_BYTES
         )
         return large_new_source_set and all(
-            not plan.replace_existing
-            for plan in plans
-            if plan.prior_source_id is not None
+            not plan.replace_existing for plan in plans if plan.prior_source_id is not None
         )
 
     def _initialize_for_explicit_refresh(self) -> None:
         initialize_operational_database(self.operational_path)
         control = load_cutover_control(self.operational_path)
         active = control.active_kernel_path
-        active_version = (
-            analytical_schema_version(active) if active is not None else None
-        )
+        active_version = analytical_schema_version(active) if active is not None else None
         base_version = analytical_schema_version(self.analytical_path)
         if active is not None and active_version == SCHEMA_VERSION:
             self._build_path_override = None
             return
         if active_version is not None or (
-            active is None
-            and base_version is not None
-            and base_version != SCHEMA_VERSION
+            active is None and base_version is not None and base_version != SCHEMA_VERSION
         ):
             legacy_cache = active if active_version is not None else self.analytical_path
             if legacy_cache is None:
@@ -583,9 +599,7 @@ class KernelIngestor:
             prior_state = self._parser_state(plan, analytical_path)
             parsed = parse_jsonl(plan, prior_state)
             parsed_batches.append(parsed)
-            normalized_batches.append(
-                normalize_batch(plan, parsed, generation=generation)
-            )
+            normalized_batches.append(normalize_batch(plan, parsed, generation=generation))
         return tuple(parsed_batches), tuple(normalized_batches)
 
     def _parser_state(self, plan: SourcePlan, analytical_path: Path):
@@ -608,8 +622,7 @@ class KernelIngestor:
     ) -> WriteResult:
         transaction_ms: list[float] = []
         parser_states = {
-            plan.observation.source_id: self._parser_state(plan, path)
-            for plan in plans
+            plan.observation.source_id: self._parser_state(plan, path) for plan in plans
         }
         prepare_initial_refresh(
             path,
@@ -618,10 +631,7 @@ class KernelIngestor:
         )
         initialize_generation = True
         pending: list[tuple[SourcePlan, ParsedBatch, NormalizedBatch]] = []
-        total_bytes = sum(
-            max(0, plan.end_byte - plan.start_byte)
-            for plan in plans
-        )
+        total_bytes = sum(max(0, plan.end_byte - plan.start_byte) for plan in plans)
         committed_bytes = 0
         pending_bytes = 0
         high_water: dict[str, int] = {}
@@ -729,13 +739,9 @@ class KernelIngestor:
         deleted_rows = written.deleted_rows
         latest = written
         catch_up_source_ids: set[str] = set()
-        selected_source_ids = frozenset(
-            item.observation.source_id for item in selection.hydrate
-        )
+        selected_source_ids = frozenset(item.observation.source_id for item in selection.hydrate)
         selected_paths = frozenset(item.path for item in selection.hydrate)
-        checkpoints = catalog_checkpoints(
-            selection.hydrate + selection.deferred
-        )
+        checkpoints = catalog_checkpoints(selection.hydrate + selection.deferred)
         for _attempt in range(3):
             catalog = catalog_sources(
                 tuple(sources),
@@ -749,19 +755,17 @@ class KernelIngestor:
                 hydrated_source_ids=selected_source_ids,
                 hydrated_paths=selected_paths,
             )
-            observations = tuple(
-                item.observation for item in selection.hydrate
-            )
+            observations = tuple(item.observation for item in selection.hydrate)
             plans = self._plans_from_artifact(observations, write_path)
             if not plans:
                 return (
                     WriteResult(
-                    inserted_calls=latest.inserted_calls,
-                    inserted_tools=latest.inserted_tools,
-                    deleted_rows=deleted_rows,
-                    canonical_calls=latest.canonical_calls,
-                    excluded_calls=latest.excluded_calls,
-                    transaction_ms=tuple(transaction_ms),
+                        inserted_calls=latest.inserted_calls,
+                        inserted_tools=latest.inserted_tools,
+                        deleted_rows=deleted_rows,
+                        canonical_calls=latest.canonical_calls,
+                        excluded_calls=latest.excluded_calls,
+                        transaction_ms=tuple(transaction_ms),
                     ),
                     selection,
                     frozenset(catch_up_source_ids),
@@ -778,15 +782,11 @@ class KernelIngestor:
             )
             deleted_rows += latest.deleted_rows
             transaction_ms.extend(latest.transaction_ms)
-            catch_up_source_ids.update(
-                plan.observation.source_id for plan in plans
-            )
+            catch_up_source_ids.update(plan.observation.source_id for plan in plans)
             selected_source_ids = frozenset(
                 item.observation.source_id for item in selection.hydrate
             )
-            selected_paths = frozenset(
-                item.path for item in selection.hydrate
-            )
+            selected_paths = frozenset(item.path for item in selection.hydrate)
         raise RuntimeError("source high water did not stabilize")
 
     def _plans_from_artifact(
@@ -842,7 +842,10 @@ class KernelIngestor:
         generation: int,
         *,
         hydration_selection: HydrationSelection | None = None,
+        promote_staged_hydration: bool = False,
     ) -> None:
+        if not generation_rollups_ready(staging_path, generation):
+            raise ValueError("analytical generation rollups are incomplete")
         digest = analytical_generation_digest(staging_path, generation)
         promote_cutover(
             self.operational_path,
@@ -850,6 +853,7 @@ class KernelIngestor:
             generation=generation,
             integrity_digest=digest,
             hydration_selection=hydration_selection,
+            promote_staged_hydration=promote_staged_hydration,
         )
 
     def _mark_cutover_failed(self) -> None:
@@ -909,19 +913,17 @@ class KernelIngestor:
                     )
             except (ValueError, sqlite3.DatabaseError):
                 latest = 0
-        compatible = (
-            staged is not None
-            and staged["preset"] == hydration_selection.preset.value
-            and staged["coverage_revision"]
-            == hydration_selection_revision(hydration_selection)
-        )
-        if latest > active and compatible and candidate is not None:
-            assert staged is not None
-            recovered_selection = replace(
-                hydration_selection,
-                captured_at=_required_timestamp(staged["captured_at"]),
-                cutoff_at=_optional_timestamp(staged["cutoff_at"]),
-            )
+        if latest > active and staged is not None and candidate is not None:
+            if not generation_rollups_ready(candidate, latest):
+                rebuild_generation_rollups(
+                    candidate,
+                    latest,
+                    incremental_from=(
+                        active
+                        if active > 0 and generation_rollups_ready(candidate, active)
+                        else None
+                    ),
+                )
             if control.state is CutoverState.FAILED:
                 self._begin_cutover(
                     control.refresh_run_id or "recovery",
@@ -930,7 +932,7 @@ class KernelIngestor:
             self._promote(
                 candidate,
                 latest,
-                hydration_selection=recovered_selection,
+                promote_staged_hydration=True,
             )
             return latest
         if control.state in {CutoverState.BUILDING, CutoverState.READY}:
@@ -954,13 +956,14 @@ class KernelIngestor:
         *,
         force_isolation: bool = False,
     ) -> tuple[Path, bool]:
-        requires_isolation = force_isolation or any(
-            plan.replace_existing and plan.prior_source_id is not None
-            for plan in plans
-        ) or self._active_collision_requires_isolation(
-            active_path,
-            plans,
-            normalized,
+        requires_isolation = (
+            force_isolation
+            or any(plan.replace_existing and plan.prior_source_id is not None for plan in plans)
+            or self._active_collision_requires_isolation(
+                active_path,
+                plans,
+                normalized,
+            )
         )
         if not requires_isolation:
             return active_path, False
@@ -968,9 +971,7 @@ class KernelIngestor:
             uuid.NAMESPACE_URL,
             f"{generation}:{refresh_run_id}",
         ).hex[:12]
-        staging = active_path.with_name(
-            f".{active_path.stem}.g{generation}-{suffix}.sqlite3"
-        )
+        staging = active_path.with_name(f".{active_path.stem}.g{generation}-{suffix}.sqlite3")
         _clone_database(active_path, staging)
         return staging, True
 
@@ -1074,9 +1075,12 @@ def _request_hash(
     *,
     scope: str = HydrationPreset.COMPLETE.value,
 ) -> str:
-    payload = scope + "|" + "|".join(
-        f"{item.source_id}:{item.complete_size}:{item.modified_ns}"
-        for item in observations
+    payload = (
+        scope
+        + "|"
+        + "|".join(
+            f"{item.source_id}:{item.complete_size}:{item.modified_ns}" for item in observations
+        )
     )
     return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()
 

--- a/src/codex_usage_tracker/kernel/interfaces/cli/main.py
+++ b/src/codex_usage_tracker/kernel/interfaces/cli/main.py
@@ -17,6 +17,7 @@ from ...application.codec import json_value
 from ...application.service import run_refresh_worker
 from ...content import ContextComposition
 from ...database import initialize_analytical_database
+from ...hydration import HydrationPreset
 from ...operational import (
     initialize_operational_database,
     load_cutover_control,
@@ -50,6 +51,10 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("status", help="show committed generation status")
     refresh = subparsers.add_parser("refresh", help="start or join refresh")
     refresh.add_argument("--wait", type=float, default=0, metavar="SECONDS")
+    refresh.add_argument(
+        "--preset",
+        choices=tuple(item.value for item in HydrationPreset),
+    )
     for name in ("query", "export"):
         command = subparsers.add_parser(name, help=f"run bounded {name}")
         command.add_argument("--request", required=True, help="JSON request")
@@ -142,7 +147,14 @@ def _run(arguments: argparse.Namespace) -> dict[str, Any] | None:
     if arguments.command == "status":
         return application.status()
     if arguments.command == "refresh":
-        return application.refresh(wait_seconds=arguments.wait)
+        return application.refresh(
+            wait_seconds=arguments.wait,
+            hydration_preset=(
+                HydrationPreset(arguments.preset)
+                if arguments.preset is not None
+                else None
+            ),
+        )
     if arguments.command in {"query", "export"}:
         result = application.query(_request_payload(arguments.request))
         if arguments.command == "export":

--- a/src/codex_usage_tracker/kernel/interfaces/http/app.py
+++ b/src/codex_usage_tracker/kernel/interfaces/http/app.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from ...application import KernelApplication
+from ...hydration import HydrationPreset
 from ...live import parse_last_event_id, validate_loopback_origin
 
 API_PREFIX = "/api/kernel/v1"
@@ -84,7 +85,8 @@ class HttpApp:
             return _json_response(
                 202,
                 self._application.refresh(
-                    wait_seconds=_float(payload.get("wait_seconds", 0))
+                    wait_seconds=_float(payload.get("wait_seconds", 0)),
+                    hydration_preset=_preset(payload.get("preset")),
                 ),
             )
         if method == "POST" and path == f"{API_PREFIX}/query":
@@ -204,3 +206,14 @@ def _float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError) as exc:
         raise ValueError("wait_seconds must be numeric") from exc
+
+
+def _preset(value: Any) -> HydrationPreset | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("preset must be a string")
+    try:
+        return HydrationPreset(value)
+    except ValueError as exc:
+        raise ValueError("preset is not allowlisted") from exc

--- a/src/codex_usage_tracker/kernel/interfaces/schema_catalog.py
+++ b/src/codex_usage_tracker/kernel/interfaces/schema_catalog.py
@@ -17,7 +17,11 @@ SCHEMAS: dict[str, dict[str, Any]] = {
                 "type": "number",
                 "minimum": 0,
                 "maximum": 30,
-            }
+            },
+            "preset": {
+                "type": "string",
+                "enum": ["recent_30d", "recent_90d", "complete"],
+            },
         },
         "additionalProperties": False,
     },

--- a/src/codex_usage_tracker/kernel/interfaces/schemas/usage_refresh.json
+++ b/src/codex_usage_tracker/kernel/interfaces/schemas/usage_refresh.json
@@ -1,1 +1,1 @@
-{"additionalProperties":false,"properties":{"wait_seconds":{"maximum":30,"minimum":0,"type":"number"}},"type":"object"}
+{"additionalProperties":false,"properties":{"preset":{"enum":["recent_30d","recent_90d","complete"],"type":"string"},"wait_seconds":{"maximum":30,"minimum":0,"type":"number"}},"type":"object"}

--- a/src/codex_usage_tracker/kernel/operational.py
+++ b/src/codex_usage_tracker/kernel/operational.py
@@ -569,12 +569,19 @@ def load_publication_snapshot(
 
     with _connect(path) as connection:
         connection.execute("BEGIN")
+        version = int(
+            connection.execute("PRAGMA user_version").fetchone()[0]
+        )
         control_row = connection.execute(
             "SELECT * FROM cutover_control WHERE singleton = 1"
         ).fetchone()
-        coverage_row = connection.execute(
-            "SELECT * FROM coverage_control WHERE singleton = 1"
-        ).fetchone()
+        coverage_row = (
+            connection.execute(
+                "SELECT * FROM coverage_control WHERE singleton = 1"
+            ).fetchone()
+            if version >= OPERATIONAL_SCHEMA_VERSION
+            else None
+        )
     if control_row is None:
         raise ValueError("operational sidecar missing cutover control")
     if coverage_row is None:
@@ -1186,16 +1193,6 @@ def _migrate_operational(path: Path) -> None:
                 ),
                 captured_at TEXT NOT NULL,
                 cutoff_at TEXT,
-                coverage_revision TEXT NOT NULL,
-                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-            ) STRICT;
-            CREATE TABLE staged_coverage_control (
-                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-                preset TEXT NOT NULL CHECK (
-                    preset IN ('recent_30d', 'recent_90d', 'complete')
-                ),
-                captured_at TEXT NOT NULL,
-                cutoff_at TEXT,
                 complete_history INTEGER NOT NULL
                     CHECK (complete_history IN (0, 1)),
                 coverage_revision TEXT NOT NULL,
@@ -1213,6 +1210,16 @@ def _migrate_operational(path: Path) -> None:
                     CHECK (deferred_bytes >= 0),
                 uncertain_source_count INTEGER NOT NULL
                     CHECK (uncertain_source_count >= 0),
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            ) STRICT;
+            CREATE TABLE staged_coverage_control (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                preset TEXT NOT NULL CHECK (
+                    preset IN ('recent_30d', 'recent_90d', 'complete')
+                ),
+                captured_at TEXT NOT NULL,
+                cutoff_at TEXT,
+                coverage_revision TEXT NOT NULL,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             ) STRICT;
             UPDATE source_registry

--- a/src/codex_usage_tracker/kernel/operational.py
+++ b/src/codex_usage_tracker/kernel/operational.py
@@ -196,9 +196,7 @@ def initialize_operational_database(path: Path) -> Path:
             connection.execute("PRAGMA foreign_keys = ON")
             connection.execute(f"PRAGMA user_version = {OPERATIONAL_SCHEMA_VERSION}")
             connection.executescript(_OPERATIONAL_SQL)
-            connection.execute(
-                "INSERT INTO cutover_control(singleton, state) VALUES (1, 'absent')"
-            )
+            connection.execute("INSERT INTO cutover_control(singleton, state) VALUES (1, 'absent')")
         staging.chmod(0o600)
         _validate_operational(staging)
         os.replace(staging, target)
@@ -242,9 +240,7 @@ def record_hydration_catalog(
             selection,
             hydrated_generation=hydrated_generation,
         )
-        connection.execute(
-            "DELETE FROM staged_coverage_control WHERE singleton = 1"
-        )
+        connection.execute("DELETE FROM staged_coverage_control WHERE singleton = 1")
     return load_hydration_coverage(path)
 
 
@@ -254,9 +250,7 @@ def stage_hydration_catalog(
 ) -> None:
     """Record build-time source states without changing active coverage."""
 
-    selected_ids = {
-        item.observation.source_id for item in selection.hydrate
-    }
+    selected_ids = {item.observation.source_id for item in selection.hydrate}
     with _connect(path) as connection:
         connection.execute("BEGIN IMMEDIATE")
         connection.execute(
@@ -297,14 +291,10 @@ def stage_hydration_catalog(
             ).fetchone()
             hydrated_generation = (
                 int(prior["hydrated_generation"])
-                if prior is not None
-                and prior["hydrated_generation"] is not None
+                if prior is not None and prior["hydrated_generation"] is not None
                 else None
             )
-            if (
-                prior is not None
-                and str(prior["source_id"]) != observation.source_id
-            ):
+            if prior is not None and str(prior["source_id"]) != observation.source_id:
                 connection.execute(
                     """
                     UPDATE source_registry
@@ -313,11 +303,7 @@ def stage_hydration_catalog(
                     WHERE source_id = ?
                     """,
                     (
-                        (
-                            "hydrating"
-                            if observation.source_id in selected_ids
-                            else "deferred"
-                        ),
+                        ("hydrating" if observation.source_id in selected_ids else "deferred"),
                         str(prior["source_id"]),
                     ),
                 )
@@ -358,11 +344,7 @@ def stage_hydration_catalog(
                 (
                     observation.source_id,
                     str(observation.path),
-                    (
-                        "hydrating"
-                        if observation.source_id in selected_ids
-                        else "deferred"
-                    ),
+                    ("hydrating" if observation.source_id in selected_ids else "deferred"),
                     observation.size_bytes,
                     observation.modified_ns,
                     _timestamp(item.latest_event_at),
@@ -410,9 +392,7 @@ def discard_staged_hydration(path: Path) -> None:
     """Forget an unusable staged selection without changing active coverage."""
 
     with _connect(path) as connection:
-        connection.execute(
-            "DELETE FROM staged_coverage_control WHERE singleton = 1"
-        )
+        connection.execute("DELETE FROM staged_coverage_control WHERE singleton = 1")
 
 
 def _record_hydration_catalog_in_connection(
@@ -421,9 +401,7 @@ def _record_hydration_catalog_in_connection(
     *,
     hydrated_generation: int,
 ) -> None:
-    hydrated_ids = {
-        item.observation.source_id for item in selection.hydrate
-    }
+    hydrated_ids = {item.observation.source_id for item in selection.hydrate}
     catalog = selection.hydrate + selection.deferred
     revision = hydration_selection_revision(selection)
     for item in catalog:
@@ -520,9 +498,7 @@ def _record_hydration_catalog_in_connection(
 def hydration_selection_revision(selection: HydrationSelection) -> str:
     """Return the effective source/preset identity for one coverage selection."""
 
-    hydrated_ids = {
-        item.observation.source_id for item in selection.hydrate
-    }
+    hydrated_ids = {item.observation.source_id for item in selection.hydrate}
     catalog = selection.hydrate + selection.deferred
     payload = {
         "preset": selection.preset.value,
@@ -533,9 +509,7 @@ def hydration_selection_revision(selection: HydrationSelection) -> str:
                 "modified_ns": item.observation.modified_ns,
                 "latest_event_at": _timestamp(item.latest_event_at),
                 "hydration_state": (
-                    "hydrated"
-                    if item.observation.source_id in hydrated_ids
-                    else "deferred"
+                    "hydrated" if item.observation.source_id in hydrated_ids else "deferred"
                 ),
             }
             for item in sorted(
@@ -544,18 +518,19 @@ def hydration_selection_revision(selection: HydrationSelection) -> str:
             )
         ],
     }
-    return "sha256:" + hashlib.sha256(
-        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
-    ).hexdigest()
+    return (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        ).hexdigest()
+    )
 
 
 def load_hydration_coverage(path: Path) -> dict[str, object]:
     """Return the active source-coverage truth without touching facts."""
 
     with _connect(path) as connection:
-        row = connection.execute(
-            "SELECT * FROM coverage_control WHERE singleton = 1"
-        ).fetchone()
+        row = connection.execute("SELECT * FROM coverage_control WHERE singleton = 1").fetchone()
     if row is None:
         return {
             "preset": None,
@@ -585,6 +560,54 @@ def load_hydration_coverage(path: Path) -> dict[str, object]:
         "deferred_bytes": int(row["deferred_bytes"]),
         "uncertain_source_count": int(row["uncertain_source_count"]),
     }
+
+
+def load_publication_snapshot(
+    path: Path,
+) -> tuple[CutoverControl, dict[str, object]]:
+    """Read active publication identity and coverage in one SQLite snapshot."""
+
+    with _connect(path) as connection:
+        connection.execute("BEGIN")
+        control_row = connection.execute(
+            "SELECT * FROM cutover_control WHERE singleton = 1"
+        ).fetchone()
+        coverage_row = connection.execute(
+            "SELECT * FROM coverage_control WHERE singleton = 1"
+        ).fetchone()
+    if control_row is None:
+        raise ValueError("operational sidecar missing cutover control")
+    if coverage_row is None:
+        coverage: dict[str, object] = {
+            "preset": None,
+            "captured_at": None,
+            "cutoff_at": None,
+            "complete_history": False,
+            "coverage_revision": None,
+            "cataloged_source_count": 0,
+            "hydrated_source_count": 0,
+            "deferred_source_count": 0,
+            "cataloged_bytes": 0,
+            "hydrated_bytes": 0,
+            "deferred_bytes": 0,
+            "uncertain_source_count": 0,
+        }
+    else:
+        coverage = {
+            "preset": str(coverage_row["preset"]),
+            "captured_at": str(coverage_row["captured_at"]),
+            "cutoff_at": coverage_row["cutoff_at"],
+            "complete_history": bool(coverage_row["complete_history"]),
+            "coverage_revision": str(coverage_row["coverage_revision"]),
+            "cataloged_source_count": int(coverage_row["cataloged_source_count"]),
+            "hydrated_source_count": int(coverage_row["hydrated_source_count"]),
+            "deferred_source_count": int(coverage_row["deferred_source_count"]),
+            "cataloged_bytes": int(coverage_row["cataloged_bytes"]),
+            "hydrated_bytes": int(coverage_row["hydrated_bytes"]),
+            "deferred_bytes": int(coverage_row["deferred_bytes"]),
+            "uncertain_source_count": int(coverage_row["uncertain_source_count"]),
+        }
+    return _control_from_row(control_row), coverage
 
 
 def hydrated_source_ids(path: Path) -> frozenset[str]:
@@ -655,9 +678,7 @@ def load_cutover_control(path: Path) -> CutoverControl:
     """Load the sole operational activation record."""
 
     with _connect(path) as connection:
-        row = connection.execute(
-            "SELECT * FROM cutover_control WHERE singleton = 1"
-        ).fetchone()
+        row = connection.execute("SELECT * FROM cutover_control WHERE singleton = 1").fetchone()
     if row is None:
         raise ValueError("operational sidecar is missing cutover control")
     return _control_from_row(row)
@@ -695,9 +716,7 @@ def rollback_cutover(path: Path) -> CutoverControl:
 
     with _connect(path) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT * FROM cutover_control WHERE singleton = 1"
-        ).fetchone()
+        row = connection.execute("SELECT * FROM cutover_control WHERE singleton = 1").fetchone()
         if row is None:
             raise ValueError("operational sidecar is missing cutover control")
         current = _control_from_row(row)
@@ -737,9 +756,7 @@ def transition_cutover(
 
     with _connect(path) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT * FROM cutover_control WHERE singleton = 1"
-        ).fetchone()
+        row = connection.execute("SELECT * FROM cutover_control WHERE singleton = 1").fetchone()
         if row is None:
             raise ValueError("operational sidecar is missing cutover control")
         current = _control_from_row(row)
@@ -774,6 +791,7 @@ def promote_cutover(
     generation: int,
     integrity_digest: str,
     hydration_selection: HydrationSelection | None = None,
+    promote_staged_hydration: bool = False,
 ) -> CutoverControl:
     """Validate one generation once and atomically publish its control record."""
 
@@ -784,9 +802,7 @@ def promote_cutover(
     )
     with _connect(path) as connection:
         connection.execute("BEGIN IMMEDIATE")
-        row = connection.execute(
-            "SELECT * FROM cutover_control WHERE singleton = 1"
-        ).fetchone()
+        row = connection.execute("SELECT * FROM cutover_control WHERE singleton = 1").fetchone()
         if row is None:
             raise ValueError("operational sidecar is missing cutover control")
         current = _control_from_row(row)
@@ -818,9 +834,22 @@ def promote_cutover(
                 hydration_selection,
                 hydrated_generation=generation,
             )
-        connection.execute(
-            "DELETE FROM staged_coverage_control WHERE singleton = 1"
-        )
+        elif promote_staged_hydration:
+            staged = connection.execute(
+                "SELECT * FROM staged_coverage_control WHERE singleton = 1"
+            ).fetchone()
+            if staged is None:
+                raise ValueError("staged hydration coverage is unavailable")
+            connection.execute(
+                """
+                UPDATE source_registry
+                SET hydration_state = 'hydrated',
+                    hydrated_generation = ?
+                WHERE hydration_state = 'hydrating'
+                """,
+                (generation,),
+            )
+        connection.execute("DELETE FROM staged_coverage_control WHERE singleton = 1")
         _write_control(connection, active)
     return load_cutover_control(path)
 
@@ -837,9 +866,7 @@ def _validate_transition(
     failure_code: str | None,
 ) -> None:
     if state not in _TRANSITIONS[current.state]:
-        raise ValueError(
-            f"invalid cutover transition: {current.state.value} -> {state.value}"
-        )
+        raise ValueError(f"invalid cutover transition: {current.state.value} -> {state.value}")
     validators = {
         CutoverState.BUILDING: _validate_building,
         CutoverState.FAILED: _validate_failed,
@@ -1116,9 +1143,7 @@ def _validate_operational(path: Path) -> None:
             raise ValueError("operational schema version is invalid")
         tables = {
             row[0]
-            for row in connection.execute(
-                "SELECT name FROM sqlite_schema WHERE type = 'table'"
-            )
+            for row in connection.execute("SELECT name FROM sqlite_schema WHERE type = 'table'")
         }
         if tables != OPERATIONAL_TABLES:
             raise ValueError(f"operational table set is invalid: {sorted(tables)}")
@@ -1161,6 +1186,16 @@ def _migrate_operational(path: Path) -> None:
                 ),
                 captured_at TEXT NOT NULL,
                 cutoff_at TEXT,
+                coverage_revision TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            ) STRICT;
+            CREATE TABLE staged_coverage_control (
+                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                preset TEXT NOT NULL CHECK (
+                    preset IN ('recent_30d', 'recent_90d', 'complete')
+                ),
+                captured_at TEXT NOT NULL,
+                cutoff_at TEXT,
                 complete_history INTEGER NOT NULL
                     CHECK (complete_history IN (0, 1)),
                 coverage_revision TEXT NOT NULL,
@@ -1178,16 +1213,6 @@ def _migrate_operational(path: Path) -> None:
                     CHECK (deferred_bytes >= 0),
                 uncertain_source_count INTEGER NOT NULL
                     CHECK (uncertain_source_count >= 0),
-                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-            ) STRICT;
-            CREATE TABLE staged_coverage_control (
-                singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-                preset TEXT NOT NULL CHECK (
-                    preset IN ('recent_30d', 'recent_90d', 'complete')
-                ),
-                captured_at TEXT NOT NULL,
-                cutoff_at TEXT,
-                coverage_revision TEXT NOT NULL,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             ) STRICT;
             UPDATE source_registry

--- a/src/codex_usage_tracker/kernel/query/catalog.py
+++ b/src/codex_usage_tracker/kernel/query/catalog.py
@@ -67,6 +67,7 @@ _CALL_DIMENSIONS = {
     "agent_role": "threads.subagent_role",
     "event_at": "model_calls.event_at",
     "time_day": "substr(model_calls.event_at, 1, 10)",
+    "time_hour": "substr(model_calls.event_at, 1, 13) || ':00:00Z'",
 }
 _CALL_ROWS = {
     "calls": "1",
@@ -143,6 +144,8 @@ DATASETS: dict[str, DatasetSpec] = {
         stable_id_sql="tool_calls.tool_call_id",
         dimensions={
             "tool": "tool_calls.tool_name",
+            "operation": "tool_calls.operation",
+            "target": "tool_calls.target_label",
             "server": "tool_calls.server_name",
             "namespace": "tool_calls.namespace",
             "category": "tool_calls.tool_category",
@@ -152,6 +155,9 @@ DATASETS: dict[str, DatasetSpec] = {
             "tool_call": "tool_calls.tool_call_id",
             "event_at": "tool_calls.started_at",
             "time_day": "substr(tool_calls.started_at, 1, 10)",
+            "time_hour": (
+                "substr(tool_calls.started_at, 1, 13) || ':00:00Z'"
+            ),
         },
         row_measures={
             "tools": "1",
@@ -165,6 +171,8 @@ DATASETS: dict[str, DatasetSpec] = {
         },
         filter_fields={
             "tool": "tool_calls.tool_name",
+            "operation": "tool_calls.operation",
+            "target": "tool_calls.target_label",
             "server": "tool_calls.server_name",
             "namespace": "tool_calls.namespace",
             "category": "tool_calls.tool_category",
@@ -714,9 +722,9 @@ def _validate_operation_shape(
         raise ValueError("comparison windows require the comparison operation")
     if (
         request.operation is Operation.TIME_SERIES
-        and "time_day" not in request.dimensions
+        and not {"time_day", "time_hour"} & set(request.dimensions)
     ):
-        raise ValueError("time series requires time_day dimension")
+        raise ValueError("time series requires time_day or time_hour dimension")
     if (
         request.operation is Operation.TIMELINE
         and "event_at" not in request.dimensions

--- a/src/codex_usage_tracker/kernel/query/contracts.py
+++ b/src/codex_usage_tracker/kernel/query/contracts.py
@@ -88,6 +88,7 @@ class QueryRequest:
     limit: int = 100
     cursor: str | None = None
     comparison: ComparisonWindow | None = None
+    allow_partial: bool = False
 
     def normalized(self) -> QueryRequest:
         from .catalog import validate_request

--- a/src/codex_usage_tracker/kernel/query/plans.py
+++ b/src/codex_usage_tracker/kernel/query/plans.py
@@ -31,6 +31,41 @@ def compile_plan(
     generation: int,
     offset: int,
 ) -> CompiledPlan:
+    rollup = _compile_thread_rollup(
+        request,
+        generation=generation,
+        offset=offset,
+    )
+    if rollup is not None:
+        return rollup
+    rollup = _compile_model_effort_rollup(
+        request,
+        generation=generation,
+        offset=offset,
+    )
+    if rollup is not None:
+        return rollup
+    rollup = _compile_time_rollup(
+        request,
+        generation=generation,
+        offset=offset,
+    )
+    if rollup is not None:
+        return rollup
+    rollup = _compile_tool_operation_rollup(
+        request,
+        generation=generation,
+        offset=offset,
+    )
+    if rollup is not None:
+        return rollup
+    rollup = _compile_global_rollup(
+        request,
+        generation=generation,
+        offset=offset,
+    )
+    if rollup is not None:
+        return rollup
     spec = DATASETS[request.dataset]
     if request.operation is Operation.COMPARISON:
         return _compile_comparison(
@@ -43,9 +78,7 @@ def compile_plan(
     predicates = [spec.generation_sql, *where_sql]
     predicate_sql = " AND ".join(f"({item})" for item in predicates)
     base_parameters = (generation,) * spec.base_generation_parameters
-    generation_parameters = (
-        () if spec.base_generation_parameters else (generation,)
-    )
+    generation_parameters = () if spec.base_generation_parameters else (generation,)
     parameters = (*base_parameters, *generation_parameters, *filter_parameters)
     base_query = _base_query(request, spec, predicate_sql)
     order_sql = _order_sql(request, spec)
@@ -68,6 +101,312 @@ def compile_plan(
     )
 
 
+def _compile_thread_rollup(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+) -> CompiledPlan | None:
+    operation = Operation(request.operation)
+    if (
+        request.dataset != "calls"
+        or operation not in {Operation.AGGREGATE, Operation.SHARE}
+        or request.dimensions != ("thread",)
+        or request.filters
+        or request.comparison is not None
+    ):
+        return None
+    expressions = {
+        "calls": "rollup.calls",
+        "input_tokens": "rollup.input_tokens",
+        "uncached_input_tokens": ("rollup.input_tokens - rollup.cached_input_tokens"),
+        "cached_input_tokens": "rollup.cached_input_tokens",
+        "output_tokens": "rollup.output_tokens",
+        "reasoning_tokens": "rollup.reasoning_tokens",
+        "total_tokens": "rollup.input_tokens + rollup.output_tokens",
+    }
+    if any(measure not in expressions for measure in request.measures):
+        return None
+    selected = [
+        "threads.logical_thread_id AS thread",
+        *(f"{expressions[measure]} AS {measure}" for measure in request.measures),
+        "COUNT(*) OVER () AS __matched_count",
+        "COUNT(*) OVER () AS __scanned_count",
+    ]
+    base_query = (
+        f"SELECT {', '.join(selected)} "
+        "FROM rollup_thread AS rollup "
+        "JOIN threads USING (thread_key) "
+        "WHERE rollup.generation = ?"
+    )
+    if operation is Operation.SHARE:
+        share_columns = ", ".join(
+            f"CASE WHEN SUM({measure}) OVER () = 0 THEN 0.0 "
+            f"ELSE 1.0 * {measure} / SUM({measure}) OVER () END "
+            f"AS share_{measure}"
+            for measure in request.measures
+        )
+        base_query = f"SELECT grouped.*, {share_columns} FROM ({base_query}) AS grouped"
+    order_name = request.order_by or (request.measures[0] if request.measures else "thread")
+    direction = "DESC" if request.descending else "ASC"
+    sql = f"{base_query} ORDER BY {order_name} {direction}, thread ASC LIMIT ? OFFSET ?"
+    count_sql = "SELECT COUNT(*) FROM rollup_thread WHERE generation = ?"
+    return CompiledPlan(
+        plan_id=f"calls.{operation.value}.rollup_thread.v{PLAN_VERSION}",
+        sql=sql,
+        count_sql=count_sql,
+        scan_sql=count_sql,
+        coverage_sql=None,
+        parameters=(generation, request.limit + 1, offset),
+        count_parameters=(generation,),
+        scan_parameters=(generation,),
+        coverage_parameters=(),
+        offset=offset,
+    )
+
+
+def _compile_model_effort_rollup(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+) -> CompiledPlan | None:
+    operation = Operation(request.operation)
+    allowed_dimensions = {"model", "effort", "service_tier"}
+    if (
+        request.dataset != "calls"
+        or operation not in {Operation.AGGREGATE, Operation.SHARE}
+        or not request.dimensions
+        or not set(request.dimensions) <= allowed_dimensions
+        or request.filters
+        or request.comparison is not None
+    ):
+        return None
+    dimensions = {
+        "model": "rollup.model",
+        "effort": "NULLIF(rollup.effort, '')",
+        "service_tier": "NULLIF(rollup.service_tier, '')",
+    }
+    return _token_rollup_plan(
+        request,
+        generation=generation,
+        offset=offset,
+        table="rollup_model_effort",
+        plan_name="rollup_model_effort",
+        dimensions=dimensions,
+        group_rows=True,
+    )
+
+
+def _compile_global_rollup(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+) -> CompiledPlan | None:
+    if (
+        request.dataset != "calls"
+        or Operation(request.operation) is not Operation.AGGREGATE
+        or request.dimensions
+        or request.filters
+        or request.comparison is not None
+    ):
+        return None
+    return _token_rollup_plan(
+        request,
+        generation=generation,
+        offset=offset,
+        table="rollup_global",
+        plan_name="rollup_global",
+        dimensions={},
+    )
+
+
+def _compile_time_rollup(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+) -> CompiledPlan | None:
+    if (
+        request.dataset != "calls"
+        or Operation(request.operation) is not Operation.TIME_SERIES
+        or request.dimensions not in {("time_day",), ("time_hour",)}
+        or request.filters
+        or request.comparison is not None
+    ):
+        return None
+    dimension = request.dimensions[0]
+    band_kind = "day" if dimension == "time_day" else "hour"
+    return _token_rollup_plan(
+        request,
+        generation=generation,
+        offset=offset,
+        table="rollup_time_band",
+        plan_name="rollup_time_band",
+        dimensions={dimension: "rollup.band_start"},
+        predicate_sql="rollup.band_kind = ?",
+        predicate_parameters=(band_kind,),
+    )
+
+
+def _compile_tool_operation_rollup(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+) -> CompiledPlan | None:
+    if (
+        request.dataset != "tools"
+        or Operation(request.operation) is not Operation.AGGREGATE
+        or not request.dimensions
+        or not set(request.dimensions) <= {"operation", "target"}
+        or request.filters
+        or request.comparison is not None
+    ):
+        return None
+    measures = {"tools": "rollup.calls"}
+    if any(measure not in measures for measure in request.measures):
+        return None
+    dimensions = {
+        "operation": "rollup.operation",
+        "target": "NULLIF(rollup.target_label, '')",
+    }
+    group_by = ", ".join(dimensions[dimension] for dimension in request.dimensions)
+    selected = [
+        *(f"{dimensions[dimension]} AS {dimension}" for dimension in request.dimensions),
+        *(f"SUM({measures[measure]}) AS {measure}" for measure in request.measures),
+        "COUNT(*) OVER () AS __matched_count",
+        "COUNT(*) OVER () AS __scanned_count",
+    ]
+    base_query = (
+        f"SELECT {', '.join(selected)} "
+        "FROM rollup_tool_operation AS rollup "
+        f"WHERE rollup.generation = ? GROUP BY {group_by}"
+    )
+    order_name = request.order_by or (
+        request.measures[0] if request.measures else request.dimensions[0]
+    )
+    direction = "DESC" if request.descending else "ASC"
+    tie_breakers = ", ".join(f"{dimension} ASC" for dimension in request.dimensions)
+    sql = f"{base_query} ORDER BY {order_name} {direction}, {tie_breakers} LIMIT ? OFFSET ?"
+    count_sql = (
+        "SELECT COUNT(*) FROM ("
+        "SELECT 1 FROM rollup_tool_operation AS rollup "
+        f"WHERE rollup.generation = ? GROUP BY {group_by}"
+        ") AS grouped"
+    )
+    return CompiledPlan(
+        plan_id=f"tools.aggregate.rollup_tool_operation.v{PLAN_VERSION}",
+        sql=sql,
+        count_sql=count_sql,
+        scan_sql=count_sql,
+        coverage_sql=None,
+        parameters=(generation, request.limit + 1, offset),
+        count_parameters=(generation,),
+        scan_parameters=(generation,),
+        coverage_parameters=(),
+        offset=offset,
+    )
+
+
+def _token_rollup_plan(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+    table: str,
+    plan_name: str,
+    dimensions: dict[str, str],
+    predicate_sql: str | None = None,
+    predicate_parameters: tuple[Any, ...] = (),
+    group_rows: bool = False,
+) -> CompiledPlan | None:
+    measures = {
+        "calls": "rollup.calls",
+        "input_tokens": "rollup.input_tokens",
+        "uncached_input_tokens": ("rollup.input_tokens - rollup.cached_input_tokens"),
+        "cached_input_tokens": "rollup.cached_input_tokens",
+        "output_tokens": "rollup.output_tokens",
+        "reasoning_tokens": "rollup.reasoning_tokens",
+        "total_tokens": "rollup.input_tokens + rollup.output_tokens",
+    }
+    if any(measure not in measures for measure in request.measures):
+        return None
+    selected_dimensions = [
+        *(f"{dimensions[dimension]} AS {dimension}" for dimension in request.dimensions),
+    ]
+    selected_measures = [
+        (
+            f"SUM({measures[measure]}) AS {measure}"
+            if group_rows
+            else f"{measures[measure]} AS {measure}"
+        )
+        for measure in request.measures
+    ]
+    selected = [
+        *selected_dimensions,
+        *selected_measures,
+        "COUNT(*) OVER () AS __matched_count",
+        "COUNT(*) OVER () AS __scanned_count",
+    ]
+    predicates = "rollup.generation = ?"
+    if predicate_sql is not None:
+        predicates = f"{predicates} AND ({predicate_sql})"
+    group_sql = (
+        " GROUP BY " + ", ".join(dimensions[dimension] for dimension in request.dimensions)
+        if group_rows
+        else ""
+    )
+    base_query = (
+        f"SELECT {', '.join(selected)} FROM {table} AS rollup WHERE {predicates}{group_sql}"
+    )
+    operation = Operation(request.operation)
+    if operation is Operation.SHARE:
+        share_columns = ", ".join(
+            f"CASE WHEN SUM({measure}) OVER () = 0 THEN 0.0 "
+            f"ELSE 1.0 * {measure} / SUM({measure}) OVER () END "
+            f"AS share_{measure}"
+            for measure in request.measures
+        )
+        base_query = f"SELECT grouped.*, {share_columns} FROM ({base_query}) AS grouped"
+    order_name = request.order_by or (
+        request.measures[0]
+        if request.measures
+        else request.dimensions[0]
+        if request.dimensions
+        else "__matched_count"
+    )
+    direction = "DESC" if request.descending else "ASC"
+    tie_breakers = ", ".join(f"{dimension} ASC" for dimension in request.dimensions)
+    ordering = f"{order_name} {direction}"
+    if tie_breakers:
+        ordering = f"{ordering}, {tie_breakers}"
+    sql = f"{base_query} ORDER BY {ordering} LIMIT ? OFFSET ?"
+    if group_rows:
+        count_sql = (
+            "SELECT COUNT(*) FROM ("
+            f"SELECT 1 FROM {table} AS rollup "
+            f"WHERE {predicates}{group_sql}"
+            ") AS grouped"
+        )
+    else:
+        count_sql = f"SELECT COUNT(*) FROM {table} AS rollup WHERE {predicates}"
+    base_parameters = (generation, *predicate_parameters)
+    return CompiledPlan(
+        plan_id=(f"calls.{operation.value}.{plan_name}.v{PLAN_VERSION}"),
+        sql=sql,
+        count_sql=count_sql,
+        scan_sql=count_sql,
+        coverage_sql=None,
+        parameters=(*base_parameters, request.limit + 1, offset),
+        count_parameters=base_parameters,
+        scan_parameters=base_parameters,
+        coverage_parameters=(),
+        offset=offset,
+    )
+
+
 def _base_query(
     request: QueryRequest,
     spec: DatasetSpec,
@@ -79,15 +418,9 @@ def _base_query(
         Operation.DISTRIBUTION,
         Operation.TIME_SERIES,
     }
-    dimensions = [
-        f"{spec.dimensions[name]} AS {name}" for name in request.dimensions
-    ]
-    measures_catalog = (
-        spec.aggregate_measures if aggregate else spec.row_measures
-    )
-    measures = [
-        f"{measures_catalog[name]} AS {name}" for name in request.measures
-    ]
+    dimensions = [f"{spec.dimensions[name]} AS {name}" for name in request.dimensions]
+    measures_catalog = spec.aggregate_measures if aggregate else spec.row_measures
+    measures = [f"{measures_catalog[name]} AS {name}" for name in request.measures]
     selected = dimensions + measures
     if not selected:
         selected = [f"{spec.stable_id_sql} AS record_id"]
@@ -111,8 +444,7 @@ def _base_query(
         else ""
     )
     base_query = (
-        f"SELECT {', '.join(selected)} FROM {spec.base_sql} "
-        f"WHERE {predicate_sql}{group_sql}"
+        f"SELECT {', '.join(selected)} FROM {spec.base_sql} WHERE {predicate_sql}{group_sql}"
     )
     if request.operation is Operation.SHARE:
         share_columns = ", ".join(
@@ -128,11 +460,7 @@ def _order_sql(request: QueryRequest, spec: DatasetSpec) -> str:
     operation = Operation(request.operation)
     order_name = request.order_by or _default_order(request, operation)
     direction = "DESC" if request.descending else "ASC"
-    tie_breakers = [
-        name
-        for name in (*request.dimensions, *request.measures)
-        if name != order_name
-    ]
+    tie_breakers = [name for name in (*request.dimensions, *request.measures) if name != order_name]
     ordering = [
         f"{order_name} {direction}",
         *(f"{name} ASC" for name in tie_breakers),
@@ -174,16 +502,10 @@ def _coverage_sql(
                     f"SUM(CASE WHEN {expression} IS NOT NULL THEN 1 ELSE 0 END) "
                     f"AS observed_{measure}"
                 ),
-                (
-                    f"SUM(CASE WHEN {expression} IS NULL THEN 1 ELSE 0 END) "
-                    f"AS missing_{measure}"
-                ),
+                (f"SUM(CASE WHEN {expression} IS NULL THEN 1 ELSE 0 END) AS missing_{measure}"),
             )
         )
-    return (
-        f"SELECT {', '.join(selected)} FROM {spec.base_sql} "
-        f"WHERE {predicate_sql}"
-    )
+    return f"SELECT {', '.join(selected)} FROM {spec.base_sql} WHERE {predicate_sql}"
 
 
 def _compile_comparison(
@@ -213,12 +535,8 @@ def _compile_comparison(
         comparison.previous_start,
         comparison.previous_end,
     )
-    dimensions = [
-        f"{spec.dimensions[name]} AS {name}" for name in request.dimensions
-    ]
-    row_measures = [
-        f"{spec.row_measures[name]} AS {name}" for name in request.measures
-    ]
+    dimensions = [f"{spec.dimensions[name]} AS {name}" for name in request.dimensions]
+    row_measures = [f"{spec.row_measures[name]} AS {name}" for name in request.measures]
     scoped = (
         f"SELECT {', '.join([*dimensions, *row_measures])}, "
         f"CASE WHEN julianday({spec.time_sql}) >= julianday(?) "
@@ -234,9 +552,7 @@ def _compile_comparison(
     selected = list(request.dimensions)
     for measure in request.measures:
         current = f"SUM(CASE WHEN comparison_period = 'current' THEN {measure} ELSE 0 END)"
-        previous = (
-            f"SUM(CASE WHEN comparison_period = 'previous' THEN {measure} ELSE 0 END)"
-        )
+        previous = f"SUM(CASE WHEN comparison_period = 'previous' THEN {measure} ELSE 0 END)"
         selected.extend(
             (
                 f"{current} AS current_{measure}",
@@ -255,33 +571,19 @@ def _compile_comparison(
             "SUM(COUNT(*)) OVER () AS __scanned_count",
         )
     )
-    group_sql = (
-        " GROUP BY " + ", ".join(request.dimensions)
-        if request.dimensions
-        else ""
-    )
-    base_query = (
-        f"WITH scoped AS ({scoped}) "
-        f"SELECT {', '.join(selected)} FROM scoped{group_sql}"
-    )
+    group_sql = " GROUP BY " + ", ".join(request.dimensions) if request.dimensions else ""
+    base_query = f"WITH scoped AS ({scoped}) SELECT {', '.join(selected)} FROM scoped{group_sql}"
     order_name = (
-        f"current_{request.order_by}"
-        if request.order_by in request.measures
-        else request.order_by
+        f"current_{request.order_by}" if request.order_by in request.measures else request.order_by
     ) or f"current_{request.measures[0]}"
     direction = "DESC" if request.descending else "ASC"
-    tie_breakers = ", ".join(
-        f"{dimension} ASC" for dimension in request.dimensions
-    )
+    tie_breakers = ", ".join(f"{dimension} ASC" for dimension in request.dimensions)
     order_sql = f"{order_name} {direction}"
     if tie_breakers:
         order_sql = f"{order_sql}, {tie_breakers}"
     sql = f"{base_query} ORDER BY {order_sql} LIMIT ? OFFSET ?"
     count_sql = f"SELECT COUNT(*) FROM ({base_query}) AS matched"
-    scan_sql = (
-        f"SELECT COUNT(*) FROM {spec.base_sql} "
-        f"WHERE {predicate_sql}"
-    )
+    scan_sql = f"SELECT COUNT(*) FROM {spec.base_sql} WHERE {predicate_sql}"
     return CompiledPlan(
         plan_id=f"{request.dataset}.comparison.v{PLAN_VERSION}",
         sql=sql,
@@ -318,14 +620,9 @@ def _filters(
         if item.operator == "in":
             values = item.value
             assert isinstance(values, tuple)
-            sql.append(
-                f"{expression} IN "
-                f"({', '.join(parameter_sql for _ in values)})"
-            )
+            sql.append(f"{expression} IN ({', '.join(parameter_sql for _ in values)})")
             parameters.extend(values)
         else:
-            sql.append(
-                f"{expression} {operators[item.operator]} {parameter_sql}"
-            )
+            sql.append(f"{expression} {operators[item.operator]} {parameter_sql}")
             parameters.append(item.value)
     return sql, tuple(parameters)

--- a/src/codex_usage_tracker/kernel/query/service.py
+++ b/src/codex_usage_tracker/kernel/query/service.py
@@ -14,7 +14,8 @@ from typing import Any
 
 from ..content import open_content_snapshot
 from ..database import open_read_snapshot
-from ..operational import load_cutover_control
+from ..models import CutoverControl
+from ..operational import load_publication_snapshot
 from .contracts import (
     MAX_BATCH_QUERIES,
     MAX_CURSOR_OFFSET,
@@ -34,9 +35,11 @@ class QueryService:
         operational_path: Path,
         *,
         content_path: Path | None = None,
+        publication: tuple[CutoverControl, dict[str, object]] | None = None,
     ) -> None:
         self._operational_path = operational_path.resolve()
         self._content_path = content_path.resolve() if content_path else None
+        self._publication = publication
 
     def execute(self, request: QueryRequest) -> QueryResult:
         return self.execute_batch((request,))[0]
@@ -48,11 +51,25 @@ class QueryService:
         if not 1 <= len(requests) <= MAX_BATCH_QUERIES:
             raise ValueError(f"query batch must contain 1 to {MAX_BATCH_QUERIES} items")
         normalized = tuple(request.normalized() for request in requests)
-        control = load_cutover_control(self._operational_path)
+        control, history_coverage = (
+            self._publication
+            if self._publication is not None
+            else load_publication_snapshot(self._operational_path)
+        )
         path = control.active_kernel_path
         generation = control.active_generation
         if path is None or generation is None:
             raise ValueError("no active analytical generation")
+        for request in normalized:
+            if (
+                not bool(history_coverage["complete_history"])
+                and _requires_partial_opt_in(request, history_coverage)
+                and not request.allow_partial
+            ):
+                raise ValueError(
+                    "all-history query requires complete coverage; "
+                    "set allow_partial=true to query the hydrated subset"
+                )
         with ExitStack() as stack:
             analytical = stack.enter_context(open_read_snapshot(path))
             analytical.execute("PRAGMA query_only = ON")
@@ -62,21 +79,20 @@ class QueryService:
                 and self._content_path is not None
                 else None
             )
-            if any(request.dataset == "context" for request in normalized) and (
-                content is None
-            ):
+            if any(request.dataset == "context" for request in normalized) and (content is None):
                 raise ValueError("context composition database is not configured")
             results: list[QueryResult] = []
             for request in normalized:
-                connection = (
-                    content if request.dataset == "context" else analytical
-                )
+                connection = content if request.dataset == "context" else analytical
                 if connection is None:
-                    raise ValueError(
-                        "context composition database is not configured"
-                    )
+                    raise ValueError("context composition database is not configured")
                 results.append(
-                    self._execute_one(connection, request, generation)
+                    self._execute_one(
+                        connection,
+                        request,
+                        generation,
+                        history_coverage=history_coverage,
+                    )
                 )
             return tuple(results)
 
@@ -85,6 +101,8 @@ class QueryService:
         connection: sqlite3.Connection,
         request: QueryRequest,
         generation: int,
+        *,
+        history_coverage: dict[str, object],
     ) -> QueryResult:
         started = time.perf_counter()
         request_hash = _request_hash(request)
@@ -101,9 +119,7 @@ class QueryService:
                 request,
                 offset,
             )
-            plan_id = (
-                f"phases.{Operation(request.operation).value}.v{PLAN_VERSION}"
-            )
+            plan_id = f"phases.{Operation(request.operation).value}.v{PLAN_VERSION}"
             coverage_counts: dict[str, int] = {}
         else:
             plan = compile_plan(request, generation=generation, offset=offset)
@@ -138,11 +154,7 @@ class QueryService:
                 else {}
             )
             rows = [
-                {
-                    key: value
-                    for key, value in dict(row).items()
-                    if not key.startswith("__")
-                }
+                {key: value for key, value in dict(row).items() if not key.startswith("__")}
                 for row in raw_rows
             ]
             plan_id = plan.plan_id
@@ -164,10 +176,9 @@ class QueryService:
             scanned=scanned,
             matched=matched,
             counts=coverage_counts,
+            history_coverage=history_coverage,
             content_metadata=(
-                _content_metadata(connection)
-                if request.dataset == "context"
-                else None
+                _content_metadata(connection) if request.dataset == "context" else None
             ),
         )
         return QueryResult(
@@ -455,6 +466,7 @@ def _result_coverage(
     scanned: int,
     matched: int,
     counts: dict[str, int],
+    history_coverage: dict[str, object],
     content_metadata: dict[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     total = matched if request.dataset == "phases" else scanned
@@ -468,39 +480,36 @@ def _result_coverage(
             "basis": _measure_basis(request.dataset, measure),
             "observed_count": observed,
             "missing_count": missing,
-            "coverage_percent": (
-                100.0 if total == 0 else 100.0 * observed / total
-            ),
+            "coverage_percent": (100.0 if total == 0 else 100.0 * observed / total),
             "limitations": _measure_limitations(request.dataset, measure),
         }
         if request.dataset == "context" and measure == "estimated_tokens":
             measures[measure]["estimator"] = (
-                content_metadata.get("estimator")
-                if content_metadata is not None
-                else None
+                content_metadata.get("estimator") if content_metadata is not None else None
             )
     grade = (
         "deterministic"
         if request.dataset == "phases"
         else "estimated"
-        if request.dataset == "context"
-        and "estimated_tokens" in request.measures
+        if request.dataset == "context" and "estimated_tokens" in request.measures
         else "exact"
     )
+    if not bool(history_coverage["complete_history"]) and _requires_partial_opt_in(
+        request, history_coverage
+    ):
+        grade = "partial"
     coverage: dict[str, Any] = {
         "generation_bound": True,
         "canonical_calls_only": request.dataset == "calls",
         "raw_content": False,
-        "phase_attribution": (
-            "deterministic" if request.dataset == "phases" else None
-        ),
+        "phase_attribution": ("deterministic" if request.dataset == "phases" else None),
         "measures": measures,
+        "history_complete": bool(history_coverage["complete_history"]),
+        "coverage_revision": history_coverage["coverage_revision"],
     }
     if request.dataset == "context":
         source_generation = (
-            content_metadata.get("indexed_generation")
-            if content_metadata is not None
-            else None
+            content_metadata.get("indexed_generation") if content_metadata is not None else None
         )
         coverage.update(
             {
@@ -512,14 +521,11 @@ def _result_coverage(
                     else None
                 ),
                 "generation_lag": (
-                    generation - source_generation
-                    if isinstance(source_generation, int)
-                    else None
+                    generation - source_generation if isinstance(source_generation, int) else None
                 ),
                 "unattributed_input_tokens": None,
                 "unattributed_limitation": (
-                    "billed input tokens cannot be safely attributed to "
-                    "observed categories"
+                    "billed input tokens cannot be safely attributed to observed categories"
                 ),
             }
         )
@@ -566,17 +572,14 @@ def _measure_basis(dataset: str, measure: str) -> str:
 def _measure_limitations(dataset: str, measure: str) -> list[str]:
     limitations: list[str] = []
     if dataset == "context" and measure == "observed_bytes":
-        limitations.append(
-            "observed payload bytes are not exact billed input tokens"
-        )
+        limitations.append("observed payload bytes are not exact billed input tokens")
     if dataset == "context" and measure == "estimated_tokens":
         limitations.append(
             "category tokens are estimates only when an explicit tokenizer is configured"
         )
     if measure == "reasoning_tokens":
         limitations.append(
-            "reasoning tokens are reported separately; overlap with output "
-            "tokens is not inferred"
+            "reasoning tokens are reported separately; overlap with output tokens is not inferred"
         )
     if dataset == "phases" and measure != "activities":
         limitations.append(
@@ -609,15 +612,11 @@ def _content_metadata(connection: sqlite3.Connection) -> dict[str, Any]:
         WHERE singleton = 1
         """
     ).fetchone()
-    observed = connection.execute(
-        "SELECT MAX(event_at) FROM composition_events"
-    ).fetchone()
+    observed = connection.execute("SELECT MAX(event_at) FROM composition_events").fetchone()
     return {
         "indexed_generation": settings[0] if settings is not None else None,
         "estimator": (
-            str(settings[1])
-            if settings is not None and settings[1] is not None
-            else None
+            str(settings[1]) if settings is not None and settings[1] is not None else None
         ),
         "observed_through": observed[0] if observed is not None else None,
     }
@@ -652,15 +651,10 @@ def _phase_scope(
         if item.operator == "in":
             values = item.value
             assert isinstance(values, tuple)
-            clauses.append(
-                f"{expression} IN "
-                f"({', '.join(parameter_sql for _ in values)})"
-            )
+            clauses.append(f"{expression} IN ({', '.join(parameter_sql for _ in values)})")
             parameters.extend(values)
         else:
-            clauses.append(
-                f"{expression} {operators[item.operator]} {parameter_sql}"
-            )
+            clauses.append(f"{expression} {operators[item.operator]} {parameter_sql}")
             parameters.append(item.value)
     return " AND ".join(f"({clause})" for clause in clauses), tuple(parameters)
 
@@ -671,12 +665,11 @@ def _request_hash(request: QueryRequest) -> str:
         "operation": Operation(request.operation).value,
         "dimensions": request.dimensions,
         "measures": request.measures,
-        "filters": [
-            (item.field, item.operator, item.value) for item in request.filters
-        ],
+        "filters": [(item.field, item.operator, item.value) for item in request.filters],
         "order_by": request.order_by,
         "descending": request.descending,
         "limit": request.limit,
+        "allow_partial": request.allow_partial,
         "comparison": (
             (
                 request.comparison.current_start,
@@ -694,6 +687,31 @@ def _request_hash(request: QueryRequest) -> str:
         separators=(",", ":"),
     ).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _requires_partial_opt_in(
+    request: QueryRequest,
+    history_coverage: dict[str, object],
+) -> bool:
+    cutoff = history_coverage.get("cutoff_at")
+    if not isinstance(cutoff, str):
+        return True
+    if request.comparison is not None:
+        return (
+            min(
+                request.comparison.current_start,
+                request.comparison.previous_start,
+            )
+            < cutoff
+        )
+    lower_bounds = [
+        item.value
+        for item in request.filters
+        if item.operator in {"gte", "gt"}
+        and item.field in {"event_at", "observed_at", "started_at", "time_day", "time_hour"}
+        and isinstance(item.value, str)
+    ]
+    return not lower_bounds or min(lower_bounds) < cutoff
 
 
 def _encode_cursor(*, generation: int, request_hash: str, offset: int) -> str:

--- a/src/codex_usage_tracker/kernel/rollups.py
+++ b/src/codex_usage_tracker/kernel/rollups.py
@@ -1,0 +1,342 @@
+"""Generation-scoped persisted rollups for bounded common reads."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from .database import open_read_snapshot, short_writer_transaction
+
+
+def generation_rollups_ready(path: Path, generation: int) -> bool:
+    """Return whether the atomic rollup marker exists for one generation."""
+
+    if generation < 1 or not path.is_file():
+        return False
+    with open_read_snapshot(path) as connection:
+        return (
+            connection.execute(
+                "SELECT 1 FROM rollup_global WHERE generation = ?",
+                (generation,),
+            ).fetchone()
+            is not None
+        )
+
+
+def rebuild_generation_rollups(
+    path: Path,
+    generation: int,
+    *,
+    incremental_from: int | None = None,
+) -> float:
+    """Replace one unpublished generation's deterministic metadata rollups."""
+
+    started = time.perf_counter()
+    with short_writer_transaction(path) as connection:
+        for table in (
+            "rollup_global",
+            "rollup_thread",
+            "rollup_model_effort",
+            "rollup_time_band",
+            "rollup_tool_operation",
+        ):
+            connection.execute(
+                f"DELETE FROM {table} WHERE generation = ?",
+                (generation,),
+            )
+        if incremental_from is not None:
+            marker = connection.execute(
+                "SELECT 1 FROM rollup_global WHERE generation = ?",
+                (incremental_from,),
+            ).fetchone()
+            if marker is None:
+                raise ValueError("incremental rollup seed is unavailable")
+            _seed_generation_rollups(
+                connection,
+                generation=generation,
+                prior_generation=incremental_from,
+            )
+            _apply_generation_delta(connection, generation=generation)
+            return (time.perf_counter() - started) * 1_000
+        connection.execute(
+            """
+            INSERT INTO rollup_global(
+                generation, calls, input_tokens, cached_input_tokens,
+                output_tokens, reasoning_tokens
+            )
+            SELECT ?, COUNT(*), COALESCE(SUM(input_tokens), 0),
+                   COALESCE(SUM(cached_input_tokens), 0),
+                   COALESCE(SUM(output_tokens), 0),
+                   COALESCE(SUM(reasoning_tokens), 0)
+            FROM model_call_facts
+            WHERE generation <= ? AND duplicate_state = 'canonical'
+            """,
+            (generation, generation),
+        )
+        connection.execute(
+            """
+            INSERT INTO rollup_thread(
+                generation, thread_key, calls, input_tokens,
+                cached_input_tokens, output_tokens, reasoning_tokens
+            )
+            SELECT ?, thread_key, COUNT(*), SUM(input_tokens),
+                   SUM(cached_input_tokens), SUM(output_tokens),
+                   SUM(reasoning_tokens)
+            FROM model_call_facts
+            WHERE generation <= ? AND duplicate_state = 'canonical'
+            GROUP BY thread_key
+            """,
+            (generation, generation),
+        )
+        connection.execute(
+            """
+            INSERT INTO rollup_model_effort(
+                generation, model, effort, service_tier, calls,
+                input_tokens, cached_input_tokens, output_tokens,
+                reasoning_tokens
+            )
+            SELECT ?, profiles.model, profiles.effort_key,
+                   profiles.service_tier_key, COUNT(*), SUM(facts.input_tokens),
+                   SUM(facts.cached_input_tokens), SUM(facts.output_tokens),
+                   SUM(facts.reasoning_tokens)
+            FROM model_call_facts AS facts
+            JOIN model_profiles AS profiles USING (model_profile_key)
+            WHERE facts.generation <= ?
+              AND facts.duplicate_state = 'canonical'
+            GROUP BY profiles.model, profiles.effort_key,
+                     profiles.service_tier_key
+            """,
+            (generation, generation),
+        )
+        connection.execute(
+            """
+            INSERT INTO rollup_time_band(
+                generation, band_kind, band_start, calls, input_tokens,
+                cached_input_tokens, output_tokens, reasoning_tokens
+            )
+            SELECT ?, bands.band_kind, bands.band_start, COUNT(*),
+                   SUM(bands.input_tokens), SUM(bands.cached_input_tokens),
+                   SUM(bands.output_tokens), SUM(bands.reasoning_tokens)
+            FROM (
+                SELECT 'day' AS band_kind, substr(event_at, 1, 10) AS band_start,
+                       input_tokens, cached_input_tokens, output_tokens,
+                       reasoning_tokens
+                FROM model_call_facts
+                WHERE generation <= ? AND duplicate_state = 'canonical'
+                UNION ALL
+                SELECT 'hour', substr(event_at, 1, 13) || ':00:00Z',
+                       input_tokens, cached_input_tokens, output_tokens,
+                       reasoning_tokens
+                FROM model_call_facts
+                WHERE generation <= ? AND duplicate_state = 'canonical'
+            ) AS bands
+            GROUP BY bands.band_kind, bands.band_start
+            """,
+            (generation, generation, generation),
+        )
+        connection.execute(
+            """
+            INSERT INTO rollup_tool_operation(
+                generation, operation, target_label, calls,
+                duration_ms, output_bytes
+            )
+            SELECT ?, profiles.operation, COALESCE(facts.target_label, ''),
+                   COUNT(*), COALESCE(SUM(facts.duration_ms), 0.0),
+                   COALESCE(SUM(facts.output_bytes), 0)
+            FROM tool_call_facts AS facts
+            JOIN tool_profiles AS profiles USING (tool_profile_key)
+            WHERE facts.generation <= ?
+            GROUP BY profiles.operation, COALESCE(facts.target_label, '')
+            """,
+            (generation, generation),
+        )
+    return (time.perf_counter() - started) * 1_000
+
+
+def _seed_generation_rollups(
+    connection: sqlite3.Connection,
+    *,
+    generation: int,
+    prior_generation: int,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO rollup_global
+        SELECT ?, calls, input_tokens, cached_input_tokens,
+               output_tokens, reasoning_tokens
+        FROM rollup_global
+        WHERE generation = ?
+        """,
+        (generation, prior_generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_thread
+        SELECT ?, thread_key, calls, input_tokens, cached_input_tokens,
+               output_tokens, reasoning_tokens
+        FROM rollup_thread
+        WHERE generation = ?
+        """,
+        (generation, prior_generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_model_effort
+        SELECT ?, model, effort, service_tier, calls, input_tokens,
+               cached_input_tokens, output_tokens, reasoning_tokens
+        FROM rollup_model_effort
+        WHERE generation = ?
+        """,
+        (generation, prior_generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_time_band
+        SELECT ?, band_kind, band_start, calls, input_tokens,
+               cached_input_tokens, output_tokens, reasoning_tokens
+        FROM rollup_time_band
+        WHERE generation = ?
+        """,
+        (generation, prior_generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_tool_operation
+        SELECT ?, operation, target_label, calls, duration_ms, output_bytes
+        FROM rollup_tool_operation
+        WHERE generation = ?
+        """,
+        (generation, prior_generation),
+    )
+
+
+def _apply_generation_delta(
+    connection: sqlite3.Connection,
+    *,
+    generation: int,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO rollup_global(
+            generation, calls, input_tokens, cached_input_tokens,
+            output_tokens, reasoning_tokens
+        )
+        SELECT ?, COUNT(*), COALESCE(SUM(input_tokens), 0),
+               COALESCE(SUM(cached_input_tokens), 0),
+               COALESCE(SUM(output_tokens), 0),
+               COALESCE(SUM(reasoning_tokens), 0)
+        FROM model_call_facts
+        WHERE generation = ? AND duplicate_state = 'canonical'
+        ON CONFLICT(generation) DO UPDATE SET
+            calls = calls + excluded.calls,
+            input_tokens = input_tokens + excluded.input_tokens,
+            cached_input_tokens =
+                cached_input_tokens + excluded.cached_input_tokens,
+            output_tokens = output_tokens + excluded.output_tokens,
+            reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens
+        """,
+        (generation, generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_thread(
+            generation, thread_key, calls, input_tokens,
+            cached_input_tokens, output_tokens, reasoning_tokens
+        )
+        SELECT ?, thread_key, COUNT(*), SUM(input_tokens),
+               SUM(cached_input_tokens), SUM(output_tokens),
+               SUM(reasoning_tokens)
+        FROM model_call_facts
+        WHERE generation = ? AND duplicate_state = 'canonical'
+        GROUP BY thread_key
+        ON CONFLICT(generation, thread_key) DO UPDATE SET
+            calls = calls + excluded.calls,
+            input_tokens = input_tokens + excluded.input_tokens,
+            cached_input_tokens =
+                cached_input_tokens + excluded.cached_input_tokens,
+            output_tokens = output_tokens + excluded.output_tokens,
+            reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens
+        """,
+        (generation, generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_model_effort(
+            generation, model, effort, service_tier, calls,
+            input_tokens, cached_input_tokens, output_tokens,
+            reasoning_tokens
+        )
+        SELECT ?, profiles.model, profiles.effort_key,
+               profiles.service_tier_key, COUNT(*), SUM(facts.input_tokens),
+               SUM(facts.cached_input_tokens), SUM(facts.output_tokens),
+               SUM(facts.reasoning_tokens)
+        FROM model_call_facts AS facts
+        JOIN model_profiles AS profiles USING (model_profile_key)
+        WHERE facts.generation = ?
+          AND facts.duplicate_state = 'canonical'
+        GROUP BY profiles.model, profiles.effort_key,
+                 profiles.service_tier_key
+        ON CONFLICT(generation, model, effort, service_tier) DO UPDATE SET
+            calls = calls + excluded.calls,
+            input_tokens = input_tokens + excluded.input_tokens,
+            cached_input_tokens =
+                cached_input_tokens + excluded.cached_input_tokens,
+            output_tokens = output_tokens + excluded.output_tokens,
+            reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens
+        """,
+        (generation, generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_time_band(
+            generation, band_kind, band_start, calls, input_tokens,
+            cached_input_tokens, output_tokens, reasoning_tokens
+        )
+        SELECT ?, bands.band_kind, bands.band_start, COUNT(*),
+               SUM(bands.input_tokens), SUM(bands.cached_input_tokens),
+               SUM(bands.output_tokens), SUM(bands.reasoning_tokens)
+        FROM (
+            SELECT 'day' AS band_kind, substr(event_at, 1, 10) AS band_start,
+                   input_tokens, cached_input_tokens, output_tokens,
+                   reasoning_tokens
+            FROM model_call_facts
+            WHERE generation = ? AND duplicate_state = 'canonical'
+            UNION ALL
+            SELECT 'hour', substr(event_at, 1, 13) || ':00:00Z',
+                   input_tokens, cached_input_tokens, output_tokens,
+                   reasoning_tokens
+            FROM model_call_facts
+            WHERE generation = ? AND duplicate_state = 'canonical'
+        ) AS bands
+        GROUP BY bands.band_kind, bands.band_start
+        ON CONFLICT(generation, band_kind, band_start) DO UPDATE SET
+            calls = calls + excluded.calls,
+            input_tokens = input_tokens + excluded.input_tokens,
+            cached_input_tokens =
+                cached_input_tokens + excluded.cached_input_tokens,
+            output_tokens = output_tokens + excluded.output_tokens,
+            reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens
+        """,
+        (generation, generation, generation),
+    )
+    connection.execute(
+        """
+        INSERT INTO rollup_tool_operation(
+            generation, operation, target_label, calls,
+            duration_ms, output_bytes
+        )
+        SELECT ?, profiles.operation, COALESCE(facts.target_label, ''),
+               COUNT(*), COALESCE(SUM(facts.duration_ms), 0.0),
+               COALESCE(SUM(facts.output_bytes), 0)
+        FROM tool_call_facts AS facts
+        JOIN tool_profiles AS profiles USING (tool_profile_key)
+        WHERE facts.generation = ?
+        GROUP BY profiles.operation, COALESCE(facts.target_label, '')
+        ON CONFLICT(generation, operation, target_label) DO UPDATE SET
+            calls = calls + excluded.calls,
+            duration_ms = duration_ms + excluded.duration_ms,
+            output_bytes = output_bytes + excluded.output_bytes
+        """,
+        (generation, generation),
+    )

--- a/tests/kernel/allowance/test_performance.py
+++ b/tests/kernel/allowance/test_performance.py
@@ -106,7 +106,7 @@ def test_bounded_allowance_read_stays_within_common_query_budget(
             )
     application = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: (source,),
     )
     application.allowance({"limit": 500})

--- a/tests/kernel/allowance/test_service.py
+++ b/tests/kernel/allowance/test_service.py
@@ -124,7 +124,7 @@ def test_allowance_service_returns_reset_aware_local_facts_and_estimates(
     _write_rate_card(runtime.cache_root / "rate-card.json")
     app = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
     operational_before = runtime.kernel.operational.read_bytes()
@@ -177,7 +177,7 @@ def test_allowance_cursor_is_bound_to_publication_identity(tmp_path: Path) -> No
     runtime = active_runtime(tmp_path)
     app = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
 
@@ -207,7 +207,7 @@ def test_explicit_refresh_rebuilds_pre_k8_schema_before_allowance_read(
     legacy_bytes = legacy_path.read_bytes()
     app = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
 
@@ -310,7 +310,7 @@ def test_appended_allowance_observation_uses_incremental_refresh(
     )
     app = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: (source,),
     )
 

--- a/tests/kernel/console/serve_fixture.py
+++ b/tests/kernel/console/serve_fixture.py
@@ -16,7 +16,7 @@ def main() -> None:
 
         application = KernelApplication(
             active_runtime(Path(root)),
-            worker_launcher=lambda _paths: None,
+            worker_launcher=lambda _paths, _preset: None,
             source_provider=lambda _home: synthetic_sources(),
         )
         server = create_server(application, port=8898)

--- a/tests/kernel/console/test_contracts.py
+++ b/tests/kernel/console/test_contracts.py
@@ -19,7 +19,7 @@ from ..interfaces.support import active_runtime, synthetic_sources
 def _application(tmp_path: Path, launches: list[object]) -> KernelApplication:
     return KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
         source_provider=lambda _home: synthetic_sources(),
     )
 

--- a/tests/kernel/content/test_service.py
+++ b/tests/kernel/content/test_service.py
@@ -146,7 +146,7 @@ def test_unavailable_content_database_does_not_break_accounting_status(
     ).status()["state"] == "unavailable"
     assert KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
     ).status()["content"]["state"] == "unavailable"
     assert _accounting_total(runtime) == 120
 
@@ -463,9 +463,17 @@ def test_context_batch_holds_one_read_snapshot(
         connection,
         normalized,
         generation,
+        *,
+        history_coverage,
     ):
         nonlocal calls
-        result = original(service, connection, normalized, generation)
+        result = original(
+            service,
+            connection,
+            normalized,
+            generation,
+            history_coverage=history_coverage,
+        )
         calls += 1
         if calls == 1:
             with sqlite3.connect(runtime.content, timeout=5) as writer:

--- a/tests/kernel/interfaces/test_application.py
+++ b/tests/kernel/interfaces/test_application.py
@@ -13,6 +13,7 @@ from codex_usage_tracker.kernel.application import (
     build_application,
 )
 from codex_usage_tracker.kernel.application.jobs import JobReader
+from codex_usage_tracker.kernel.hydration import HydrationPreset
 from codex_usage_tracker.kernel.ingest import refresh_request_hash
 from codex_usage_tracker.kernel.lease import RefreshLeaseRepository
 from codex_usage_tracker.kernel.operational import initialize_operational_database
@@ -24,7 +25,7 @@ def test_read_use_cases_share_one_generation_and_never_write(tmp_path: Path) -> 
     runtime = active_runtime(tmp_path)
     app = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
     operational_before = runtime.kernel.operational.read_bytes()
@@ -71,7 +72,7 @@ def test_query_guidance_is_available_without_a_database_or_refresh(
     launches: list[RuntimePaths] = []
     app = KernelApplication(
         RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
     )
 
     response = app.query({"requests": [], "include_guidance": True})
@@ -95,7 +96,7 @@ def test_query_guidance_is_available_without_a_database_or_refresh(
 def test_query_rejects_an_empty_batch_without_guidance(tmp_path: Path) -> None:
     app = KernelApplication(
         RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
     )
 
     with pytest.raises(ValueError, match="query request or guidance"):
@@ -109,7 +110,7 @@ def test_query_response_budget_fails_closed(
     monkeypatch.setattr(application_service, "MAX_QUERY_RESPONSE_BYTES", 1)
     app = KernelApplication(
         RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
     )
 
     with pytest.raises(ValueError, match="response exceeds byte budget"):
@@ -121,7 +122,7 @@ def test_repeated_guided_batch_is_deterministic_except_for_elapsed_time(
 ) -> None:
     app = KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
     payload = {
@@ -149,6 +150,7 @@ def test_repeated_guided_batch_is_deterministic_except_for_elapsed_time(
     for response in (first, second):
         for result in response["results"]:
             result.pop("elapsed_ms")
+        response.pop("cache")
 
     assert first == second
 
@@ -162,13 +164,16 @@ def test_refresh_joins_compatible_live_job_without_launching_worker(
     sources = synthetic_sources()
     repository = RefreshLeaseRepository(runtime.kernel.operational)
     lease = repository.acquire(
-        refresh_request_hash(list(sources)),
+        refresh_request_hash(
+            list(sources),
+            hydration_preset=HydrationPreset.RECENT_30D,
+        ),
         "existing-owner",
     )
     launches: list[RuntimePaths] = []
     app = KernelApplication(
         runtime,
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
         source_provider=lambda _home: sources,
     )
 
@@ -187,12 +192,15 @@ def test_concurrent_refresh_callers_launch_one_worker(tmp_path: Path) -> None:
     launches = 0
     launch_lock = threading.Lock()
 
-    def launch(_paths: RuntimePaths) -> None:
+    def launch(_paths: RuntimePaths, _preset: object) -> None:
         nonlocal launches
         with launch_lock:
             launches += 1
         repository.acquire(
-            refresh_request_hash(list(sources)),
+            refresh_request_hash(
+                list(sources),
+                hydration_preset=HydrationPreset.RECENT_30D,
+            ),
             "concurrent-owner",
         )
 
@@ -226,17 +234,23 @@ def test_expired_refresh_is_recovered_and_replaced_once(tmp_path: Path) -> None:
     sources = synthetic_sources()
     repository = RefreshLeaseRepository(runtime.kernel.operational)
     expired = repository.acquire(
-        refresh_request_hash(list(sources)),
+        refresh_request_hash(
+            list(sources),
+            hydration_preset=HydrationPreset.RECENT_30D,
+        ),
         "dead-owner",
         now=1,
     )
     launches = 0
 
-    def launch(_paths: RuntimePaths) -> None:
+    def launch(_paths: RuntimePaths, _preset: object) -> None:
         nonlocal launches
         launches += 1
         repository.acquire(
-            refresh_request_hash(list(sources)),
+            refresh_request_hash(
+                list(sources),
+                hydration_preset=HydrationPreset.RECENT_30D,
+            ),
             "replacement-owner",
         )
 
@@ -263,7 +277,7 @@ def test_job_status_waits_on_host_and_returns_one_terminal_snapshot(
     initialize_operational_database(runtime.kernel.operational)
     repository = RefreshLeaseRepository(runtime.kernel.operational)
     lease = repository.acquire("sha256:synthetic", "owner")
-    app = KernelApplication(runtime, worker_launcher=lambda _paths: None)
+    app = KernelApplication(runtime, worker_launcher=lambda _paths, _preset: None)
 
     def complete() -> None:
         threading.Event().wait(0.05)
@@ -305,8 +319,14 @@ def test_refresh_waits_for_a_new_job_after_a_previous_terminal_run(
     repository.complete(previous.refresh_run_id, generation=1, result={})
     sources = synthetic_sources()
 
-    def launch(_paths: RuntimePaths) -> None:
-        repository.acquire(refresh_request_hash(list(sources)), "new-owner")
+    def launch(_paths: RuntimePaths, _preset: object) -> None:
+        repository.acquire(
+            refresh_request_hash(
+                list(sources),
+                hydration_preset=HydrationPreset.RECENT_30D,
+            ),
+            "new-owner",
+        )
 
     app = KernelApplication(
         runtime,
@@ -327,7 +347,10 @@ def test_real_background_worker_reaches_terminal_on_synthetic_input(
     shutil.copytree(ORACLE_ROOT / "logs", runtime.codex_home / "sessions")
     app = build_application(runtime)
 
-    result = app.refresh(wait_seconds=30)
+    result = app.refresh(
+        wait_seconds=30,
+        hydration_preset=HydrationPreset.COMPLETE,
+    )
 
     assert result["disposition"] == "started"
     assert result["job"]["state"] == "completed"

--- a/tests/kernel/interfaces/test_http.py
+++ b/tests/kernel/interfaces/test_http.py
@@ -4,12 +4,14 @@ import json
 import socket
 import threading
 from pathlib import Path
+from unittest.mock import create_autospec
 from urllib.request import Request, urlopen
 
 import pytest
 
 import codex_usage_tracker.kernel.application.service as application_service
 from codex_usage_tracker.kernel.application import KernelApplication, RuntimePaths
+from codex_usage_tracker.kernel.hydration import HydrationPreset
 from codex_usage_tracker.kernel.interfaces.http.app import API_PREFIX, HttpApp
 from codex_usage_tracker.kernel.interfaces.http.server import create_server
 
@@ -19,7 +21,7 @@ from .support import active_runtime, synthetic_sources
 def _application(tmp_path: Path) -> KernelApplication:
     return KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
 
@@ -76,6 +78,31 @@ def test_real_loopback_listener_serves_new_status_prefix(tmp_path: Path) -> None
     assert payload["generation"] == 1
 
 
+def test_http_refresh_transports_hydration_preset() -> None:
+    launches = []
+    application = create_autospec(KernelApplication, instance=True)
+
+    def refresh(
+        *,
+        wait_seconds: float,
+        hydration_preset: HydrationPreset,
+    ) -> dict:
+        launches.append(hydration_preset.value)
+        return {"state": "queued", "wait_seconds": wait_seconds}
+
+    application.refresh.side_effect = refresh
+
+    response = HttpApp(application).handle(
+        "POST",
+        f"{API_PREFIX}/refresh",
+        body=b'{"preset":"recent_90d"}',
+        headers={"Host": "127.0.0.1:8765"},
+    )
+
+    assert response.status == 202
+    assert launches == ["recent_90d"]
+
+
 def test_real_listener_rejects_invalid_content_length(tmp_path: Path) -> None:
     server = create_server(_application(tmp_path))
     worker = threading.Thread(target=server.serve_forever, daemon=True)
@@ -108,7 +135,7 @@ def test_http_query_response_budget_returns_a_bounded_client_error(
     response = HttpApp(
         KernelApplication(
             RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
-            worker_launcher=lambda _paths: None,
+            worker_launcher=lambda _paths, _preset: None,
         )
     ).handle(
         "POST",
@@ -132,7 +159,7 @@ def test_corrupt_cache_returns_sanitized_service_unavailable(
     runtime.kernel.operational.parent.mkdir(parents=True)
     runtime.kernel.operational.write_bytes(b"not sqlite")
     response = HttpApp(
-        KernelApplication(runtime, worker_launcher=lambda _paths: None)
+        KernelApplication(runtime, worker_launcher=lambda _paths, _preset: None)
     ).handle(
         "GET",
         f"{API_PREFIX}/status",

--- a/tests/kernel/interfaces/test_mcp.py
+++ b/tests/kernel/interfaces/test_mcp.py
@@ -22,7 +22,7 @@ def test_mcp_catalog_and_calls_use_structured_results_without_duplication(
 ) -> None:
     app = KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
     server = McpServer(app)
@@ -76,7 +76,7 @@ def test_guided_scope_batch_and_evidence_use_three_read_only_mcp_calls(
     runtime = active_runtime(tmp_path)
     app = KernelApplication(
         runtime,
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
         source_provider=lambda _home: synthetic_sources(),
     )
     server = McpServer(app)
@@ -148,6 +148,34 @@ def test_guided_scope_batch_and_evidence_use_three_read_only_mcp_calls(
     assert runtime.kernel.analytical.read_bytes() == analytical_before
 
 
+def test_mcp_refresh_transports_hydration_preset(tmp_path: Path) -> None:
+    launches = []
+    server = McpServer(
+        KernelApplication(
+            RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
+            worker_launcher=lambda _paths, preset: launches.append(
+                preset.value
+            ),
+            source_provider=lambda _home: (),
+        )
+    )
+
+    response = server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "usage_refresh",
+                "arguments": {"preset": "complete"},
+            },
+        }
+    )
+
+    assert "error" not in response
+    assert launches == ["complete"]
+
+
 def test_direct_stdio_handshake_lists_exact_catalog(tmp_path: Path) -> None:
     environment = os.environ.copy()
     environment["PYTHONPATH"] = str(Path(__file__).parents[3] / "src")
@@ -190,7 +218,7 @@ def test_mcp_query_response_budget_returns_a_structured_tool_error(
     server = McpServer(
         KernelApplication(
             RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
-            worker_launcher=lambda _paths: None,
+            worker_launcher=lambda _paths, _preset: None,
         )
     )
 
@@ -224,7 +252,7 @@ def test_invalid_envelopes_and_inputs_are_rejected_before_side_effects(
     launches = []
     app = KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
         source_provider=lambda _home: synthetic_sources(),
     )
     server = McpServer(app)
@@ -267,7 +295,7 @@ def test_corrupt_cache_returns_a_sanitized_tool_error(tmp_path: Path) -> None:
     runtime.kernel.operational.parent.mkdir(parents=True)
     runtime.kernel.operational.write_bytes(b"not sqlite")
     server = McpServer(
-        KernelApplication(runtime, worker_launcher=lambda _paths: None)
+        KernelApplication(runtime, worker_launcher=lambda _paths, _preset: None)
     )
 
     response = server.handle(

--- a/tests/kernel/interfaces/test_performance.py
+++ b/tests/kernel/interfaces/test_performance.py
@@ -19,7 +19,7 @@ _GUIDANCE_RESPONSE_BUDGET_BYTES = 24_000
 def test_warm_status_and_batched_query_adapter_budgets(tmp_path: Path) -> None:
     application = KernelApplication(
         active_runtime(tmp_path),
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: synthetic_sources(),
     )
     query = {

--- a/tests/kernel/interfaces/test_r4_coverage_contract.py
+++ b/tests/kernel/interfaces/test_r4_coverage_contract.py
@@ -1,0 +1,368 @@
+"""R4 coverage-aware interface contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.kernel.application import (
+    KernelApplication,
+    RuntimePaths,
+    build_application,
+)
+from codex_usage_tracker.kernel.application import service as application_service
+from codex_usage_tracker.kernel.hydration import HydrationPreset
+from codex_usage_tracker.kernel.ingest import KernelIngestor, RefreshTrigger
+
+from .support import active_runtime
+
+
+def test_status_and_query_expose_committed_history_coverage(tmp_path: Path) -> None:
+    runtime = active_runtime(tmp_path)
+    application = KernelApplication(
+        runtime,
+        worker_launcher=lambda _paths, _preset: None,
+    )
+
+    status = application.status()
+    query = application.query(
+        {
+            "requests": [
+                {
+                    "dataset": "calls",
+                    "operation": "aggregate",
+                    "dimensions": ["thread"],
+                    "measures": [
+                        "uncached_input_tokens",
+                        "cached_input_tokens",
+                        "reasoning_tokens",
+                        "output_tokens",
+                    ],
+                    "limit": 10,
+                }
+            ]
+        }
+    )
+
+    expected = {
+        "preset": "complete",
+        "cutoff_at": None,
+        "complete_history": True,
+        "cataloged_source_count": 3,
+        "hydrated_source_count": 3,
+        "deferred_source_count": 0,
+    }
+    assert status["history_coverage"] | expected == status["history_coverage"]
+    assert (
+        query["history_coverage"]["coverage_revision"]
+        == status["history_coverage"]["coverage_revision"]
+    )
+    assert query["history_coverage"] | expected == query["history_coverage"]
+
+
+def test_partial_history_requires_explicit_query_opt_in(tmp_path: Path) -> None:
+    runtime = _partial_runtime(tmp_path)
+    application = KernelApplication(
+        runtime,
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    request = {
+        "dataset": "calls",
+        "operation": "aggregate",
+        "dimensions": ["thread"],
+        "measures": ["calls", "total_tokens"],
+        "limit": 10,
+    }
+
+    with pytest.raises(ValueError, match="allow_partial"):
+        application.query({"requests": [request]})
+
+    accepted = application.query({"requests": [{**request, "allow_partial": True}]})
+
+    assert accepted["history_coverage"]["complete_history"] is False
+    assert accepted["results"][0]["grade"] == "partial"
+    assert accepted["results"][0]["coverage"]["history_complete"] is False
+
+
+def test_query_never_launches_refresh_for_partial_history(tmp_path: Path) -> None:
+    launches: list[tuple[RuntimePaths, HydrationPreset]] = []
+    application = KernelApplication(
+        _partial_runtime(tmp_path),
+        worker_launcher=lambda paths, preset: launches.append((paths, preset)),
+    )
+
+    with pytest.raises(ValueError, match="allow_partial"):
+        application.query(
+            {
+                "requests": [
+                    {
+                        "dataset": "calls",
+                        "operation": "aggregate",
+                        "dimensions": ["thread"],
+                        "measures": ["calls"],
+                    }
+                ]
+            }
+        )
+
+    assert launches == []
+
+
+def test_query_binds_generation_and_coverage_to_one_publication_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _partial_runtime(tmp_path)
+    application = KernelApplication(
+        runtime,
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    real_snapshot = application_service.load_publication_snapshot
+    promoted = False
+
+    def promote_after_snapshot(path: Path):
+        nonlocal promoted
+        snapshot = real_snapshot(path)
+        if not promoted:
+            promoted = True
+            KernelIngestor(
+                runtime.kernel.analytical,
+                runtime.kernel.operational,
+            ).refresh(
+                [
+                    runtime.codex_home / "sessions" / "recent.jsonl",
+                    runtime.codex_home / "archived_sessions" / "old.jsonl",
+                ],
+                trigger=RefreshTrigger.CLI_REFRESH,
+                owner_id="r4-publication-interleave",
+                hydration_preset=HydrationPreset.COMPLETE,
+            )
+        return snapshot
+
+    monkeypatch.setattr(
+        application_service,
+        "load_publication_snapshot",
+        promote_after_snapshot,
+    )
+    with pytest.raises(ValueError, match="allow_partial"):
+        application.query(
+            {
+                "requests": [
+                    {
+                        "dataset": "calls",
+                        "operation": "aggregate",
+                        "dimensions": ["thread"],
+                        "measures": ["calls"],
+                    }
+                ]
+            }
+        )
+    assert real_snapshot(runtime.kernel.operational)[1]["complete_history"] is True
+
+
+def test_partial_history_comparisons_must_stay_inside_coverage(
+    tmp_path: Path,
+) -> None:
+    application = KernelApplication(
+        _partial_runtime(tmp_path),
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    base = {
+        "dataset": "calls",
+        "operation": "comparison",
+        "dimensions": ["model"],
+        "measures": ["calls", "total_tokens"],
+        "limit": 10,
+    }
+
+    covered = application.query(
+        {
+            "requests": [
+                {
+                    **base,
+                    "comparison": {
+                        "current_start": "2026-07-25T00:00:00Z",
+                        "current_end": "2026-07-27T00:00:00Z",
+                        "previous_start": "2026-07-23T00:00:00Z",
+                        "previous_end": "2026-07-25T00:00:00Z",
+                    },
+                }
+            ]
+        }
+    )
+    with pytest.raises(ValueError, match="allow_partial"):
+        application.query(
+            {
+                "requests": [
+                    {
+                        **base,
+                        "comparison": {
+                            "current_start": "2026-01-03T00:00:00Z",
+                            "current_end": "2026-01-04T00:00:00Z",
+                            "previous_start": "2026-01-01T00:00:00Z",
+                            "previous_end": "2026-01-02T00:00:00Z",
+                        },
+                    }
+                ]
+            }
+        )
+
+    assert covered["results"][0]["grade"] == "exact"
+
+
+def test_repeated_query_reports_generation_safe_cache_reuse(tmp_path: Path) -> None:
+    application = KernelApplication(
+        active_runtime(tmp_path),
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    payload = {
+        "requests": [
+            {
+                "dataset": "calls",
+                "operation": "aggregate",
+                "dimensions": ["thread"],
+                "measures": ["calls", "total_tokens"],
+            }
+        ]
+    }
+
+    first = application.query(payload)
+    second = application.query(payload)
+
+    assert first["cache"]["hit"] is False
+    assert second["cache"]["hit"] is True
+    assert first["cache"]["key"] == second["cache"]["key"]
+    assert first["results"] == second["results"]
+
+
+def test_query_cache_invalidates_when_coverage_generation_changes(
+    tmp_path: Path,
+) -> None:
+    runtime = _partial_runtime(tmp_path)
+    application = KernelApplication(
+        runtime,
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    payload = {
+        "requests": [
+            {
+                "dataset": "calls",
+                "operation": "aggregate",
+                "dimensions": ["thread"],
+                "measures": ["calls"],
+                "allow_partial": True,
+            }
+        ]
+    }
+
+    first = application.query(payload)
+    assert application.query(payload)["cache"]["hit"] is True
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [
+            runtime.codex_home / "sessions" / "recent.jsonl",
+            runtime.codex_home / "archived_sessions" / "old.jsonl",
+        ],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-cache-invalidation",
+        hydration_preset=HydrationPreset.COMPLETE,
+    )
+    after_expansion = application.query(payload)
+
+    assert after_expansion["cache"]["hit"] is False
+    assert after_expansion["cache"]["key"] != first["cache"]["key"]
+    assert after_expansion["history_coverage"]["complete_history"] is True
+
+
+def test_new_install_defaults_recent_then_retains_explicit_complete(
+    tmp_path: Path,
+) -> None:
+    runtime = RuntimePaths(tmp_path / "codex-home", tmp_path / "cache")
+    _write_source(
+        runtime.codex_home / "sessions" / "recent.jsonl",
+        thread_id="recent-thread",
+        timestamp="2026-07-26T00:00:00Z",
+    )
+    _write_source(
+        runtime.codex_home / "archived_sessions" / "old.jsonl",
+        thread_id="old-thread",
+        timestamp="2025-01-01T00:00:00Z",
+    )
+    application = build_application(runtime)
+
+    first = application.refresh(wait_seconds=30)
+    recent = application.status()["history_coverage"]
+    expanded = application.refresh(
+        wait_seconds=30,
+        hydration_preset=HydrationPreset.COMPLETE,
+    )
+    complete = application.status()["history_coverage"]
+    retained = application.refresh(wait_seconds=30)
+
+    assert first["job"]["state"] == "completed"
+    assert recent["preset"] == "recent_30d"
+    assert recent["hydrated_source_count"] == 1
+    assert recent["deferred_source_count"] == 1
+    assert expanded["job"]["state"] == "completed"
+    assert complete["preset"] == "complete"
+    assert complete["complete_history"] is True
+    assert retained["job"]["result"]["planner_reason"] == "no_changes"
+    assert application.status()["history_coverage"]["preset"] == "complete"
+
+
+def test_refresh_transports_requested_hydration_preset(tmp_path: Path) -> None:
+    runtime = RuntimePaths(tmp_path / "codex-home", tmp_path / "cache")
+    runtime.codex_home.mkdir(parents=True)
+    launches: list[tuple[RuntimePaths, HydrationPreset]] = []
+
+    application = KernelApplication(
+        runtime,
+        worker_launcher=lambda paths, preset: launches.append((paths, preset)),
+        source_provider=lambda _home: (),
+    )
+
+    with pytest.raises(RuntimeError, match="did not start"):
+        application.refresh(
+            wait_seconds=0,
+            hydration_preset=HydrationPreset.RECENT_30D,
+        )
+
+    assert launches == [(runtime, HydrationPreset.RECENT_30D)]
+
+
+def _partial_runtime(root: Path) -> RuntimePaths:
+    runtime = RuntimePaths(root / "codex-home", root / "cache")
+    recent = runtime.codex_home / "sessions" / "recent.jsonl"
+    old = runtime.codex_home / "archived_sessions" / "old.jsonl"
+    _write_source(recent, thread_id="recent-thread", timestamp="2026-07-26T00:00:00Z")
+    _write_source(old, thread_id="old-thread", timestamp="2025-01-01T00:00:00Z")
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [recent, old],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-coverage-contract",
+        hydration_preset=HydrationPreset.RECENT_30D,
+    )
+    return runtime
+
+
+def _write_source(path: Path, *, thread_id: str, timestamp: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'{{"timestamp":"{timestamp}","type":"session_meta",'
+        f'"payload":{{"id":"{thread_id}"}}}}\n'
+        f'{{"timestamp":"{timestamp}","type":"turn_context",'
+        f'"payload":{{"turn_id":"turn-1","model":"gpt-synthetic",'
+        '"effort":"low"}}}\n'
+        f'{{"event_id":"event-1","timestamp":"{timestamp}",'
+        '"type":"event_msg","payload":{"type":"token_count","info":'
+        '{"last_token_usage":{"input_tokens":10,"cached_input_tokens":2,'
+        '"output_tokens":3,"reasoning_output_tokens":1,"total_tokens":13},'
+        '"model_context_window":200000}}}\n',
+        encoding="utf-8",
+    )

--- a/tests/kernel/interfaces/test_r4_coverage_contract.py
+++ b/tests/kernel/interfaces/test_r4_coverage_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,28 @@ def test_status_and_query_expose_committed_history_coverage(tmp_path: Path) -> N
         == status["history_coverage"]["coverage_revision"]
     )
     assert query["history_coverage"] | expected == query["history_coverage"]
+
+
+def test_status_reads_pre_coverage_sidecar_conservatively_without_migration(
+    tmp_path: Path,
+) -> None:
+    runtime = active_runtime(tmp_path)
+    with sqlite3.connect(runtime.kernel.operational) as connection:
+        connection.execute("DROP TABLE coverage_control")
+        connection.execute("DROP TABLE staged_coverage_control")
+        connection.execute("PRAGMA user_version = 2")
+    before = runtime.kernel.operational.read_bytes()
+
+    status = KernelApplication(
+        runtime,
+        worker_launcher=lambda _paths, _preset: None,
+    ).status()
+
+    assert status["state"] == "active"
+    assert status["generation"] == 1
+    assert status["history_coverage"]["complete_history"] is False
+    assert status["history_coverage"]["coverage_revision"] is None
+    assert runtime.kernel.operational.read_bytes() == before
 
 
 def test_partial_history_requires_explicit_query_opt_in(tmp_path: Path) -> None:

--- a/tests/kernel/live/test_overlay_adapter_contract.py
+++ b/tests/kernel/live/test_overlay_adapter_contract.py
@@ -211,7 +211,7 @@ def test_contract_routes_work_through_a_real_read_only_loopback_listener(
     launches = []
     application = KernelApplication(
         runtime,
-        worker_launcher=launches.append,
+        worker_launcher=lambda paths, _preset: launches.append(paths),
         source_provider=lambda _home: synthetic_sources(),
     )
     query = application.query(

--- a/tests/kernel/query/test_performance.py
+++ b/tests/kernel/query/test_performance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+import sqlite3
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -27,6 +28,7 @@ from codex_usage_tracker.kernel.query import (
     QueryRequest,
     QueryService,
 )
+from codex_usage_tracker.kernel.rollups import rebuild_generation_rollups
 
 _CALL_COUNT = 100_000
 
@@ -38,6 +40,23 @@ def large_service(tmp_path_factory: pytest.TempPathFactory) -> QueryService:
     initialize_analytical_database(paths.analytical)
     initialize_operational_database(paths.operational)
     _populate_calls(paths.analytical)
+    rebuild_generation_rollups(paths.analytical, 1)
+    with sqlite3.connect(paths.operational) as connection:
+        connection.execute(
+            """
+            INSERT INTO coverage_control(
+                singleton, preset, captured_at, cutoff_at, complete_history,
+                coverage_revision, cataloged_source_count,
+                hydrated_source_count, deferred_source_count,
+                cataloged_bytes, hydrated_bytes, deferred_bytes,
+                uncertain_source_count
+            )
+            VALUES (
+                1, 'complete', '2026-01-29T00:00:00Z', NULL, 1,
+                'sha256:synthetic-complete', 1, 1, 0, 1, 1, 0, 0
+            )
+            """
+        )
     transition_cutover(
         paths.operational,
         CutoverState.BUILDING,
@@ -88,6 +107,15 @@ def test_100k_common_comparison_and_concentration_budgets(
         ("calls", "total_tokens"),
         limit=25,
     )
+    daily = QueryRequest(
+        "calls",
+        Operation.TIME_SERIES,
+        ("time_day",),
+        ("calls", "total_tokens"),
+        order_by="time_day",
+        descending=False,
+        limit=31,
+    )
 
     common_p95 = _p95(lambda: large_service.execute(common), repeats=20)
     comparison_p95 = _p95(
@@ -98,6 +126,10 @@ def test_100k_common_comparison_and_concentration_budgets(
         lambda: large_service.execute(concentration),
         repeats=12,
     )
+    daily_p95 = _p95(lambda: large_service.execute(daily), repeats=12)
+    common_result = large_service.execute(common)
+    concentration_result = large_service.execute(concentration)
+    daily_result = large_service.execute(daily)
 
     print(
         json.dumps(
@@ -106,6 +138,7 @@ def test_100k_common_comparison_and_concentration_budgets(
                 "common_p95_ms": round(common_p95, 3),
                 "comparison_p95_ms": round(comparison_p95, 3),
                 "concentration_p95_ms": round(concentration_p95, 3),
+                "daily_p95_ms": round(daily_p95, 3),
             },
             sort_keys=True,
         )
@@ -113,6 +146,13 @@ def test_100k_common_comparison_and_concentration_budgets(
     assert common_p95 <= 500.0
     assert comparison_p95 <= 1_000.0
     assert concentration_p95 <= 1_000.0
+    assert daily_p95 <= 500.0
+    assert common_result.plan_id.endswith("rollup_model_effort.v1")
+    assert common_result.scanned_count == 4
+    assert concentration_result.plan_id.endswith("rollup_thread.v1")
+    assert concentration_result.scanned_count == 250
+    assert daily_result.plan_id.endswith("rollup_time_band.v1")
+    assert daily_result.scanned_count == 28
 
 
 def _p95(operation: Callable[[], object], *, repeats: int) -> float:

--- a/tests/kernel/query/test_r4_rollups.py
+++ b/tests/kernel/query/test_r4_rollups.py
@@ -1,0 +1,426 @@
+"""R4 persisted-rollup and common-query contracts."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.kernel import ingest
+from codex_usage_tracker.kernel.application import KernelApplication, RuntimePaths
+from codex_usage_tracker.kernel.database import short_writer_transaction
+from codex_usage_tracker.kernel.hydration import HydrationPreset
+from codex_usage_tracker.kernel.ingest import KernelIngestor, RefreshTrigger
+from codex_usage_tracker.kernel.operational import (
+    kernel_paths,
+    load_cutover_control,
+)
+from codex_usage_tracker.kernel.query import Operation, QueryRequest, QueryService
+from codex_usage_tracker.kernel.rollups import generation_rollups_ready
+from tests.kernel.interfaces.support import active_runtime
+from tests.kernel.test_ingest_pipeline import _token_line
+
+
+def test_refresh_publishes_generation_scoped_rollups(tmp_path: Path) -> None:
+    runtime = active_runtime(tmp_path)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        generation = control.active_generation
+        assert generation is not None
+        assert connection.execute(
+            "SELECT calls FROM rollup_global WHERE generation = ?",
+            (generation,),
+        ).fetchone() == (4,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rollup_thread WHERE generation = ?",
+            (generation,),
+        ).fetchone() == (2,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM rollup_model_effort WHERE generation = ?",
+            (generation,),
+        ).fetchone() == (2,)
+
+
+def test_top_threads_uses_bounded_rollup_plan(tmp_path: Path) -> None:
+    runtime = active_runtime(tmp_path)
+    result = QueryService(runtime.kernel.operational).execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=("thread",),
+            measures=(
+                "calls",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens",
+                "total_tokens",
+            ),
+            order_by="total_tokens",
+            limit=25,
+        )
+    )
+
+    assert result.plan_id == "calls.aggregate.rollup_thread.v1"
+    assert result.scanned_count == 2
+    assert result.returned_count == 2
+    assert sum(int(row["calls"]) for row in result.rows) == 4
+
+
+def test_model_effort_and_global_queries_use_small_rollups(tmp_path: Path) -> None:
+    runtime = active_runtime(tmp_path)
+    service = QueryService(runtime.kernel.operational)
+
+    model_effort = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=("model", "effort"),
+            measures=("calls", "total_tokens"),
+            limit=25,
+        )
+    )
+    global_totals = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            measures=(
+                "calls",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens",
+            ),
+            limit=1,
+        )
+    )
+
+    assert model_effort.plan_id.endswith("rollup_model_effort.v1")
+    assert model_effort.scanned_count == 2
+    assert global_totals.plan_id.endswith("rollup_global.v1")
+    assert global_totals.scanned_count == 1
+    assert global_totals.rows[0]["calls"] == 4
+
+
+def test_time_bands_and_tool_operations_use_bounded_rollups(
+    tmp_path: Path,
+) -> None:
+    runtime = active_runtime(tmp_path)
+    service = QueryService(runtime.kernel.operational)
+
+    daily = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.TIME_SERIES,
+            dimensions=("time_day",),
+            measures=("calls", "total_tokens"),
+            order_by="time_day",
+            descending=False,
+            limit=31,
+        )
+    )
+    hourly = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.TIME_SERIES,
+            dimensions=("time_hour",),
+            measures=("calls", "total_tokens"),
+            order_by="time_hour",
+            descending=False,
+            limit=168,
+        )
+    )
+    tools = service.execute(
+        QueryRequest(
+            dataset="tools",
+            operation=Operation.AGGREGATE,
+            dimensions=("operation",),
+            measures=("tools",),
+            order_by="tools",
+            limit=25,
+        )
+    )
+
+    assert daily.plan_id.endswith("rollup_time_band.v1")
+    assert daily.scanned_count == daily.matched_count
+    assert sum(int(row["calls"]) for row in daily.rows) == 4
+    assert hourly.plan_id.endswith("rollup_time_band.v1")
+    assert hourly.scanned_count == hourly.matched_count
+    assert sum(int(row["calls"]) for row in hourly.rows) == 4
+    assert tools.plan_id == "tools.aggregate.rollup_tool_operation.v1"
+    assert tools.scanned_count == tools.matched_count
+    assert sum(int(row["tools"]) for row in tools.rows) > 0
+    assert len(tools.rows) == len({str(row["operation"]) for row in tools.rows})
+
+    nullable_metrics = service.execute(
+        QueryRequest(
+            dataset="tools",
+            operation=Operation.AGGREGATE,
+            dimensions=("operation",),
+            measures=("tools", "duration_ms", "output_bytes"),
+            order_by="tools",
+            limit=25,
+        )
+    )
+    assert nullable_metrics.plan_id == "tools.aggregate.v1"
+
+
+def test_model_rollup_regroups_unselected_effort_and_tier(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "sessions" / "model-groups.jsonl"
+    source.parent.mkdir()
+    source.write_text(
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta",'
+        '"payload":{"id":"synthetic-model-groups"}}\n'
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context",'
+        '"payload":{"turn_id":"turn-1","model":"gpt-synthetic",'
+        '"effort":"low"}}\n'
+        + _token_line("event-1", 10)
+        + '{"timestamp":"2026-01-01T00:00:02Z","type":"turn_context",'
+        '"payload":{"turn_id":"turn-2","model":"gpt-synthetic",'
+        '"effort":"high"}}\n' + _token_line("event-2", 20),
+        encoding="utf-8",
+    )
+    paths = kernel_paths(tmp_path / "cache")
+    KernelIngestor(paths.analytical, paths.operational).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-model-regroup",
+        hydration_preset=HydrationPreset.COMPLETE,
+    )
+    service = QueryService(paths.operational)
+    by_model = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=("model",),
+            measures=("calls", "total_tokens"),
+            limit=10,
+        )
+    )
+    by_effort = service.execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=("model", "effort"),
+            measures=("calls", "total_tokens"),
+            limit=10,
+        )
+    )
+    assert by_model.plan_id.endswith("rollup_model_effort.v1")
+    assert by_model.rows == ({"model": "gpt-synthetic", "calls": 2, "total_tokens": 34},)
+    assert len(by_effort.rows) == 2
+    assert sum(int(row["calls"]) for row in by_effort.rows) == 2
+
+
+def test_append_rollups_equal_published_canonical_facts(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="rollup-owner",
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(_token_line("event-2", 20))
+        handle.write(_token_line("event-3", 30))
+
+    result = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.MCP_USAGE_REFRESH,
+        owner_id="rollup-owner",
+    )
+
+    with sqlite3.connect(paths.analytical) as connection:
+        canonical_calls = connection.execute(
+            """
+            SELECT COUNT(*)
+            FROM model_call_facts
+            WHERE generation <= ? AND duplicate_state = 'canonical'
+            """,
+            (result.generation,),
+        ).fetchone()[0]
+        assert connection.execute(
+            "SELECT calls FROM rollup_global WHERE generation = ?",
+            (result.generation,),
+        ).fetchone() == (canonical_calls,)
+        for table, expected_calls in (
+            ("rollup_thread", canonical_calls),
+            ("rollup_model_effort", canonical_calls),
+            ("rollup_time_band", canonical_calls * 2),
+        ):
+            assert (
+                connection.execute(
+                    f"SELECT SUM(calls) FROM {table} WHERE generation = ?",
+                    (result.generation,),
+                ).fetchone()[0]
+                == expected_calls
+            )
+
+
+def test_interrupted_rollup_update_recovers_before_promotion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path)
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="rollup-owner",
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(_token_line("event-2", 20))
+    real_rebuild = ingest.rebuild_generation_rollups
+
+    def interrupt_rollups(*args: object, **kwargs: object) -> float:
+        raise RuntimeError("synthetic rollup interruption")
+
+    monkeypatch.setattr(ingest, "rebuild_generation_rollups", interrupt_rollups)
+    with pytest.raises(RuntimeError, match="synthetic rollup interruption"):
+        ingestor.refresh(
+            [source],
+            trigger=RefreshTrigger.MCP_USAGE_REFRESH,
+            owner_id="rollup-owner",
+        )
+    assert load_cutover_control(paths.operational).active_generation == 1
+
+    monkeypatch.setattr(ingest, "rebuild_generation_rollups", real_rebuild)
+    recovered = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.MCP_USAGE_REFRESH,
+        owner_id="rollup-owner",
+    )
+
+    assert recovered.generation == 2
+    assert load_cutover_control(paths.operational).active_generation == 2
+    assert generation_rollups_ready(paths.analytical, 2)
+    with sqlite3.connect(paths.analytical) as connection:
+        assert connection.execute(
+            "SELECT calls FROM rollup_global WHERE generation = 2"
+        ).fetchone() == (2,)
+
+
+def test_no_change_refresh_backfills_upgrade_rollups_off_active_path(
+    tmp_path: Path,
+) -> None:
+    source = _source(tmp_path)
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="rollup-owner",
+    )
+    prior_active = load_cutover_control(paths.operational).active_kernel_path
+    assert prior_active is not None
+    with short_writer_transaction(prior_active) as connection:
+        for table in (
+            "rollup_global",
+            "rollup_thread",
+            "rollup_model_effort",
+            "rollup_time_band",
+            "rollup_tool_operation",
+        ):
+            connection.execute(f"DELETE FROM {table} WHERE generation = 1")
+    application = KernelApplication(
+        RuntimePaths(tmp_path / "codex-home", tmp_path / "cache"),
+        worker_launcher=lambda _paths, _preset: None,
+    )
+    query = {
+        "requests": [
+            {
+                "dataset": "calls",
+                "operation": "aggregate",
+                "measures": ["calls", "total_tokens"],
+                "limit": 1,
+            }
+        ]
+    }
+    before = application.query(query)
+
+    result = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="rollup-owner",
+    )
+    control = load_cutover_control(paths.operational)
+
+    assert result.planner_reason == "no_changes"
+    assert control.active_generation == 1
+    assert control.active_kernel_path is not None
+    assert control.active_kernel_path != prior_active
+    assert generation_rollups_ready(control.active_kernel_path, 1)
+    after = application.query(query)
+    assert before["results"][0]["rows"] == []
+    assert after["cache"]["hit"] is False
+    assert after["cache"]["key"] != before["cache"]["key"]
+    assert after["results"][0]["rows"][0]["calls"] == 1
+
+
+def _source(root: Path) -> Path:
+    source = root / "sessions" / "rollout-r4.jsonl"
+    source.parent.mkdir()
+    source.write_text(
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta",'
+        '"payload":{"id":"synthetic-r4-session"}}\n'
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context",'
+        '"payload":{"turn_id":"turn-1","model":"gpt-synthetic","effort":"low"}}\n'
+        + _token_line("event-1", 10),
+        encoding="utf-8",
+    )
+    return source
+
+
+def test_cross_preset_retry_recovers_appended_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path)
+    captured_at = datetime(2026, 1, 15, tzinfo=timezone.utc)
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-cross-preset",
+        hydration_preset=HydrationPreset.RECENT_30D,
+        captured_at=captured_at,
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(_token_line("event-2", 20))
+
+    monkeypatch.setattr(ingestor, "_promote", lambda *_args, **_kwargs: None)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-cross-preset",
+        hydration_preset=HydrationPreset.RECENT_30D,
+        captured_at=captured_at,
+    )
+
+    recovered = KernelIngestor(
+        paths.analytical,
+        paths.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r4-cross-preset-retry",
+        hydration_preset=HydrationPreset.RECENT_90D,
+        captured_at=captured_at,
+    )
+    control = load_cutover_control(paths.operational)
+    assert recovered.generation == 2
+    assert control.active_generation == 2
+    assert control.active_kernel_path is not None
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM model_call_facts WHERE generation <= 2"
+        ).fetchone() == (2,)

--- a/tests/kernel/query/test_service.py
+++ b/tests/kernel/query/test_service.py
@@ -57,7 +57,9 @@ def test_batch_uses_one_generation_and_returns_accounting_rows(
     )
 
     assert {result.generation for result in results} == {1}
-    assert results[0].plan_id == "calls.aggregate.v1"
+    assert results[0].plan_id == (
+        "calls.aggregate.rollup_model_effort.v1"
+    )
     assert results[0].rows == (
         {
             "model": "gpt-synthetic",
@@ -439,8 +441,15 @@ def test_batch_read_snapshot_is_stable_during_concurrent_commit(
             connection: sqlite3.Connection,
             request: QueryRequest,
             generation: int,
+            *,
+            history_coverage: dict[str, object],
         ):
-            result = super()._execute_one(connection, request, generation)
+            result = super()._execute_one(
+                connection,
+                request,
+                generation,
+                history_coverage=history_coverage,
+            )
             if not self.mutated:
                 with short_writer_transaction(analytical) as writer:
                     writer.execute(

--- a/tests/kernel/test_fault_recovery_scale.py
+++ b/tests/kernel/test_fault_recovery_scale.py
@@ -348,7 +348,7 @@ def test_console_mcp_and_export_reads_stay_on_the_active_generation_during_refre
     runtime = RuntimePaths(tmp_path / "codex-home", tmp_path / "cache")
     application = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: (source,),
     )
     writer_paused = threading.Event()
@@ -465,7 +465,7 @@ def test_real_sse_slow_and_disconnected_clients_do_not_block_reads(
     runtime = RuntimePaths(tmp_path / "codex-home", tmp_path / "cache")
     application = KernelApplication(
         runtime,
-        worker_launcher=lambda _paths: None,
+        worker_launcher=lambda _paths, _preset: None,
         source_provider=lambda _home: (),
     )
     server = create_server(application)

--- a/tests/kernel/test_ingest_performance.py
+++ b/tests/kernel/test_ingest_performance.py
@@ -82,7 +82,10 @@ def test_append_safe_refresh_keeps_active_writer_lock_bounded(tmp_path: Path) ->
         '"payload":{"id":"synthetic-tail-session"}}\n'
         '{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context",'
         '"payload":{"turn_id":"turn-1","model":"gpt-synthetic","effort":"low"}}\n'
-        + _token_line("event-initial", 1),
+        + "".join(
+            _token_line(f"event-initial-{index}", index % 100)
+            for index in range(_CALL_COUNT)
+        ),
         encoding="utf-8",
     )
     paths = kernel_paths(tmp_path / "cache")
@@ -108,6 +111,17 @@ def test_append_safe_refresh_keeps_active_writer_lock_bounded(tmp_path: Path) ->
 
     ordered = sorted(result.writer_transaction_ms)
     p95 = ordered[max(0, math.ceil(len(ordered) * 0.95) - 1)]
+    print(
+        json.dumps(
+            {
+                "active_calls": _CALL_COUNT,
+                "appended_calls": result.inserted_calls,
+                "writer_p95_ms": round(p95, 3),
+                "writer_transactions": len(ordered),
+            },
+            sort_keys=True,
+        )
+    )
     assert result.planner_reason == "append_safe"
     assert result.inserted_calls == 2_000
     assert p95 <= _ACTIVE_WRITER_P95_BUDGET_MS, (

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -24,6 +24,7 @@ from scripts.check_kernel_scope import (
     R1_ADDITIONS,
     R2_ADDITIONS,
     R3_ADDITIONS,
+    R4_ADDITIONS,
     RECOVERY_ROADMAP_ADDITIONS,
     active_paths,
     load_disposition_manifest,
@@ -247,6 +248,11 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/kernel/test_agent_outcome_baseline.py",
     } == R1_ADDITIONS
     assert {"tests/kernel/test_schema_v3.py"} == R2_ADDITIONS
+    assert {
+        "src/codex_usage_tracker/kernel/rollups.py",
+        "tests/kernel/interfaces/test_r4_coverage_contract.py",
+        "tests/kernel/query/test_r4_rollups.py",
+    } == R4_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -267,6 +273,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
             | R1_ADDITIONS
             | R2_ADDITIONS
             | R3_ADDITIONS
+            | R4_ADDITIONS
         )
 
 

--- a/tests/kernel/test_release_028_qualification.py
+++ b/tests/kernel/test_release_028_qualification.py
@@ -42,21 +42,15 @@ def test_release_028_sdist_rejects_stale_source_bytes(tmp_path: Path) -> None:
             source_root=source,
         )
 
-    assert failures == [
-        "integration sdist contains stale source bytes: README.md"
-    ]
+    assert failures == ["integration sdist contains stale source bytes: README.md"]
 
 
 def test_release_028_identity_is_coherent_and_anchored_to_merged_main() -> None:
     project = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     package = json.loads((_ROOT / "package.json").read_text(encoding="utf-8"))
-    plugin = json.loads(
-        (_ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
-    )
+    plugin = json.loads((_ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
     qualification = json.loads(
-        (_ROOT / "config" / "kernel-release-qualification-v1.json").read_text(
-            encoding="utf-8"
-        )
+        (_ROOT / "config" / "kernel-release-qualification-v1.json").read_text(encoding="utf-8")
     )
 
     assert project["project"]["version"] == _VERSION
@@ -101,25 +95,23 @@ def test_release_028_ci_and_public_install_paths_are_current() -> None:
     assert "github.head_ref == 'release/0.28.0'" in ci
     assert "config/kernel-release-qualification-v1.json" in ci
     assert "--version 0.28.0" in ci
-    assert 'codex-usage-tracking==0.28.0' in readme
+    assert "codex-usage-tracking==0.28.0" in readme
     assert "--ref v0.28.0" in readme
 
 
 def test_release_028_golden_prompt_uses_three_bounded_read_only_mcp_calls(
     tmp_path: Path,
 ) -> None:
-    qualification = json.loads(
-        (_ROOT / "config" / "kernel-release-qualification-v1.json").read_text(
-            encoding="utf-8"
-        )
+    candidate = json.loads(
+        (_ROOT / "config" / "kernel-release-candidate-budget.json").read_text(encoding="utf-8")
     )
-    budget = qualification["golden_prompt"]
+    budget = candidate["mcp_golden_prompt"]
     launches = []
     runtime = active_runtime(tmp_path)
     server = McpServer(
         KernelApplication(
             runtime,
-            worker_launcher=launches.append,
+            worker_launcher=lambda paths, _preset: launches.append(paths),
             source_provider=lambda _home: synthetic_sources(),
         )
     )


### PR DESCRIPTION
## Summary
- add generation-scoped persisted rollups and bounded fast paths for common MCP/API queries
- add publication-safe response caching and coverage-aware recent-history hydration presets
- preserve exact missingness and generic fallbacks while hardening interrupted refresh recovery

## Performance
- 100k-call model/effort query: 4.744 ms p95
- 100k-call thread concentration: 2.157 ms p95
- 100k-call daily bands: 2.258 ms p95
- 2k append over 100k active calls: 35.565 ms writer p95 (from 229.652 ms)

## Validation
- 386 Python tests passed
- frontend build/lint/typecheck/tests passed
- Ruff, MyPy, Pyright, maintainability, scope, manifests, and release safety passed
- exact distributions: 148,013-byte wheel; 449,325-byte sdist
- installed two-fresh-task smoke passed; warm Console p95 0.853 ms
- one final read-only review: 5 findings, all accepted and remediated; token attribution pending

## Notes
- PR #314 was separately audited and closed as superseded; no unique implementation was imported.
- Synthetic fixtures only; no real usage content inspected.