### PR TITLE
fix: query hydrated history through templates

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
     "name": "Douglas Monsky"
   },
   "bundle": {
-    "digest": "sha256:bfc2612d4109c49b83717677931e75d58512b106452f6da097cb06e71178fd82",
+    "digest": "sha256:78e609b7ece844ffa0c91d8fad389e4c01d549d5ab3bef9d7779706a41029dfc",
     "publishable": true,
     "runtime_version": "0.28.0",
     "schema": "codex-usage-tracker.kernel-plugin-bundle.v1"

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -761,6 +761,43 @@ bounded human label. The exact query, ingestion oracle, equivalence, and R5
 analytical suite passes 30 focused tests. Final PR CI remains pending on this
 cross-host correction.
 
+### R7 qualification correction — issue #356
+
+A fresh installed Desktop task against the default selective-history index
+sent the documented `top_threads` template and received a partial-coverage
+error. The frozen named-template shape had no caller field for opting into the
+hydrated subset, so the agent tried an invalid string parameter, requested
+guidance, called status, and finally started an unnecessary complete-history
+refresh. This made a tens-of-milliseconds leaderboard path appear unavailable
+until long historical hydration completed.
+
+Curated templates now materialize their closed typed requests with
+`allow_partial=true`. The named template itself selects this documented
+coverage-aware behavior; caller-authored typed all-history requests still fail
+closed unless their existing public shape explicitly opts into partial
+coverage. Responses preserve the partial grade and complete coverage metadata,
+and the bundled skill tells agents to state that scope and refresh complete
+history only when the user asks. The exact six-tool schema and frozen `0.28`
+schema hash remain unchanged.
+
+The synthetic partial-history regression proves that `top_threads` returns both
+leaderboard and cost-context results without launching a worker. Materializer,
+schema, plugin, and stable-contract tests pass as a 39-test focused set. The
+maintained `just v` profile passes 441 Python tests, nine frontend tests, Ruff,
+MyPy, Pyright, deterministic assets, scope, maintainability, and release-safety
+gates. The plugin bundle measures 5,601 bytes under its 5,620-byte ceiling.
+GitNexus classified the changed materializer itself low risk after refreshing
+the exact worktree index; application, MCP, cache, and coverage callers are
+covered by the focused and complete interface suites. Branch:
+`fix/template-partial-coverage`. Final review, PR CI, merge identity, and
+installed fresh-task confirmation remain pending. The single final read-only
+reviewer reported one medium-severity finding and it was accepted: partial
+facts now require the agent to state the hydration preset/cutoff and never
+generalize the result to all history, with an exact bundled-skill regression.
+Review totals are one finding and one accepted finding (`R1`); reviewer-token
+status and tokens per accepted finding are `pending` because the metrics helper
+still invokes the retired `strict` command. No retry or second review was run.
+
 ## R4 — Build Persisted Rollups And Fast MCP/API Paths
 
 **State:** In progress

--- a/skills/usage-kernel/SKILL.md
+++ b/skills/usage-kernel/SKILL.md
@@ -24,10 +24,11 @@ Use the three-step loop **scope → batch → evidence**:
    one or more query requests in the `requests` array. Execute a curated
    server-side template with
    `{"requests":[{"template":"<name>"}]}`; for the common thread leaderboard
-   use `{"requests":[{"template":"top_threads"}]}`. That template returns the
-   exact token leaderboard first and the cost/credit context second in the same
-   batch; do not run another query or resolve every selector unless the user
-   asks for deeper evidence. Use
+   use `{"requests":[{"template":"top_threads"}]}`. Templates query the
+   hydrated snapshot and report its coverage; refresh complete history only
+   when the user asks. This template returns the token leaderboard and
+   cost/credit context together; do not run another query or resolve every
+   selector unless the user asks for deeper evidence. Use
    `{"requests":[{"template":"weekly_drivers"}]}` for the latest indexed
    seven-day thread leaderboard,
    `{"requests":[{"template":"week_over_week"}]}` for that window versus the
@@ -54,7 +55,8 @@ Use the three-step loop **scope → batch → evidence**:
 
 Label every claim:
 
-- **fact** — directly returned exact or deterministic data with generation;
+- **fact** — returned exact/deterministic data; for `partial`, state the
+  hydration preset/cutoff and never generalize to all history;
 - **estimate** — returned estimated data with coverage and provenance;
 - **hypothesis** — model inference that still needs evidence;
 - **unsupported** — unavailable from the returned scope and not asserted.

--- a/src/codex_usage_tracker/kernel/query/catalog.py
+++ b/src/codex_usage_tracker/kernel/query/catalog.py
@@ -1001,10 +1001,13 @@ def materialize_query_requests(
                 for key in required_context
             },
         }
-        materialized.extend(
+        resolved_requests = [
             _resolve_template_value(item, resolved_parameters)
             for item in template["requests"]
-        )
+        ]
+        for resolved_request in resolved_requests:
+            resolved_request["allow_partial"] = True
+        materialized.extend(resolved_requests)
     if len(materialized) > MAX_BATCH_QUERIES:
         raise ValueError(
             f"query supports at most {MAX_BATCH_QUERIES} materialized requests"

--- a/tests/kernel/interfaces/test_contracts.py
+++ b/tests/kernel/interfaces/test_contracts.py
@@ -101,6 +101,7 @@ def test_usage_query_schema_teaches_closed_named_and_typed_requests() -> None:
     for request in (
         {"template": "missing"},
         {"template": "top_threads", "dataset": "calls"},
+        {"template": "top_threads", "allow_partial": True},
         {"dataset": "calls", "operation": "share", "unknown": True},
     ):
         with pytest.raises(ValueError):

--- a/tests/kernel/interfaces/test_plugin.py
+++ b/tests/kernel/interfaces/test_plugin.py
@@ -85,6 +85,8 @@ def test_skill_teaches_scope_batch_evidence_and_claim_grading() -> None:
     assert "estimate" in skill
     assert "hypothesis" in skill
     assert "unsupported" in skill
+    assert "for `partial`, state the" in skill
+    assert "never generalize to all history" in skill
     assert "after ranking" in skill
     assert '{"requests":[{"template":"top_threads"}]}' in skill
     assert '{"requests":[{"template":"weekly_drivers"}]}' in skill

--- a/tests/kernel/interfaces/test_r4_coverage_contract.py
+++ b/tests/kernel/interfaces/test_r4_coverage_contract.py
@@ -108,6 +108,24 @@ def test_partial_history_requires_explicit_query_opt_in(tmp_path: Path) -> None:
     assert accepted["results"][0]["coverage"]["history_complete"] is False
 
 
+def test_named_template_queries_the_current_hydrated_snapshot(tmp_path: Path) -> None:
+    launches: list[tuple[RuntimePaths, HydrationPreset]] = []
+    application = KernelApplication(
+        _partial_runtime(tmp_path),
+        worker_launcher=lambda paths, preset: launches.append((paths, preset)),
+    )
+
+    accepted = application.query({"requests": [{"template": "top_threads"}]})
+
+    assert accepted["history_coverage"]["complete_history"] is False
+    assert {result["grade"] for result in accepted["results"]} == {"partial"}
+    assert all(
+        result["coverage"]["history_complete"] is False
+        for result in accepted["results"]
+    )
+    assert launches == []
+
+
 def test_query_never_launches_refresh_for_partial_history(tmp_path: Path) -> None:
     launches: list[tuple[RuntimePaths, HydrationPreset]] = []
     application = KernelApplication(

--- a/tests/kernel/query/test_contracts.py
+++ b/tests/kernel/query/test_contracts.py
@@ -155,12 +155,25 @@ def test_server_side_template_materialization_matches_every_guided_template() ->
             context=_TEMPLATE_CONTEXT,
         )
 
-        assert list(materialized) == _materialize(
+        expected_requests = _materialize(
             template["requests"],
             {**_TEMPLATE_CONTEXT, **selected},
         )
+        for expected_request in expected_requests:
+            expected_request["allow_partial"] = True
+        assert list(materialized) == expected_requests
         for request in materialized:
             query_request(request).normalized()
+
+
+def test_named_templates_use_the_current_hydrated_snapshot() -> None:
+    materialized = materialize_query_requests(
+        [{"template": "top_threads"}],
+        context=_TEMPLATE_CONTEXT,
+    )
+
+    assert materialized
+    assert all(request["allow_partial"] is True for request in materialized)
 
 
 def test_every_console_dataset_default_is_a_valid_query() -> None:


### PR DESCRIPTION
## Summary
- make closed curated templates query the currently hydrated snapshot instead of forcing complete historical hydration
- preserve explicit partial-history opt-in for caller-authored typed queries and keep the frozen six-tool schema hash unchanged
- teach the installed skill to state partial preset/cutoff scope and regenerate the plugin bundle digest
- record the R7 installed-qualification correction for issue #356

## Verification
- 39 focused query/interface/plugin/stable-contract tests passed
- just v passed: 441 Python tests, 9 frontend tests, Ruff, MyPy, Pyright, deterministic assets, release safety
- just vp passed after the accepted review correction
- plugin bundle: 5,601 bytes under the 5,620-byte ceiling
- GitNexus final diff: low risk, 8 files / 12 symbols / 0 affected indexed processes

## Review
- single read-only reviewer: 1 finding, 1 accepted (R1)
- token attribution: pending because the metrics helper invokes the retired strict command

Closes #356