### PR TITLE
fix: restore CLI version contract

### DIFF
--- a/scripts/smoke_installed_package.py
+++ b/scripts/smoke_installed_package.py
@@ -631,6 +631,19 @@ def smoke_install(
         ).stdout
         if any(name not in help_text for name in CLI_HELP_SUBCOMMANDS):
             raise RuntimeError("installed CLI catalog is incomplete")
+        package = _run_json([command, "package"], environment=environment)
+        installed_version = package.get("version")
+        version_text = subprocess.run(
+            [command, "--version"],
+            check=True,
+            capture_output=True,
+            env=environment,
+            text=True,
+        ).stdout.strip()
+        if version_text != f"codex-usage-tracker {installed_version}":
+            raise RuntimeError(
+                f"installed CLI version differs: {version_text}"
+            )
         installed_root = next(
             python.parent.parent.glob(
                 "lib/python*/site-packages/codex_usage_tracker"
@@ -645,7 +658,6 @@ def smoke_install(
             raise RuntimeError(
                 f"installed package resources are missing: {missing_resources}"
             )
-        package = _run_json([command, "package"], environment=environment)
         if version is not None and package.get("version") != version:
             raise RuntimeError(f"installed version differs: {package}")
         _run_json(

--- a/src/codex_usage_tracker/kernel/interfaces/cli/main.py
+++ b/src/codex_usage_tracker/kernel/interfaces/cli/main.py
@@ -46,6 +46,11 @@ def build_parser() -> argparse.ArgumentParser:
         prog="codex-usage-tracker",
         description="Exact local Codex usage facts and evidence.",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("setup", help="initialize the kernel cache")
     subparsers.add_parser("status", help="show committed generation status")

--- a/tests/kernel/interfaces/test_cli.py
+++ b/tests/kernel/interfaces/test_cli.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from codex_usage_tracker.kernel import __version__
 from codex_usage_tracker.kernel.interfaces.cli.main import build_parser, main
 
 from .support import active_runtime
@@ -29,6 +32,14 @@ def test_cli_help_contains_only_retained_public_commands() -> None:
         assert command in help_text
     for removed in ("analyze", "dashboard", "open-dashboard", "admin"):
         assert removed not in help_text
+
+
+def test_cli_reports_the_installed_package_version(capsys) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        build_parser().parse_args(["--version"])
+
+    assert exit_info.value.code == 0
+    assert capsys.readouterr().out == f"codex-usage-tracker {__version__}\n"
 
 
 def test_status_is_read_only_and_setup_is_explicit(


### PR DESCRIPTION
## What changed

- restore `codex-usage-tracker --version` with standard argparse exit-zero behavior
- verify the real installed console script version during wheel smoke
- add a focused CLI regression test

## Why

R7 installed-candidate qualification found that the package version was coherent internally, but the public console script rejected `--version` because required subcommand parsing ran first.

## Validation

- `just vc`: 439 Python tests; Ruff, MyPy, Pyright, frontend, maintainability, release, build, and dist checks passed
- exact built-wheel installed smoke passed with two fresh MCP tasks and warm Console p95 0.708 ms
- single final read-only reviewer: 0 findings

This is a focused pre-release correction required before R7 qualification resumes.