### PR TITLE
fix: harden production refresh tails

### DIFF
--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -1,10 +1,10 @@
 {
   "schema": "codex-usage-tracker.kernel-rc-budget.v1",
   "headroom_percent": 3,
-  "kernel_source_bytes": 619316,
+  "kernel_source_bytes": 640718,
   "console_asset_bytes": 81450,
   "analytical_tables": 17,
-  "analytical_indexes": 14,
+  "analytical_indexes": 15,
   "required_schema_objects": 9,
   "mcp_tools": 6,
   "http_routes": 7,

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -17,7 +17,7 @@ benchmark, a source-only tag, or an unpublished package.
 | R3 | Complete | R2 | `feature/r3-build-refresh-performance` | PR #344 merged as `f740939`; selective hydration and refresh gates pass |
 | R4 | Complete | R2 | `feature/r4-fast-query-mcp` | PR #345 merged as `da42350`; persisted rollups and fast bounded paths |
 | R5 | Complete | R3, R4 | `feature/r5-analytical-primitives` | PR #346 merged as `34528d1`; analytical facts and human semantics restored |
-| R6 | In progress | R4, R5 | `feature/r6-console-usability` | Human-first Console implementation and browser qualification underway |
+| R6 | Complete | R4, R5 | `feature/r6-console-usability` | PR #347 merged as `10b509d`; human-first Console and browser qualification pass |
 | R7 | Pending | R1; completes after R3–R6 | — | Installed fresh-task qualification |
 | R8 | Pending | R0; completes after R6, R7 | — | Public documentation |
 | R9 | Pending | R7, R8 | — | Public `0.29.0` release |
@@ -549,6 +549,72 @@ reparsing the first 52 sources.
   contract or explicitly document why SQLite integrity, foreign-key checks,
   accounting oracles, and exact release hashes remain the chosen layers.
 
+### R7 qualification correction — issue #348
+
+R7's first production-shaped installed qualification correctly returned a
+cross-cutting refresh failure to R3/R4 ownership instead of patching product
+behavior in the qualification harness. On the 643-source, roughly 1.1 GB
+synthetic corpus, the merged implementation committed facts but did not finish
+within 240 seconds. The candidate contained 1,316,864 calls and 658,432 tools
+but remained in full rollup validation. A one-call complete-history tail then
+took 9.151 seconds.
+
+The root cause was a correlated unresolved-tool query executed once per tool
+row, plus repeated view expansion, source-registry transactions, per-source
+cursor database opens, complete catalog rewrites, and full rollup rebuilds on
+ordinary tails. The correction:
+
+- uses a set-based unresolved-tool candidate set and a turn-key index;
+- incrementally carries forward unaffected rollups and rebuilds tool-operation
+  totals only when tool facts change;
+- batches source planning and registration and avoids rewriting unchanged
+  hydration catalogs;
+- uses physical compact fact tables for validation counts and collision probes;
+- backfills the additive turn-key index only on an unpublished clone; and
+- uses an APFS copy-on-write clone only while a short guarded snapshot proves
+  the WAL empty, retaining SQLite backup everywhere else.
+
+No schema version changed, no integrity or freshness boundary weakened, and no
+real local usage content was read. The additive index remains optional for
+opening an existing schema-v3 database and is created on the next unpublished
+write path.
+
+| Production-shaped workload | Before | Corrected |
+| --- | ---: | ---: |
+| Cold complete build | nonterminal after 240 s | 129.835 s |
+| Warm no-change refresh, five runs | 926–1,067 ms | 185–192 ms after one 306 ms catalog restoration sample |
+| One-call complete-history tail | 9.151 s | 1.078 s |
+| One-tool complete-history tail | not separately frozen | 2.228 s |
+| Published analytical database | 618,766,336 bytes before completion | 627,216,384 bytes, below 700 MiB |
+
+The complete-history one-call result is 88.2% faster but does not satisfy the
+literal 500 ms tail target. Its measured floor includes two full 643-source
+moving-tail catalogs and a roughly 320 ms exact incremental rollup
+transaction. The existing owned 160-source tail gate still passes at 420 ms;
+R7 must report the complete-history residual rather than presenting the smaller
+fixture as universal. A future watcher-provided dirty-source set may remove the
+full-catalog tax, but is not assumed by this correction.
+
+Integrity evidence on the active 1,316,875-call candidate passes
+`PRAGMA quick_check`, has zero foreign-key violations, and exactly matches both
+global canonical-call totals and tool-operation grouped facts. The focused
+ingestion, hydration, reconciliation, concurrency, live-integration, rollup,
+and performance suite passes 92 tests. Ruff, MyPy over 50 kernel source files,
+and Pyright pass. The complete repository suite passes 445 tests; the measured
+kernel source and exact 15-index release-candidate budgets pass with no more
+than 3% headroom. Attribution-only `agent-perf` run
+`20260728T063501Z-8987ee88` completed; unprofiled repeated timings above remain
+the speed evidence. No subagents were used for implementation.
+
+The single final read-only reviewer reported one high-severity finding and it
+was accepted. An old schema-v3 database needing the additive index could meet a
+late active duplicate in the same isolated refresh; canonical reselection then
+made prior-generation rollups unsafe to copy. Index-backfill refreshes now
+perform a one-time full rollup rebuild, with a regression that proves persisted
+global calls and tokens exactly equal canonical facts. Review totals are one
+finding, one accepted finding, and reviewer-token attribution `pending`; no
+retry blocks the correction.
+
 ## R4 — Build Persisted Rollups And Fast MCP/API Paths
 
 **State:** In progress
@@ -919,4 +985,6 @@ below the retained 90,000-byte ceiling.
   performance command passed all eight contracts, and the full repository gate
   passed all 415 tests.
 
-PR/CI merge remains before R6 completion.
+R6 merged through PR #347 as `10b509d`. Its task branch and worktree remain
+preserved. R7 consumes the qualified Console behavior and installed-package
+fixtures.

--- a/src/codex_usage_tracker/kernel/hydration.py
+++ b/src/codex_usage_tracker/kernel/hydration.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from functools import partial
 from pathlib import Path
 
 from .discovery import SourceObservation, observe_source
 
 _TAIL_SCAN_BYTES = 256 * 1024
+_CATALOG_WORKERS = 4
+_PARALLEL_CATALOG_MIN_SOURCES = 8
 
 
 class HydrationPreset(str, Enum):
@@ -68,26 +72,33 @@ def catalog_sources(
     """Observe every source and extract one bounded structural high water."""
 
     known = checkpoints or {}
-    catalog = []
-    for path in paths:
-        observation = observe_source(path)
-        checkpoint = known.get(observation.source_id)
-        unchanged = (
-            checkpoint is not None
-            and checkpoint.size_bytes == observation.size_bytes
-            and checkpoint.modified_ns == observation.modified_ns
-        )
-        catalog.append(
-            CatalogSource(
-                observation=observation,
-                latest_event_at=(
-                    checkpoint.latest_event_at
-                    if unchanged and checkpoint is not None
-                    else _latest_structural_timestamp(observation)
-                ),
-            )
-        )
-    return tuple(catalog)
+    catalog_one = partial(_catalog_source, checkpoints=known)
+    if len(paths) < _PARALLEL_CATALOG_MIN_SOURCES:
+        return tuple(map(catalog_one, paths))
+    with ThreadPoolExecutor(max_workers=_CATALOG_WORKERS) as pool:
+        return tuple(pool.map(catalog_one, paths))
+
+
+def _catalog_source(
+    path: Path,
+    *,
+    checkpoints: Mapping[str, CatalogCheckpoint],
+) -> CatalogSource:
+    observation = observe_source(path)
+    checkpoint = checkpoints.get(observation.source_id)
+    unchanged = (
+        checkpoint is not None
+        and checkpoint.size_bytes == observation.size_bytes
+        and checkpoint.modified_ns == observation.modified_ns
+    )
+    return CatalogSource(
+        observation=observation,
+        latest_event_at=(
+            checkpoint.latest_event_at
+            if unchanged and checkpoint is not None
+            else _latest_structural_timestamp(observation)
+        ),
+    )
 
 
 def catalog_checkpoints(

--- a/src/codex_usage_tracker/kernel/ingest.py
+++ b/src/codex_usage_tracker/kernel/ingest.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import ctypes
 import hashlib
+import os
 import sqlite3
+import sys
 import time
 import uuid
 from collections.abc import Callable
@@ -41,17 +44,20 @@ from .operational import (
     hydrated_source_ids,
     hydrated_source_locations,
     hydration_catalog_checkpoints,
+    hydration_selection_revision,
     initialize_operational_database,
     load_cutover_control,
+    load_hydration_coverage,
     load_staged_hydration,
     promote_cutover,
     record_hydration_catalog,
     record_legacy_cache_metadata,
-    register_source,
+    register_sources,
     reset_cutover_for_schema_upgrade,
     restore_hydration_states,
     stage_hydration_catalog,
     transition_cutover,
+    update_hydration_capture,
 )
 from .parser import (
     PARSER_VERSION,
@@ -60,7 +66,7 @@ from .parser import (
     parse_jsonl,
 )
 from .rollups import generation_rollups_ready, rebuild_generation_rollups
-from .schema import SCHEMA_VERSION
+from .schema import SCHEMA_VERSION, create_missing_secondary_indexes
 from .thread_labels import load_thread_labels
 from .writer import (
     WriteResult,
@@ -156,11 +162,17 @@ class KernelIngestor:
                 self._register_observations(observations)
             active_path = self._active_path()
             plans = self._plans(observations, active_path)
-            stage_hydration_catalog(self.operational_path, selection)
+            catalog_current = (
+                load_hydration_coverage(self.operational_path)["coverage_revision"]
+                == hydration_selection_revision(selection)
+            )
+            if plans or not catalog_current:
+                stage_hydration_catalog(self.operational_path, selection)
             if not plans:
                 return self._complete_without_plans(
                     sources,
                     selection,
+                    catalog_current=catalog_current,
                     active_path=active_path,
                     recovered_generation=recovered_generation,
                     owner_id=owner_id,
@@ -220,18 +232,20 @@ class KernelIngestor:
         self,
         observations: tuple[SourceObservation, ...],
     ) -> None:
-        for observation in observations:
-            register_source(
-                self.operational_path,
-                observation.source_id,
-                observation.path,
-            )
+        register_sources(
+            self.operational_path,
+            tuple(
+                (observation.source_id, observation.path)
+                for observation in observations
+            ),
+        )
 
     def _complete_without_plans(
         self,
         sources: list[Path],
         selection: HydrationSelection,
         *,
+        catalog_current: bool,
         active_path: Path,
         recovered_generation: int,
         owner_id: str,
@@ -241,7 +255,7 @@ class KernelIngestor:
         if recovered_generation > 0:
             if not generation_rollups_ready(active_path, recovered_generation):
                 with leases.maintain(refresh_run_id, owner_id) as guard:
-                    staging_path, _isolated = self._write_path(
+                    staging_path, _isolated, _incremental_safe = self._write_path(
                         active_path,
                         (),
                         (),
@@ -265,11 +279,17 @@ class KernelIngestor:
                 recovered_generation,
                 "no_changes",
             )
-            record_hydration_catalog(
-                self.operational_path,
-                selection,
-                hydrated_generation=recovered_generation,
-            )
+            if not catalog_current:
+                record_hydration_catalog(
+                    self.operational_path,
+                    selection,
+                    hydrated_generation=recovered_generation,
+                )
+            else:
+                update_hydration_capture(
+                    self.operational_path,
+                    selection,
+                )
         else:
             result = self._publish_empty_generation(
                 sources,
@@ -389,7 +409,7 @@ class KernelIngestor:
             requires_rollup_backfill = active_generation > 0 and not generation_rollups_ready(
                 active_path, active_generation
             )
-            write_path, isolated = self._write_path(
+            write_path, isolated, incremental_rollup_safe = self._write_path(
                 active_path,
                 plans,
                 normalized,
@@ -433,8 +453,11 @@ class KernelIngestor:
                 write_path,
                 generation,
                 incremental_from=(
-                    active_generation if active_generation > 0 and not isolated else None
+                    active_generation
+                    if active_generation > 0 and incremental_rollup_safe
+                    else None
                 ),
+                tool_facts_changed=written.inserted_tools > 0,
             )
             written = replace(
                 written,
@@ -557,46 +580,68 @@ class KernelIngestor:
         observations: tuple[SourceObservation, ...],
         analytical_path: Path,
     ) -> tuple[SourcePlan, ...]:
+        with sqlite3.connect(self.operational_path) as connection:
+            registered = connection.execute(
+                "SELECT source_id, source_location FROM source_registry"
+            ).fetchall()
+        source_by_location = {
+            str(location): str(source_id) for source_id, location in registered
+        }
+        registered_ids = {str(source_id) for source_id, _location in registered}
+        selected_ids = tuple(
+            sorted(
+                {
+                    source_by_location.get(
+                        str(observation.path),
+                        observation.source_id,
+                    )
+                    for observation in observations
+                    if (
+                        str(observation.path) in source_by_location
+                        or observation.source_id in registered_ids
+                    )
+                }
+            )
+        )
+        source_rows: dict[str, sqlite3.Row] = {}
+        with open_read_snapshot(analytical_path) as connection:
+            for start in range(0, len(selected_ids), 500):
+                chunk = selected_ids[start : start + 500]
+                placeholders = ", ".join("?" for _ in chunk)
+                for row in connection.execute(
+                    f"SELECT * FROM sources WHERE source_id IN ({placeholders})",
+                    chunk,
+                ):
+                    source_rows[str(row["source_id"])] = row
         plans = []
         for observation in observations:
+            source_id = source_by_location.get(
+                str(observation.path),
+                observation.source_id,
+            )
+            row = source_rows.get(source_id)
+            cursor = None
+            if row is not None:
+                parser_upgrade = str(row["parser_version"]) != PARSER_VERSION
+                cursor = SourceCursor(
+                    source_id=str(row["source_id"]),
+                    parsed_byte_offset=int(row["parsed_byte_offset"]),
+                    parsed_line_number=int(row["parsed_line_number"]),
+                    size_bytes=int(row["size_bytes"]),
+                    prefix_fingerprint=(
+                        "parser-upgrade-required"
+                        if parser_upgrade
+                        else str(row["replacement_fingerprint"])
+                    ),
+                    is_archived=str(row["archive_state"]) == "archived",
+                )
             planned = plan_source(
                 observation,
-                self._cursor(observation, analytical_path),
+                cursor,
             )
             if planned is not None:
                 plans.append(planned)
         return tuple(plans)
-
-    def _cursor(
-        self,
-        observation: SourceObservation,
-        analytical_path: Path,
-    ) -> SourceCursor | None:
-        source = _registered_source_id(
-            self.operational_path,
-            observation.path,
-            observation.source_id,
-        )
-        if source is None:
-            return None
-        with open_read_snapshot(analytical_path) as connection:
-            row = connection.execute(
-                "SELECT * FROM sources WHERE source_id = ?",
-                (source,),
-            ).fetchone()
-        if row is None:
-            return None
-        parser_upgrade = str(row["parser_version"]) != PARSER_VERSION
-        return SourceCursor(
-            source_id=str(row["source_id"]),
-            parsed_byte_offset=int(row["parsed_byte_offset"]),
-            parsed_line_number=int(row["parsed_line_number"]),
-            size_bytes=int(row["size_bytes"]),
-            prefix_fingerprint=(
-                "parser-upgrade-required" if parser_upgrade else str(row["replacement_fingerprint"])
-            ),
-            is_archived=str(row["archive_state"]) == "archived",
-        )
 
     def _prepare(
         self,
@@ -978,100 +1023,62 @@ class KernelIngestor:
         refresh_run_id: str,
         *,
         force_isolation: bool = False,
-    ) -> tuple[Path, bool]:
-        requires_isolation = (
-            force_isolation
-            or any(plan.replace_existing and plan.prior_source_id is not None for plan in plans)
-            or self._active_collision_requires_isolation(
-                active_path,
-                plans,
-                normalized,
+    ) -> tuple[Path, bool, bool]:
+        replacement = any(
+            plan.replace_existing and plan.prior_source_id is not None for plan in plans
+        )
+        index_backfill = self._active_generation() > 0 and not _tool_turn_index_ready(
+            active_path
+        )
+        if force_isolation or replacement or index_backfill:
+            collision, collision_incremental_safe = False, False
+        else:
+            collision, collision_incremental_safe = (
+                self._active_collision_requires_isolation(
+                    active_path,
+                    plans,
+                    normalized,
+                )
             )
+        requires_isolation = force_isolation or replacement or index_backfill or collision
+        incremental_rollup_safe = (
+            not force_isolation
+            and not replacement
+            and not index_backfill
+            and collision_incremental_safe
         )
         if not requires_isolation:
-            return active_path, False
+            return active_path, False, True
         suffix = uuid.uuid5(
             uuid.NAMESPACE_URL,
             f"{generation}:{refresh_run_id}",
         ).hex[:12]
         staging = active_path.with_name(f".{active_path.stem}.g{generation}-{suffix}.sqlite3")
         _clone_database(active_path, staging)
-        return staging, True
+        if index_backfill:
+            with sqlite3.connect(staging) as connection:
+                create_missing_secondary_indexes(connection)
+        return staging, True, incremental_rollup_safe
 
     def _active_collision_requires_isolation(
         self,
         active_path: Path,
         plans: tuple[SourcePlan, ...],
         normalized: tuple[NormalizedBatch, ...],
-    ) -> bool:
+    ) -> tuple[bool, bool]:
         if self._active_generation() == 0:
-            return False
-        tool_ids = tuple(
-            sorted(
-                {
-                    str(row["tool_call_id"])
-                    for batch in normalized
-                    for row in batch.tool_calls
-                }
-            )
-        )
-        call_turn_ids = tuple(
-            sorted(
-                {
-                    str(row["turn_id"])
-                    for batch in normalized
-                    for row in batch.model_calls
-                    if row.get("turn_id") is not None
-                }
-            )
-        )
-        fingerprints = tuple(
-            sorted(
-                {
-                    str(row["canonical_call_id"])
-                    for plan, batch in zip(plans, normalized, strict=True)
-                    if not plan.observation.is_archived
-                    for row in batch.model_calls
-                }
-            )
-        )
+            return False, True
+        tool_ids = _incoming_tool_ids(normalized)
+        call_turn_ids = _incoming_call_turn_ids(normalized)
+        fingerprints = _incoming_active_fingerprints(plans, normalized)
         with open_read_snapshot(active_path) as connection:
-            for column, values in (
-                ("tool_call_id", tool_ids),
-                ("turn_id", call_turn_ids),
-            ):
-                for start in range(0, len(values), 500):
-                    chunk = values[start : start + 500]
-                    placeholders = ", ".join("?" for _ in chunk)
-                    row = connection.execute(
-                        f"""
-                        SELECT 1
-                        FROM tool_calls
-                        WHERE {column} IN ({placeholders})
-                        LIMIT 1
-                        """,
-                        chunk,
-                    ).fetchone()
-                    if row is not None:
-                        return True
-            for start in range(0, len(fingerprints), 500):
-                chunk = fingerprints[start : start + 500]
-                placeholders = ", ".join("?" for _ in chunk)
-                row = connection.execute(
-                    f"""
-                    SELECT 1
-                    FROM model_calls
-                    JOIN sources USING (source_id)
-                    WHERE model_calls.duplicate_state = 'canonical'
-                      AND sources.archive_state = 'archived'
-                      AND model_calls.canonical_call_id IN ({placeholders})
-                    LIMIT 1
-                    """,
-                    chunk,
-                ).fetchone()
-                if row is not None:
-                    return True
-        return False
+            if _has_tool_id_collision(connection, tool_ids):
+                return True, True
+            if _has_tool_turn_collision(connection, call_turn_ids):
+                return True, True
+            if _has_archived_fingerprint_collision(connection, fingerprints):
+                return True, False
+        return False, True
 
 
 def refresh_request_hash(
@@ -1087,34 +1094,131 @@ def refresh_request_hash(
     )
 
 
-def _registered_source_id(
-    path: Path,
-    source: Path,
-    observed_source_id: str,
-) -> str | None:
-    if not path.is_file():
-        return None
-    with sqlite3.connect(path) as connection:
-        row = connection.execute(
-            """
-            SELECT source_id
-            FROM source_registry
-            WHERE source_location = ? OR source_id = ?
-            ORDER BY source_location = ? DESC
-            LIMIT 1
-            """,
-            (
-                str(source.resolve()),
-                observed_source_id,
-                str(source.resolve()),
-            ),
-        ).fetchone()
-        return str(row[0]) if row else None
+def _selector_bytes(value: str, prefix: str) -> bytes:
+    if not value.startswith(prefix):
+        raise ValueError(f"invalid selector prefix: {prefix}")
+    return bytes.fromhex(value[len(prefix) :])
+
+
+def _incoming_tool_ids(
+    normalized: tuple[NormalizedBatch, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(row["tool_call_id"])
+                for batch in normalized
+                for row in batch.tool_calls
+            }
+        )
+    )
+
+
+def _incoming_call_turn_ids(
+    normalized: tuple[NormalizedBatch, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(row["turn_id"])
+                for batch in normalized
+                for row in batch.model_calls
+                if row.get("turn_id") is not None
+            }
+        )
+    )
+
+
+def _incoming_active_fingerprints(
+    plans: tuple[SourcePlan, ...],
+    normalized: tuple[NormalizedBatch, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(row["canonical_call_id"])
+                for plan, batch in zip(plans, normalized, strict=True)
+                if not plan.observation.is_archived
+                for row in batch.model_calls
+            }
+        )
+    )
+
+
+def _has_tool_id_collision(
+    connection: sqlite3.Connection,
+    tool_ids: tuple[str, ...],
+) -> bool:
+    return _has_chunked_collision(
+        connection,
+        """
+        SELECT 1
+        FROM tool_call_facts
+        WHERE tool_call_id IN ({placeholders})
+        LIMIT 1
+        """,
+        tuple(_selector_bytes(value, "tool_") for value in tool_ids),
+    )
+
+
+def _has_tool_turn_collision(
+    connection: sqlite3.Connection,
+    turn_ids: tuple[str, ...],
+) -> bool:
+    return _has_chunked_collision(
+        connection,
+        """
+        SELECT 1
+        FROM turns
+        JOIN tool_call_facts USING (turn_key)
+        WHERE turns.turn_id IN ({placeholders})
+        LIMIT 1
+        """,
+        turn_ids,
+    )
+
+
+def _has_archived_fingerprint_collision(
+    connection: sqlite3.Connection,
+    fingerprints: tuple[str, ...],
+) -> bool:
+    return _has_chunked_collision(
+        connection,
+        """
+        SELECT 1
+        FROM model_call_facts
+        JOIN sources USING (source_key)
+        WHERE model_call_facts.duplicate_state = 'canonical'
+          AND sources.archive_state = 'archived'
+          AND model_call_facts.canonical_call_id IN ({placeholders})
+        LIMIT 1
+        """,
+        tuple(_selector_bytes(value, "fp_") for value in fingerprints),
+    )
+
+
+def _has_chunked_collision(
+    connection: sqlite3.Connection,
+    query: str,
+    values: tuple[object, ...],
+) -> bool:
+    for start in range(0, len(values), 500):
+        chunk = values[start : start + 500]
+        placeholders = ", ".join("?" for _ in chunk)
+        if connection.execute(
+            query.format(placeholders=placeholders),
+            chunk,
+        ).fetchone() is not None:
+            return True
+    return False
 
 
 def _clone_database(source: Path, destination: Path) -> None:
     if destination.exists():
         raise ValueError("staging analytical database already exists")
+    if _clone_checkpointed_database(source, destination):
+        destination.chmod(0o600)
+        return
     source_uri = source.as_uri() + "?mode=ro"
     try:
         with (
@@ -1126,6 +1230,62 @@ def _clone_database(source: Path, destination: Path) -> None:
         destination.unlink(missing_ok=True)
         raise
     destination.chmod(0o600)
+
+
+def _tool_turn_index_ready(path: Path) -> bool:
+    with sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True) as connection:
+        return (
+            connection.execute(
+                """
+                SELECT 1 FROM sqlite_schema
+                WHERE type = 'index' AND name = 'idx_tool_calls_turn'
+                """
+            ).fetchone()
+            is not None
+        )
+
+
+def _clone_checkpointed_database(source: Path, destination: Path) -> bool:
+    """Use a filesystem snapshot only while the validated main file is stable."""
+
+    try:
+        with sqlite3.connect(source, isolation_level=None, timeout=0.25) as guard:
+            guard.execute("BEGIN IMMEDIATE")
+            wal = source.with_name(source.name + "-wal")
+            checkpointed = not wal.exists() or wal.stat().st_size == 0
+            cloned = checkpointed and _copy_on_write_clone(source, destination)
+            guard.execute("ROLLBACK")
+        if not cloned:
+            destination.unlink(missing_ok=True)
+            return False
+        with open_read_snapshot(destination) as connection:
+            connection.execute("SELECT 1").fetchone()
+        return True
+    except (OSError, sqlite3.Error, ValueError):
+        destination.unlink(missing_ok=True)
+        return False
+
+
+def _copy_on_write_clone(source: Path, destination: Path) -> bool:
+    """Clone one file on APFS; other platforms retain SQLite backup."""
+
+    if sys.platform != "darwin":
+        return False
+    library = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True)
+    clonefile = getattr(library, "clonefile", None)
+    if clonefile is None:
+        return False
+    clonefile.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int)
+    clonefile.restype = ctypes.c_int
+    result = clonefile(
+        os.fsencode(source),
+        os.fsencode(destination),
+        0,
+    )
+    if result == 0:
+        return True
+    destination.unlink(missing_ok=True)
+    return False
 
 
 def _request_hash(

--- a/src/codex_usage_tracker/kernel/operational.py
+++ b/src/codex_usage_tracker/kernel/operational.py
@@ -209,8 +209,19 @@ def initialize_operational_database(path: Path) -> Path:
 def register_source(path: Path, identifier: str, source: Path) -> None:
     """Record the minimum source mapping in the non-exportable sidecar."""
 
+    register_sources(path, ((identifier, source),))
+
+
+def register_sources(
+    path: Path,
+    sources: tuple[tuple[str, Path], ...],
+) -> None:
+    """Record source mappings in one bounded sidecar transaction."""
+
+    if not sources:
+        return
     with _connect(path) as connection:
-        connection.execute(
+        connection.executemany(
             """
             INSERT OR REPLACE INTO source_registry(
                 source_id, source_location, first_seen_at, last_seen_at, state
@@ -221,7 +232,10 @@ def register_source(path: Path, identifier: str, source: Path) -> None:
                 last_seen_at = CURRENT_TIMESTAMP,
                 state = 'tracked'
             """,
-            (identifier, str(source.resolve())),
+            (
+                (identifier, str(source.resolve()))
+                for identifier, source in sources
+            ),
         )
 
 
@@ -560,6 +574,33 @@ def load_hydration_coverage(path: Path) -> dict[str, object]:
         "deferred_bytes": int(row["deferred_bytes"]),
         "uncertain_source_count": int(row["uncertain_source_count"]),
     }
+
+
+def update_hydration_capture(
+    path: Path,
+    selection: HydrationSelection,
+) -> None:
+    """Advance no-change capture metadata without rewriting source rows."""
+
+    with _connect(path) as connection:
+        cursor = connection.execute(
+            """
+            UPDATE coverage_control
+            SET captured_at = ?,
+                cutoff_at = ?,
+                complete_history = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE singleton = 1 AND coverage_revision = ?
+            """,
+            (
+                _timestamp(selection.captured_at),
+                _timestamp(selection.cutoff_at),
+                int(selection.complete_history),
+                hydration_selection_revision(selection),
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("hydration capture revision changed")
 
 
 def load_publication_snapshot(

--- a/src/codex_usage_tracker/kernel/rollups.py
+++ b/src/codex_usage_tracker/kernel/rollups.py
@@ -8,6 +8,52 @@ from pathlib import Path
 
 from .database import open_read_snapshot, short_writer_transaction
 
+_LINK_UNRESOLVED_TOOL_CALLS_SQL = """
+UPDATE tool_call_facts AS tools
+SET nearest_model_call_key = COALESCE(
+    (
+        SELECT calls.model_call_key
+        FROM model_call_facts AS calls
+        WHERE calls.turn_key = tools.turn_key
+          AND calls.generation <= ?
+          AND calls.duplicate_state = 'canonical'
+          AND calls.event_at >= COALESCE(
+              tools.ended_at,
+              tools.started_at,
+              ''
+          )
+        ORDER BY calls.event_at, calls.model_call_key
+        LIMIT 1
+    ),
+    (
+        SELECT calls.model_call_key
+        FROM model_call_facts AS calls
+        WHERE calls.turn_key = tools.turn_key
+          AND calls.generation <= ?
+          AND calls.duplicate_state = 'canonical'
+          AND calls.event_at < COALESCE(
+              tools.ended_at,
+              tools.started_at,
+              ''
+          )
+        ORDER BY calls.event_at DESC, calls.model_call_key DESC
+        LIMIT 1
+    )
+),
+    generation = ?
+WHERE tools.generation <= ?
+  AND (
+      tools.nearest_model_call_key IS NULL
+      OR tools.generation < ?
+  )
+  AND tools.turn_key IN (
+      SELECT changed_calls.turn_key
+      FROM model_call_facts AS changed_calls
+      WHERE changed_calls.generation = ?
+        AND changed_calls.duplicate_state = 'canonical'
+  )
+"""
+
 
 def generation_rollups_ready(path: Path, generation: int) -> bool:
     """Return whether the atomic rollup marker exists for one generation."""
@@ -29,6 +75,7 @@ def rebuild_generation_rollups(
     generation: int,
     *,
     incremental_from: int | None = None,
+    tool_facts_changed: bool = True,
 ) -> float:
     """Replace one unpublished generation's deterministic metadata rollups."""
 
@@ -58,7 +105,11 @@ def rebuild_generation_rollups(
                 generation=generation,
                 prior_generation=incremental_from,
             )
-            _apply_generation_delta(connection, generation=generation)
+            _apply_generation_delta(
+                connection,
+                generation=generation,
+                rebuild_tool_operation=tool_facts_changed,
+            )
             return (time.perf_counter() - started) * 1_000
         connection.execute(
             """
@@ -160,49 +211,8 @@ def _link_unresolved_tool_calls(
     generation: int,
 ) -> None:
     connection.execute(
-        """
-        UPDATE tool_call_facts AS tools
-        SET nearest_model_call_key = COALESCE(
-            (
-                SELECT calls.model_call_key
-                FROM model_call_facts AS calls
-                WHERE calls.turn_key = tools.turn_key
-                  AND calls.generation <= ?
-                  AND calls.duplicate_state = 'canonical'
-                  AND calls.event_at >= COALESCE(
-                      tools.ended_at,
-                      tools.started_at,
-                      ''
-                  )
-                ORDER BY calls.event_at, calls.model_call_key
-                LIMIT 1
-            ),
-            (
-                SELECT calls.model_call_key
-                FROM model_call_facts AS calls
-                WHERE calls.turn_key = tools.turn_key
-                  AND calls.generation <= ?
-                  AND calls.duplicate_state = 'canonical'
-                  AND calls.event_at < COALESCE(
-                      tools.ended_at,
-                      tools.started_at,
-                      ''
-                  )
-                ORDER BY calls.event_at DESC, calls.model_call_key DESC
-                LIMIT 1
-            )
-        ),
-            generation = ?
-        WHERE tools.generation <= ?
-          AND EXISTS (
-              SELECT 1
-              FROM model_call_facts AS changed_calls
-              WHERE changed_calls.turn_key = tools.turn_key
-                AND changed_calls.generation = ?
-                AND changed_calls.duplicate_state = 'canonical'
-          )
-        """,
-        (generation, generation, generation, generation, generation),
+        _LINK_UNRESOLVED_TOOL_CALLS_SQL,
+        (generation, generation, generation, generation, generation, generation),
     )
 
 
@@ -267,6 +277,7 @@ def _apply_generation_delta(
     connection: sqlite3.Connection,
     *,
     generation: int,
+    rebuild_tool_operation: bool,
 ) -> None:
     connection.execute(
         """
@@ -372,23 +383,24 @@ def _apply_generation_delta(
         """,
         (generation, generation, generation),
     )
-    connection.execute(
-        "DELETE FROM rollup_tool_operation WHERE generation = ?",
-        (generation,),
-    )
-    connection.execute(
-        """
-        INSERT INTO rollup_tool_operation(
-            generation, operation, target_label, calls,
-            duration_ms, output_bytes
+    if rebuild_tool_operation:
+        connection.execute(
+            "DELETE FROM rollup_tool_operation WHERE generation = ?",
+            (generation,),
         )
-        SELECT ?, profiles.operation, COALESCE(facts.target_label, ''),
-               COUNT(*), COALESCE(SUM(facts.duration_ms), 0.0),
-               COALESCE(SUM(facts.output_bytes), 0)
-        FROM tool_call_facts AS facts
-        JOIN tool_profiles AS profiles USING (tool_profile_key)
-        WHERE facts.generation <= ?
-        GROUP BY profiles.operation, COALESCE(facts.target_label, '')
-        """,
-        (generation, generation),
-    )
+        connection.execute(
+            """
+            INSERT INTO rollup_tool_operation(
+                generation, operation, target_label, calls,
+                duration_ms, output_bytes
+            )
+            SELECT ?, profiles.operation, COALESCE(facts.target_label, ''),
+                   COUNT(*), COALESCE(SUM(facts.duration_ms), 0.0),
+                   COALESCE(SUM(facts.output_bytes), 0)
+            FROM tool_call_facts AS facts
+            JOIN tool_profiles AS profiles USING (tool_profile_key)
+            WHERE facts.generation <= ?
+            GROUP BY profiles.operation, COALESCE(facts.target_label, '')
+            """,
+            (generation, generation),
+        )

--- a/src/codex_usage_tracker/kernel/schema.py
+++ b/src/codex_usage_tracker/kernel/schema.py
@@ -6,7 +6,7 @@ import sqlite3
 
 SCHEMA_VERSION = 3
 APPLICATION_ID = 0x43555431
-MAX_INDEX_COUNT = 14
+MAX_INDEX_COUNT = 15
 SCHEMA_CAPABILITIES = frozenset(
     {
         "stable-identities",
@@ -90,6 +90,10 @@ SECONDARY_INDEX_SQL = {
     "idx_tool_calls_thread_time": (
         "CREATE INDEX idx_tool_calls_thread_time "
         "ON tool_call_facts(thread_key, started_at)"
+    ),
+    "idx_tool_calls_turn": (
+        "CREATE INDEX idx_tool_calls_turn "
+        "ON tool_call_facts(turn_key, generation)"
     ),
     "idx_activity_thread_time": (
         "CREATE INDEX idx_activity_thread_time "
@@ -441,6 +445,8 @@ CREATE INDEX idx_model_calls_time
 ON model_call_facts(event_at, generation, duplicate_state);
 CREATE INDEX idx_tool_calls_thread_time
 ON tool_call_facts(thread_key, started_at);
+CREATE INDEX idx_tool_calls_turn
+ON tool_call_facts(turn_key, generation);
 CREATE INDEX idx_activity_thread_time
 ON activity_facts(thread_key, event_at);
 CREATE INDEX idx_allowance_window_time
@@ -833,3 +839,12 @@ def create_secondary_indexes(connection: sqlite3.Connection) -> None:
 
     for statement in SECONDARY_INDEX_SQL.values():
         connection.execute(statement)
+
+
+def create_missing_secondary_indexes(connection: sqlite3.Connection) -> None:
+    """Backfill additive query indexes on an unpublished clone."""
+
+    for statement in SECONDARY_INDEX_SQL.values():
+        connection.execute(
+            statement.replace("CREATE INDEX", "CREATE INDEX IF NOT EXISTS", 1)
+        )

--- a/src/codex_usage_tracker/kernel/writer.py
+++ b/src/codex_usage_tracker/kernel/writer.py
@@ -380,18 +380,20 @@ def _read_counts(
     connection = sqlite3.connect(path)
     try:
         calls = connection.execute(
-            "SELECT COUNT(*) FROM model_calls WHERE generation = ?",
+            "SELECT COUNT(*) FROM model_call_facts WHERE generation = ?",
             (generation,),
         ).fetchone()[0]
         tools = connection.execute(
-            "SELECT COUNT(*) FROM tool_calls WHERE generation = ?",
+            "SELECT COUNT(*) FROM tool_call_facts WHERE generation = ?",
             (generation,),
         ).fetchone()[0]
         canonical = connection.execute(
-            "SELECT COUNT(*) FROM model_calls WHERE duplicate_state = 'canonical'"
+            "SELECT COUNT(*) FROM model_call_facts "
+            "WHERE duplicate_state = 'canonical'"
         ).fetchone()[0]
         excluded = connection.execute(
-            "SELECT COUNT(*) FROM model_calls WHERE duplicate_state != 'canonical'"
+            "SELECT COUNT(*) FROM model_call_facts "
+            "WHERE duplicate_state != 'canonical'"
         ).fetchone()[0]
         yield int(calls), int(tools), int(canonical), int(excluded)
     finally:

--- a/tests/kernel/query/test_performance.py
+++ b/tests/kernel/query/test_performance.py
@@ -36,13 +36,21 @@ _TOOL_COUNT = 25_000
 
 
 @pytest.fixture(scope="module")
-def large_service(tmp_path_factory: pytest.TempPathFactory) -> QueryService:
+def large_rollup_metrics() -> dict[str, float]:
+    return {}
+
+
+@pytest.fixture(scope="module")
+def large_service(
+    tmp_path_factory: pytest.TempPathFactory,
+    large_rollup_metrics: dict[str, float],
+) -> QueryService:
     root = tmp_path_factory.mktemp("query-performance")
     paths = kernel_paths(root)
     initialize_analytical_database(paths.analytical)
     initialize_operational_database(paths.operational)
     _populate_calls(paths.analytical)
-    rebuild_generation_rollups(paths.analytical, 1)
+    large_rollup_metrics["elapsed_ms"] = rebuild_generation_rollups(paths.analytical, 1)
     rate_card = root / "rates.json"
     _write_rate_card(rate_card)
     with sqlite3.connect(paths.operational) as connection:
@@ -79,6 +87,14 @@ def large_service(tmp_path_factory: pytest.TempPathFactory) -> QueryService:
         generation=1,
     )
     return QueryService(paths.operational, rate_card_path=rate_card)
+
+
+def test_100k_rollup_rebuild_budget(
+    large_service: QueryService,
+    large_rollup_metrics: dict[str, float],
+) -> None:
+    assert large_service is not None
+    assert large_rollup_metrics["elapsed_ms"] <= 5_500
 
 
 def test_100k_common_comparison_and_concentration_budgets(

--- a/tests/kernel/query/test_r4_rollups.py
+++ b/tests/kernel/query/test_r4_rollups.py
@@ -18,7 +18,10 @@ from codex_usage_tracker.kernel.operational import (
     load_cutover_control,
 )
 from codex_usage_tracker.kernel.query import Operation, QueryRequest, QueryService
-from codex_usage_tracker.kernel.rollups import generation_rollups_ready
+from codex_usage_tracker.kernel.rollups import (
+    _LINK_UNRESOLVED_TOOL_CALLS_SQL,
+    generation_rollups_ready,
+)
 from tests.kernel.interfaces.support import active_runtime
 from tests.kernel.test_ingest_pipeline import _token_line
 
@@ -167,6 +170,32 @@ def test_time_bands_and_tool_operations_use_bounded_rollups(
         )
     )
     assert nullable_metrics.plan_id == "tools.aggregate.v1"
+
+
+def test_tool_relink_changed_turn_filter_is_set_based(tmp_path: Path) -> None:
+    runtime = active_runtime(tmp_path)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+    assert control.active_generation is not None
+
+    generation = control.active_generation
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        plan = connection.execute(
+            "EXPLAIN QUERY PLAN " + _LINK_UNRESOLVED_TOOL_CALLS_SQL,
+            (
+                generation,
+                generation,
+                generation,
+                generation,
+                generation,
+                generation,
+            ),
+        ).fetchall()
+
+    details = tuple(str(row[3]) for row in plan)
+    assert any("idx_tool_calls_turn" in detail for detail in details)
+    assert any("LIST SUBQUERY" in detail for detail in details)
+    assert sum("CORRELATED SCALAR SUBQUERY" in detail for detail in details) == 2
 
 
 def test_model_rollup_regroups_unselected_effort_and_tier(

--- a/tests/kernel/test_hydration_policy.py
+++ b/tests/kernel/test_hydration_policy.py
@@ -169,6 +169,40 @@ def test_unchanged_catalog_reuses_bounded_structural_timestamp(
     assert second == first
 
 
+def test_no_change_refresh_reuses_committed_coverage_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _usage_source(
+        tmp_path / "sessions" / "unchanged.jsonl",
+        session_id="unchanged",
+        timestamp="2026-07-20T00:00:00Z",
+    )
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="coverage-initial",
+        captured_at=_AS_OF,
+    )
+
+    def unexpected_catalog_write(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("unchanged coverage must not be rewritten")
+
+    monkeypatch.setattr(ingest, "stage_hydration_catalog", unexpected_catalog_write)
+    monkeypatch.setattr(ingest, "record_hydration_catalog", unexpected_catalog_write)
+    result = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="coverage-no-change",
+        captured_at=_AS_OF,
+    )
+
+    assert result.planner_reason == "no_changes"
+    assert result.writer_transaction_ms == ()
+
+
 def test_previously_hydrated_source_stays_selected_when_window_narrows(
     tmp_path: Path,
 ) -> None:

--- a/tests/kernel/test_ingest_performance.py
+++ b/tests/kernel/test_ingest_performance.py
@@ -4,21 +4,130 @@ from __future__ import annotations
 
 import json
 import math
+import shutil
 import sqlite3
 import time
 from pathlib import Path
 
 import pytest
 
-from codex_usage_tracker.kernel import writer
+from codex_usage_tracker.kernel import ingest, writer
+from codex_usage_tracker.kernel.database import initialize_analytical_database
 from codex_usage_tracker.kernel.ingest import KernelIngestor, RefreshTrigger
-from codex_usage_tracker.kernel.operational import kernel_paths
+from codex_usage_tracker.kernel.operational import kernel_paths, load_cutover_control
 from tests.kernel.test_ingest_pipeline import _token_line
 
 _CALL_COUNT = 100_000
 _ACTIVE_WRITER_P95_BUDGET_MS = 50.0
 _INITIAL_WRITER_P95_BUDGET_MS = 2_000.0
 _INITIAL_BUILD_TRANSACTION_BUDGET = 10
+
+
+def test_checkpointed_clone_uses_copy_on_write_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    destination = tmp_path / "destination.sqlite3"
+    initialize_analytical_database(source)
+    with sqlite3.connect(source) as connection:
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    clone_calls: list[tuple[Path, Path]] = []
+
+    def clone_file(current: Path, staging: Path) -> bool:
+        clone_calls.append((current, staging))
+        shutil.copyfile(current, staging)
+        return True
+
+    monkeypatch.setattr(ingest, "_copy_on_write_clone", clone_file)
+    ingest._clone_database(source, destination)
+
+    assert clone_calls == [(source, destination)]
+    with sqlite3.connect(destination) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone() == (3,)
+
+
+def test_nonempty_wal_uses_sqlite_snapshot_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.sqlite3"
+    destination = tmp_path / "destination.sqlite3"
+    initialize_analytical_database(source)
+    connection = sqlite3.connect(source)
+    try:
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA wal_autocheckpoint = 0")
+        connection.execute(
+            """
+            INSERT INTO generations VALUES (
+                1, 'sha256:source', CURRENT_TIMESTAMP, 'sha256:water',
+                0, 0, 0, 0, 0, NULL, '{}', 'valid'
+            )
+            """
+        )
+        connection.commit()
+        wal = source.with_name(source.name + "-wal")
+        assert wal.stat().st_size > 0
+
+        def unexpected_clone(_source: Path, _destination: Path) -> bool:
+            raise AssertionError("nonempty WAL must use SQLite backup")
+
+        monkeypatch.setattr(ingest, "_copy_on_write_clone", unexpected_clone)
+        ingest._clone_database(source, destination)
+    finally:
+        connection.close()
+
+    with sqlite3.connect(destination) as copied:
+        assert copied.execute("SELECT generation FROM generations").fetchone() == (1,)
+
+
+def test_tail_backfills_tool_turn_index_on_unpublished_clone(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "sessions" / "rollout-index-upgrade.jsonl"
+    source.parent.mkdir()
+    source.write_text(
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta",'
+        '"payload":{"id":"synthetic-index-upgrade"}}\n'
+        '{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context",'
+        '"payload":{"turn_id":"turn-1","model":"gpt-synthetic","effort":"low"}}\n'
+        + _token_line("event-1", 10),
+        encoding="utf-8",
+    )
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="index-upgrade-initial",
+    )
+    prior = load_cutover_control(paths.operational).active_kernel_path
+    assert prior is not None
+    with sqlite3.connect(prior) as connection:
+        connection.execute("DROP INDEX idx_tool_calls_turn")
+    with source.open("a", encoding="utf-8") as handle:
+        handle.write(_token_line("event-2", 20))
+
+    result = ingestor.refresh(
+        [source],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="index-upgrade-tail",
+    )
+    current = load_cutover_control(paths.operational).active_kernel_path
+
+    assert result.generation == 2
+    assert current is not None
+    assert current != prior
+    with sqlite3.connect(current) as connection:
+        assert connection.execute(
+            """
+            SELECT 1 FROM sqlite_schema
+            WHERE type = 'index' AND name = 'idx_tool_calls_turn'
+            """
+        ).fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM model_calls").fetchone() == (2,)
 
 
 def test_100k_call_build_meets_bounded_writer_budget(tmp_path: Path) -> None:

--- a/tests/kernel/test_ingest_reconciliation.py
+++ b/tests/kernel/test_ingest_reconciliation.py
@@ -378,6 +378,51 @@ def test_late_active_duplicate_uses_isolated_canonical_promotion(
     assert states == [("active", "canonical"), ("archived", "copied")]
 
 
+def test_index_backfill_rebuilds_rollups_after_late_active_duplicate(
+    tmp_path: Path,
+) -> None:
+    archived = tmp_path / "archived_sessions" / "rollout-copy.jsonl"
+    active = tmp_path / "sessions" / "rollout-active.jsonl"
+    _write_usage(archived, session="copy-session", event="shared", tokens=10)
+    paths = kernel_paths(tmp_path / "cache")
+    ingestor = KernelIngestor(paths.analytical, paths.operational)
+    ingestor.refresh(
+        [archived],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="owner-1",
+    )
+    before = load_cutover_control(paths.operational)
+    assert before.active_kernel_path is not None
+    with sqlite3.connect(before.active_kernel_path) as connection:
+        connection.execute("DROP INDEX idx_tool_calls_turn")
+
+    _write_usage(active, session="active-session", event="shared", tokens=10)
+    ingestor.refresh(
+        [archived, active],
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="owner-2",
+    )
+
+    after = load_cutover_control(paths.operational)
+    assert after.active_kernel_path is not None
+    with sqlite3.connect(after.active_kernel_path) as connection:
+        exact = connection.execute(
+            """
+            SELECT COUNT(*), SUM(input_tokens)
+            FROM model_call_facts
+            WHERE duplicate_state = 'canonical'
+            """
+        ).fetchone()
+        persisted = connection.execute(
+            """
+            SELECT calls, input_tokens
+            FROM rollup_global
+            WHERE generation = 2
+            """
+        ).fetchone()
+    assert persisted == exact == (1, 10)
+
+
 def _write_usage(
     path: Path,
     *,

--- a/tests/kernel/test_r5_analytical_primitives.py
+++ b/tests/kernel/test_r5_analytical_primitives.py
@@ -785,6 +785,31 @@ def test_moving_tail_relinks_tool_to_following_model_call(
     )
 
     assert result.rows == ({"adjacent_total_tokens": 102},)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+    assert control.active_generation == 2
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        persisted = connection.execute(
+            """
+            SELECT operation, target_label, calls, duration_ms, output_bytes
+            FROM rollup_tool_operation
+            WHERE generation = 2
+            ORDER BY operation, target_label
+            """
+        ).fetchall()
+        exact = connection.execute(
+            """
+            SELECT profiles.operation, COALESCE(facts.target_label, ''),
+                   COUNT(*), COALESCE(SUM(facts.duration_ms), 0.0),
+                   COALESCE(SUM(facts.output_bytes), 0)
+            FROM tool_call_facts AS facts
+            JOIN tool_profiles AS profiles USING (tool_profile_key)
+            WHERE facts.generation <= 2
+            GROUP BY profiles.operation, COALESCE(facts.target_label, '')
+            ORDER BY profiles.operation, COALESCE(facts.target_label, '')
+            """
+        ).fetchall()
+    assert persisted == exact
 
 
 def test_failed_tool_update_never_mutates_active_generation(


### PR DESCRIPTION
## Summary
- replace the production-scale correlated tool relink with a set-based indexed path
- preserve exact incremental rollups while forcing full rebuilds for canonical-changing index backfills
- batch source discovery/catalog persistence and use guarded APFS clone snapshots with SQLite fallback
- ratchet release budgets and record production-shaped correction evidence

## Validation
- 445 Python tests passed
- `just vp` passed
- Ruff, MyPy, Pyright, maintainability, frontend lint/type/tests, manifests, and release-candidate budgets passed
- 1.3M-call synthetic candidate: quick-check clean, zero FK violations, exact global/tool rollup parity
- cold complete build: 129.835s; warm no-change: 185–192ms; one-call complete-history tail: 1.078s

## Residual
The complete-history one-call tail is 88.2% faster than the 9.151s failure but remains above the literal 500ms roadmap target; the ledger records this without weakening the gate.

Closes #348