### PR TITLE
feat: restore analytical usage primitives

### DIFF
--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -1,7 +1,7 @@
 {
   "schema": "codex-usage-tracker.kernel-rc-budget.v1",
   "headroom_percent": 3,
-  "kernel_source_bytes": 541436,
+  "kernel_source_bytes": 588010,
   "console_asset_bytes": 48811,
   "analytical_tables": 17,
   "analytical_indexes": 14,
@@ -9,14 +9,14 @@
   "mcp_tools": 6,
   "http_routes": 7,
   "cli_commands": 11,
-  "wheel_bytes": 151960,
-  "sdist_bytes": 461160,
+  "wheel_bytes": 161943,
+  "sdist_bytes": 480189,
   "plugin_bundle_bytes": 3900,
   "mcp_golden_prompt": {
     "mcp_calls": 3,
-    "measured_response_bytes": [889, 10517, 906],
-    "response_byte_ceilings": [915, 10832, 933],
-    "measured_total_bytes": 12312,
-    "total_byte_ceiling": 12681
+    "measured_response_bytes": [889, 12096, 1023],
+    "response_byte_ceilings": [915, 12458, 1053],
+    "measured_total_bytes": 14008,
+    "total_byte_ceiling": 14428
   }
 }

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -15,8 +15,8 @@ benchmark, a source-only tag, or an unpublished package.
 | R1 | Complete | R0 | `feature/r1-agent-outcome-baseline` | PR #342 merged as `aefb216`; frozen benchmark and measured failures |
 | R2 | Complete | R1 | `feature/r2-schema-v3-compact-storage` | PR #344 merged as `f740939`; compact schema v3 published to `main` |
 | R3 | Complete | R2 | `feature/r3-build-refresh-performance` | PR #344 merged as `f740939`; selective hydration and refresh gates pass |
-| R4 | In progress | R2 | `feature/r4-fast-query-mcp` | Rollup/query contracts pass; final review and merge pending |
-| R5 | Pending | R3, R4 | — | Analytical primitives and human semantics |
+| R4 | Complete | R2 | `feature/r4-fast-query-mcp` | PR #345 merged as `da42350`; persisted rollups and fast bounded paths |
+| R5 | In progress | R3, R4 | `feature/r5-analytical-primitives` | Correctness and privacy contracts pass; full validation pending |
 | R6 | Pending | R4, R5 | — | Console usability |
 | R7 | Pending | R1; completes after R3–R6 | — | Installed fresh-task qualification |
 | R8 | Pending | R0; completes after R6, R7 | — | Public documentation |
@@ -645,8 +645,8 @@ query, recovery, and performance contracts, scope allowlist, and this ledger
 
 ### Residual risk and next action
 
-- Commit and open the R4 pull request, require green CI, and merge before
-  starting R5. No second reviewer is permitted.
+- PR #345 passed CI and squash-merged as `da42350`. The source branch and
+  worktree remain preserved.
 - The first PR CI attempt exposed one stale installed-Console assumption: its
   synthetic allowance fixture relied on the former complete-history default.
   The smoke now explicitly requests `complete`; the local installed
@@ -656,3 +656,120 @@ query, recovery, and performance contracts, scope allowlist, and this ledger
   migrated. Publication snapshots now report conservative empty coverage for
   pre-v3 sidecars without writing. The v2-to-v3 migration creates the exact
   active/staged coverage schemas, and both published upgrade paths pass locally.
+
+## R5 — Restore Analytical Primitives And Human Semantics
+
+State: in progress on `feature/r5-analytical-primitives`, based on merged R4
+commit `da42350`.
+
+### Contract added first
+
+- Added synthetic contracts for the four token classes and total, configured
+  cost, estimated credits, coverage, allowance intervals, human thread labels,
+  turn ordinal/completion basis, bounded tool semantics, adjacent-call impact,
+  and copied-row exclusion.
+- Added explicit upgrade, append, and parser-boundary contracts:
+  parser v1 is replaced once by parser v2 and then returns to `no_changes`; a
+  later completion event closes the existing turn without double-counting its
+  call or tool; and tool start/output records merge across the 1,000-line
+  parser batch boundary.
+- Added privacy contracts proving that raw arguments, tool output, full source
+  paths, and absolute targets are not persisted. Partial rate coverage keeps
+  unrated usage visible rather than presenting it as zero.
+
+### Implementation checkpoint
+
+- Thread results pair a prompt-derived, bounded, control-stripped display label
+  with the stable exact selector. Session-index renames are resolved without
+  reparsing transcript JSONL.
+- Tool facts retain only operation class, safe project-relative target,
+  timestamps, status, duration, output byte count, argument-key shape, turn,
+  and deterministic adjacent model-call token classes. The response caveat
+  states that adjacency is not causal attribution.
+- Turns remain open until an observed completion, abort, or rollback event and
+  accumulate append-safe call/tool counts across generations.
+- Configured cost and estimated credits use the local dated rate card with
+  provenance, confidence, rated/unrated call coverage, and distinct semantics
+  from observed allowance drain.
+- Allowance rows are time-first and expose interval-local calls, turns, four
+  token classes, total tokens, and observed drain without assigning the drain
+  to the revealing call.
+- Parser version 2 deliberately reparses a legacy source once. The source
+  upsert now persists the new parser version; this fixed a defect that would
+  otherwise have forced the same replacement reparse on every subsequent
+  refresh.
+- Tool upserts now report only genuinely new tool rows and preserve the active
+  source/canonical adjacent call when an archived copy is encountered.
+- The final review exposed and the implementation now covers nine additional
+  edge contracts: label-less thread dimensions, pre-promotion tool isolation,
+  moving-tail relinking, non-project target rejection, structural-only copy
+  ownership, missing-ID tool occurrence identity, normalized structured-output
+  byte semantics, invalid-rate-card degradation, and effective turn completion
+  across every evidence view.
+- Refreshes stage whenever an existing tool will be enriched or a new call can
+  relink a prior tool in the same turn. Failed pre-promotion refreshes therefore
+  leave the active generation unchanged, while successful moving-tail refreshes
+  publish the following canonical call as the deterministic adjacent call.
+
+### Unprofiled performance evidence
+
+All measurements use fixed synthetic data; no local usage content was read.
+
+| Workload | Current p95 | Budget/result |
+| --- | ---: | --- |
+| 100,000-call top threads with four token classes, cost, credits, and labels | 508.637 ms | passes 1 s concentration gate |
+| 25,000-tool detailed adjacent-impact first page | 380.419 ms | passes 500 ms common-query gate |
+| 100,000-call allowance read | 402.455 ms | passes 500 ms gate |
+| 100,000-call evidence first page | 117.200 ms | passes 500 ms gate |
+| Warm batched adapter query | 0.370 ms | passes 500 ms gate |
+| Warm status | 0.567 ms | passes 50 ms local gate |
+
+The linked-tool canonicality path was measured at 456.274 ms p95 before the
+bounded fast-path change and 370.013 ms immediately afterward, a 19% reduction
+on the identical 25,000-tool workload. The combined final run measured
+380.419 ms p95. Common responses were 18,442 bytes for top threads and 10,071
+bytes for tool impact, both below the 64,000-byte focused ceiling.
+
+### Profiling evidence
+
+- `agent-perf` run `20260728T021431Z-de01d540` completed the R5 synthetic
+  workload under Scalene 2.3.0 in 22.235 seconds.
+- Ranked application attribution identified query execution and the two
+  deterministic per-call pricing functions on the cost/credit path. The
+  profile is attribution evidence only; the unprofiled timings above are the
+  performance evidence.
+- A pricing lookup micro-optimization did not improve the identical
+  end-to-end workload and was removed rather than retained as speculative
+  complexity.
+
+### Verification checkpoint
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| R5 correctness/privacy focus | Pass | 24 dedicated R5 contracts plus focused query, allowance, evidence, application, rollup, ingestion, and concurrency suites |
+| Performance suite | Pass | 10 synthetic query, allowance, evidence, adapter, ingest, and kernel benchmark tests |
+| Ruff | Pass | changed R5 implementation and tests |
+| MyPy, Pyright | Pass | 62-source MyPy surface; Pyright 0 errors and 0 warnings |
+| Full repository | Pass | 412 Python tests, 7 frontend tests, scope, manifests, maintainability, release safety, lint, typecheck, and deterministic Console assets |
+| Built distributions | Pass | wheel 158,032 bytes and sdist 469,613 bytes before the final ledger-only rebuild; both remain below their release-candidate ceilings; artifact digests stay in the external build manifest because this ledger is packaged in the sdist and ordinary wheel builds carry archive timestamps |
+| Installed package | Pass | clean candidate, public 0.27 upgrade, exact R4-base 0.28 upgrade with one-time parser-v2 replacement, two fresh MCP tasks each, and installed Console/allowance smoke; warm Console p95 no worse than 0.953 ms |
+| Final review | Pass after remediation | one read-only reviewer reported nine findings; R1–R9 were accepted and fixed; reviewer token attribution is pending because the installed tracker CLI lacks the metrics helper's legacy `strict` command |
+
+### Deviations and decisions
+
+- No explicitly authorized subagents were used. Shared parser, writer, query,
+  evidence, and allowance ownership made sequential integration safer.
+- SQLite timestamp subtraction can vary by a few microseconds; duration
+  contracts retain exact observed endpoints and use a 0.02 ms assertion
+  tolerance.
+- Configured-cost concentration currently remains a bounded fact query because
+  token pricing depends on the external rate-card revision. It passes the
+  required 1-second gate without adding a query-time database writer.
+
+### Residual risk and next action
+
+- Rebuild and check the final distributions, rerun installed-package smoke
+  against the corrected wheel, then open the R5 pull request. GitNexus classed
+  the writer/rollup remediation as critical blast radius; the failed-promotion,
+  moving-tail, focused 107-test surface, ingest-performance gates, and full
+  repository gate all pass after the change.

--- a/justfile
+++ b/justfile
@@ -51,6 +51,7 @@ vp:
         tests/kernel/test_source_registry_privacy.py \
         tests/kernel/test_oracle_equivalence.py \
         tests/kernel/test_privacy_oracle.py \
+        tests/kernel/test_r5_analytical_primitives.py \
         tests/kernel/test_source_lifecycle_oracle.py \
         tests/kernel/test_stable_contract_028.py \
         tests/kernel/test_watcher.py
@@ -87,6 +88,7 @@ v:
         tests/kernel/test_ingest_*.py \
         tests/kernel/test_oracle_equivalence.py \
         tests/kernel/test_privacy_oracle.py \
+        tests/kernel/test_r5_analytical_primitives.py \
         tests/kernel/test_source_lifecycle_oracle.py \
         tests/kernel/test_stable_contract_028.py \
         tests/kernel/test_watcher.py \

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -259,6 +259,12 @@ R4_ADDITIONS = frozenset(
         "tests/kernel/query/test_r4_rollups.py",
     }
 )
+R5_ADDITIONS = frozenset(
+    {
+        "src/codex_usage_tracker/kernel/thread_labels.py",
+        "tests/kernel/test_r5_analytical_primitives.py",
+    }
+)
 
 INTEGRATION_ADDITIONS = (
     K1A_ADDITIONS
@@ -281,10 +287,9 @@ INTEGRATION_ADDITIONS = (
     | R2_ADDITIONS
     | R3_ADDITIONS
     | R4_ADDITIONS
+    | R5_ADDITIONS
 )
-_BLOCKED_TASK_REF = re.compile(
-    r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))"
-)
+_BLOCKED_TASK_REF = re.compile(r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))")
 
 
 def load_disposition_manifest(path: Path) -> dict[str, Any]:
@@ -312,9 +317,7 @@ def active_paths(repo_root: Path) -> set[str]:
     )
     paths = {line for line in result.stdout.splitlines() if line}
     return {
-        path
-        for path in paths
-        if (repo_root / path).exists() or (repo_root / path).is_symlink()
+        path for path in paths if (repo_root / path).exists() or (repo_root / path).is_symlink()
     }
 
 
@@ -325,9 +328,7 @@ def scope_failures(repo_root: Path, manifest: dict[str, Any]) -> list[str]:
     current = active_paths(repo_root)
     classified = {entry["path"] for entry in entries}
     kept = {entry["path"] for entry in entries if entry["disposition"] == "keep"}
-    removed = {
-        entry["path"] for entry in entries if entry["disposition"] != "keep"
-    }
+    removed = {entry["path"] for entry in entries if entry["disposition"] != "keep"}
     failures: list[str] = []
 
     physically_present = {
@@ -351,13 +352,8 @@ def scope_failures(repo_root: Path, manifest: dict[str, Any]) -> list[str]:
             "retire": {"removed", "verified"},
             "transplant": {"removed", "implemented", "verified"},
         }
-        if (
-            disposition != "keep"
-            and status not in valid_absent_statuses[disposition]
-        ):
-            failures.append(
-                f"{entry['path']}: invalid absent {disposition} status {status}"
-            )
+        if disposition != "keep" and status not in valid_absent_statuses[disposition]:
+            failures.append(f"{entry['path']}: invalid absent {disposition} status {status}")
         if disposition == "transplant":
             if not entry["source_ref"].startswith("v0.25.1:"):
                 failures.append(f"{entry['path']}: transplant lacks tag provenance")

--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -295,11 +295,13 @@ def _assert_dogfood_results(results: list[object]) -> None:
         != 360
     ):
         raise RuntimeError("installed MCP comparison differs from the oracle")
-    if (
-        sum(int(row["tools"]) for row in tool_rows) != 2
-        or sum(int(row["turns"]) for row in turn_rows) != 5
-    ):
-        raise RuntimeError("installed MCP structural totals differ from the oracle")
+    actual_tools = sum(int(row["tools"]) for row in tool_rows)
+    actual_turns = sum(int(row["turns"]) for row in turn_rows)
+    if actual_tools != 2 or actual_turns != 4:
+        raise RuntimeError(
+            "installed MCP structural totals differ from the oracle: "
+            f"tools={actual_tools}, turns={actual_turns}"
+        )
 
 
 def _result_rows(
@@ -525,7 +527,11 @@ def smoke_install(
         venv.EnvBuilder(with_pip=True, clear=True).create(venv_root)
         python = _python(venv_root)
         initial_target = (
-            f"{DISTRIBUTION_NAME}=={upgrade_from}"
+            (
+                str(Path(upgrade_from).resolve())
+                if Path(upgrade_from).is_file()
+                else f"{DISTRIBUTION_NAME}=={upgrade_from}"
+            )
             if upgrade_from is not None
             else target
         )
@@ -732,7 +738,10 @@ def main() -> int:
     parser.add_argument("--from-pypi", action="store_true")
     parser.add_argument("--version")
     parser.add_argument("--artifact-dir", type=Path)
-    parser.add_argument("--upgrade-from")
+    parser.add_argument(
+        "--upgrade-from",
+        help="public version or local wheel used to create the pre-upgrade cache",
+    )
     arguments = parser.parse_args()
     if arguments.from_pypi and arguments.artifact_dir is not None:
         parser.error("--from-pypi and --artifact-dir are mutually exclusive")

--- a/src/codex_usage_tracker/kernel/allowance/rates.py
+++ b/src/codex_usage_tracker/kernel/allowance/rates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import re
@@ -41,6 +42,7 @@ class ModelRates:
 class RateCard:
     source: dict[str, str]
     models: dict[str, ModelRates]
+    digest: str
 
 
 @dataclass(frozen=True)
@@ -52,6 +54,7 @@ class UsageEstimate:
     coverage_percent: float
     unrated_models: tuple[str, ...]
     provenance: dict[str, str] | None
+    confidence: str | None
 
 
 def load_rate_card(path: Path) -> RateCard | None:
@@ -62,29 +65,24 @@ def load_rate_card(path: Path) -> RateCard | None:
     try:
         if path.stat().st_size > MAX_RATE_CARD_BYTES:
             raise ValueError("rate card exceeds the size limit")
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        encoded = path.read_bytes()
+        payload = json.loads(encoded)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("rate card is unreadable") from exc
     if not isinstance(payload, dict) or payload.get("schema") != RATE_CARD_SCHEMA:
         raise ValueError("rate card schema is invalid")
     source = _source(payload.get("source"))
     raw_models = payload.get("models")
-    if (
-        not isinstance(raw_models, dict)
-        or not 1 <= len(raw_models) <= MAX_RATE_CARD_MODELS
-    ):
+    if not isinstance(raw_models, dict) or not 1 <= len(raw_models) <= MAX_RATE_CARD_MODELS:
         raise ValueError("rate card models are invalid")
     if any(
-        not isinstance(model, str) or _MODEL_NAME.fullmatch(model) is None
-        for model in raw_models
+        not isinstance(model, str) or _MODEL_NAME.fullmatch(model) is None for model in raw_models
     ):
         raise ValueError("rate card model name is invalid")
     return RateCard(
         source=source,
-        models={
-            model: _model_rates(model, raw)
-            for model, raw in raw_models.items()
-        },
+        models={model: _model_rates(model, raw) for model, raw in raw_models.items()},
+        digest="sha256:" + hashlib.sha256(encoded).hexdigest(),
     )
 
 
@@ -102,6 +100,7 @@ def rate_card_status(path: Path) -> dict[str, Any]:
         "status": "ready",
         "source": card.source,
         "model_count": len(card.models),
+        "revision": card.digest,
     }
 
 
@@ -121,17 +120,20 @@ def estimate_local_usage(
             coverage_percent=100.0 if total_tokens == 0 else 0.0,
             unrated_models=tuple(sorted(usage_by_model)),
             provenance=None,
+            confidence=None,
         )
     cost = 0.0
     credits = 0.0
     rated_tokens = 0
     unrated: list[str] = []
+    confidences: set[str] = set()
     for model, usage in usage_by_model.items():
         rates = card.models.get(model)
         if rates is None:
             unrated.append(model)
             continue
         rated_tokens += usage.total_tokens
+        confidences.add(rates.confidence)
         cost += _estimate(
             usage,
             rates.input_per_million,
@@ -153,6 +155,13 @@ def estimate_local_usage(
         coverage_percent=coverage,
         unrated_models=tuple(sorted(unrated)),
         provenance=card.source,
+        confidence=(
+            next(iter(confidences))
+            if len(confidences) == 1
+            else "mixed"
+            if confidences
+            else None
+        ),
     )
 
 

--- a/src/codex_usage_tracker/kernel/allowance/service.py
+++ b/src/codex_usage_tracker/kernel/allowance/service.py
@@ -206,12 +206,16 @@ FROM local_facts
 ) AS allowance_intervals
 """
 
-_OBSERVATION_SQL = """
+_OBSERVATION_SQL = (
+    """
 SELECT *
-FROM """ + ALLOWANCE_BASE_SQL + """
+FROM """
+    + ALLOWANCE_BASE_SQL
+    + """
 ORDER BY observed_at DESC, allowance_observation_id DESC
 LIMIT ? OFFSET ?
 """
+)
 
 _LOCAL_USAGE_SQL = """
 SELECT model,
@@ -230,6 +234,7 @@ GROUP BY model
 ORDER BY model
 """
 
+
 class AllowanceService:
     """Return exact observations plus deterministic local-efficiency facts."""
 
@@ -239,9 +244,7 @@ class AllowanceService:
 
     def read(self, *, limit: int = 100, cursor: str | None = None) -> dict[str, Any]:
         if not 1 <= limit <= MAX_ALLOWANCE_LIMIT:
-            raise ValueError(
-                f"allowance limit must be between 1 and {MAX_ALLOWANCE_LIMIT}"
-            )
+            raise ValueError(f"allowance limit must be between 1 and {MAX_ALLOWANCE_LIMIT}")
         started = time.perf_counter()
         control = load_cutover_control(self._operational_path)
         path = control.active_kernel_path
@@ -256,7 +259,12 @@ class AllowanceService:
             generation=generation,
             publication_id=publication_id,
         )
-        card = load_rate_card(self._rate_card_path)
+        rate_card_error: str | None = None
+        try:
+            card = load_rate_card(self._rate_card_path)
+        except ValueError:
+            card = None
+            rate_card_error = "invalid local rate card; unpriced usage remains visible"
         with open_read_snapshot(path) as connection:
             matched = int(
                 connection.execute(
@@ -293,9 +301,7 @@ class AllowanceService:
             else None
         )
         observed_through = (
-            max(str(row["observed_at"]) for row in returned_rows)
-            if returned_rows
-            else None
+            max(str(row["observed_at"]) for row in returned_rows) if returned_rows else None
         )
         grades = {str(item["grade"]) for item in intervals}
         grade = "deterministic" if "deterministic" in grades else "exact"
@@ -315,10 +321,12 @@ class AllowanceService:
             "next_cursor": next_cursor,
             "elapsed_ms": (time.perf_counter() - started) * 1000,
             "grade": grade,
-            "coverage": _coverage(intervals, card is not None),
-            "evidence_selectors": [
-                str(item["evidence_selector"]) for item in intervals
-            ],
+            "coverage": _coverage(
+                intervals,
+                card is not None,
+                rate_card_error=rate_card_error,
+            ),
+            "evidence_selectors": [str(item["evidence_selector"]) for item in intervals],
         }
 
 
@@ -355,15 +363,13 @@ def _interval_payload(
     if estimate.coverage_percent < 100:
         limitations.append("incomplete_rate_card_coverage")
     payload = {
-        "allowance_observation_id": current.allowance_observation_id,
-        "previous_observation_id": (
-            previous.allowance_observation_id if previous else None
-        ),
-        "evidence_selector": (
-            f"allowance:{current.allowance_observation_id}"
-        ),
-        "observed_at": _timestamp_text(current.observed_at),
+        "interval_start": (_timestamp_text(previous.observed_at) if previous else None),
+        "interval_end": _timestamp_text(current.observed_at),
         "window_kind": current.window_kind,
+        "allowance_observation_id": current.allowance_observation_id,
+        "previous_observation_id": (previous.allowance_observation_id if previous else None),
+        "evidence_selector": (f"allowance:{current.allowance_observation_id}"),
+        "observed_at": _timestamp_text(current.observed_at),
         "limit_id": current.limit_id,
         "plan_type": current.plan_type,
         "used_percent": current.used_percent,
@@ -385,23 +391,19 @@ def _interval_payload(
             else "exact_observation"
         ),
         "source_generation": generation,
+        "observed_allowance_drain": interval.delta_used_percent,
+        "allowance_attribution": ("interval_observation_not_revealing_call"),
         "delta_used_percent": interval.delta_used_percent,
         "elapsed_hours": interval.elapsed_hours,
         "percentage_points_per_hour": interval.percentage_points_per_hour,
-        "local_tokens_per_percentage_point": (
-            interval.local_tokens_per_percentage_point
-        ),
-        "local_calls_per_percentage_point": (
-            interval.local_calls_per_percentage_point
-        ),
-        "local_turns_per_percentage_point": (
-            interval.local_turns_per_percentage_point
-        ),
+        "local_tokens_per_percentage_point": (interval.local_tokens_per_percentage_point),
+        "local_calls_per_percentage_point": (interval.local_calls_per_percentage_point),
+        "local_turns_per_percentage_point": (interval.local_turns_per_percentage_point),
         "local_usage": {
             **asdict(usage),
             "total_tokens": usage.total_tokens,
         },
-        "estimated_cost_usd": estimate.estimated_cost_usd,
+        "configured_cost_usd": estimate.estimated_cost_usd,
         "estimated_credits": estimate.estimated_credits,
         "pricing_coverage": {
             "rated_tokens": estimate.rated_tokens,
@@ -409,6 +411,7 @@ def _interval_payload(
             "coverage_percent": estimate.coverage_percent,
             "unrated_models": list(estimate.unrated_models),
             "provenance": estimate.provenance,
+            "confidence": estimate.confidence,
         },
         "limitations": limitations,
     }
@@ -483,16 +486,16 @@ def _local_usage(
         )
         for row in rows
     }
+
+
 def _coverage(
     intervals: list[dict[str, Any]],
     configured: bool,
+    *,
+    rate_card_error: str | None = None,
 ) -> dict[str, Any]:
-    total_tokens = sum(
-        int(item["pricing_coverage"]["total_tokens"]) for item in intervals
-    )
-    rated_tokens = sum(
-        int(item["pricing_coverage"]["rated_tokens"]) for item in intervals
-    )
+    total_tokens = sum(int(item["pricing_coverage"]["total_tokens"]) for item in intervals)
+    rated_tokens = sum(int(item["pricing_coverage"]["rated_tokens"]) for item in intervals)
     return {
         "generation_bound": True,
         "raw_content": False,
@@ -504,14 +507,20 @@ def _coverage(
         },
         "ratios": {
             "basis": "deterministic_adjacent_observations",
-            "calculated_count": sum(
-                item["grade"] == "deterministic" for item in intervals
-            ),
+            "calculated_count": sum(item["grade"] == "deterministic" for item in intervals),
             "total_count": len(intervals),
         },
         "pricing": {
             "basis": "source_stamped_local_rate_card",
             "configured": configured,
+            "status": (
+                "invalid"
+                if rate_card_error is not None
+                else "ready"
+                if configured
+                else "absent"
+            ),
+            "limitation": rate_card_error,
             "rated_tokens": rated_tokens,
             "total_tokens": total_tokens,
             "coverage_percent": (
@@ -575,11 +584,7 @@ def _decode_cursor(
         encoded = cursor.encode()
         padding = b"=" * (-len(encoded) % 4)
         payload = json.loads(base64.urlsafe_b64decode(encoded + padding))
-        if (
-            payload["g"] != generation
-            or payload["p"] != publication_id
-            or payload["v"] != 1
-        ):
+        if payload["g"] != generation or payload["p"] != publication_id or payload["v"] != 1:
             raise ValueError
         offset = int(payload["o"])
         if offset < 0 or offset > MAX_ALLOWANCE_OFFSET:
@@ -592,6 +597,4 @@ def _decode_cursor(
         ValueError,
         json.JSONDecodeError,
     ) as exc:
-        raise ValueError(
-            "allowance cursor does not match analytical publication"
-        ) from exc
+        raise ValueError("allowance cursor does not match analytical publication") from exc

--- a/src/codex_usage_tracker/kernel/application/service.py
+++ b/src/codex_usage_tracker/kernel/application/service.py
@@ -34,6 +34,7 @@ from ..operational import (
 )
 from ..query import QueryService, exploration_guidance
 from ..query.contracts import MAX_QUERY_RESPONSE_BYTES
+from ..thread_labels import load_thread_label_hashes, thread_label_revision
 from .codec import evidence_request, json_value, query_request
 from .jobs import JobReader
 from .runtime import (
@@ -139,6 +140,8 @@ class KernelApplication:
                 requests,
                 history_coverage=history_coverage,
                 content=self.paths.content,
+                rate_card=self.paths.rate_card,
+                thread_labels=self.paths.codex_home,
             )
         cached = self._cached_query(cache_key) if cache_key is not None else None
         cache_hit = cached is not None
@@ -147,6 +150,10 @@ class KernelApplication:
                 QueryService(
                     self.paths.kernel.operational,
                     content_path=self.paths.content,
+                    rate_card_path=self.paths.rate_card,
+                    thread_labels=load_thread_label_hashes(
+                        self.paths.codex_home,
+                    ),
                     publication=publication,
                 ).execute_batch(requests)
                 if requests
@@ -190,7 +197,12 @@ class KernelApplication:
                 self._query_cache.popitem(last=False)
 
     def evidence(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = EvidenceService(self.paths.kernel.operational).read(evidence_request(payload))
+        result = EvidenceService(
+            self.paths.kernel.operational,
+            thread_labels=load_thread_label_hashes(
+                self.paths.codex_home,
+            ),
+        ).read(evidence_request(payload))
         return json_value(result)
 
     def allowance(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -444,6 +456,8 @@ def _query_cache_key(
     *,
     history_coverage: dict[str, object],
     content: Path,
+    rate_card: Path,
+    thread_labels: Path,
 ) -> str:
     payload = {
         "generation": control.active_generation,
@@ -452,6 +466,8 @@ def _query_cache_key(
         "coverage_revision": history_coverage["coverage_revision"],
         "requests": [json_value(request.normalized()) for request in requests],
         "content": content_status(content),
+        "rate_card": rate_card_status(rate_card),
+        "thread_labels": thread_label_revision(thread_labels),
     }
     return (
         "sha256:"

--- a/src/codex_usage_tracker/kernel/evidence/service.py
+++ b/src/codex_usage_tracker/kernel/evidence/service.py
@@ -23,6 +23,45 @@ from .contracts import (
 
 EVIDENCE_PLAN_VERSION = 1
 
+_EFFECTIVE_TURNS_CTE = """
+WITH ranked_completion AS (
+    SELECT activity_events.turn_id,
+           activity_events.event_at,
+           activity_events.event_kind,
+           ROW_NUMBER() OVER (
+               PARTITION BY activity_events.turn_id
+               ORDER BY activity_events.event_at DESC,
+                        activity_events.activity_event_id DESC
+           ) AS rank
+    FROM activity_events
+    WHERE activity_events.generation <= ?
+      AND activity_events.event_kind IN ('task', 'turn_aborted', 'rollback')
+),
+completion AS (
+    SELECT turn_id,
+           event_at AS ended_at,
+           'observed_event' AS completion_basis,
+           CASE event_kind
+               WHEN 'task' THEN 'completed'
+               WHEN 'turn_aborted' THEN 'aborted'
+               ELSE 'rolled_back'
+           END AS status
+    FROM ranked_completion
+    WHERE rank = 1
+),
+effective_turns AS (
+    SELECT turns.*,
+           COALESCE(completion.ended_at, turns.ended_at) AS effective_ended_at,
+           COALESCE(completion.status, turns.status) AS effective_status,
+           COALESCE(
+               completion.completion_basis,
+               turns.completion_basis
+           ) AS effective_completion_basis
+    FROM turns
+    LEFT JOIN completion USING (turn_id)
+)
+"""
+
 
 @dataclass(frozen=True)
 class _Resolution:
@@ -43,8 +82,14 @@ class _EvidencePlan:
 class EvidenceService:
     """Resolve stable logical selectors into bounded privacy-safe rows."""
 
-    def __init__(self, operational_path: Path) -> None:
+    def __init__(
+        self,
+        operational_path: Path,
+        *,
+        thread_labels: dict[str, str] | None = None,
+    ) -> None:
         self._operational_path = operational_path.resolve()
+        self._thread_labels = dict(thread_labels or {})
 
     def read(self, request: EvidenceRequest) -> EvidenceResult:
         normalized = request.normalized()
@@ -68,6 +113,10 @@ class EvidenceService:
             limit=normalized.limit,
         )
         with open_read_snapshot(path) as connection:
+            _register_thread_label_function(
+                connection,
+                self._thread_labels,
+            )
             connection.execute("PRAGMA query_only = ON")
             resolution = _resolve(connection, selector, generation)
             plan = _compile_plan(
@@ -114,6 +163,21 @@ class EvidenceService:
                 "generation_bound": True,
                 "logical_selector": True,
                 "content_included": False,
+                "thread_labels": {
+                    "basis": ("prompt_derived_session_index_metadata_when_available"),
+                    "sanitized": True,
+                },
+                "tool_impact": (
+                    {
+                        "basis": "deterministic_adjacent_model_call",
+                        "causal_attribution": False,
+                        "limitation": (
+                            "multiple preceding tools may contribute to one adjacent model call"
+                        ),
+                    }
+                    if view in {EvidenceView.TOOLS, EvidenceView.TIMELINE}
+                    else None
+                ),
             },
         )
 
@@ -129,18 +193,23 @@ def _resolve(
             SELECT thread_id, NULL, NULL, NULL, NULL
             FROM threads
             WHERE logical_thread_id = ? AND first_generation <= ?
-            ORDER BY first_generation
+            ORDER BY archive_state = 'active' DESC,
+                     last_generation DESC,
+                     thread_key
             LIMIT 1
             """,
             (selector.logical_id, generation),
         ),
         "turn": (
             """
-            SELECT thread_id, turn_id, NULL, NULL, NULL
+            SELECT turns.thread_id, turns.turn_id, NULL, NULL, NULL
             FROM turns
-            WHERE COALESCE(source_turn_id_hash, turn_id) = ?
-              AND first_generation <= ?
-            ORDER BY first_generation
+            JOIN threads USING (thread_id)
+            WHERE COALESCE(turns.source_turn_id_hash, turns.turn_id) = ?
+              AND turns.first_generation <= ?
+            ORDER BY threads.archive_state = 'active' DESC,
+                     turns.last_generation DESC,
+                     turns.turn_key
             LIMIT 1
             """,
             (selector.logical_id, generation),
@@ -196,7 +265,7 @@ def _compile_plan(
     offset: int,
 ) -> _EvidencePlan:
     if view is EvidenceView.SUMMARY:
-        sql, parameters = _summary_plan(selector, generation)
+        sql, parameters = _summary_plan(selector, resolution, generation)
     elif view is EvidenceView.CALLS:
         sql, parameters = _calls_plan(resolution, generation)
     elif view is EvidenceView.TOOLS:
@@ -207,10 +276,7 @@ def _compile_plan(
         sql, parameters = _allowance_plan(resolution, generation)
     else:
         sql, parameters = _timeline_plan(selector, resolution, generation)
-    paged = (
-        f"SELECT * FROM ({sql}) AS evidence_rows "
-        f"ORDER BY {_order_by(view)} LIMIT ? OFFSET ?"
-    )
+    paged = f"SELECT * FROM ({sql}) AS evidence_rows ORDER BY {_order_by(view)} LIMIT ? OFFSET ?"
     count = f"SELECT COUNT(*) FROM ({sql}) AS evidence_rows"
     return _EvidencePlan(
         sql=paged,
@@ -221,49 +287,124 @@ def _compile_plan(
 
 def _summary_plan(
     selector: EvidenceSelector,
+    resolution: _Resolution,
     generation: int,
 ) -> tuple[str, tuple[Any, ...]]:
     plans = {
         "thread": (
             """
-            SELECT logical_thread_id AS thread, display_label, project_label,
+            SELECT logical_thread_id AS thread,
+                   resolved_thread_label(
+                       session_identity_hash,
+                       display_label
+                   ) AS display_label,
+                   project_label,
                    created_at, updated_at, archive_state,
                    parent_logical_thread_id, subagent_type, subagent_role
             FROM threads
-            WHERE logical_thread_id = ? AND first_generation <= ?
+            WHERE thread_id = ? AND first_generation <= ?
             ORDER BY first_generation
             """,
-            (selector.logical_id, generation),
+            (resolution.thread_id, generation),
         ),
         "turn": (
-            """
+            _EFFECTIVE_TURNS_CTE
+            + """,
+            call_counts AS (
+                SELECT turn_id, COUNT(*) AS model_call_count
+                FROM model_calls
+                WHERE generation <= ?
+                  AND duplicate_state = 'canonical'
+                GROUP BY turn_id
+            ),
+            tool_counts AS (
+                SELECT turn_id, COUNT(*) AS tool_call_count
+                FROM tool_calls
+                WHERE generation <= ?
+                GROUP BY turn_id
+            ),
+            activity_counts AS (
+                SELECT turn_id,
+                       SUM(event_kind = 'skill') AS skill_count,
+                       SUM(event_kind = 'compaction') AS compaction_count,
+                       SUM(event_kind = 'patch') AS patch_count,
+                       SUM(event_kind IN (
+                           'rollback',
+                           'turn_aborted'
+                       )) AS error_count
+                FROM activity_events
+                WHERE generation <= ?
+                GROUP BY turn_id
+            )
             SELECT COALESCE(turns.source_turn_id_hash, turns.turn_id) AS turn,
-                   threads.logical_thread_id AS thread, turns.ordinal,
-                   turns.started_at, turns.ended_at, turns.status,
-                   turns.model_call_count, turns.tool_call_count,
-                   turns.skill_count, turns.compaction_count,
-                   turns.patch_count, turns.error_count
-            FROM turns JOIN threads USING (thread_id)
-            WHERE COALESCE(turns.source_turn_id_hash, turns.turn_id) = ?
+                   threads.logical_thread_id AS thread,
+                   resolved_thread_label(
+                       threads.session_identity_hash,
+                       threads.display_label
+                   ) AS thread_label,
+                   turns.ordinal,
+                   turns.started_at,
+                   turns.effective_ended_at AS ended_at,
+                   turns.effective_status AS status,
+                   turns.start_basis,
+                   turns.effective_completion_basis AS completion_basis,
+                   CASE WHEN turns.effective_completion_basis = 'observed_event'
+                        THEN 'exact' ELSE turns.basis_confidence
+                   END AS basis_confidence,
+                   COALESCE(call_counts.model_call_count, 0)
+                       AS model_call_count,
+                   COALESCE(tool_counts.tool_call_count, 0)
+                       AS tool_call_count,
+                   COALESCE(activity_counts.skill_count, 0) AS skill_count,
+                   COALESCE(activity_counts.compaction_count, 0)
+                       AS compaction_count,
+                   COALESCE(activity_counts.patch_count, 0) AS patch_count,
+                   COALESCE(activity_counts.error_count, 0) AS error_count
+            FROM effective_turns AS turns JOIN threads USING (thread_id)
+            LEFT JOIN call_counts USING (turn_id)
+            LEFT JOIN tool_counts USING (turn_id)
+            LEFT JOIN activity_counts USING (turn_id)
+            WHERE turns.turn_id = ?
               AND turns.first_generation <= ?
             """,
-            (selector.logical_id, generation),
+            (
+                generation,
+                generation,
+                generation,
+                generation,
+                resolution.turn_id,
+                generation,
+            ),
         ),
         "call": (
             _CALLS_SQL + " AND model_calls.canonical_call_id = ?",
-            (generation, selector.logical_id),
+            (generation, generation, selector.logical_id),
         ),
         "tool": (
             _TOOLS_SQL + " AND tool_calls.tool_call_id = ?",
-            (generation, selector.logical_id),
+            (generation, generation, selector.logical_id),
         ),
         "allowance": (
-            _ALLOWANCE_SQL
-            + " AND allowance_observations.allowance_observation_id = ?",
+            _ALLOWANCE_SQL + " AND allowance_observations.allowance_observation_id = ?",
             (generation, selector.logical_id),
         ),
     }
     return plans[selector.kind]
+
+
+def _register_thread_label_function(
+    connection: sqlite3.Connection,
+    labels: dict[str, str],
+) -> None:
+    connection.create_function(
+        "resolved_thread_label",
+        2,
+        lambda session_hash, stored: labels.get(
+            str(session_hash),
+            str(stored),
+        ),
+        deterministic=True,
+    )
 
 
 def _calls_plan(
@@ -276,7 +417,7 @@ def _calls_plan(
         turn="model_calls.turn_id",
         call="model_calls.model_call_id",
     )
-    return _CALLS_SQL + " AND " + clause, (generation, value)
+    return _CALLS_SQL + " AND " + clause, (generation, generation, value)
 
 
 def _tools_plan(
@@ -290,7 +431,7 @@ def _tools_plan(
         call="tool_calls.nearest_model_call_id",
         tool="tool_calls.tool_call_id",
     )
-    return _TOOLS_SQL + " AND " + clause, (generation, value)
+    return _TOOLS_SQL + " AND " + clause, (generation, generation, value)
 
 
 def _activities_plan(
@@ -349,26 +490,38 @@ def _timeline_plan(
             SELECT 'activity:' || activity_events.activity_event_id,
                    activity_events.event_at, activity_events.event_kind,
                    NULL, activity_events.safe_label, activity_events.category,
+                   activity_turns.ordinal,
+                   activity_turns.effective_completion_basis,
+                   NULL, NULL, NULL, NULL, NULL,
                    NULL, NULL, NULL, NULL, NULL,
                    activity_events.generation
             FROM activity_events
+            LEFT JOIN effective_turns AS activity_turns
+              ON activity_turns.turn_id = activity_events.turn_id
             WHERE activity_events.generation <= ? AND {activity_clause}
         """
         activity_parameters: tuple[Any, ...] = (generation, activity_value)
     else:
         activity_sql = ""
         activity_parameters = ()
-    sql = f"""
+    sql = _EFFECTIVE_TURNS_CTE + f"""
         SELECT 'call:' || model_calls.canonical_call_id AS event_id,
                model_calls.event_at, 'model_call' AS event_kind,
                'call:' || model_calls.canonical_call_id AS selector,
                model_calls.model AS safe_label, 'model_call' AS category,
+               call_turns.ordinal AS turn_ordinal,
+               call_turns.effective_completion_basis AS completion_basis,
+               NULL AS operation, NULL AS target_label,
+               NULL AS duration_ms, NULL AS output_bytes,
+               NULL AS impact_grade,
                model_calls.input_tokens - model_calls.cached_input_tokens
                    AS uncached_input_tokens,
                model_calls.cached_input_tokens, model_calls.reasoning_tokens,
                model_calls.output_tokens, NULL AS status,
                model_calls.generation
         FROM model_calls
+        LEFT JOIN effective_turns AS call_turns
+          ON call_turns.turn_id = model_calls.turn_id
         WHERE model_calls.generation <= ?
           AND model_calls.duplicate_state = 'canonical'
           AND {call_clause}
@@ -377,15 +530,32 @@ def _timeline_plan(
                COALESCE(tool_calls.started_at, tool_calls.ended_at),
                'tool_call', 'tool:' || tool_calls.tool_call_id,
                tool_calls.tool_name, tool_calls.tool_category,
-               NULL, NULL, NULL, NULL, tool_calls.status,
+               tool_turns.ordinal, tool_turns.effective_completion_basis,
+               tool_calls.operation, tool_calls.target_label,
+               tool_calls.duration_ms, tool_calls.output_bytes,
+               CASE WHEN adjacent.model_call_id IS NULL
+                    THEN 'structural_only'
+                    ELSE 'deterministic_adjacent_call'
+               END,
+               adjacent.input_tokens - adjacent.cached_input_tokens,
+               adjacent.cached_input_tokens,
+               adjacent.reasoning_tokens,
+               adjacent.output_tokens,
+               tool_calls.status,
                tool_calls.generation
         FROM tool_calls
+        LEFT JOIN effective_turns AS tool_turns
+          ON tool_turns.turn_id = tool_calls.turn_id
+        LEFT JOIN model_calls AS adjacent
+          ON adjacent.model_call_id = tool_calls.nearest_model_call_id
+         AND adjacent.generation <= tool_calls.generation
         WHERE tool_calls.generation <= ? AND {tool_clause}
         {activity_sql}
     """
     return (
         sql,
         (
+            generation,
             generation,
             call_value,
             generation,
@@ -433,10 +603,16 @@ def _activity_scope(resolution: _Resolution) -> tuple[str, str]:
     raise ValueError("selector has no activity evidence")
 
 
-_CALLS_SQL = """
+_CALLS_SQL = _EFFECTIVE_TURNS_CTE + """
 SELECT model_calls.canonical_call_id AS call,
        threads.logical_thread_id AS thread,
+       resolved_thread_label(
+           threads.session_identity_hash,
+           threads.display_label
+       ) AS thread_label,
        COALESCE(turns.source_turn_id_hash, turns.turn_id) AS turn,
+       turns.ordinal AS turn_ordinal,
+       turns.effective_completion_basis AS completion_basis,
        model_calls.event_at, model_calls.model, model_calls.effort,
        model_calls.service_tier, model_calls.origin,
        model_calls.input_tokens - model_calls.cached_input_tokens
@@ -447,23 +623,44 @@ SELECT model_calls.canonical_call_id AS call,
        model_calls.generation
 FROM model_calls
 JOIN threads USING (thread_id)
-LEFT JOIN turns ON turns.turn_id = model_calls.turn_id
+LEFT JOIN effective_turns AS turns ON turns.turn_id = model_calls.turn_id
 WHERE model_calls.generation <= ?
   AND model_calls.duplicate_state = 'canonical'
 """
 
-_TOOLS_SQL = """
+_TOOLS_SQL = _EFFECTIVE_TURNS_CTE + """
 SELECT tool_calls.tool_call_id AS tool,
        threads.logical_thread_id AS thread,
+       resolved_thread_label(
+           threads.session_identity_hash,
+           threads.display_label
+       ) AS thread_label,
        COALESCE(turns.source_turn_id_hash, turns.turn_id) AS turn,
+       turns.ordinal AS turn_ordinal,
+       turns.effective_completion_basis AS completion_basis,
        tool_calls.tool_name, tool_calls.server_name, tool_calls.namespace,
-       tool_calls.tool_category, tool_calls.started_at, tool_calls.ended_at,
+       tool_calls.tool_category, tool_calls.operation,
+       tool_calls.target_label, tool_calls.started_at, tool_calls.ended_at,
        tool_calls.duration_ms, tool_calls.status, tool_calls.error_category,
        tool_calls.output_bytes, tool_calls.observation_confidence,
+       CASE WHEN nearest.model_call_id IS NULL
+            THEN 'structural_only'
+            ELSE 'deterministic_adjacent_call'
+       END AS impact_grade,
+       nearest.input_tokens - nearest.cached_input_tokens
+           AS adjacent_uncached_input_tokens,
+       nearest.cached_input_tokens AS adjacent_cached_input_tokens,
+       nearest.reasoning_tokens AS adjacent_reasoning_tokens,
+       nearest.output_tokens AS adjacent_output_tokens,
+       nearest.input_tokens + nearest.output_tokens
+           AS adjacent_total_tokens,
        tool_calls.generation
 FROM tool_calls
 JOIN threads USING (thread_id)
-LEFT JOIN turns ON turns.turn_id = tool_calls.turn_id
+LEFT JOIN effective_turns AS turns ON turns.turn_id = tool_calls.turn_id
+LEFT JOIN model_calls AS nearest
+  ON nearest.model_call_id = tool_calls.nearest_model_call_id
+ AND nearest.generation <= tool_calls.generation
 WHERE tool_calls.generation <= ?
 """
 
@@ -510,9 +707,7 @@ def _destination(
     view: EvidenceView,
     live: bool,
 ) -> str:
-    query = urlencode(
-        {"selector": selector.value, "view": view.value, "live": int(live)}
-    )
+    query = urlencode({"selector": selector.value, "view": view.value, "live": int(live)})
     return f"/evidence/{quote(selector.value, safe='')}?{query}"
 
 
@@ -554,9 +749,7 @@ def _decode_cursor(
     if cursor is None:
         return 0
     try:
-        payload = json.loads(
-            base64.urlsafe_b64decode(cursor + "=" * (-len(cursor) % 4))
-        )
+        payload = json.loads(base64.urlsafe_b64decode(cursor + "=" * (-len(cursor) % 4)))
         offset = payload["o"]
         if (
             payload["g"] != generation
@@ -575,6 +768,4 @@ def _decode_cursor(
         TypeError,
         ValueError,
     ) as exc:
-        raise ValueError(
-            "evidence cursor does not match selector generation"
-        ) from exc
+        raise ValueError("evidence cursor does not match selector generation") from exc

--- a/src/codex_usage_tracker/kernel/ingest.py
+++ b/src/codex_usage_tracker/kernel/ingest.py
@@ -53,9 +53,15 @@ from .operational import (
     stage_hydration_catalog,
     transition_cutover,
 )
-from .parser import ParsedBatch, iter_jsonl_batches, parse_jsonl
+from .parser import (
+    PARSER_VERSION,
+    ParsedBatch,
+    iter_jsonl_batches,
+    parse_jsonl,
+)
 from .rollups import generation_rollups_ready, rebuild_generation_rollups
 from .schema import SCHEMA_VERSION
+from .thread_labels import load_thread_labels
 from .writer import (
     WriteResult,
     commit_empty_initial_refresh,
@@ -107,6 +113,7 @@ class KernelIngestor:
         self.operational_path = operational_path.resolve()
         self._journal = journal
         self._build_path_override: Path | None = None
+        self._thread_labels: dict[str, str] = {}
 
     def refresh(
         self,
@@ -122,6 +129,7 @@ class KernelIngestor:
         if trigger is RefreshTrigger.WATCHER and not self._has_active_kernel():
             raise ValueError("watcher requires an existing active kernel")
         self._initialize_for_explicit_refresh()
+        self._thread_labels = load_thread_labels(sources)
         selection, observations, request_hash = self._select_hydration(
             sources,
             hydration_preset=hydration_preset,
@@ -578,12 +586,15 @@ class KernelIngestor:
             ).fetchone()
         if row is None:
             return None
+        parser_upgrade = str(row["parser_version"]) != PARSER_VERSION
         return SourceCursor(
             source_id=str(row["source_id"]),
             parsed_byte_offset=int(row["parsed_byte_offset"]),
             parsed_line_number=int(row["parsed_line_number"]),
             size_bytes=int(row["size_bytes"]),
-            prefix_fingerprint=str(row["replacement_fingerprint"]),
+            prefix_fingerprint=(
+                "parser-upgrade-required" if parser_upgrade else str(row["replacement_fingerprint"])
+            ),
             is_archived=str(row["archive_state"]) == "archived",
         )
 
@@ -599,7 +610,14 @@ class KernelIngestor:
             prior_state = self._parser_state(plan, analytical_path)
             parsed = parse_jsonl(plan, prior_state)
             parsed_batches.append(parsed)
-            normalized_batches.append(normalize_batch(plan, parsed, generation=generation))
+            normalized_batches.append(
+                normalize_batch(
+                    plan,
+                    parsed,
+                    generation=generation,
+                    thread_labels=self._thread_labels,
+                )
+            )
         return tuple(parsed_batches), tuple(normalized_batches)
 
     def _parser_state(self, plan: SourcePlan, analytical_path: Path):
@@ -664,6 +682,7 @@ class KernelIngestor:
                     chunk_plan,
                     parsed,
                     generation=generation,
+                    thread_labels=self._thread_labels,
                 )
                 for row in normalized.model_calls:
                     row["duplicate_state"] = "canonical"
@@ -737,6 +756,8 @@ class KernelIngestor:
 
         transaction_ms = list(written.transaction_ms)
         deleted_rows = written.deleted_rows
+        inserted_calls = written.inserted_calls
+        inserted_tools = written.inserted_tools
         latest = written
         catch_up_source_ids: set[str] = set()
         selected_source_ids = frozenset(item.observation.source_id for item in selection.hydrate)
@@ -760,8 +781,8 @@ class KernelIngestor:
             if not plans:
                 return (
                     WriteResult(
-                        inserted_calls=latest.inserted_calls,
-                        inserted_tools=latest.inserted_tools,
+                        inserted_calls=inserted_calls,
+                        inserted_tools=inserted_tools,
                         deleted_rows=deleted_rows,
                         canonical_calls=latest.canonical_calls,
                         excluded_calls=latest.excluded_calls,
@@ -781,6 +802,8 @@ class KernelIngestor:
                 assert_fence=assert_fence,
             )
             deleted_rows += latest.deleted_rows
+            inserted_calls += latest.inserted_calls
+            inserted_tools += latest.inserted_tools
             transaction_ms.extend(latest.transaction_ms)
             catch_up_source_ids.update(plan.observation.source_id for plan in plans)
             selected_source_ids = frozenset(
@@ -983,6 +1006,25 @@ class KernelIngestor:
     ) -> bool:
         if self._active_generation() == 0:
             return False
+        tool_ids = tuple(
+            sorted(
+                {
+                    str(row["tool_call_id"])
+                    for batch in normalized
+                    for row in batch.tool_calls
+                }
+            )
+        )
+        call_turn_ids = tuple(
+            sorted(
+                {
+                    str(row["turn_id"])
+                    for batch in normalized
+                    for row in batch.model_calls
+                    if row.get("turn_id") is not None
+                }
+            )
+        )
         fingerprints = tuple(
             sorted(
                 {
@@ -993,9 +1035,25 @@ class KernelIngestor:
                 }
             )
         )
-        if not fingerprints:
-            return False
         with open_read_snapshot(active_path) as connection:
+            for column, values in (
+                ("tool_call_id", tool_ids),
+                ("turn_id", call_turn_ids),
+            ):
+                for start in range(0, len(values), 500):
+                    chunk = values[start : start + 500]
+                    placeholders = ", ".join("?" for _ in chunk)
+                    row = connection.execute(
+                        f"""
+                        SELECT 1
+                        FROM tool_calls
+                        WHERE {column} IN ({placeholders})
+                        LIMIT 1
+                        """,
+                        chunk,
+                    ).fetchone()
+                    if row is not None:
+                        return True
             for start in range(0, len(fingerprints), 500):
                 chunk = fingerprints[start : start + 500]
                 placeholders = ", ".join("?" for _ in chunk)

--- a/src/codex_usage_tracker/kernel/normalize.py
+++ b/src/codex_usage_tracker/kernel/normalize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import Any
 
 from .discovery import SourcePlan
@@ -30,13 +31,14 @@ def normalize_batch(
     parsed: ParsedBatch,
     *,
     generation: int,
+    thread_labels: dict[str, str] | None = None,
 ) -> NormalizedBatch:
     """Create deterministic rows without reading or writing SQLite."""
 
     threads: dict[str, Row] = {}
     turns: dict[str, Row] = {}
     calls: list[Row] = []
-    tools: list[Row] = []
+    tools: dict[str, Row] = {}
     activities: list[Row] = []
     allowances: list[Row] = []
     thread_ids: dict[
@@ -67,6 +69,7 @@ def normalize_batch(
                 plan,
                 thread_id,
                 generation,
+                thread_labels or {},
             )
         if turn_id not in turns:
             turns[turn_id] = _turn_row(
@@ -79,21 +82,21 @@ def normalize_batch(
         if event.kind == "model_call":
             calls.append(_call_row(event, plan, thread_id, turn_id, generation))
         elif event.kind == "tool":
-            tools.append(_tool_row(event, plan, thread_id, turn_id, generation))
+            tool = _tool_row(event, plan, thread_id, turn_id, generation)
+            identifier = str(tool["tool_call_id"])
+            tools[identifier] = _merge_tool_rows(tools.get(identifier), tool)
         elif event.kind == "activity":
-            activities.append(
-                _activity_row(event, plan, thread_id, turn_id, generation)
-            )
+            activities.append(_activity_row(event, plan, thread_id, turn_id, generation))
         elif event.kind == "allowance":
-            allowances.append(
-                _allowance_row(event, plan, thread_id, generation)
-            )
-    _apply_turn_counts(turns, calls, tools, activities)
+            allowances.append(_allowance_row(event, plan, thread_id, generation))
+        _update_turn_span(turns[turn_id], event)
+    _link_nearest_calls(tuple(tools.values()), calls)
+    _apply_turn_counts(turns, calls, list(tools.values()), activities)
     return NormalizedBatch(
         threads=tuple(threads.values()),
         turns=tuple(turns.values()),
         model_calls=tuple(calls),
-        tool_calls=tuple(tools),
+        tool_calls=tuple(tools.values()),
         activities=tuple(activities),
         allowances=tuple(allowances),
         parser_state_json=_state_json(parsed.final_state),
@@ -134,13 +137,10 @@ def _thread_row(
     plan: SourcePlan,
     thread_id: str,
     generation: int,
+    thread_labels: dict[str, str],
 ) -> Row:
-    label = event.agent_nickname
-    parent = (
-        stable_id("thr", event.parent_session_id)
-        if event.parent_session_id
-        else None
-    )
+    label = thread_labels.get(event.session_id or "") or event.agent_nickname
+    parent = stable_id("thr", event.parent_session_id) if event.parent_session_id else None
     return {
         "thread_id": thread_id,
         "source_id": plan.observation.source_id,
@@ -171,16 +171,14 @@ def _turn_row(
 ) -> Row:
     return {
         "turn_id": turn_id,
-        "source_turn_id_hash": (
-            stable_id("uturn", event.turn_id) if event.turn_id else None
-        ),
+        "source_turn_id_hash": (stable_id("uturn", event.turn_id) if event.turn_id else None),
         "thread_id": thread_id,
         "ordinal": event.turn_ordinal,
-        "started_at": event.timestamp,
-        "ended_at": event.timestamp,
-        "status": "completed",
+        "started_at": event.turn_started_at or event.timestamp,
+        "ended_at": None,
+        "status": "open",
         "start_basis": "turn_context" if event.turn_id else "event_order",
-        "completion_basis": "observed_event",
+        "completion_basis": None,
         "basis_confidence": "exact" if event.turn_id else "inferred",
         "first_source_offset": event.source_offset,
         "last_source_offset": event.source_offset,
@@ -252,25 +250,45 @@ def _tool_row(
     generation: int,
 ) -> Row:
     name = event.tool_name or "unknown"
-    return {
-        "tool_call_id": stable_id(
+    tool_call_id = (
+        stable_id(
             "tool",
-            plan.observation.source_id,
-            event.source_offset,
+            "upstream",
+            event.tool_call_id,
+        )
+        if event.tool_call_id
+        else stable_id(
+            "tool",
+            "structural",
+            event.turn_id or "",
+            event.timestamp,
             name,
+            event.source_offset,
+        )
+    )
+    ended_at = event.timestamp if event.tool_phase == "end" else None
+    return {
+        "tool_call_id": tool_call_id,
+        "upstream_call_id_hash": (
+            stable_id("upcall", event.tool_call_id) if event.tool_call_id else None
         ),
         "source_id": plan.observation.source_id,
         "thread_id": thread_id,
         "turn_id": turn_id,
+        "nearest_model_call_id": None,
         "tool_name": name,
         "server_name": event.server_name,
         "namespace": name.split("__", 1)[0] if "__" in name else None,
         "tool_category": "mcp" if event.server_name else "function",
-        "started_at": event.timestamp,
-        "ended_at": event.timestamp,
-        "status": "completed",
-        "output_bytes": None,
-        "argument_shape": None,
+        "operation": event.tool_operation or "unknown",
+        "target_label": event.tool_target_label,
+        "started_at": None if event.tool_phase == "end" else event.timestamp,
+        "ended_at": ended_at,
+        "duration_ms": None,
+        "status": event.tool_status or "incomplete",
+        "error_category": None,
+        "output_bytes": event.tool_output_bytes,
+        "argument_shape": event.tool_argument_shape,
         "first_source_offset": event.source_offset,
         "last_source_offset": event.source_offset,
         "generation": generation,
@@ -362,6 +380,88 @@ def _apply_turn_counts(
             row["patch_count"] += 1
         elif kind in {"rollback", "turn_aborted"}:
             row["error_count"] += 1
+
+
+def _update_turn_span(row: Row, event: StructuralEvent) -> None:
+    if event.timestamp:
+        row["ended_at"] = max(str(row["ended_at"] or ""), event.timestamp)
+    if event.kind != "activity":
+        return
+    if event.activity_kind == "task":
+        row["status"] = "completed"
+        row["completion_basis"] = "observed_event"
+        row["basis_confidence"] = "exact"
+    elif event.activity_kind == "turn_aborted":
+        row["status"] = "aborted"
+        row["completion_basis"] = "observed_event"
+        row["basis_confidence"] = "exact"
+    elif event.activity_kind == "rollback":
+        row["status"] = "rolled_back"
+        row["completion_basis"] = "observed_event"
+        row["basis_confidence"] = "exact"
+
+
+def _merge_tool_rows(current: Row | None, observed: Row) -> Row:
+    if current is None:
+        return observed
+    merged = dict(current)
+    if current["tool_name"] == "unknown" and observed["tool_name"] != "unknown":
+        for field in (
+            "tool_name",
+            "server_name",
+            "namespace",
+            "tool_category",
+            "operation",
+            "target_label",
+            "argument_shape",
+        ):
+            merged[field] = observed[field]
+    for field in ("started_at", "ended_at", "output_bytes"):
+        if observed[field] is not None:
+            merged[field] = observed[field]
+    merged["status"] = observed["status"]
+    merged["first_source_offset"] = min(
+        int(current["first_source_offset"]),
+        int(observed["first_source_offset"]),
+    )
+    merged["last_source_offset"] = max(
+        int(current["last_source_offset"]),
+        int(observed["last_source_offset"]),
+    )
+    merged["duration_ms"] = _duration_ms(
+        merged["started_at"],
+        merged["ended_at"],
+    )
+    return merged
+
+
+def _link_nearest_calls(tools: tuple[Row, ...], calls: list[Row]) -> None:
+    calls_by_turn: dict[str, list[Row]] = {}
+    for call in calls:
+        calls_by_turn.setdefault(str(call["turn_id"]), []).append(call)
+    for candidates in calls_by_turn.values():
+        candidates.sort(key=lambda item: (str(item["event_at"]), str(item["model_call_id"])))
+    for tool in tools:
+        candidates = calls_by_turn.get(str(tool["turn_id"]), [])
+        boundary = str(tool["ended_at"] or tool["started_at"] or "")
+        following = next(
+            (call for call in candidates if str(call["event_at"]) >= boundary),
+            None,
+        )
+        nearest = following or (candidates[-1] if candidates else None)
+        if nearest is not None:
+            tool["nearest_model_call_id"] = nearest["model_call_id"]
+
+
+def _duration_ms(started_at: Any, ended_at: Any) -> float | None:
+    if not isinstance(started_at, str) or not isinstance(ended_at, str):
+        return None
+    try:
+        start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(ended_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (end - start).total_seconds() * 1000.0)
 
 
 def _state_json(state: ParserState) -> str:

--- a/src/codex_usage_tracker/kernel/parser.py
+++ b/src/codex_usage_tracker/kernel/parser.py
@@ -6,14 +6,21 @@ import json
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
+from pathlib import PurePosixPath
 from typing import Any
 
 from .discovery import SourcePlan
 from .identity import safe_label
 
 PARSER_ADAPTER = "codex-jsonl-structural"
-PARSER_VERSION = "1"
+PARSER_VERSION = "2"
 _SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:/@+-]{0,127}\Z")
+_TEST_COMMAND = re.compile(
+    r"(?:^|[;&|]\s*)(?:[^;&|]*?/)?"
+    r"(?:pytest|ruff|mypy|pyright|just\s+v|npm\s+test|pnpm\s+test)\b"
+)
+_SEARCH_COMMAND = re.compile(r"(?:^|[;&|]\s*)(?:[^;&|]*?/)?(?:rg|grep|find)\b")
+_READ_COMMAND = re.compile(r"(?:^|[;&|]\s*)(?:[^;&|]*?/)?(?:sed|head|tail|cat|ls|wc)\b")
 _ACTIVITY_KINDS = {
     "context_compacted": "compaction",
     "patch_apply_end": "patch",
@@ -32,6 +39,7 @@ class ParserState:
     agent_nickname: str | None = None
     turn_id: str | None = None
     turn_ordinal: int = 0
+    turn_started_at: str | None = None
     model: str = "unknown"
     effort: str | None = None
     service_tier: str | None = None
@@ -49,6 +57,7 @@ class StructuralEvent:
     agent_nickname: str | None
     turn_id: str | None
     turn_ordinal: int
+    turn_started_at: str | None
     model: str
     effort: str | None
     service_tier: str | None
@@ -61,6 +70,13 @@ class StructuralEvent:
     context_window: int | None = None
     tool_name: str | None = None
     server_name: str | None = None
+    tool_call_id: str | None = None
+    tool_phase: str | None = None
+    tool_operation: str | None = None
+    tool_target_label: str | None = None
+    tool_status: str | None = None
+    tool_output_bytes: int | None = None
+    tool_argument_shape: str | None = None
     activity_kind: str | None = None
     activity_label: str | None = None
     allowance_window: str | None = None
@@ -196,16 +212,42 @@ def _parse_envelope(
     if envelope_type == "session_meta":
         return [], _session_state(state, payload), True
     if envelope_type == "turn_context":
-        return [], _turn_state(state, payload), True
+        return [], _turn_state(state, payload, timestamp), True
     if envelope_type == "response_item":
         if payload.get("type") == "function_call":
+            tool_name = _safe_name(payload.get("name")) or "function_call"
+            arguments = _tool_arguments(payload.get("arguments"))
             event = _base_event(
                 "tool",
                 timestamp,
                 source_offset,
                 line_number,
                 state,
-                tool_name=_safe_name(payload.get("name")) or "function_call",
+                upstream_id=_safe_identifier(payload.get("call_id")),
+                tool_name=tool_name,
+                server_name=_tool_server(tool_name),
+                tool_call_id=_safe_identifier(payload.get("call_id")),
+                tool_phase="start",
+                tool_operation=_tool_operation(tool_name, arguments),
+                tool_target_label=_tool_target(arguments),
+                tool_status="started",
+                tool_argument_shape=_argument_shape(arguments),
+            )
+            return [event], state, True
+        if payload.get("type") == "function_call_output":
+            event = _base_event(
+                "tool",
+                timestamp,
+                source_offset,
+                line_number,
+                state,
+                upstream_id=_safe_identifier(payload.get("call_id")),
+                tool_name="unknown",
+                tool_call_id=_safe_identifier(payload.get("call_id")),
+                tool_phase="end",
+                tool_operation="unknown",
+                tool_status="completed",
+                tool_output_bytes=_observed_output_bytes(payload.get("output")),
             )
             return [event], state, True
         return [], state, True
@@ -213,23 +255,34 @@ def _parse_envelope(
         return [], state, False
     event_type = payload.get("type")
     if event_type == "token_count":
-        return _token_events(
-            envelope,
-            payload,
+        return (
+            _token_events(
+                envelope,
+                payload,
+                state,
+                timestamp,
+                source_offset,
+                line_number,
+            ),
             state,
-            timestamp,
-            source_offset,
-            line_number,
-        ), state, True
+            True,
+        )
     if event_type == "mcp_tool_call_end":
+        tool_name = _safe_name(payload.get("tool_name")) or "mcp_tool"
         event = _base_event(
             "tool",
             timestamp,
             source_offset,
             line_number,
             state,
-            tool_name=_safe_name(payload.get("tool_name")) or "mcp_tool",
+            upstream_id=_safe_identifier(payload.get("call_id")),
+            tool_name=tool_name,
             server_name=_safe_name(payload.get("server_name")),
+            tool_call_id=_safe_identifier(payload.get("call_id")),
+            tool_phase="end",
+            tool_operation="mcp",
+            tool_status="completed",
+            tool_output_bytes=_observed_output_bytes(payload.get("result")),
         )
         return [event], state, True
     activity = _ACTIVITY_KINDS.get(str(event_type))
@@ -262,11 +315,16 @@ def _session_state(state: ParserState, payload: dict[str, Any]) -> ParserState:
     )
 
 
-def _turn_state(state: ParserState, payload: dict[str, Any]) -> ParserState:
+def _turn_state(
+    state: ParserState,
+    payload: dict[str, Any],
+    timestamp: str,
+) -> ParserState:
     return replace(
         state,
         turn_id=_safe_identifier(payload.get("turn_id")),
         turn_ordinal=state.turn_ordinal + 1,
+        turn_started_at=timestamp or None,
         model=_safe_name(payload.get("model")) or "unknown",
         effort=_safe_name(payload.get("effort")),
         service_tier=_safe_name(payload.get("service_tier")),
@@ -353,6 +411,7 @@ def _base_event(
         agent_nickname=state.agent_nickname,
         turn_id=state.turn_id,
         turn_ordinal=state.turn_ordinal,
+        turn_started_at=state.turn_started_at,
         model=state.model,
         effort=state.effort,
         service_tier=state.service_tier,
@@ -364,6 +423,103 @@ def _activity_label(activity: str, payload: dict[str, Any]) -> str | None:
     if activity == "skill":
         return _safe_display(payload.get("skill_name"))
     return None
+
+
+def _tool_arguments(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or len(value.encode("utf-8")) > 64 * 1024:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _tool_server(tool_name: str) -> str | None:
+    if not tool_name.startswith("mcp__"):
+        return None
+    parts = tool_name.split("__", 2)
+    return _safe_name(parts[1]) if len(parts) == 3 else None
+
+
+def _tool_operation(tool_name: str, arguments: dict[str, Any]) -> str:
+    lowered = tool_name.lower()
+    leaf = re.split(r"[.:/]|__", lowered)[-1]
+    if lowered.startswith("mcp__"):
+        return "mcp"
+    if any(name in lowered for name in ("browser", "playwright", "chrome")):
+        return "browser"
+    if "apply_patch" in leaf or leaf in {"patch", "patch_file"}:
+        return "patch"
+    if leaf in {"read", "read_file", "view_file", "view_image", "open_file"}:
+        return "read"
+    if leaf in {"write", "write_file", "create_file", "edit_file"}:
+        return "write"
+    if leaf in {"search", "search_files", "find_files", "grep"}:
+        return "search"
+    if leaf in {"test", "run_tests"}:
+        return "test"
+    if leaf in {"exec", "exec_command", "run", "run_command"}:
+        command = arguments.get("cmd")
+        if isinstance(command, str):
+            if _TEST_COMMAND.search(command):
+                return "test"
+            if _SEARCH_COMMAND.search(command):
+                return "search"
+            if _READ_COMMAND.search(command):
+                return "read"
+        return "execute"
+    return "unknown"
+
+
+def _tool_target(arguments: dict[str, Any]) -> str | None:
+    for field in ("path", "file_path", "filename", "target"):
+        value = arguments.get(field)
+        if not isinstance(value, str):
+            continue
+        normalized = value.replace("\\", "/").strip()
+        if (
+            not normalized
+            or len(normalized) > 240
+            or any(ord(character) < 32 for character in normalized)
+            or normalized.startswith(("~", "//"))
+            or re.match(r"^[A-Za-z]:/", normalized) is not None
+            or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", normalized) is not None
+        ):
+            continue
+        path = PurePosixPath(normalized)
+        if path.is_absolute() or ".." in path.parts:
+            continue
+        return str(path)[:160]
+    return None
+
+
+def _argument_shape(arguments: dict[str, Any]) -> str | None:
+    keys = sorted(
+        key
+        for key in arguments
+        if isinstance(key, str) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", key)
+    )
+    return json.dumps(keys[:32], separators=(",", ":")) if keys else None
+
+
+def _observed_output_bytes(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+    return len(encoded)
 
 
 def _safe_name(value: Any) -> str | None:

--- a/src/codex_usage_tracker/kernel/query/catalog.py
+++ b/src/codex_usage_tracker/kernel/query/catalog.py
@@ -54,10 +54,100 @@ _CONTEXT_OPERATIONS = frozenset(
         Operation.SHARE,
     }
 )
+_THREAD_LABEL_SQL = "resolved_thread_label(threads.session_identity_hash, threads.display_label)"
+_CANONICAL_THREAD_SQL = """
+(
+    threads.thread_key = (
+        SELECT candidate_threads.thread_key
+        FROM threads AS candidate_threads
+        WHERE candidate_threads.logical_thread_id = threads.logical_thread_id
+          AND candidate_threads.first_generation <= ?
+        ORDER BY candidate_threads.archive_state = 'active' DESC,
+                 candidate_threads.last_generation DESC,
+                 candidate_threads.thread_key
+        LIMIT 1
+    )
+)
+"""
+_CANONICAL_TOOL_SQL = f"""
+(
+    (
+        nearest_call.model_call_id IS NOT NULL
+        AND nearest_call.duplicate_state = 'canonical'
+    )
+    OR (
+        nearest_call.model_call_id IS NULL
+        AND {_CANONICAL_THREAD_SQL}
+    )
+)
+"""
+_CANONICAL_TURN_SQL = """
+(
+    turns.turn_key = (
+        SELECT candidate_turns.turn_key
+        FROM turns AS candidate_turns
+        JOIN threads AS candidate_threads
+          ON candidate_threads.thread_key = candidate_turns.thread_key
+        WHERE COALESCE(
+                  candidate_turns.source_turn_id_hash,
+                  candidate_turns.turn_id
+              ) = COALESCE(turns.source_turn_id_hash, turns.turn_id)
+          AND candidate_turns.first_generation <= ?
+        ORDER BY candidate_threads.archive_state = 'active' DESC,
+                 candidate_turns.last_generation DESC,
+                 candidate_turns.turn_key
+        LIMIT 1
+    )
+)
+"""
+_TURN_BASE_SQL = """
+(
+    SELECT stored_turns.*,
+           COALESCE(completion.status, stored_turns.status)
+               AS effective_status,
+           COALESCE(
+               completion.completion_basis,
+               stored_turns.completion_basis
+           ) AS effective_completion_basis,
+           COALESCE(completion.ended_at, stored_turns.ended_at)
+               AS effective_ended_at
+    FROM turns AS stored_turns
+    LEFT JOIN (
+        SELECT ranked.turn_id,
+               ranked.event_at AS ended_at,
+               'observed_event' AS completion_basis,
+               CASE ranked.event_kind
+                   WHEN 'task' THEN 'completed'
+                   WHEN 'turn_aborted' THEN 'aborted'
+                   ELSE 'rolled_back'
+               END AS status
+        FROM (
+            SELECT activity_events.turn_id,
+                   activity_events.event_at,
+                   activity_events.event_kind,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY activity_events.turn_id
+                       ORDER BY activity_events.event_at DESC,
+                                activity_events.activity_event_id DESC
+                   ) AS rank
+            FROM activity_events
+            WHERE activity_events.generation <= ?
+              AND activity_events.event_kind IN (
+                  'task',
+                  'turn_aborted',
+                  'rollback'
+              )
+        ) AS ranked
+        WHERE ranked.rank = 1
+    ) AS completion ON completion.turn_id = stored_turns.turn_id
+) AS turns
+JOIN threads ON threads.thread_id = turns.thread_id
+"""
 
 _CALL_DIMENSIONS = {
     "call": "model_calls.canonical_call_id",
     "thread": "threads.logical_thread_id",
+    "thread_label": _THREAD_LABEL_SQL,
     "turn": "COALESCE(turns.source_turn_id_hash, turns.turn_id)",
     "project": "threads.project_label",
     "model": "model_calls.model",
@@ -72,13 +162,21 @@ _CALL_DIMENSIONS = {
 _CALL_ROWS = {
     "calls": "1",
     "input_tokens": "model_calls.input_tokens",
-    "uncached_input_tokens": (
-        "model_calls.input_tokens - model_calls.cached_input_tokens"
-    ),
+    "uncached_input_tokens": ("model_calls.input_tokens - model_calls.cached_input_tokens"),
     "cached_input_tokens": "model_calls.cached_input_tokens",
     "reasoning_tokens": "model_calls.reasoning_tokens",
     "output_tokens": "model_calls.output_tokens",
     "total_tokens": "model_calls.input_tokens + model_calls.output_tokens",
+    "configured_cost_usd": (
+        "configured_cost_usd("
+        "model_calls.model, model_calls.input_tokens, "
+        "model_calls.cached_input_tokens, model_calls.output_tokens)"
+    ),
+    "estimated_credits": (
+        "estimated_credits("
+        "model_calls.model, model_calls.input_tokens, "
+        "model_calls.cached_input_tokens, model_calls.output_tokens)"
+    ),
     "cache_reuse": (
         "CASE WHEN model_calls.input_tokens = 0 THEN 0.0 "
         "ELSE 1.0 * model_calls.cached_input_tokens / model_calls.input_tokens END"
@@ -91,13 +189,21 @@ _CALL_ROWS = {
 _CALL_AGGREGATES = {
     "calls": "COUNT(*)",
     "input_tokens": "SUM(model_calls.input_tokens)",
-    "uncached_input_tokens": (
-        "SUM(model_calls.input_tokens - model_calls.cached_input_tokens)"
-    ),
+    "uncached_input_tokens": ("SUM(model_calls.input_tokens - model_calls.cached_input_tokens)"),
     "cached_input_tokens": "SUM(model_calls.cached_input_tokens)",
     "reasoning_tokens": "SUM(model_calls.reasoning_tokens)",
     "output_tokens": "SUM(model_calls.output_tokens)",
     "total_tokens": "SUM(model_calls.input_tokens + model_calls.output_tokens)",
+    "configured_cost_usd": (
+        "SUM(configured_cost_usd("
+        "model_calls.model, model_calls.input_tokens, "
+        "model_calls.cached_input_tokens, model_calls.output_tokens))"
+    ),
+    "estimated_credits": (
+        "SUM(estimated_credits("
+        "model_calls.model, model_calls.input_tokens, "
+        "model_calls.cached_input_tokens, model_calls.output_tokens))"
+    ),
     "cache_reuse": (
         "CASE WHEN SUM(model_calls.input_tokens) = 0 THEN 0.0 "
         "ELSE 1.0 * SUM(model_calls.cached_input_tokens) "
@@ -118,8 +224,7 @@ DATASETS: dict[str, DatasetSpec] = {
             "LEFT JOIN turns ON turns.turn_id = model_calls.turn_id"
         ),
         generation_sql=(
-            "model_calls.generation <= ? "
-            "AND model_calls.duplicate_state = 'canonical'"
+            "model_calls.generation <= ? AND model_calls.duplicate_state = 'canonical'"
         ),
         time_sql="model_calls.event_at",
         stable_id_sql="model_calls.canonical_call_id",
@@ -131,15 +236,30 @@ DATASETS: dict[str, DatasetSpec] = {
             "event_at": "model_calls.event_at",
         },
         operations=_CALL_OPERATIONS,
-        coverage_fields={"context_pressure": "model_calls.context_window"},
+        coverage_fields={
+            "context_pressure": "model_calls.context_window",
+            "configured_cost_usd": (
+                "configured_cost_usd("
+                "model_calls.model, model_calls.input_tokens, "
+                "model_calls.cached_input_tokens, model_calls.output_tokens)"
+            ),
+            "estimated_credits": (
+                "estimated_credits("
+                "model_calls.model, model_calls.input_tokens, "
+                "model_calls.cached_input_tokens, model_calls.output_tokens)"
+            ),
+        },
     ),
     "tools": DatasetSpec(
         base_sql=(
             "tool_calls "
             "JOIN threads ON threads.thread_id = tool_calls.thread_id "
-            "LEFT JOIN turns ON turns.turn_id = tool_calls.turn_id"
+            "LEFT JOIN turns ON turns.turn_id = tool_calls.turn_id "
+            "LEFT JOIN model_calls AS nearest_call "
+            "ON nearest_call.model_call_id = tool_calls.nearest_model_call_id "
+            "AND nearest_call.generation <= tool_calls.generation"
         ),
-        generation_sql="tool_calls.generation <= ?",
+        generation_sql=("tool_calls.generation <= ? AND " + _CANONICAL_TOOL_SQL),
         time_sql="tool_calls.started_at",
         stable_id_sql="tool_calls.tool_call_id",
         dimensions={
@@ -150,24 +270,45 @@ DATASETS: dict[str, DatasetSpec] = {
             "namespace": "tool_calls.namespace",
             "category": "tool_calls.tool_category",
             "status": "tool_calls.status",
+            "impact_grade": (
+                "CASE WHEN nearest_call.model_call_id IS NULL "
+                "THEN 'structural_only' "
+                "ELSE 'deterministic_adjacent_call' END"
+            ),
             "thread": "threads.logical_thread_id",
+            "thread_label": _THREAD_LABEL_SQL,
             "turn": "COALESCE(turns.source_turn_id_hash, turns.turn_id)",
+            "turn_ordinal": "turns.ordinal",
             "tool_call": "tool_calls.tool_call_id",
             "event_at": "tool_calls.started_at",
             "time_day": "substr(tool_calls.started_at, 1, 10)",
-            "time_hour": (
-                "substr(tool_calls.started_at, 1, 13) || ':00:00Z'"
-            ),
+            "time_hour": ("substr(tool_calls.started_at, 1, 13) || ':00:00Z'"),
         },
         row_measures={
             "tools": "1",
             "duration_ms": "tool_calls.duration_ms",
             "output_bytes": "tool_calls.output_bytes",
+            "adjacent_uncached_input_tokens": (
+                "nearest_call.input_tokens - nearest_call.cached_input_tokens"
+            ),
+            "adjacent_cached_input_tokens": "nearest_call.cached_input_tokens",
+            "adjacent_reasoning_tokens": "nearest_call.reasoning_tokens",
+            "adjacent_output_tokens": "nearest_call.output_tokens",
+            "adjacent_total_tokens": ("nearest_call.input_tokens + nearest_call.output_tokens"),
         },
         aggregate_measures={
             "tools": "COUNT(*)",
             "duration_ms": "SUM(tool_calls.duration_ms)",
             "output_bytes": "SUM(tool_calls.output_bytes)",
+            "adjacent_uncached_input_tokens": (
+                "SUM(nearest_call.input_tokens - nearest_call.cached_input_tokens)"
+            ),
+            "adjacent_cached_input_tokens": "SUM(nearest_call.cached_input_tokens)",
+            "adjacent_reasoning_tokens": "SUM(nearest_call.reasoning_tokens)",
+            "adjacent_output_tokens": "SUM(nearest_call.output_tokens)",
+            "adjacent_total_tokens": (
+                "SUM(nearest_call.input_tokens + nearest_call.output_tokens)"
+            ),
         },
         filter_fields={
             "tool": "tool_calls.tool_name",
@@ -178,13 +319,20 @@ DATASETS: dict[str, DatasetSpec] = {
             "category": "tool_calls.tool_category",
             "status": "tool_calls.status",
             "thread": "threads.logical_thread_id",
+            "thread_label": _THREAD_LABEL_SQL,
             "started_at": "tool_calls.started_at",
         },
         operations=_COMMON_OPERATIONS,
         coverage_fields={
             "duration_ms": "tool_calls.duration_ms",
             "output_bytes": "tool_calls.output_bytes",
+            "adjacent_uncached_input_tokens": "nearest_call.input_tokens",
+            "adjacent_cached_input_tokens": "nearest_call.input_tokens",
+            "adjacent_reasoning_tokens": "nearest_call.input_tokens",
+            "adjacent_output_tokens": "nearest_call.input_tokens",
+            "adjacent_total_tokens": "nearest_call.input_tokens",
         },
+        base_generation_parameters=2,
     ),
     "context": DatasetSpec(
         base_sql="composition_events",
@@ -240,16 +388,13 @@ DATASETS: dict[str, DatasetSpec] = {
         row_measures={"activities": "1"},
         aggregate_measures={
             "activities": "COUNT(*)",
-            "completions": (
-                "SUM(CASE WHEN activity_events.event_kind = 'task' THEN 1 ELSE 0 END)"
-            ),
+            "completions": ("SUM(CASE WHEN activity_events.event_kind = 'task' THEN 1 ELSE 0 END)"),
             "aborts": (
                 "SUM(CASE WHEN activity_events.event_kind IN "
                 "('rollback', 'turn_aborted') THEN 1 ELSE 0 END)"
             ),
             "compactions": (
-                "SUM(CASE WHEN activity_events.event_kind = 'compaction' "
-                "THEN 1 ELSE 0 END)"
+                "SUM(CASE WHEN activity_events.event_kind = 'compaction' THEN 1 ELSE 0 END)"
             ),
         },
         filter_fields={
@@ -277,16 +422,14 @@ DATASETS: dict[str, DatasetSpec] = {
         row_measures={
             "allowance_observations": "1",
             "allowance_used_percent": "allowance_intervals.used_percent",
-            "allowance_remaining_percent": (
-                "allowance_intervals.remaining_percent"
-            ),
-            "allowance_delta_percent": (
-                "allowance_intervals.delta_used_percent"
-            ),
-            "allowance_burn_rate": (
-                "allowance_intervals.percentage_points_per_hour"
-            ),
+            "allowance_remaining_percent": ("allowance_intervals.remaining_percent"),
+            "allowance_delta_percent": ("allowance_intervals.delta_used_percent"),
+            "allowance_burn_rate": ("allowance_intervals.percentage_points_per_hour"),
             "local_total_tokens": "allowance_intervals.local_total_tokens",
+            "local_uncached_input_tokens": ("allowance_intervals.local_uncached_input_tokens"),
+            "local_cached_input_tokens": ("allowance_intervals.local_cached_input_tokens"),
+            "local_reasoning_tokens": ("allowance_intervals.local_reasoning_tokens"),
+            "local_output_tokens": ("allowance_intervals.local_output_tokens"),
             "local_calls": "allowance_intervals.local_calls",
             "local_turns": "allowance_intervals.local_turns",
             "local_tokens_per_percentage_point": (
@@ -307,12 +450,8 @@ DATASETS: dict[str, DatasetSpec] = {
         },
         operations=frozenset({Operation.ROWS, Operation.TIMELINE}),
         coverage_fields={
-            "allowance_delta_percent": (
-                "allowance_intervals.delta_used_percent"
-            ),
-            "allowance_burn_rate": (
-                "allowance_intervals.percentage_points_per_hour"
-            ),
+            "allowance_delta_percent": ("allowance_intervals.delta_used_percent"),
+            "allowance_burn_rate": ("allowance_intervals.percentage_points_per_hour"),
             "local_tokens_per_percentage_point": (
                 "allowance_intervals.local_tokens_per_percentage_point"
             ),
@@ -327,11 +466,12 @@ DATASETS: dict[str, DatasetSpec] = {
     ),
     "threads": DatasetSpec(
         base_sql="threads",
-        generation_sql="threads.first_generation <= ?",
+        generation_sql=("threads.first_generation <= ? AND " + _CANONICAL_THREAD_SQL),
         time_sql="threads.updated_at",
         stable_id_sql="threads.logical_thread_id",
         dimensions={
             "thread": "threads.logical_thread_id",
+            "thread_label": _THREAD_LABEL_SQL,
             "project": "threads.project_label",
             "agent_role": "threads.subagent_role",
             "agent_type": "threads.subagent_type",
@@ -347,42 +487,45 @@ DATASETS: dict[str, DatasetSpec] = {
             "archive_state": "threads.archive_state",
         },
         operations=_COMMON_OPERATIONS,
+        base_generation_parameters=2,
     ),
     "turns": DatasetSpec(
-        base_sql=(
-            "turns JOIN threads ON threads.thread_id = turns.thread_id"
-        ),
-        generation_sql="turns.first_generation <= ?",
+        base_sql=_TURN_BASE_SQL,
+        generation_sql=("turns.first_generation <= ? AND " + _CANONICAL_TURN_SQL),
         time_sql="turns.started_at",
         stable_id_sql="turns.turn_id",
         dimensions={
             "turn": "COALESCE(turns.source_turn_id_hash, turns.turn_id)",
             "thread": "threads.logical_thread_id",
-            "status": "turns.status",
+            "thread_label": _THREAD_LABEL_SQL,
+            "turn_ordinal": "turns.ordinal",
+            "completion_basis": "turns.effective_completion_basis",
+            "status": "turns.effective_status",
             "event_at": "turns.started_at",
             "time_day": "substr(turns.started_at, 1, 10)",
         },
         row_measures={
             "turns": "1",
             "duration_ms": (
-                "MAX(0.0, (julianday(turns.ended_at) - "
+                "MAX(0.0, (julianday(turns.effective_ended_at) - "
                 "julianday(turns.started_at)) * 86400000.0)"
             ),
         },
         aggregate_measures={
             "turns": "COUNT(*)",
             "duration_ms": (
-                "SUM(MAX(0.0, (julianday(turns.ended_at) - "
+                "SUM(MAX(0.0, (julianday(turns.effective_ended_at) - "
                 "julianday(turns.started_at)) * 86400000.0))"
             ),
         },
         filter_fields={
             "turn": "COALESCE(turns.source_turn_id_hash, turns.turn_id)",
             "thread": "threads.logical_thread_id",
-            "status": "turns.status",
+            "status": "turns.effective_status",
             "started_at": "turns.started_at",
         },
         operations=_COMMON_OPERATIONS,
+        base_generation_parameters=3,
         coverage_fields={"duration_ms": "turns.ended_at"},
     ),
 }
@@ -402,12 +545,8 @@ _PHASE_GUIDANCE = {
     "filters": ("event_at", "thread", "turn"),
     "requires_scope_filter": True,
     "scope_filter_templates": {
-        "thread": (
-            {"field": "thread", "operator": "eq", "value": "$thread"},
-        ),
-        "turn": (
-            {"field": "turn", "operator": "eq", "value": "$turn"},
-        ),
+        "thread": ({"field": "thread", "operator": "eq", "value": "$thread"},),
+        "turn": ({"field": "turn", "operator": "eq", "value": "$turn"},),
         "time_window": (
             {"field": "event_at", "operator": "gte", "value": "$start"},
             {"field": "event_at", "operator": "lt", "value": "$end"},
@@ -440,12 +579,28 @@ _GUIDED_TEMPLATES: dict[str, dict[str, Any]] = {
                     "allowance_used_percent",
                     "allowance_delta_percent",
                     "allowance_burn_rate",
-                    "local_tokens_per_percentage_point",
+                    "local_total_tokens",
+                    "local_calls",
+                    "local_turns",
                 ],
                 "order_by": "event_at",
                 "descending": True,
                 "limit": 25,
-            }
+            },
+            {
+                "dataset": "allowance",
+                "operation": "rows",
+                "dimensions": ["allowance", "window", "event_at"],
+                "measures": [
+                    "local_uncached_input_tokens",
+                    "local_cached_input_tokens",
+                    "local_reasoning_tokens",
+                    "local_output_tokens",
+                ],
+                "order_by": "event_at",
+                "descending": True,
+                "limit": 25,
+            },
         ],
     },
     "concentration": {
@@ -457,7 +612,16 @@ _GUIDED_TEMPLATES: dict[str, dict[str, Any]] = {
                 "dataset": "calls",
                 "operation": "share",
                 "dimensions": ["thread"],
-                "measures": ["calls", "total_tokens"],
+                "measures": [
+                    "calls",
+                    "uncached_input_tokens",
+                    "cached_input_tokens",
+                    "reasoning_tokens",
+                    "output_tokens",
+                    "total_tokens",
+                    "configured_cost_usd",
+                    "estimated_credits",
+                ],
                 "order_by": "total_tokens",
                 "descending": True,
                 "limit": 25,
@@ -496,6 +660,8 @@ _GUIDED_TEMPLATES: dict[str, dict[str, Any]] = {
                     "reasoning_tokens",
                     "output_tokens",
                     "total_tokens",
+                    "configured_cost_usd",
+                    "estimated_credits",
                 ],
                 "order_by": "total_tokens",
                 "descending": True,
@@ -560,7 +726,24 @@ _GUIDED_TEMPLATES: dict[str, dict[str, Any]] = {
                 "order_by": "tools",
                 "descending": True,
                 "limit": 25,
-            }
+            },
+            {
+                "dataset": "tools",
+                "operation": "rows",
+                "dimensions": ["tool_call", "operation", "target"],
+                "measures": [
+                    "duration_ms",
+                    "output_bytes",
+                    "adjacent_uncached_input_tokens",
+                    "adjacent_cached_input_tokens",
+                    "adjacent_reasoning_tokens",
+                    "adjacent_output_tokens",
+                    "adjacent_total_tokens",
+                ],
+                "order_by": "adjacent_total_tokens",
+                "descending": True,
+                "limit": 25,
+            },
         ],
     },
     "turns": {
@@ -615,9 +798,7 @@ def exploration_guidance() -> dict[str, Any]:
         name: {
             "operations": sorted(operation.value for operation in spec.operations),
             "dimensions": sorted(spec.dimensions),
-            "measures": sorted(
-                set(spec.row_measures) | set(spec.aggregate_measures)
-            ),
+            "measures": sorted(set(spec.row_measures) | set(spec.aggregate_measures)),
             "filters": sorted(spec.filter_fields),
         }
         for name, spec in sorted(DATASETS.items())
@@ -678,9 +859,7 @@ def _measure_catalog(
         Operation.TIME_SERIES,
     }
     return (
-        spec.aggregate_measures
-        if request.operation in aggregate_operations
-        else spec.row_measures
+        spec.aggregate_measures if request.operation in aggregate_operations else spec.row_measures
     )
 
 
@@ -688,13 +867,17 @@ def _validate_operation_shape(
     request: QueryRequest,
     spec: DatasetSpec,
 ) -> None:
-    if request.operation in {
-        Operation.AGGREGATE,
-        Operation.SHARE,
-        Operation.COMPARISON,
-        Operation.DISTRIBUTION,
-        Operation.TIME_SERIES,
-    } and not request.measures:
+    if (
+        request.operation
+        in {
+            Operation.AGGREGATE,
+            Operation.SHARE,
+            Operation.COMPARISON,
+            Operation.DISTRIBUTION,
+            Operation.TIME_SERIES,
+        }
+        and not request.measures
+    ):
         raise ValueError("aggregate query requires at least one measure")
     if request.operation is Operation.SHARE and (
         len(request.dimensions) != 1 or not request.measures
@@ -702,9 +885,7 @@ def _validate_operation_shape(
         raise ValueError("share requires one dimension and at least one measure")
     if request.operation is Operation.COMPARISON:
         if request.comparison is None or spec.time_sql is None or not request.measures:
-            raise ValueError(
-                "comparison requires a timed dataset, measures, and two windows"
-            )
+            raise ValueError("comparison requires a timed dataset, measures, and two windows")
         unsupported = set(request.measures) - {
             "calls",
             "input_tokens",
@@ -715,20 +896,14 @@ def _validate_operation_shape(
             "total_tokens",
         }
         if request.dataset != "calls" or unsupported:
-            raise ValueError(
-                "comparison supports exact additive call measures only"
-            )
+            raise ValueError("comparison supports exact additive call measures only")
     elif request.comparison is not None:
         raise ValueError("comparison windows require the comparison operation")
-    if (
-        request.operation is Operation.TIME_SERIES
-        and not {"time_day", "time_hour"} & set(request.dimensions)
+    if request.operation is Operation.TIME_SERIES and not {"time_day", "time_hour"} & set(
+        request.dimensions
     ):
         raise ValueError("time series requires time_day or time_hour dimension")
-    if (
-        request.operation is Operation.TIMELINE
-        and "event_at" not in request.dimensions
-    ):
+    if request.operation is Operation.TIMELINE and "event_at" not in request.dimensions:
         raise ValueError("timeline requires event_at dimension")
     if request.operation is Operation.DISTRIBUTION and not request.dimensions:
         raise ValueError("distribution requires at least one dimension")
@@ -753,10 +928,7 @@ def _validate_phases(request: QueryRequest) -> None:
         raise ValueError("query field is not allowlisted for phases")
     if not request.filters:
         raise ValueError("phase timeline requires a bounded scope filter")
-    if (
-        request.operation is Operation.TIMELINE
-        and "event_at" not in request.dimensions
-    ):
+    if request.operation is Operation.TIMELINE and "event_at" not in request.dimensions:
         raise ValueError("phase timeline requires event_at dimension")
     available_order = set(request.dimensions) | set(request.measures)
     if request.order_by and request.order_by not in available_order:

--- a/src/codex_usage_tracker/kernel/query/plans.py
+++ b/src/codex_usage_tracker/kernel/query/plans.py
@@ -129,6 +129,7 @@ def _compile_thread_rollup(
         return None
     selected = [
         "threads.logical_thread_id AS thread",
+        (f"{DATASETS['calls'].dimensions['thread_label']} AS thread_label"),
         *(f"{expressions[measure]} AS {measure}" for measure in request.measures),
         "COUNT(*) OVER () AS __matched_count",
         "COUNT(*) OVER () AS __scanned_count",
@@ -419,6 +420,12 @@ def _base_query(
         Operation.TIME_SERIES,
     }
     dimensions = [f"{spec.dimensions[name]} AS {name}" for name in request.dimensions]
+    if (
+        "thread" in request.dimensions
+        and "thread_label" not in request.dimensions
+        and "thread_label" in spec.dimensions
+    ):
+        dimensions.append(f"{spec.dimensions['thread_label']} AS thread_label")
     measures_catalog = spec.aggregate_measures if aggregate else spec.row_measures
     measures = [f"{measures_catalog[name]} AS {name}" for name in request.measures]
     selected = dimensions + measures
@@ -439,7 +446,21 @@ def _base_query(
             )
         )
     group_sql = (
-        " GROUP BY " + ", ".join(spec.dimensions[name] for name in request.dimensions)
+        " GROUP BY "
+        + ", ".join(
+            (
+                *(spec.dimensions[name] for name in request.dimensions),
+                *(
+                    (spec.dimensions["thread_label"],)
+                    if (
+                        "thread" in request.dimensions
+                        and "thread_label" not in request.dimensions
+                        and "thread_label" in spec.dimensions
+                    )
+                    else ()
+                ),
+            )
+        )
         if aggregate and request.dimensions
         else ""
     )

--- a/src/codex_usage_tracker/kernel/query/service.py
+++ b/src/codex_usage_tracker/kernel/query/service.py
@@ -12,6 +12,7 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
+from ..allowance.rates import ModelRates, RateCard, load_rate_card
 from ..content import open_content_snapshot
 from ..database import open_read_snapshot
 from ..models import CutoverControl
@@ -35,10 +36,20 @@ class QueryService:
         operational_path: Path,
         *,
         content_path: Path | None = None,
+        rate_card_path: Path | None = None,
+        thread_labels: dict[str, str] | None = None,
         publication: tuple[CutoverControl, dict[str, object]] | None = None,
     ) -> None:
         self._operational_path = operational_path.resolve()
         self._content_path = content_path.resolve() if content_path else None
+        self._rate_card: RateCard | None = None
+        self._rate_card_error: str | None = None
+        if rate_card_path is not None:
+            try:
+                self._rate_card = load_rate_card(rate_card_path.resolve())
+            except ValueError as exc:
+                self._rate_card_error = str(exc)
+        self._thread_labels = dict(thread_labels or {})
         self._publication = publication
 
     def execute(self, request: QueryRequest) -> QueryResult:
@@ -72,6 +83,11 @@ class QueryService:
                 )
         with ExitStack() as stack:
             analytical = stack.enter_context(open_read_snapshot(path))
+            _register_pricing_functions(analytical, self._rate_card)
+            _register_thread_label_function(
+                analytical,
+                self._thread_labels,
+            )
             analytical.execute("PRAGMA query_only = ON")
             content = (
                 stack.enter_context(open_content_snapshot(self._content_path))
@@ -177,6 +193,8 @@ class QueryService:
             matched=matched,
             counts=coverage_counts,
             history_coverage=history_coverage,
+            rate_card=self._rate_card,
+            rate_card_error=self._rate_card_error,
             content_metadata=(
                 _content_metadata(connection) if request.dataset == "context" else None
             ),
@@ -467,37 +485,26 @@ def _result_coverage(
     matched: int,
     counts: dict[str, int],
     history_coverage: dict[str, object],
+    rate_card: RateCard | None,
+    rate_card_error: str | None,
     content_metadata: dict[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     total = matched if request.dataset == "phases" else scanned
-    measures: dict[str, dict[str, Any]] = {}
-    partial = False
-    for measure in request.measures:
-        observed = counts.get(f"observed_{measure}", total)
-        missing = counts.get(f"missing_{measure}", 0)
-        partial = partial or missing > 0
-        measures[measure] = {
-            "basis": _measure_basis(request.dataset, measure),
-            "observed_count": observed,
-            "missing_count": missing,
-            "coverage_percent": (100.0 if total == 0 else 100.0 * observed / total),
-            "limitations": _measure_limitations(request.dataset, measure),
-        }
-        if request.dataset == "context" and measure == "estimated_tokens":
-            measures[measure]["estimator"] = (
-                content_metadata.get("estimator") if content_metadata is not None else None
-            )
-    grade = (
-        "deterministic"
-        if request.dataset == "phases"
-        else "estimated"
-        if request.dataset == "context" and "estimated_tokens" in request.measures
-        else "exact"
+    measures = {
+        measure: _measure_coverage_entry(
+            request.dataset,
+            measure,
+            total=total,
+            counts=counts,
+            rate_card=rate_card,
+            content_metadata=content_metadata,
+        )
+        for measure in request.measures
+    }
+    grade = _result_grade(
+        request,
+        history_coverage=history_coverage,
     )
-    if not bool(history_coverage["complete_history"]) and _requires_partial_opt_in(
-        request, history_coverage
-    ):
-        grade = "partial"
     coverage: dict[str, Any] = {
         "generation_bound": True,
         "canonical_calls_only": request.dataset == "calls",
@@ -507,29 +514,103 @@ def _result_coverage(
         "history_complete": bool(history_coverage["complete_history"]),
         "coverage_revision": history_coverage["coverage_revision"],
     }
+    if "thread" in request.dimensions:
+        coverage["thread_labels"] = {
+            "basis": "prompt_derived_session_index_metadata_when_available",
+            "fallback": "bounded_opaque_thread_label",
+            "sanitized": True,
+            "content_included": False,
+        }
+    if any(
+        measure in {"configured_cost_usd", "estimated_credits"}
+        for measure in request.measures
+    ):
+        coverage["rate_card"] = {
+            "status": (
+                "invalid"
+                if rate_card_error is not None
+                else "ready"
+                if rate_card is not None
+                else "absent"
+            ),
+            "limitation": (
+                "invalid local rate card; unpriced usage remains visible"
+                if rate_card_error is not None
+                else None
+            ),
+        }
     if request.dataset == "context":
-        source_generation = (
-            content_metadata.get("indexed_generation") if content_metadata is not None else None
-        )
-        coverage.update(
-            {
-                "observed_content_only": True,
-                "source_generation": source_generation,
-                "observed_through": (
-                    content_metadata.get("observed_through")
-                    if content_metadata is not None
-                    else None
-                ),
-                "generation_lag": (
-                    generation - source_generation if isinstance(source_generation, int) else None
-                ),
-                "unattributed_input_tokens": None,
-                "unattributed_limitation": (
-                    "billed input tokens cannot be safely attributed to observed categories"
-                ),
-            }
-        )
+        coverage.update(_content_coverage(generation, content_metadata))
     return grade, coverage
+
+
+def _measure_coverage_entry(
+    dataset: str,
+    measure: str,
+    *,
+    total: int,
+    counts: dict[str, int],
+    rate_card: RateCard | None,
+    content_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    observed = counts.get(f"observed_{measure}", total)
+    missing = counts.get(f"missing_{measure}", 0)
+    entry: dict[str, Any] = {
+        "basis": _measure_basis(dataset, measure),
+        "observed_count": observed,
+        "missing_count": missing,
+        "coverage_percent": 100.0 if total == 0 else 100.0 * observed / total,
+        "limitations": _measure_limitations(dataset, measure),
+    }
+    if measure in {"configured_cost_usd", "estimated_credits"}:
+        entry["provenance"] = rate_card.source if rate_card is not None else None
+        entry["confidence"] = _rate_card_confidence(rate_card)
+    if dataset == "context" and measure == "estimated_tokens":
+        entry["estimator"] = (
+            content_metadata.get("estimator") if content_metadata is not None else None
+        )
+    return entry
+
+
+def _result_grade(
+    request: QueryRequest,
+    *,
+    history_coverage: dict[str, object],
+) -> str:
+    if not bool(history_coverage["complete_history"]) and _requires_partial_opt_in(
+        request, history_coverage
+    ):
+        return "partial"
+    if (
+        request.dataset == "context" and "estimated_tokens" in request.measures
+    ) or "estimated_credits" in request.measures:
+        return "estimated"
+    if request.dataset == "phases" or "configured_cost_usd" in request.measures:
+        return "deterministic"
+    return "exact"
+
+
+def _content_coverage(
+    generation: int,
+    content_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    source_generation = (
+        content_metadata.get("indexed_generation") if content_metadata is not None else None
+    )
+    return {
+        "observed_content_only": True,
+        "source_generation": source_generation,
+        "observed_through": (
+            content_metadata.get("observed_through") if content_metadata is not None else None
+        ),
+        "generation_lag": (
+            generation - source_generation if isinstance(source_generation, int) else None
+        ),
+        "unattributed_input_tokens": None,
+        "unattributed_limitation": (
+            "billed input tokens cannot be safely attributed to observed categories"
+        ),
+    }
 
 
 def _measure_basis(dataset: str, measure: str) -> str:
@@ -541,9 +622,20 @@ def _measure_basis(dataset: str, measure: str) -> str:
         return "tokenizer_estimate"
     if measure in {"uncached_input_tokens", "total_tokens"}:
         return "derived_exact"
+    if measure == "configured_cost_usd":
+        return "configured_dated_rate_card"
+    if measure == "estimated_credits":
+        return "explicit_local_credit_rate_card_estimate"
     if measure in {
         "allowance_delta_percent",
         "allowance_burn_rate",
+        "local_uncached_input_tokens",
+        "local_cached_input_tokens",
+        "local_reasoning_tokens",
+        "local_output_tokens",
+        "local_total_tokens",
+        "local_calls",
+        "local_turns",
         "local_tokens_per_percentage_point",
         "local_calls_per_percentage_point",
         "local_turns_per_percentage_point",
@@ -551,8 +643,14 @@ def _measure_basis(dataset: str, measure: str) -> str:
         return "deterministic_adjacent_observations"
     if measure in {"cache_reuse", "context_pressure"}:
         return "derived_ratio"
+    if dataset == "tools" and measure == "duration_ms":
+        return "deterministic_observed_timestamps"
+    if dataset == "tools" and measure == "output_bytes":
+        return "deterministic_normalized_tool_output_utf8_bytes"
     if measure in {"duration_ms", "output_bytes"}:
         return "upstream_observed"
+    if measure.startswith("adjacent_") and measure.endswith("_tokens"):
+        return "deterministic_adjacent_model_call"
     if measure in {
         "aborts",
         "activities",
@@ -581,6 +679,12 @@ def _measure_limitations(dataset: str, measure: str) -> list[str]:
         limitations.append(
             "reasoning tokens are reported separately; overlap with output tokens is not inferred"
         )
+    if measure == "configured_cost_usd":
+        limitations.append(
+            "configured token cost is a dated local rate-card calculation, not observed billing"
+        )
+    if measure == "estimated_credits":
+        limitations.append("estimated credits are separate from observed allowance drain")
     if dataset == "phases" and measure != "activities":
         limitations.append(
             "tokens are assigned to the preceding or enclosing phase "
@@ -588,6 +692,17 @@ def _measure_limitations(dataset: str, measure: str) -> list[str]:
         )
     if measure in {"duration_ms", "output_bytes", "context_pressure"}:
         limitations.append("null upstream observations are excluded")
+    if dataset == "tools" and measure == "output_bytes":
+        limitations.append(
+            "structured outputs are measured after deterministic JSON normalization"
+        )
+    if measure.startswith("adjacent_") and measure.endswith("_tokens"):
+        limitations.extend(
+            (
+                "adjacency is deterministic but does not prove causal tool attribution",
+                "multiple preceding tools may contribute to one adjacent model call",
+            )
+        )
     if measure in {
         "allowance_delta_percent",
         "allowance_burn_rate",
@@ -602,6 +717,107 @@ def _measure_limitations(dataset: str, measure: str) -> list[str]:
             )
         )
     return limitations
+
+
+def _register_pricing_functions(
+    connection: sqlite3.Connection,
+    card: RateCard | None,
+) -> None:
+    def configured_cost(
+        model: Any,
+        input_tokens: Any,
+        cached_input_tokens: Any,
+        output_tokens: Any,
+    ) -> float | None:
+        rates = _model_rates(card, model)
+        if rates is None:
+            return None
+        return _priced_value(
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            rates.input_per_million,
+            rates.cached_input_per_million,
+            rates.output_per_million,
+        )
+
+    def estimated_credits(
+        model: Any,
+        input_tokens: Any,
+        cached_input_tokens: Any,
+        output_tokens: Any,
+    ) -> float | None:
+        rates = _model_rates(card, model)
+        if rates is None:
+            return None
+        return _priced_value(
+            input_tokens,
+            cached_input_tokens,
+            output_tokens,
+            rates.credits_input_per_million,
+            rates.credits_cached_input_per_million,
+            rates.credits_output_per_million,
+        )
+
+    connection.create_function(
+        "configured_cost_usd",
+        4,
+        configured_cost,
+        deterministic=True,
+    )
+    connection.create_function(
+        "estimated_credits",
+        4,
+        estimated_credits,
+        deterministic=True,
+    )
+
+
+def _register_thread_label_function(
+    connection: sqlite3.Connection,
+    labels: dict[str, str],
+) -> None:
+    def resolved_thread_label(
+        session_identity_hash: Any,
+        stored_label: Any,
+    ) -> str:
+        return labels.get(str(session_identity_hash), str(stored_label))
+
+    connection.create_function(
+        "resolved_thread_label",
+        2,
+        resolved_thread_label,
+        deterministic=True,
+    )
+
+
+def _model_rates(card: RateCard | None, model: Any) -> ModelRates | None:
+    return card.models.get(str(model)) if card is not None else None
+
+
+def _rate_card_confidence(card: RateCard | None) -> str | None:
+    if card is None:
+        return None
+    values = {rates.confidence for rates in card.models.values()}
+    return next(iter(values)) if len(values) == 1 else "mixed"
+
+
+def _priced_value(
+    input_tokens: Any,
+    cached_input_tokens: Any,
+    output_tokens: Any,
+    input_rate: float,
+    cached_rate: float,
+    output_rate: float,
+) -> float:
+    input_count = int(input_tokens or 0)
+    cached_count = int(cached_input_tokens or 0)
+    output_count = int(output_tokens or 0)
+    return (
+        max(0, input_count - cached_count) * input_rate
+        + max(0, cached_count) * cached_rate
+        + max(0, output_count) * output_rate
+    ) / 1_000_000
 
 
 def _content_metadata(connection: sqlite3.Connection) -> dict[str, Any]:

--- a/src/codex_usage_tracker/kernel/rollups.py
+++ b/src/codex_usage_tracker/kernel/rollups.py
@@ -34,6 +34,7 @@ def rebuild_generation_rollups(
 
     started = time.perf_counter()
     with short_writer_transaction(path) as connection:
+        _link_unresolved_tool_calls(connection, generation)
         for table in (
             "rollup_global",
             "rollup_thread",
@@ -152,6 +153,57 @@ def rebuild_generation_rollups(
             (generation, generation),
         )
     return (time.perf_counter() - started) * 1_000
+
+
+def _link_unresolved_tool_calls(
+    connection: sqlite3.Connection,
+    generation: int,
+) -> None:
+    connection.execute(
+        """
+        UPDATE tool_call_facts AS tools
+        SET nearest_model_call_key = COALESCE(
+            (
+                SELECT calls.model_call_key
+                FROM model_call_facts AS calls
+                WHERE calls.turn_key = tools.turn_key
+                  AND calls.generation <= ?
+                  AND calls.duplicate_state = 'canonical'
+                  AND calls.event_at >= COALESCE(
+                      tools.ended_at,
+                      tools.started_at,
+                      ''
+                  )
+                ORDER BY calls.event_at, calls.model_call_key
+                LIMIT 1
+            ),
+            (
+                SELECT calls.model_call_key
+                FROM model_call_facts AS calls
+                WHERE calls.turn_key = tools.turn_key
+                  AND calls.generation <= ?
+                  AND calls.duplicate_state = 'canonical'
+                  AND calls.event_at < COALESCE(
+                      tools.ended_at,
+                      tools.started_at,
+                      ''
+                  )
+                ORDER BY calls.event_at DESC, calls.model_call_key DESC
+                LIMIT 1
+            )
+        ),
+            generation = ?
+        WHERE tools.generation <= ?
+          AND EXISTS (
+              SELECT 1
+              FROM model_call_facts AS changed_calls
+              WHERE changed_calls.turn_key = tools.turn_key
+                AND changed_calls.generation = ?
+                AND changed_calls.duplicate_state = 'canonical'
+          )
+        """,
+        (generation, generation, generation, generation, generation),
+    )
 
 
 def _seed_generation_rollups(
@@ -321,6 +373,10 @@ def _apply_generation_delta(
         (generation, generation, generation),
     )
     connection.execute(
+        "DELETE FROM rollup_tool_operation WHERE generation = ?",
+        (generation,),
+    )
+    connection.execute(
         """
         INSERT INTO rollup_tool_operation(
             generation, operation, target_label, calls,
@@ -331,12 +387,8 @@ def _apply_generation_delta(
                COALESCE(SUM(facts.output_bytes), 0)
         FROM tool_call_facts AS facts
         JOIN tool_profiles AS profiles USING (tool_profile_key)
-        WHERE facts.generation = ?
+        WHERE facts.generation <= ?
         GROUP BY profiles.operation, COALESCE(facts.target_label, '')
-        ON CONFLICT(generation, operation, target_label) DO UPDATE SET
-            calls = calls + excluded.calls,
-            duration_ms = duration_ms + excluded.duration_ms,
-            output_bytes = output_bytes + excluded.output_bytes
         """,
         (generation, generation),
     )

--- a/src/codex_usage_tracker/kernel/thread_labels.py
+++ b/src/codex_usage_tracker/kernel/thread_labels.py
@@ -1,0 +1,136 @@
+"""Bounded prompt-derived thread labels from Codex session metadata."""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+from collections.abc import Iterable
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from .identity import stable_id
+
+MAX_THREAD_LABEL_CHARACTERS = 160
+MAX_SESSION_INDEX_BYTES = 64 * 1024 * 1024
+MAX_SESSION_INDEX_LINE_BYTES = 64 * 1024
+MAX_SESSION_INDEX_ENTRIES = 250_000
+
+
+def load_thread_labels(sources: Iterable[Path]) -> dict[str, str]:
+    """Read bounded session-index metadata adjacent to selected sources."""
+
+    labels: dict[str, str] = {}
+    for index_path in _session_index_paths(sources):
+        labels.update(_read_session_index(index_path))
+    return labels
+
+
+def load_thread_label_hashes(codex_home: Path) -> dict[str, str]:
+    """Return cached session-hash labels without exposing session IDs."""
+
+    path = codex_home.resolve() / "session_index.jsonl"
+    try:
+        stat = path.stat()
+    except OSError:
+        return {}
+    return dict(
+        _cached_thread_label_hashes(
+            path,
+            stat.st_mtime_ns,
+            stat.st_size,
+        )
+    )
+
+
+def thread_label_revision(codex_home: Path) -> dict[str, int] | None:
+    """Return a bounded cache identity for session-index metadata."""
+
+    path = codex_home.resolve() / "session_index.jsonl"
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return {"modified_ns": stat.st_mtime_ns, "size_bytes": stat.st_size}
+
+
+def sanitize_thread_label(value: Any) -> str | None:
+    """Collapse controls and whitespace into bounded untrusted display text."""
+
+    if not isinstance(value, str):
+        return None
+    characters = (
+        " " if character.isspace() or unicodedata.category(character).startswith("C") else character
+        for character in value
+    )
+    collapsed = " ".join("".join(characters).split())
+    if not collapsed:
+        return None
+    return collapsed[:MAX_THREAD_LABEL_CHARACTERS].rstrip()
+
+
+def _session_index_paths(sources: Iterable[Path]) -> tuple[Path, ...]:
+    paths: set[Path] = set()
+    for source in sources:
+        resolved = source.resolve()
+        parts = resolved.parts
+        for marker in ("sessions", "archived_sessions"):
+            if marker not in parts:
+                continue
+            marker_index = parts.index(marker)
+            root = Path(*parts[:marker_index])
+            candidate = root / "session_index.jsonl"
+            if candidate.is_file():
+                paths.add(candidate)
+            break
+    return tuple(sorted(paths, key=str))
+
+
+def _read_session_index(path: Path) -> dict[str, str]:
+    if path.stat().st_size > MAX_SESSION_INDEX_BYTES:
+        return {}
+    labels: dict[str, str] = {}
+    with path.open("rb") as handle:
+        while len(labels) < MAX_SESSION_INDEX_ENTRIES:
+            line = handle.readline(MAX_SESSION_INDEX_LINE_BYTES + 1)
+            if not line:
+                break
+            if len(line) > MAX_SESSION_INDEX_LINE_BYTES:
+                _discard_line_remainder(handle)
+                continue
+            try:
+                payload = json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            session_id = payload.get("id")
+            label = sanitize_thread_label(payload.get("thread_name"))
+            if isinstance(session_id, str) and session_id and label is not None:
+                labels[session_id] = label
+    return labels
+
+
+@lru_cache(maxsize=8)
+def _cached_thread_label_hashes(
+    path: Path,
+    modified_ns: int,
+    size_bytes: int,
+) -> tuple[tuple[str, str], ...]:
+    del modified_ns, size_bytes
+    return tuple(
+        sorted(
+            (
+                (stable_id("sess", session_id), label)
+                for session_id, label in _read_session_index(path).items()
+            ),
+            key=lambda item: item[0],
+        )
+    )
+
+
+def _discard_line_remainder(handle: Any) -> None:
+    while True:
+        remainder = handle.readline(MAX_SESSION_INDEX_LINE_BYTES + 1)
+        if not remainder or remainder.endswith(b"\n"):
+            return

--- a/src/codex_usage_tracker/kernel/writer.py
+++ b/src/codex_usage_tracker/kernel/writer.py
@@ -82,6 +82,7 @@ def commit_refresh(
         _upsert_turns(
             connection,
             tuple(row for batch in normalized for row in batch.turns),
+            accumulate_existing=True,
         )
         connection.execute(
             "UPDATE generations SET deleted_count = ? WHERE generation = ?",
@@ -94,14 +95,15 @@ def commit_refresh(
         ("activity_events", _rows(normalized, "activities")),
         ("allowance_observations", _rows(normalized, "allowances")),
     )
+    inserted_facts = {"model_calls": 0, "tool_calls": 0}
     for table, rows in table_rows:
         for chunk in _chunks(rows):
             with _timed_writer(path, transaction_ms, assert_fence) as connection:
-                _insert_rows(connection, table, chunk)
+                inserted = _insert_rows(connection, table, chunk)
+                if table in inserted_facts:
+                    inserted_facts[table] += inserted
     if canonicalize_touched:
-        touched_fingerprints.update(
-            str(row["canonical_call_id"]) for row in table_rows[0][1]
-        )
+        touched_fingerprints.update(str(row["canonical_call_id"]) for row in table_rows[0][1])
         for fingerprint_chunk in _chunks(tuple(sorted(touched_fingerprints))):
             with _timed_writer(path, transaction_ms, assert_fence) as connection:
                 _canonicalize(
@@ -111,7 +113,9 @@ def commit_refresh(
                 )
 
     with _read_counts(path, generation) as counts:
-        inserted_calls, inserted_tools, canonical, excluded = counts
+        _generation_calls, _generation_tools, canonical, excluded = counts
+    inserted_calls = inserted_facts["model_calls"]
+    inserted_tools = inserted_facts["tool_calls"]
 
     with _timed_writer(path, transaction_ms, assert_fence) as connection:
         for plan, parsed_batch, batch in zip(
@@ -358,11 +362,7 @@ def _rows(
     batches: tuple[NormalizedBatch, ...],
     attribute: str,
 ) -> tuple[dict[str, Any], ...]:
-    return tuple(
-        row
-        for batch in batches
-        for row in getattr(batch, attribute)
-    )
+    return tuple(row for batch in batches for row in getattr(batch, attribute))
 
 
 def _chunks(
@@ -405,9 +405,7 @@ def _insert_generation(
     generation: int,
     plans: tuple[SourcePlan, ...],
 ) -> None:
-    revision = "|".join(
-        f"{plan.observation.source_id}:{plan.end_byte}" for plan in plans
-    )
+    revision = "|".join(f"{plan.observation.source_id}:{plan.end_byte}" for plan in plans)
     connection.execute(
         """
         INSERT INTO generations(
@@ -462,6 +460,8 @@ def _upsert_source(
             trailing_incomplete_bytes = excluded.trailing_incomplete_bytes,
             trailing_incomplete_hash = excluded.trailing_incomplete_hash,
             replacement_fingerprint = excluded.replacement_fingerprint,
+            parser_adapter = excluded.parser_adapter,
+            parser_version = excluded.parser_version,
             parser_state_json = excluded.parser_state_json,
             last_observed_at = CURRENT_TIMESTAMP,
             last_generation = excluded.last_generation,
@@ -528,7 +528,32 @@ def _upsert_threads(connection: sqlite3.Connection, rows: tuple[dict[str, Any], 
             f"""
             INSERT INTO threads({", ".join(columns)})
             VALUES ({", ".join("?" for _ in columns)})
-            ON CONFLICT(thread_id) DO NOTHING
+            ON CONFLICT(thread_id) DO UPDATE SET
+                source_key = excluded.source_key,
+                source_id = excluded.source_id,
+                display_label = CASE
+                    WHEN excluded.display_label NOT LIKE 'Thread %'
+                    THEN excluded.display_label
+                    ELSE threads.display_label
+                END,
+                updated_at = MAX(
+                    COALESCE(threads.updated_at, ''),
+                    COALESCE(excluded.updated_at, '')
+                ),
+                archive_state = excluded.archive_state,
+                last_generation = MAX(
+                    threads.last_generation,
+                    excluded.last_generation
+                )
+            WHERE threads.archive_state != (
+                      SELECT archive_state
+                      FROM sources
+                      WHERE source_key = threads.source_key
+                  )
+               OR (
+                      excluded.archive_state = 'active'
+                  AND threads.archive_state != 'active'
+               )
             """,
             values,
         )
@@ -581,6 +606,7 @@ def _upsert_turns(
                 patch_count = turns.patch_count + excluded.patch_count,
                 error_count = turns.error_count + excluded.error_count,
                 last_generation = excluded.last_generation
+            WHERE turns.last_generation = excluded.last_generation
             """
             if accumulate_existing
             else "DO NOTHING"
@@ -630,15 +656,187 @@ def _insert_rows(
         ).append(tuple(compact.values()))
     inserted = 0
     for (physical_table, columns), values in prepared.items():
+        inserted_tool_ids: set[Any] | None = None
+        if physical_table == "tool_call_facts":
+            tool_id_index = columns.index("tool_call_id")
+            candidate_ids = {value[tool_id_index] for value in values}
+            existing_ids: set[Any] = set()
+            ordered_ids = tuple(sorted(candidate_ids, key=repr))
+            for start in range(0, len(ordered_ids), 500):
+                chunk = ordered_ids[start : start + 500]
+                placeholders = ", ".join("?" for _ in chunk)
+                existing_ids.update(
+                    row[0]
+                    for row in connection.execute(
+                        f"""
+                        SELECT tool_call_id
+                        FROM tool_call_facts
+                        WHERE tool_call_id IN ({placeholders})
+                        """,
+                        chunk,
+                    )
+                )
+            inserted_tool_ids = candidate_ids - existing_ids
+        conflict_sql = (
+            """
+            ON CONFLICT(tool_call_id) DO UPDATE SET
+                source_key = CASE
+                    WHEN (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = tool_call_facts.thread_key
+                    ) = 'archived'
+                     AND (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = excluded.thread_key
+                    ) = 'active'
+                    THEN excluded.source_key
+                    ELSE tool_call_facts.source_key
+                END,
+                thread_key = CASE
+                    WHEN (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = tool_call_facts.thread_key
+                    ) = 'archived'
+                     AND (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = excluded.thread_key
+                    ) = 'active'
+                    THEN excluded.thread_key
+                    ELSE tool_call_facts.thread_key
+                END,
+                turn_key = CASE
+                    WHEN (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = tool_call_facts.thread_key
+                    ) = 'archived'
+                     AND (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = excluded.thread_key
+                    ) = 'active'
+                    THEN excluded.turn_key
+                    ELSE tool_call_facts.turn_key
+                END,
+                tool_profile_key = CASE
+                    WHEN (
+                        SELECT tool_name FROM tool_profiles
+                        WHERE tool_profile_key = tool_call_facts.tool_profile_key
+                    ) = 'unknown'
+                    THEN excluded.tool_profile_key
+                    ELSE tool_call_facts.tool_profile_key
+                END,
+                nearest_model_call_key = CASE
+                    WHEN (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = tool_call_facts.thread_key
+                    ) = 'archived'
+                     AND (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = excluded.thread_key
+                    ) = 'active'
+                    THEN excluded.nearest_model_call_key
+                    WHEN (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = tool_call_facts.thread_key
+                    ) = 'active'
+                     AND (
+                        SELECT archive_state FROM threads
+                        WHERE thread_key = excluded.thread_key
+                    ) = 'archived'
+                    THEN tool_call_facts.nearest_model_call_key
+                    ELSE COALESCE(
+                        excluded.nearest_model_call_key,
+                        tool_call_facts.nearest_model_call_key
+                    )
+                END,
+                target_label = COALESCE(
+                    tool_call_facts.target_label,
+                    excluded.target_label
+                ),
+                started_at = COALESCE(
+                    tool_call_facts.started_at,
+                    excluded.started_at
+                ),
+                ended_at = COALESCE(
+                    excluded.ended_at,
+                    tool_call_facts.ended_at
+                ),
+                duration_ms = COALESCE(
+                    excluded.duration_ms,
+                    CASE
+                        WHEN COALESCE(
+                            tool_call_facts.started_at,
+                            excluded.started_at
+                        ) IS NOT NULL
+                         AND COALESCE(
+                            excluded.ended_at,
+                            tool_call_facts.ended_at
+                        ) IS NOT NULL
+                        THEN MAX(
+                            0.0,
+                            (
+                                julianday(COALESCE(
+                                    excluded.ended_at,
+                                    tool_call_facts.ended_at
+                                ))
+                                - julianday(COALESCE(
+                                    tool_call_facts.started_at,
+                                    excluded.started_at
+                                ))
+                            ) * 86400000.0
+                        )
+                        ELSE tool_call_facts.duration_ms
+                    END
+                ),
+                status = CASE
+                    WHEN excluded.status IN ('completed', 'failed')
+                    THEN excluded.status
+                    ELSE tool_call_facts.status
+                END,
+                error_category = COALESCE(
+                    excluded.error_category,
+                    tool_call_facts.error_category
+                ),
+                output_bytes = COALESCE(
+                    excluded.output_bytes,
+                    tool_call_facts.output_bytes
+                ),
+                argument_shape = COALESCE(
+                    tool_call_facts.argument_shape,
+                    excluded.argument_shape
+                ),
+                first_source_offset = MIN(
+                    tool_call_facts.first_source_offset,
+                    excluded.first_source_offset
+                ),
+                last_source_offset = MAX(
+                    tool_call_facts.last_source_offset,
+                    excluded.last_source_offset
+                ),
+                generation = MAX(
+                    tool_call_facts.generation,
+                    excluded.generation
+                ),
+                observation_confidence = CASE
+                    WHEN tool_call_facts.observation_confidence = 'exact'
+                      OR excluded.observation_confidence = 'exact'
+                    THEN 'exact'
+                    ELSE excluded.observation_confidence
+                END
+            """
+            if physical_table == "tool_call_facts"
+            else "ON CONFLICT DO NOTHING"
+        )
         cursor = connection.executemany(
             f"""
             INSERT INTO {physical_table}({", ".join(columns)})
             VALUES ({", ".join("?" for _ in columns)})
-            ON CONFLICT DO NOTHING
+            {conflict_sql}
             """,
             values,
         )
-        inserted += max(0, cursor.rowcount)
+        inserted += (
+            len(inserted_tool_ids) if inserted_tool_ids is not None else max(0, cursor.rowcount)
+        )
     return inserted
 
 
@@ -828,11 +1026,7 @@ def _fact_key_maps(
         if table != "allowance_observations"
         else {}
     )
-    call_field = (
-        "nearest_model_call_id"
-        if table == "tool_calls"
-        else "source_model_call_id"
-    )
+    call_field = "nearest_model_call_id" if table == "tool_calls" else "source_model_call_id"
     model_calls = (
         _selector_key_map(
             connection,
@@ -862,22 +1056,16 @@ def _selector_key_map(
     *,
     selector_prefix: str | None = None,
 ) -> dict[str, int]:
-    originals = tuple(
-        sorted({str(selector) for selector in selectors if selector is not None})
-    )
+    originals = tuple(sorted({str(selector) for selector in selectors if selector is not None}))
     if not originals:
         return {}
     stored_by_original: dict[str, object] = {
         selector: (
-            _selector_blob(selector, selector_prefix)
-            if selector_prefix is not None
-            else selector
+            _selector_blob(selector, selector_prefix) if selector_prefix is not None else selector
         )
         for selector in originals
     }
-    original_by_stored = {
-        stored: original for original, stored in stored_by_original.items()
-    }
+    original_by_stored = {stored: original for original, stored in stored_by_original.items()}
     resolved: dict[str, int] = {}
     stored = tuple(stored_by_original.values())
     for chunk in _chunks(stored, size=800):

--- a/tests/e2e/kernel-console.spec.mjs
+++ b/tests/e2e/kernel-console.spec.mjs
@@ -67,7 +67,9 @@ test("every guided query template submits an allowlisted request", async ({ page
   ]) {
     await page.getByLabel("Guided template").selectOption(template);
     await page.getByRole("button", { name: "Run bounded query" }).click();
-    await expect(page.getByText(/Generation 1 · \d+ of \d+ rows/)).toBeVisible();
+    await expect(
+      page.locator(".query-result .result-meta").first(),
+    ).toContainText(/Generation 1 · \d+ of \d+ rows/);
     await expect(page.getByText("This view could not load")).toHaveCount(0);
   }
 });
@@ -78,7 +80,9 @@ test("non-comparison templates ignore blank comparison controls", async ({ page 
   await page.getByLabel("Current end").fill("");
   await page.getByLabel("Guided template").selectOption("tools");
   await page.getByRole("button", { name: "Run bounded query" }).click();
-  await expect(page.getByText(/Generation 1 · \d+ of \d+ rows/)).toBeVisible();
+  await expect(
+    page.locator(".query-result .result-meta").first(),
+  ).toContainText(/Generation 1 · \d+ of \d+ rows/);
   await expect(page.getByText("This view could not load")).toHaveCount(0);
 });
 

--- a/tests/kernel/allowance/test_rates.py
+++ b/tests/kernel/allowance/test_rates.py
@@ -83,6 +83,7 @@ def test_source_stamped_rate_card_estimates_cost_credits_and_coverage(
             "fetched_at": "2026-01-02",
         },
         "model_count": 1,
+        "revision": card.digest,
     }
 
 

--- a/tests/kernel/allowance/test_service.py
+++ b/tests/kernel/allowance/test_service.py
@@ -135,15 +135,11 @@ def test_allowance_service_returns_reset_aware_local_facts_and_estimates(
     interval = next(
         item
         for item in result["intervals"]
-        if item["allowance_observation_id"]
-        == "allow_00000000000000000000000000000002"
+        if item["allowance_observation_id"] == "allow_00000000000000000000000000000002"
     )
     assert result["schema"] == "codex-usage-tracker.allowance-efficiency.v1"
     assert result["generation"] == control.active_generation
-    assert (
-        interval["previous_observation_id"]
-        == "allow_00000000000000000000000000000001"
-    )
+    assert interval["previous_observation_id"] == "allow_00000000000000000000000000000001"
     assert interval["grade"] == "deterministic"
     assert interval["used_percent"] == 12
     assert interval["remaining_percent"] == 88
@@ -161,13 +157,10 @@ def test_allowance_service_returns_reset_aware_local_facts_and_estimates(
         "calls": 2,
         "turns": 2,
     }
-    assert interval["estimated_cost_usd"] == pytest.approx(0.00231)
+    assert interval["configured_cost_usd"] == pytest.approx(0.00231)
     assert interval["estimated_credits"] == pytest.approx(0.001155)
     assert interval["pricing_coverage"]["coverage_percent"] == 100
-    assert (
-        interval["evidence_selector"]
-        == "allowance:allow_00000000000000000000000000000002"
-    )
+    assert interval["evidence_selector"] == "allowance:allow_00000000000000000000000000000002"
     assert interval["limitations"] == ["outside_usage_possible"]
     assert runtime.kernel.operational.read_bytes() == operational_before
     assert control.active_kernel_path.read_bytes() == analytical_before
@@ -322,8 +315,7 @@ def test_appended_allowance_observation_uses_incremental_refresh(
     assert result["generation"] == second.generation
     assert result["returned_count"] == 2
     assert any(
-        interval["grade"] == "deterministic"
-        and interval["delta_used_percent"] == 2
+        interval["grade"] == "deterministic" and interval["delta_used_percent"] == 2
         for interval in result["intervals"]
     )
 

--- a/tests/kernel/query/test_performance.py
+++ b/tests/kernel/query/test_performance.py
@@ -7,6 +7,7 @@ import math
 import sqlite3
 import time
 from collections.abc import Callable
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,7 @@ from codex_usage_tracker.kernel.query import (
 from codex_usage_tracker.kernel.rollups import rebuild_generation_rollups
 
 _CALL_COUNT = 100_000
+_TOOL_COUNT = 25_000
 
 
 @pytest.fixture(scope="module")
@@ -41,6 +43,8 @@ def large_service(tmp_path_factory: pytest.TempPathFactory) -> QueryService:
     initialize_operational_database(paths.operational)
     _populate_calls(paths.analytical)
     rebuild_generation_rollups(paths.analytical, 1)
+    rate_card = root / "rates.json"
+    _write_rate_card(rate_card)
     with sqlite3.connect(paths.operational) as connection:
         connection.execute(
             """
@@ -74,7 +78,7 @@ def large_service(tmp_path_factory: pytest.TempPathFactory) -> QueryService:
         active_kernel_path=paths.analytical,
         generation=1,
     )
-    return QueryService(paths.operational)
+    return QueryService(paths.operational, rate_card_path=rate_card)
 
 
 def test_100k_common_comparison_and_concentration_budgets(
@@ -153,6 +157,90 @@ def test_100k_common_comparison_and_concentration_budgets(
     assert concentration_result.scanned_count == 250
     assert daily_result.plan_id.endswith("rollup_time_band.v1")
     assert daily_result.scanned_count == 28
+
+
+def test_100k_r5_analytical_primitive_budgets(
+    large_service: QueryService,
+) -> None:
+    top_threads = QueryRequest(
+        "calls",
+        Operation.SHARE,
+        ("thread",),
+        (
+            "calls",
+            "uncached_input_tokens",
+            "cached_input_tokens",
+            "reasoning_tokens",
+            "output_tokens",
+            "total_tokens",
+            "configured_cost_usd",
+            "estimated_credits",
+        ),
+        limit=25,
+    )
+    tool_impact = QueryRequest(
+        "tools",
+        Operation.ROWS,
+        ("tool_call", "operation", "target"),
+        (
+            "adjacent_uncached_input_tokens",
+            "adjacent_cached_input_tokens",
+            "adjacent_reasoning_tokens",
+            "adjacent_output_tokens",
+            "adjacent_total_tokens",
+        ),
+        order_by="adjacent_total_tokens",
+        limit=25,
+    )
+
+    top_threads_p95 = _p95(
+        lambda: large_service.execute(top_threads),
+        repeats=12,
+    )
+    tool_impact_p95 = _p95(
+        lambda: large_service.execute(tool_impact),
+        repeats=12,
+    )
+    top_threads_result = large_service.execute(top_threads)
+    tool_impact_result = large_service.execute(tool_impact)
+    top_threads_bytes = len(
+        json.dumps(
+            asdict(top_threads_result),
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    )
+    tool_impact_bytes = len(
+        json.dumps(
+            asdict(tool_impact_result),
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    )
+
+    print(
+        json.dumps(
+            {
+                "calls": _CALL_COUNT,
+                "tools": _TOOL_COUNT,
+                "tool_impact_bytes": tool_impact_bytes,
+                "tool_impact_p95_ms": round(tool_impact_p95, 3),
+                "top_threads_bytes": top_threads_bytes,
+                "top_threads_p95_ms": round(top_threads_p95, 3),
+            },
+            sort_keys=True,
+        )
+    )
+    assert top_threads_p95 <= 1_000.0
+    assert tool_impact_p95 <= 500.0
+    assert top_threads_bytes <= 64_000
+    assert tool_impact_bytes <= 64_000
+    assert top_threads_result.returned_count == 25
+    assert tool_impact_result.returned_count == 25
+    assert all("thread_label" in row for row in top_threads_result.rows)
+    assert (
+        top_threads_result.coverage["measures"]["configured_cost_usd"]["coverage_percent"] == 100.0
+    )
 
 
 def _p95(operation: Callable[[], object], *, repeats: int) -> float:
@@ -234,6 +322,32 @@ def _populate_calls(path: Path) -> None:
             """,
             (_call_row(index) for index in range(_CALL_COUNT)),
         )
+        connection.execute(
+            """
+            INSERT INTO tool_profiles(
+                tool_profile_key, tool_name, server_name_key, namespace_key,
+                tool_category, operation
+            )
+            VALUES (1, 'functions.read_file', '', 'functions', 'function', 'read')
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO tool_call_facts(
+                tool_call_id, upstream_call_id_hash, source_key, thread_key,
+                turn_key, tool_profile_key, nearest_model_call_key,
+                target_label, started_at, ended_at, duration_ms, status,
+                error_category, output_bytes, argument_shape,
+                first_source_offset, last_source_offset, generation,
+                observation_confidence
+            )
+            VALUES (
+                ?, ?, 1, ?, ?, 1, ?, ?, ?, ?, ?, 'completed',
+                NULL, ?, '["path"]', ?, ?, 1, 'exact'
+            )
+            """,
+            (_tool_row(index) for index in range(_TOOL_COUNT)),
+        )
 
 
 def _call_row(index: int) -> tuple[object, ...]:
@@ -255,4 +369,54 @@ def _call_row(index: int) -> tuple[object, ...]:
         output_tokens,
         output_tokens // 3,
         index,
+    )
+
+
+def _tool_row(index: int) -> tuple[object, ...]:
+    thread_key = index % 250 + 1
+    call_key = index + 1
+    timestamp = f"2026-01-{1 + (index % 28):02d}T{index % 24:02d}:00:00Z"
+    return (
+        index.to_bytes(16, "big"),
+        f"upstream-{index:08d}",
+        thread_key,
+        thread_key,
+        call_key,
+        f"src/synthetic_{index % 50:02d}.py",
+        timestamp,
+        timestamp,
+        float(index % 1_000),
+        index % 8_192,
+        index,
+        index + 1,
+    )
+
+
+def _write_rate_card(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "codex-usage-tracker.kernel-rate-card.v1",
+                "source": {
+                    "name": "Synthetic performance rates",
+                    "url": "https://example.invalid/performance-rates",
+                    "effective_at": "2026-01-01",
+                    "fetched_at": "2026-01-01T00:00:00Z",
+                },
+                "models": {
+                    model: {
+                        "input_per_million": 1.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 2.0,
+                        "credits_input_per_million": 3.0,
+                        "credits_cached_input_per_million": 1.0,
+                        "credits_output_per_million": 4.0,
+                        "confidence": "estimated",
+                    }
+                    for model in ("gpt-synthetic-a", "gpt-synthetic-b")
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
     )

--- a/tests/kernel/query/test_service.py
+++ b/tests/kernel/query/test_service.py
@@ -365,7 +365,7 @@ def test_missing_tool_observations_are_partial_not_zero(tmp_path: Path) -> None:
     )
     assert result.grade == "exact"
     assert result.coverage["measures"]["duration_ms"] == {
-        "basis": "upstream_observed",
+        "basis": "deterministic_observed_timestamps",
         "observed_count": 0,
         "missing_count": 1,
         "coverage_percent": 0.0,

--- a/tests/kernel/test_ingest_pipeline.py
+++ b/tests/kernel/test_ingest_pipeline.py
@@ -17,13 +17,9 @@ from codex_usage_tracker.kernel.operational import (
 
 def _token_line(event_id: str, value: int) -> str:
     return (
-        '{"event_id":"'
-        + event_id
-        + '","timestamp":"2026-01-01T00:00:01Z","type":"event_msg",'
+        '{"event_id":"' + event_id + '","timestamp":"2026-01-01T00:00:01Z","type":"event_msg",'
         '"payload":{"type":"token_count","info":{"last_token_usage":'
-        '{"input_tokens":'
-        + str(value)
-        + ',"cached_input_tokens":1,"output_tokens":2,'
+        '{"input_tokens":' + str(value) + ',"cached_input_tokens":1,"output_tokens":2,'
         '"reasoning_output_tokens":1,"total_tokens":'
         + str(value + 2)
         + '},"model_context_window":200000}}}\n'
@@ -162,9 +158,7 @@ def test_source_appended_during_hydration_is_caught_before_promotion(
     assert second.planner_reason == "no_changes"
     assert second.inserted_calls == 0
     with sqlite3.connect(paths.analytical) as connection:
-        assert connection.execute(
-            "SELECT COUNT(*) FROM model_calls"
-        ).fetchone()[0] == 2
+        assert connection.execute("SELECT COUNT(*) FROM model_calls").fetchone()[0] == 2
 
 
 def test_initial_hydration_normalizes_bounded_batches(
@@ -184,9 +178,14 @@ def test_initial_hydration_normalizes_bounded_batches(
     observed_batch_sizes: list[int] = []
     real_normalize = ingest.normalize_batch
 
-    def record_batch(plan, parsed, *, generation):
+    def record_batch(plan, parsed, *, generation, thread_labels=None):
         observed_batch_sizes.append(parsed.parsed_line_count)
-        return real_normalize(plan, parsed, generation=generation)
+        return real_normalize(
+            plan,
+            parsed,
+            generation=generation,
+            thread_labels=thread_labels,
+        )
 
     monkeypatch.setattr(ingest, "normalize_batch", record_batch)
     paths = kernel_paths(tmp_path / "cache")
@@ -342,9 +341,5 @@ def test_partial_batch_crash_retries_same_generation_idempotently(
     assert recovered.inserted_calls == 600
     assert load_cutover_control(paths.operational).state is CutoverState.ACTIVE
     with sqlite3.connect(paths.analytical) as connection:
-        assert connection.execute(
-            "SELECT COUNT(*) FROM generations"
-        ).fetchone()[0] == 1
-        assert connection.execute(
-            "SELECT COUNT(*) FROM model_calls"
-        ).fetchone()[0] == 600
+        assert connection.execute("SELECT COUNT(*) FROM generations").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM model_calls").fetchone()[0] == 600

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -25,6 +25,7 @@ from scripts.check_kernel_scope import (
     R2_ADDITIONS,
     R3_ADDITIONS,
     R4_ADDITIONS,
+    R5_ADDITIONS,
     RECOVERY_ROADMAP_ADDITIONS,
     active_paths,
     load_disposition_manifest,
@@ -37,9 +38,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_integration_tree_matches_quarantine_manifest() -> None:
-    manifest = load_disposition_manifest(
-        _REPO_ROOT / "config" / "kernel-code-disposition-v1.json"
-    )
+    manifest = load_disposition_manifest(_REPO_ROOT / "config" / "kernel-code-disposition-v1.json")
 
     assert scope_failures(_REPO_ROOT, manifest) == []
 
@@ -84,15 +83,18 @@ def test_active_paths_excludes_indexed_files_deleted_from_worktree(
 
 
 def test_k1a_additions_are_explicit_and_bounded() -> None:
-    assert frozenset(
-        {
-            "docs/kernel-development-scope.md",
-            "scripts/check_kernel_scope.py",
-            "src/codex_usage_tracker/kernel/AGENTS.md",
-            "src/codex_usage_tracker/kernel/__init__.py",
-            "tests/kernel/test_kernel_scope.py",
-        }
-    ) == K1A_ADDITIONS
+    assert (
+        frozenset(
+            {
+                "docs/kernel-development-scope.md",
+                "scripts/check_kernel_scope.py",
+                "src/codex_usage_tracker/kernel/AGENTS.md",
+                "src/codex_usage_tracker/kernel/__init__.py",
+                "tests/kernel/test_kernel_scope.py",
+            }
+        )
+        == K1A_ADDITIONS
+    )
 
 
 def test_k2_additions_are_explicit_and_bounded() -> None:
@@ -253,6 +255,10 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/kernel/interfaces/test_r4_coverage_contract.py",
         "tests/kernel/query/test_r4_rollups.py",
     } == R4_ADDITIONS
+    assert {
+        "src/codex_usage_tracker/kernel/thread_labels.py",
+        "tests/kernel/test_r5_analytical_primitives.py",
+    } == R5_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -269,12 +275,13 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | K14_ADDITIONS
         | K15_ADDITIONS
         | K16_ADDITIONS
-            | RECOVERY_ROADMAP_ADDITIONS
-            | R1_ADDITIONS
-            | R2_ADDITIONS
-            | R3_ADDITIONS
-            | R4_ADDITIONS
-        )
+        | RECOVERY_ROADMAP_ADDITIONS
+        | R1_ADDITIONS
+        | R2_ADDITIONS
+        | R3_ADDITIONS
+        | R4_ADDITIONS
+        | R5_ADDITIONS
+    )
 
 
 def test_kernel_skeleton_imports_without_legacy_runtime() -> None:
@@ -357,19 +364,15 @@ def test_publication_guard_rejects_correct_tag_on_unmerged_commit(
         package_version="0.28.0",
     )
 
-    assert failure == (
-        f"publication SHA {unmerged_sha} is not merged into origin/main"
-    )
+    assert failure == (f"publication SHA {unmerged_sha} is not merged into origin/main")
 
 
 def test_publish_workflow_calls_persistent_kernel_guard() -> None:
-    workflow = (_REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
 
     assert "Enforce kernel publication source" in workflow
     assert "scripts/check_kernel_scope.py" in workflow
     assert '--publication-ref "$GITHUB_REF"' in workflow
-    assert 'git fetch --no-tags origin main:refs/remotes/origin/main' in workflow
+    assert "git fetch --no-tags origin main:refs/remotes/origin/main" in workflow
     assert '--publication-sha "$GITHUB_SHA"' in workflow
     assert "--main-ref origin/main" in workflow

--- a/tests/kernel/test_r5_analytical_primitives.py
+++ b/tests/kernel/test_r5_analytical_primitives.py
@@ -1,0 +1,1146 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.kernel.allowance import AllowanceService
+from codex_usage_tracker.kernel.application import RuntimePaths
+from codex_usage_tracker.kernel.evidence import EvidenceRequest, EvidenceService
+from codex_usage_tracker.kernel.ingest import KernelIngestor, RefreshTrigger
+from codex_usage_tracker.kernel.operational import load_cutover_control
+from codex_usage_tracker.kernel.query import QueryService
+from codex_usage_tracker.kernel.query.contracts import Operation, QueryRequest
+from codex_usage_tracker.kernel.query.plans import compile_plan
+from codex_usage_tracker.kernel.thread_labels import load_thread_label_hashes
+
+
+def test_thread_results_pair_prompt_derived_label_with_stable_selector(
+    tmp_path: Path,
+) -> None:
+    runtime, _source = _refresh_r5_fixture(tmp_path)
+
+    result = QueryService(runtime.kernel.operational).execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=("thread",),
+            measures=("total_tokens",),
+        )
+    )
+
+    assert result.rows == (
+        {
+            "thread": result.rows[0]["thread"],
+            "thread_label": "Investigate fast usage",
+            "total_tokens": 28,
+        },
+    )
+    assert result.evidence_selectors == (f"thread:{result.rows[0]['thread']}",)
+    assert result.coverage["thread_labels"] == {
+        "basis": "prompt_derived_session_index_metadata_when_available",
+        "fallback": "bounded_opaque_thread_label",
+        "sanitized": True,
+        "content_included": False,
+    }
+
+
+def test_thread_dimension_compiles_for_datasets_without_thread_labels() -> None:
+    activities = compile_plan(
+        QueryRequest(
+            "activities",
+            Operation.AGGREGATE,
+            ("thread",),
+            ("activities",),
+        ).normalized(),
+        generation=1,
+        offset=0,
+    )
+    context = compile_plan(
+        QueryRequest(
+            "context",
+            Operation.AGGREGATE,
+            ("thread",),
+            ("events",),
+        ).normalized(),
+        generation=1,
+        offset=0,
+    )
+
+    assert "AS thread_label" not in activities.sql
+    assert "AS thread_label" not in context.sql
+
+
+def test_turn_and_tool_rows_expose_bounded_inference_facts(
+    tmp_path: Path,
+) -> None:
+    runtime, source = _refresh_r5_fixture(tmp_path)
+    query = QueryService(runtime.kernel.operational)
+
+    turns = query.execute(
+        QueryRequest(
+            dataset="turns",
+            operation=Operation.ROWS,
+            dimensions=(
+                "turn",
+                "turn_ordinal",
+                "completion_basis",
+            ),
+            measures=("turns", "duration_ms"),
+            descending=False,
+        )
+    )
+    assert turns.rows == (
+        {
+            "turn": turns.rows[0]["turn"],
+            "turn_ordinal": 1,
+            "completion_basis": "observed_event",
+            "turns": 1,
+            "duration_ms": pytest.approx(200.0, abs=0.01),
+        },
+    )
+
+    tool_identity, tool_semantics, tool_impact = query.execute_batch(
+        (
+            QueryRequest(
+                dataset="tools",
+                operation=Operation.ROWS,
+                dimensions=("tool_call", "thread", "turn"),
+                measures=(),
+                descending=False,
+            ),
+            QueryRequest(
+                dataset="tools",
+                operation=Operation.ROWS,
+                dimensions=("tool_call", "operation", "target"),
+                measures=("duration_ms", "output_bytes"),
+                descending=False,
+            ),
+            QueryRequest(
+                dataset="tools",
+                operation=Operation.ROWS,
+                dimensions=("tool_call", "status", "impact_grade"),
+                measures=(
+                    "adjacent_uncached_input_tokens",
+                    "adjacent_cached_input_tokens",
+                    "adjacent_reasoning_tokens",
+                    "adjacent_output_tokens",
+                    "adjacent_total_tokens",
+                ),
+                descending=False,
+            ),
+        )
+    )
+    assert tool_identity.rows == (
+        {
+            "tool_call": tool_identity.rows[0]["tool_call"],
+            "thread": tool_identity.rows[0]["thread"],
+            "thread_label": "Investigate fast usage",
+            "turn": tool_identity.rows[0]["turn"],
+        },
+    )
+    assert tool_semantics.rows == (
+        {
+            "tool_call": tool_semantics.rows[0]["tool_call"],
+            "operation": "read",
+            "target": "src/example.py",
+            "duration_ms": pytest.approx(50.0),
+            "output_bytes": len(b"synthetic result"),
+        },
+    )
+    assert tool_impact.rows == (
+        {
+            "tool_call": tool_impact.rows[0]["tool_call"],
+            "status": "completed",
+            "impact_grade": "deterministic_adjacent_call",
+            "adjacent_uncached_input_tokens": 15,
+            "adjacent_cached_input_tokens": 5,
+            "adjacent_reasoning_tokens": 3,
+            "adjacent_output_tokens": 8,
+            "adjacent_total_tokens": 28,
+        },
+    )
+    persisted = runtime.kernel.analytical.read_bytes()
+    assert b"PRIVATE_SYNTHETIC_ARGUMENT" not in persisted
+    assert b"synthetic result" not in persisted
+    assert str(source.resolve()).encode() not in persisted
+
+
+def test_query_cost_and_credit_estimates_are_explicit_and_covered(
+    tmp_path: Path,
+) -> None:
+    runtime, _source = _refresh_r5_fixture(tmp_path)
+    _write_rate_card(runtime.rate_card)
+
+    result = QueryService(
+        runtime.kernel.operational,
+        rate_card_path=runtime.rate_card,
+    ).execute(
+        QueryRequest(
+            dataset="calls",
+            operation=Operation.AGGREGATE,
+            dimensions=(),
+            measures=(
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens",
+                "total_tokens",
+                "configured_cost_usd",
+                "estimated_credits",
+            ),
+        )
+    )
+
+    assert result.rows == (
+        {
+            "uncached_input_tokens": 15,
+            "cached_input_tokens": 5,
+            "reasoning_tokens": 3,
+            "output_tokens": 8,
+            "total_tokens": 28,
+            "configured_cost_usd": pytest.approx(0.0000335),
+            "estimated_credits": pytest.approx(0.000082),
+        },
+    )
+    assert result.coverage["measures"]["configured_cost_usd"] == {
+        "basis": "configured_dated_rate_card",
+        "observed_count": 1,
+        "missing_count": 0,
+        "coverage_percent": 100.0,
+        "limitations": [
+            "configured token cost is a dated local rate-card calculation, not observed billing"
+        ],
+        "provenance": {
+            "name": "Synthetic rates",
+            "url": "https://example.invalid/rates",
+            "effective_at": "2026-07-01",
+            "fetched_at": "2026-07-01T00:00:00Z",
+        },
+        "confidence": "estimated",
+    }
+    assert result.coverage["measures"]["estimated_credits"]["basis"] == (
+        "explicit_local_credit_rate_card_estimate"
+    )
+    assert result.grade == "estimated"
+
+
+def test_allowance_bands_are_time_first_and_keep_four_token_classes(
+    tmp_path: Path,
+) -> None:
+    runtime, _source = _refresh_r5_fixture(tmp_path)
+    result = AllowanceService(
+        runtime.kernel.operational,
+        runtime.rate_card,
+    ).read()
+
+    interval = result["rows"][0]
+    assert tuple(interval)[:4] == (
+        "interval_start",
+        "interval_end",
+        "window_kind",
+        "allowance_observation_id",
+    )
+    assert interval["interval_start"] is None
+    assert interval["interval_end"] == "2026-07-27T12:00:00.150000Z"
+    assert interval["local_usage"] == {
+        "uncached_input_tokens": 0,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0,
+        "calls": 0,
+        "turns": 0,
+        "total_tokens": 0,
+    }
+    assert interval["observed_allowance_drain"] is None
+    assert interval["allowance_attribution"] == ("interval_observation_not_revealing_call")
+
+
+def test_copied_sources_are_excluded_from_every_foundational_aggregate(
+    tmp_path: Path,
+) -> None:
+    runtime, source = _refresh_r5_fixture(tmp_path)
+    archived = runtime.codex_home / "archived_sessions" / source.name
+    archived.parent.mkdir(parents=True)
+    shutil.copyfile(source, archived)
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [archived, source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-copy-contract",
+    )
+    query = QueryService(runtime.kernel.operational)
+
+    results = query.execute_batch(
+        (
+            QueryRequest("calls", Operation.AGGREGATE, (), ("calls",)),
+            QueryRequest("tools", Operation.AGGREGATE, (), ("tools",)),
+            QueryRequest("turns", Operation.AGGREGATE, (), ("turns",)),
+            QueryRequest("threads", Operation.AGGREGATE, (), ("threads",)),
+            QueryRequest(
+                "tools",
+                Operation.AGGREGATE,
+                ("operation", "target"),
+                ("tools",),
+            ),
+        )
+    )
+
+    assert [result.rows[0][result.dataset] for result in results[:4]] == [
+        1,
+        1,
+        1,
+        1,
+    ]
+    assert results[4].rows == ({"operation": "read", "target": "src/example.py", "tools": 1},)
+
+
+def test_session_index_label_changes_do_not_require_transcript_reparse(
+    tmp_path: Path,
+) -> None:
+    runtime, _source = _refresh_r5_fixture(tmp_path)
+    index = runtime.codex_home / "session_index.jsonl"
+    payload = json.loads(index.read_text(encoding="utf-8"))
+    payload["thread_name"] = "Renamed after refresh"
+    index.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    result = QueryService(
+        runtime.kernel.operational,
+        thread_labels=load_thread_label_hashes(runtime.codex_home),
+    ).execute(
+        QueryRequest(
+            "calls",
+            Operation.AGGREGATE,
+            ("thread",),
+            ("total_tokens",),
+        )
+    )
+
+    assert result.rows[0]["thread_label"] == "Renamed after refresh"
+
+
+def test_parser_upgrade_replaces_once_then_returns_to_no_changes(
+    tmp_path: Path,
+) -> None:
+    runtime, source = _refresh_r5_fixture(tmp_path)
+    initial = load_cutover_control(runtime.kernel.operational)
+    assert initial.active_kernel_path is not None
+    with sqlite3.connect(initial.active_kernel_path) as connection:
+        connection.execute("UPDATE sources SET parser_version = '1'")
+
+    upgraded = KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-parser-upgrade",
+    )
+    unchanged = KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-parser-no-change",
+    )
+
+    promoted = load_cutover_control(runtime.kernel.operational)
+    assert promoted.active_kernel_path is not None
+    with sqlite3.connect(promoted.active_kernel_path) as connection:
+        assert connection.execute("SELECT parser_version FROM sources").fetchone() == ("2",)
+        assert connection.execute("SELECT COUNT(*) FROM tool_calls").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM turns").fetchone() == (1,)
+    assert upgraded.planner_reason == "replace_source"
+    assert upgraded.generation == 2
+    assert unchanged.planner_reason == "no_changes"
+    assert unchanged.generation == 2
+
+
+def test_append_completes_existing_turn_without_double_counting_tool(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    events = _r5_events()
+    source = _write_r5_source(runtime, events[:-1])
+    ingestor = KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    )
+    first = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-open-turn",
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(events[-1], separators=(",", ":")) + "\n")
+    completed = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-complete-turn",
+    )
+
+    active = load_cutover_control(runtime.kernel.operational).active_kernel_path
+    assert active is not None
+    with sqlite3.connect(active) as connection:
+        assert connection.execute(
+            """
+            SELECT model_call_count, tool_call_count
+            FROM turns
+            """
+        ).fetchone() == (1, 1)
+        assert connection.execute("SELECT COUNT(*) FROM tool_calls").fetchone() == (1,)
+    turn = (
+        QueryService(runtime.kernel.operational)
+        .execute(
+            QueryRequest(
+                "turns",
+                Operation.ROWS,
+                ("turn", "status", "completion_basis"),
+                ("duration_ms",),
+            )
+        )
+        .rows[0]
+    )
+    assert turn == {
+        "turn": turn["turn"],
+        "status": "completed",
+        "completion_basis": "observed_event",
+        "duration_ms": pytest.approx(200.0, abs=0.02),
+    }
+    evidence = (
+        EvidenceService(runtime.kernel.operational)
+        .read(EvidenceRequest(f"turn:{turn['turn']}"))
+        .rows[0]
+    )
+    assert evidence["status"] == "completed"
+    assert evidence["completion_basis"] == "observed_event"
+    assert evidence["model_call_count"] == 1
+    assert evidence["tool_call_count"] == 1
+    service = EvidenceService(runtime.kernel.operational)
+    for view in ("calls", "tools", "timeline"):
+        rows = service.read(EvidenceRequest(f"turn:{turn['turn']}", view=view)).rows
+        assert rows
+        relevant = (
+            [row for row in rows if row["event_kind"] != "activity"]
+            if view == "timeline"
+            else list(rows)
+        )
+        assert all(
+            row.get("completion_basis") == "observed_event" for row in relevant
+        ), (view, rows)
+    assert first.inserted_tools == 1
+    assert completed.planner_reason == "append_safe"
+    assert completed.inserted_tools == 0
+
+
+def test_tool_completion_crosses_parser_batch_without_losing_metadata(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    session_id = "00000000-0000-4000-8000-000000000506"
+    lines: list[dict[str, object]] = [
+        {
+            "timestamp": "2026-07-27T12:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": session_id},
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.000Z",
+            "type": "turn_context",
+            "payload": {"turn_id": "turn-batch", "model": "gpt-r5"},
+        },
+    ]
+    lines.extend(
+        {
+            "timestamp": "2026-07-27T12:00:00.010Z",
+            "type": "event_msg",
+            "payload": {"type": "synthetic_ignored"},
+        }
+        for _ in range(997)
+    )
+    lines.extend(
+        (
+            {
+                "timestamp": "2026-07-27T12:00:00.050Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "functions.read_file",
+                    "call_id": "call-cross-batch",
+                    "arguments": json.dumps({"path": "src/cross_batch.py"}),
+                },
+            },
+            {
+                "timestamp": "2026-07-27T12:00:00.100Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-cross-batch",
+                    "output": "bounded synthetic output",
+                },
+            },
+        )
+    )
+    source = _write_r5_source(runtime, tuple(lines))
+    result = KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-cross-batch",
+    )
+
+    row = (
+        QueryService(runtime.kernel.operational)
+        .execute(
+            QueryRequest(
+                "tools",
+                Operation.ROWS,
+                ("operation", "target", "status"),
+                ("duration_ms", "output_bytes"),
+            )
+        )
+        .rows[0]
+    )
+    assert result.inserted_tools == 1
+    assert row == {
+        "operation": "read",
+        "target": "src/cross_batch.py",
+        "status": "completed",
+        "duration_ms": pytest.approx(50.0, abs=0.02),
+        "output_bytes": len(b"bounded synthetic output"),
+    }
+
+
+def test_tool_completion_appends_without_counting_a_second_tool(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    events = _r5_events()
+    source = _write_r5_source(runtime, events[:3])
+    ingestor = KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    )
+    first = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-tool-start",
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write("".join(json.dumps(line, separators=(",", ":")) + "\n" for line in events[3:]))
+    completed = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-tool-complete",
+    )
+
+    tool = (
+        QueryService(runtime.kernel.operational)
+        .execute(
+            QueryRequest(
+                "tools",
+                Operation.ROWS,
+                ("status",),
+                ("duration_ms", "output_bytes"),
+            )
+        )
+        .rows[0]
+    )
+    assert first.inserted_tools == 1
+    assert completed.inserted_tools == 0
+    assert tool == {
+        "status": "completed",
+        "duration_ms": pytest.approx(50.0, abs=0.02),
+        "output_bytes": len(b"synthetic result"),
+    }
+
+
+@pytest.mark.parametrize(
+    "unsafe_target",
+    (
+        "/Users/synthetic/private/secret.py",
+        "~/.ssh/id_rsa",
+        r"C:\Users\synthetic\secret.txt",
+        r"\\server\share\secret.txt",
+        "file:///Users/synthetic/private/secret.py",
+        "https://example.invalid/private",
+    ),
+)
+def test_non_project_relative_tool_target_is_rejected_instead_of_persisted(
+    tmp_path: Path,
+    unsafe_target: str,
+) -> None:
+    runtime = _runtime(tmp_path)
+    events = list(_r5_events())
+    tool_payload = events[2]["payload"]
+    assert isinstance(tool_payload, dict)
+    tool_payload["arguments"] = json.dumps({"path": unsafe_target})
+    source = _write_r5_source(runtime, tuple(events))
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-absolute-target",
+    )
+
+    row = (
+        QueryService(runtime.kernel.operational)
+        .execute(QueryRequest("tools", Operation.ROWS, ("target",), ()))
+        .rows[0]
+    )
+    active = load_cutover_control(runtime.kernel.operational).active_kernel_path
+    assert active is not None
+    assert row["target"] is None
+    assert unsafe_target.encode() not in active.read_bytes()
+
+
+def test_repeated_same_timestamp_tools_without_upstream_ids_remain_distinct(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    events = (
+        _session_event(),
+        _turn_event("turn-r5-missing-id"),
+        {
+            "timestamp": "2026-07-27T12:00:00.050Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "mcp_tool_call_end",
+                "tool_name": "usage_query",
+                "server_name": "synthetic",
+                "result": {"row": 1},
+            },
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.050Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "mcp_tool_call_end",
+                "tool_name": "usage_query",
+                "server_name": "synthetic",
+                "result": {"row": 2},
+            },
+        },
+    )
+    source = _write_r5_source(runtime, events)
+    KernelIngestor(runtime.kernel.analytical, runtime.kernel.operational).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-missing-tool-id",
+    )
+
+    result = QueryService(runtime.kernel.operational).execute(
+        QueryRequest("tools", Operation.AGGREGATE, (), ("tools",))
+    )
+
+    assert result.rows == ({"tools": 2},)
+
+
+def test_structured_tool_output_uses_normalized_byte_basis(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    result_payload = {"unicode": "λ", "escaped": "\n", "items": [2, 1]}
+    source = _write_r5_source(
+        runtime,
+        (
+            _session_event(),
+            _turn_event("turn-r5-structured-output"),
+            {
+                "timestamp": "2026-07-27T12:00:00.050Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "mcp_tool_call_end",
+                    "tool_name": "usage_query",
+                    "server_name": "synthetic",
+                    "call_id": "structured-output",
+                    "result": result_payload,
+                },
+            },
+        ),
+    )
+    KernelIngestor(runtime.kernel.analytical, runtime.kernel.operational).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-structured-output",
+    )
+
+    result = QueryService(runtime.kernel.operational).execute(
+        QueryRequest("tools", Operation.ROWS, (), ("output_bytes",))
+    )
+
+    expected = len(
+        json.dumps(
+            result_payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    )
+    assert result.rows == ({"output_bytes": expected},)
+    assert result.coverage["measures"]["output_bytes"]["basis"] == (
+        "deterministic_normalized_tool_output_utf8_bytes"
+    )
+
+
+def test_invalid_rate_card_does_not_disable_unpriced_query_or_allowance(
+    tmp_path: Path,
+) -> None:
+    runtime, _source = _refresh_r5_fixture(tmp_path)
+    runtime.rate_card.parent.mkdir(parents=True, exist_ok=True)
+    runtime.rate_card.write_text("{invalid", encoding="utf-8")
+    service = QueryService(
+        runtime.kernel.operational,
+        rate_card_path=runtime.rate_card,
+    )
+
+    tokens = service.execute(
+        QueryRequest("calls", Operation.AGGREGATE, (), ("total_tokens",))
+    )
+    priced = service.execute(
+        QueryRequest("calls", Operation.AGGREGATE, (), ("configured_cost_usd",))
+    )
+    allowance = AllowanceService(
+        runtime.kernel.operational,
+        runtime.rate_card,
+    ).read()
+
+    assert tokens.rows == ({"total_tokens": 28},)
+    assert priced.rows == ({"configured_cost_usd": None},)
+    assert priced.coverage["rate_card"]["status"] == "invalid"
+    assert allowance["rows"]
+    assert allowance["coverage"]["pricing"]["status"] == "invalid"
+
+
+def test_moving_tail_relinks_tool_to_following_model_call(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    source = _write_r5_source(
+        runtime,
+        (
+            _session_event(),
+            _turn_event("turn-r5-moving-tail"),
+            _token_event(
+                "preceding",
+                "2026-07-27T12:00:00.010Z",
+                input_tokens=10,
+                output_tokens=1,
+            ),
+            {
+                "timestamp": "2026-07-27T12:00:00.020Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "mcp_tool_call_end",
+                    "tool_name": "usage_query",
+                    "server_name": "synthetic",
+                    "call_id": "moving-tail-tool",
+                    "result": "done",
+                },
+            },
+        ),
+    )
+    ingestor = KernelIngestor(runtime.kernel.analytical, runtime.kernel.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-moving-tail-first",
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                _token_event(
+                    "following",
+                    "2026-07-27T12:00:00.030Z",
+                    input_tokens=100,
+                    output_tokens=2,
+                ),
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-moving-tail-following",
+    )
+
+    result = QueryService(runtime.kernel.operational).execute(
+        QueryRequest(
+            "tools",
+            Operation.ROWS,
+            (),
+            ("adjacent_total_tokens",),
+        )
+    )
+
+    assert result.rows == ({"adjacent_total_tokens": 102},)
+
+
+def test_failed_tool_update_never_mutates_active_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+    events = _r5_events()
+    source = _write_r5_source(runtime, events[:3])
+    ingestor = KernelIngestor(runtime.kernel.analytical, runtime.kernel.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-isolation-first",
+    )
+    active_before = load_cutover_control(runtime.kernel.operational).active_kernel_path
+    assert active_before is not None
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(events[3], separators=(",", ":")) + "\n")
+
+    def fail_before_promotion(
+        candidate: Path,
+        generation: int,
+        **_kwargs: object,
+    ) -> None:
+        assert candidate != active_before
+        assert generation == 2
+        current = QueryService(runtime.kernel.operational).execute(
+            QueryRequest("tools", Operation.ROWS, ("status",), ())
+        )
+        assert current.rows == ({"status": "started"},)
+        raise RuntimeError("synthetic promotion failure")
+
+    monkeypatch.setattr(ingestor, "_promote", fail_before_promotion)
+    with pytest.raises(RuntimeError, match="synthetic promotion failure"):
+        ingestor.refresh(
+            [source],
+            trigger=RefreshTrigger.CLI_REFRESH,
+            owner_id="r5-isolation-failure",
+        )
+
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path == active_before
+    assert control.active_generation == 1
+    with sqlite3.connect(active_before) as connection:
+        assert connection.execute(
+            "SELECT status, generation FROM tool_calls"
+        ).fetchone() == ("started", 1)
+
+
+def test_structural_only_copies_have_one_canonical_owner_and_evidence_row(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path)
+    source = _write_r5_source(
+        runtime,
+        (
+            _session_event(),
+            _turn_event("turn-r5-structural-copy"),
+            {
+                "timestamp": "2026-07-27T12:00:00.100Z",
+                "type": "event_msg",
+                "payload": {"type": "task_complete"},
+            },
+        ),
+    )
+    archived = runtime.codex_home / "archived_sessions" / source.name
+    archived.parent.mkdir(parents=True)
+    shutil.copyfile(source, archived)
+    KernelIngestor(runtime.kernel.analytical, runtime.kernel.operational).refresh(
+        [archived, source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-structural-copy",
+    )
+    query = QueryService(runtime.kernel.operational)
+
+    threads, turns = query.execute_batch(
+        (
+            QueryRequest("threads", Operation.ROWS, ("thread",), ("threads",)),
+            QueryRequest("turns", Operation.ROWS, ("turn",), ("turns",)),
+        )
+    )
+
+    assert len(threads.rows) == 1
+    assert len(turns.rows) == 1
+    thread_evidence = EvidenceService(runtime.kernel.operational).read(
+        EvidenceRequest(f"thread:{threads.rows[0]['thread']}")
+    )
+    turn_evidence = EvidenceService(runtime.kernel.operational).read(
+        EvidenceRequest(f"turn:{turns.rows[0]['turn']}")
+    )
+    assert thread_evidence.matched_count == 1
+    assert turn_evidence.matched_count == 1
+
+
+def test_partial_rate_coverage_keeps_unrated_usage_visible(
+    tmp_path: Path,
+) -> None:
+    runtime, source = _refresh_r5_fixture(tmp_path)
+    _write_rate_card(runtime.rate_card)
+    extra = (
+        {
+            "timestamp": "2026-07-27T12:01:00.000Z",
+            "type": "turn_context",
+            "payload": {
+                "turn_id": "turn-r5-unrated",
+                "model": "gpt-unrated",
+                "effort": "low",
+            },
+        },
+        {
+            "event_id": "event-r5-unrated",
+            "timestamp": "2026-07-27T12:01:00.100Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 10,
+                        "cached_input_tokens": 0,
+                        "reasoning_output_tokens": 1,
+                        "output_tokens": 2,
+                        "total_tokens": 13,
+                    }
+                },
+            },
+        },
+    )
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write("".join(json.dumps(line, separators=(",", ":")) + "\n" for line in extra))
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-partial-rates",
+    )
+
+    result = QueryService(
+        runtime.kernel.operational,
+        rate_card_path=runtime.rate_card,
+    ).execute(
+        QueryRequest(
+            "calls",
+            Operation.AGGREGATE,
+            (),
+            ("calls", "total_tokens", "configured_cost_usd"),
+        )
+    )
+
+    assert result.rows == (
+        {
+            "calls": 2,
+            "total_tokens": 40,
+            "configured_cost_usd": pytest.approx(0.0000335),
+        },
+    )
+    assert result.coverage["measures"]["configured_cost_usd"]["observed_count"] == 1
+    assert result.coverage["measures"]["configured_cost_usd"]["missing_count"] == 1
+    assert result.coverage["measures"]["configured_cost_usd"]["coverage_percent"] == 50.0
+
+
+def _refresh_r5_fixture(tmp_path: Path) -> tuple[RuntimePaths, Path]:
+    runtime = _runtime(tmp_path)
+    source = _write_r5_source(runtime, _r5_events())
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+    ).refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="r5-contract",
+    )
+    return runtime, source
+
+
+def _runtime(tmp_path: Path) -> RuntimePaths:
+    return RuntimePaths(
+        codex_home=tmp_path / "codex-home",
+        cache_root=tmp_path / "cache",
+    )
+
+
+def _write_r5_source(
+    runtime: RuntimePaths,
+    lines: tuple[dict[str, object], ...],
+) -> Path:
+    _write_session_index(runtime)
+    source = runtime.codex_home / "sessions" / "2026" / "07" / "27" / "rollout-r5-session.jsonl"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "".join(json.dumps(line, separators=(",", ":")) + "\n" for line in lines),
+        encoding="utf-8",
+    )
+    return source
+
+
+def _r5_events() -> tuple[dict[str, object], ...]:
+    session_id = "00000000-0000-4000-8000-000000000505"
+    return (
+        {
+            "timestamp": "2026-07-27T12:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": session_id},
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.000Z",
+            "type": "turn_context",
+            "payload": {
+                "turn_id": "turn-r5-1",
+                "model": "gpt-r5",
+                "effort": "high",
+            },
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.050Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "functions.read_file",
+                "call_id": "call-r5-tool",
+                "arguments": json.dumps(
+                    {
+                        "path": "src/example.py",
+                        "private": "PRIVATE_SYNTHETIC_ARGUMENT",
+                    }
+                ),
+            },
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.100Z",
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call-r5-tool",
+                "output": "synthetic result",
+            },
+        },
+        {
+            "event_id": "event-r5-call",
+            "timestamp": "2026-07-27T12:00:00.150Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 20,
+                        "cached_input_tokens": 5,
+                        "reasoning_output_tokens": 3,
+                        "output_tokens": 8,
+                        "total_tokens": 28,
+                    },
+                    "model_context_window": 200_000,
+                },
+                "rate_limits": {
+                    "plan_type": "synthetic",
+                    "limit_id": "synthetic-limit",
+                    "primary": {
+                        "used_percent": 10.0,
+                        "window_minutes": 300,
+                        "resets_at": 1_785_170_000,
+                    },
+                },
+            },
+        },
+        {
+            "timestamp": "2026-07-27T12:00:00.200Z",
+            "type": "event_msg",
+            "payload": {"type": "task_complete"},
+        },
+    )
+
+
+def _session_event() -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-27T12:00:00.000Z",
+        "type": "session_meta",
+        "payload": {"id": "00000000-0000-4000-8000-000000000505"},
+    }
+
+
+def _turn_event(turn_id: str) -> dict[str, object]:
+    return {
+        "timestamp": "2026-07-27T12:00:00.000Z",
+        "type": "turn_context",
+        "payload": {"turn_id": turn_id, "model": "gpt-r5"},
+    }
+
+
+def _token_event(
+    event_id: str,
+    timestamp: str,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+) -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": 0,
+                    "reasoning_output_tokens": 0,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                }
+            },
+        },
+    }
+
+
+def _write_session_index(runtime: RuntimePaths) -> None:
+    runtime.codex_home.mkdir(parents=True, exist_ok=True)
+    runtime.codex_home.joinpath("session_index.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "00000000-0000-4000-8000-000000000505",
+                "thread_name": "  Investigate\n\tfast   usage  ",
+                "updated_at": "2026-07-27T12:00:00.300Z",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_rate_card(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "codex-usage-tracker.kernel-rate-card.v1",
+                "source": {
+                    "name": "Synthetic rates",
+                    "url": "https://example.invalid/rates",
+                    "effective_at": "2026-07-01",
+                    "fetched_at": "2026-07-01T00:00:00Z",
+                },
+                "models": {
+                    "gpt-r5": {
+                        "input_per_million": 1.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 2.0,
+                        "credits_input_per_million": 3.0,
+                        "credits_cached_input_per_million": 1.0,
+                        "credits_output_per_million": 4.0,
+                        "confidence": "estimated",
+                    }
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
## Summary

- restore four-class token accounting, configured cost, estimated credits, and interval-based allowance facts
- add sanitized human thread labels, turn completion semantics, bounded structural tool facts, and deterministic adjacent-call impact
- preserve generation isolation during tool enrichment and moving-tail relinking
- exclude copied structural facts, degrade safely on invalid optional rate cards, and keep raw arguments/output/full paths out of SQLite
- update package budgets, installed-package upgrade smoke, and the Product Recovery execution ledger

## User impact

Agents and the Console can now work from human-readable threads, truthful token/cost/credit coverage, turn and tool structure, and evidence-linked exact facts without depending on server-authored narrative analysis. Append refreshes retain published-generation consistency and re-link tools when their following model call arrives.

## Validation

- `just v`: 412 Python tests and 7 frontend tests passed; Ruff, MyPy, Pyright, scope, manifests, maintainability, deterministic assets, and release safety passed
- 107 focused query/evidence/allowance/ingestion tests passed after review remediation
- synthetic ingest-performance and 100k query/allowance/evidence budgets passed
- `python -m build` and `python scripts/check_release.py --dist` passed
- clean wheel, public 0.27 upgrade, and exact merged-R4 0.28 upgrade smokes passed with two fresh MCP tasks each
- installed Console and allowance smoke passed
- final review: 9 findings, 9 accepted and fixed; reviewer token attribution pending

## Privacy

All fixtures and profiling inputs are synthetic. The change does not persist raw tool arguments, commands, tool output, message content, secrets, or full local paths.
