### PR TITLE
fix: clarify top threads result order

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
     "name": "Douglas Monsky"
   },
   "bundle": {
-    "digest": "sha256:78e609b7ece844ffa0c91d8fad389e4c01d549d5ab3bef9d7779706a41029dfc",
+    "digest": "sha256:de41ec1d4346879913560bab92ad81ccc1a2bf260f356a19b3c4651bff2eba3b",
     "publishable": true,
     "runtime_version": "0.28.0",
     "schema": "codex-usage-tracker.kernel-plugin-bundle.v1"

--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -798,6 +798,39 @@ Review totals are one finding and one accepted finding (`R1`); reviewer-token
 status and tokens per accepted finding are `pending` because the metrics helper
 still invokes the retired `strict` command. No retry or second review was run.
 
+### R7 qualification correction — issue #358
+
+The first clean installed Desktop run after issue #356 returned an accurate
+top-five leaderboard, complete generation-3 coverage, human labels, and all
+four token classes. It still made two `usage_query` calls in 57.453 seconds:
+the template took 2.687 seconds, then the agent spent another 0.927 seconds
+re-querying the same five threads because it described the template's two
+results as different rollup grains.
+
+A structural-only inspection confirmed that the first result already contains
+the ranked thread labels, total tokens, all four token classes, shares, and
+selectors. The second result contains only the separate cost/credit context.
+No local labels, selectors, or values were persisted in qualification
+artifacts. The installed skill now names that order explicitly and tells the
+agent not to query again unless the user asks for evidence. The public schema,
+six-tool surface, response shape, and query implementation are unchanged.
+
+The exact skill regression and frozen stable-contract checks pass as a
+seven-test focused set. Release safety passes, and the regenerated plugin
+bundle measures 5,617 bytes under its 5,620-byte ceiling. The maintained
+`just v` profile passes 441 Python tests, nine frontend tests, Ruff, MyPy,
+Pyright, deterministic assets, scope, maintainability, and release-safety
+gates. Branch: `fix/top-threads-result-order`. Final review, PR CI, merge
+identity, and repeated installed fresh-task evidence remain pending.
+
+The single final read-only reviewer reported one medium-severity finding and
+it was accepted: result order alone did not prove both results cover the same
+five ranked threads. The skill now assigns the complete labels, selectors,
+totals, shares, token classes, and cost/credit roles in one frozen instruction.
+Review totals are one finding and one accepted finding (`R1`); reviewer-token
+status and tokens per accepted finding are `pending` because the metrics helper
+still invokes the retired `strict` command. No retry or second review was run.
+
 ## R4 — Build Persisted Rollups And Fast MCP/API Paths
 
 **State:** In progress

--- a/skills/usage-kernel/SKILL.md
+++ b/skills/usage-kernel/SKILL.md
@@ -26,9 +26,9 @@ Use the three-step loop **scope → batch → evidence**:
    `{"requests":[{"template":"<name>"}]}`; for the common thread leaderboard
    use `{"requests":[{"template":"top_threads"}]}`. Templates query the
    hydrated snapshot and report its coverage; refresh complete history only
-   when the user asks. This template returns the token leaderboard and
-   cost/credit context together; do not run another query or resolve every
-   selector unless the user asks for deeper evidence. Use
+   when the user asks. For same five ranked threads, use result 1 for
+   labels, selectors, totals, shares, and token classes; use result 2 only for
+   cost/credits. Do not query again unless user asks for evidence. Use
    `{"requests":[{"template":"weekly_drivers"}]}` for the latest indexed
    seven-day thread leaderboard,
    `{"requests":[{"template":"week_over_week"}]}` for that window versus the

--- a/tests/kernel/interfaces/test_plugin.py
+++ b/tests/kernel/interfaces/test_plugin.py
@@ -79,6 +79,7 @@ def test_skill_teaches_scope_batch_evidence_and_claim_grading() -> None:
     skill = (
         _REPO_ROOT / "skills" / "usage-kernel" / "SKILL.md"
     ).read_text(encoding="utf-8")
+    compact_skill = " ".join(skill.split())
 
     assert "scope → batch → evidence" in skill
     assert "fact" in skill
@@ -89,6 +90,12 @@ def test_skill_teaches_scope_batch_evidence_and_claim_grading() -> None:
     assert "never generalize to all history" in skill
     assert "after ranking" in skill
     assert '{"requests":[{"template":"top_threads"}]}' in skill
+    assert (
+        "For same five ranked threads, use result 1 for labels, selectors, "
+        "totals, shares, and token classes; use result 2 only for cost/credits. "
+        "Do not query again unless user asks for evidence."
+        in compact_skill
+    )
     assert '{"requests":[{"template":"weekly_drivers"}]}' in skill
     assert '{"requests":[{"template":"week_over_week"}]}' in skill
     assert '{"requests":[{"template":"latest_incremental_change"}]}' in skill


### PR DESCRIPTION
## Summary
- tell installed agents that both top_threads results cover the same five ranked threads
- assign labels/selectors/totals/shares/token classes to result 1 and cost/credits only to result 2
- forbid the redundant second query unless the user requests deeper evidence
- regenerate the plugin digest and record the installed R7 qualification finding

## Verification
- exact skill and stable-contract set: 7 passed
- just v: 441 Python tests, 9 frontend tests, Ruff, MyPy, Pyright, deterministic assets, release safety
- just vp passed after the accepted review correction
- plugin bundle: 5,617 bytes under the 5,620-byte ceiling
- GitNexus: low risk, 4 files / 7 symbols / 0 affected indexed processes

## Review
- single read-only reviewer: 1 finding, 1 accepted (R1)
- token status: pending because the metrics helper invokes the retired strict command

Closes #358