### PR TITLE
fix: consolidate logical thread rollups

### DIFF
--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -789,8 +789,8 @@ gates. The plugin bundle measures 5,601 bytes under its 5,620-byte ceiling.
 GitNexus classified the changed materializer itself low risk after refreshing
 the exact worktree index; application, MCP, cache, and coverage callers are
 covered by the focused and complete interface suites. Branch:
-`fix/template-partial-coverage`. Final review, PR CI, merge identity, and
-installed fresh-task confirmation remain pending. The single final read-only
+`fix/template-partial-coverage`. PR #357 merged as `bd0d295`; all three
+required CI jobs passed. The single final read-only
 reviewer reported one medium-severity finding and it was accepted: partial
 facts now require the agent to state the hydration preset/cutoff and never
 generalize the result to all history, with an exact bundled-skill regression.
@@ -820,8 +820,8 @@ seven-test focused set. Release safety passes, and the regenerated plugin
 bundle measures 5,617 bytes under its 5,620-byte ceiling. The maintained
 `just v` profile passes 441 Python tests, nine frontend tests, Ruff, MyPy,
 Pyright, deterministic assets, scope, maintainability, and release-safety
-gates. Branch: `fix/top-threads-result-order`. Final review, PR CI, merge
-identity, and repeated installed fresh-task evidence remain pending.
+gates. Branch: `fix/top-threads-result-order`. PR #359 merged as `2afba3d`;
+all three required CI jobs passed.
 
 The single final read-only reviewer reported one medium-severity finding and
 it was accepted: result order alone did not prove both results cover the same
@@ -830,6 +830,61 @@ totals, shares, token classes, and cost/credit roles in one frozen instruction.
 Review totals are one finding and one accepted finding (`R1`); reviewer-token
 status and tokens per accepted finding are `pending` because the metrics helper
 still invokes the retired `strict` command. No retry or second review was run.
+
+### R7 qualification correction — issue #360
+
+The first fresh installed Desktop task after the issue #358 correction still
+made a necessary second query. The `top_threads` result returned five physical
+rollup rows but only two distinct logical thread identities, while a companion
+cost/credit plan returned five distinct identities. Structural-only installed
+queries reproduced the duplicate multiplicity without persisting or printing
+local labels, selectors, identities, or usage values.
+
+The root cause was `rollup_thread`'s physical `thread_key` grain. The fast
+query plan exposed `threads.logical_thread_id` but did not consolidate physical
+rows that share that logical identity. The corrected plan groups physical
+rollups by logical thread, sums all token classes and calls, derives shares
+from those consolidated rows, and selects the current canonical human label.
+Matched and scanned counts now describe logical results rather than physical
+storage rows. The persisted schema, writer, six-tool surface, public request
+schema, and frozen `0.28` contract remain unchanged.
+
+The contract-red regression first returned three rows where the two-row
+logical result was expected. Its final synthetic fixture builds an active
+continuation, archived physical history, and copied duplicate through normal
+ingestion. It proves unique logical identities, canonical copied-call
+exclusion, every token class against a direct canonical-fact oracle, the
+active/newest human label, exact logical matched/scanned counts, and shares
+that sum to one. Application and MCP regressions prove the token and
+cost/credit results contain the same ordered logical identities and labels,
+the repeated batch hits the application cache, and the model-facing MCP
+payload preserves both results. The focused query and interface set passes
+129 tests. The maintained `just v` profile passes 444 Python
+tests, nine frontend tests, Ruff, MyPy, Pyright, deterministic assets, scope,
+maintainability, and release-safety gates.
+
+On the unchanged 100,000-call synthetic workload, unprofiled common-query p95
+improved from 1.538 ms to 1.197 ms; comparison p95 improved from 145.494 ms to
+140.182 ms; concentration remained effectively flat at 2.072 ms versus
+2.051 ms; and daily p95 improved from 1.597 ms to 1.211 ms. These repeatable
+unprofiled timings are the speed evidence. Agent-perf runs
+`20260728T125643Z-c8f7f1d5` before and
+`20260728T131552Z-b9a5cfc0` after the final review remediation provide
+attribution only. GitNexus classified `_compile_thread_rollup` LOW symbol-level
+risk with five impacted symbols and one direct caller; final-diff detection is
+MEDIUM overall through the `compile_plan` and `execute_batch` query/application
+paths.
+
+The single final read-only reviewer reported three findings and all three were
+accepted: logical consolidation now covers the direct cost/credit companion
+plan, synthetic ingestion and public application/MCP contracts replace the
+narrow direct-rollup mutation, and this ledger distinguishes symbol-level
+LOW impact from final-diff MEDIUM risk. Review totals are three findings and
+three accepted findings (`R1`, `R2`, `R3`); reviewer-token status and tokens
+per accepted finding are `pending` because the metrics helper invokes the
+retired `strict` command. No retry or second review was run. Branch:
+`fix/logical-thread-rollup`. PR CI, merge identity, and repeated installed
+fresh-task confirmation remain pending.
 
 ## R4 — Build Persisted Rollups And Fast MCP/API Paths
 

--- a/src/codex_usage_tracker/kernel/query/catalog.py
+++ b/src/codex_usage_tracker/kernel/query/catalog.py
@@ -54,7 +54,20 @@ _CONTEXT_OPERATIONS = frozenset(
         Operation.SHARE,
     }
 )
-_THREAD_LABEL_SQL = "resolved_thread_label(threads.session_identity_hash, threads.display_label)"
+_THREAD_LABEL_SQL = """
+(
+    SELECT resolved_thread_label(
+        candidate_threads.session_identity_hash,
+        candidate_threads.display_label
+    )
+    FROM threads AS candidate_threads
+    WHERE candidate_threads.logical_thread_id = threads.logical_thread_id
+    ORDER BY candidate_threads.archive_state = 'active' DESC,
+             candidate_threads.last_generation DESC,
+             candidate_threads.thread_key
+    LIMIT 1
+)
+"""
 _CANONICAL_THREAD_SQL = """
 (
     threads.thread_key = (

--- a/src/codex_usage_tracker/kernel/query/plans.py
+++ b/src/codex_usage_tracker/kernel/query/plans.py
@@ -246,28 +246,49 @@ def _compile_thread_rollup(
     ):
         return None
     expressions = {
-        "calls": "rollup.calls",
-        "input_tokens": "rollup.input_tokens",
-        "uncached_input_tokens": ("rollup.input_tokens - rollup.cached_input_tokens"),
-        "cached_input_tokens": "rollup.cached_input_tokens",
-        "output_tokens": "rollup.output_tokens",
-        "reasoning_tokens": "rollup.reasoning_tokens",
-        "total_tokens": "rollup.input_tokens + rollup.output_tokens",
+        "calls": "SUM(rollup.calls)",
+        "input_tokens": "SUM(rollup.input_tokens)",
+        "uncached_input_tokens": (
+            "SUM(rollup.input_tokens) - SUM(rollup.cached_input_tokens)"
+        ),
+        "cached_input_tokens": "SUM(rollup.cached_input_tokens)",
+        "output_tokens": "SUM(rollup.output_tokens)",
+        "reasoning_tokens": "SUM(rollup.reasoning_tokens)",
+        "total_tokens": "SUM(rollup.input_tokens) + SUM(rollup.output_tokens)",
     }
     if any(measure not in expressions for measure in request.measures):
         return None
+    thread_label = (
+        "resolved_thread_label("
+        "canonical_threads.session_identity_hash, "
+        "canonical_threads.display_label)"
+    )
     selected = [
         "threads.logical_thread_id AS thread",
-        (f"{DATASETS['calls'].dimensions['thread_label']} AS thread_label"),
+        f"{thread_label} AS thread_label",
         *(f"{expressions[measure]} AS {measure}" for measure in request.measures),
         "COUNT(*) OVER () AS __matched_count",
         "COUNT(*) OVER () AS __scanned_count",
     ]
-    base_query = (
-        f"SELECT {', '.join(selected)} "
+    grouped_rows = (
         "FROM rollup_thread AS rollup "
         "JOIN threads USING (thread_key) "
-        "WHERE rollup.generation = ?"
+        "JOIN threads AS canonical_threads "
+        "ON canonical_threads.thread_key = ("
+        "SELECT candidate_threads.thread_key "
+        "FROM threads AS candidate_threads "
+        "WHERE candidate_threads.logical_thread_id = threads.logical_thread_id "
+        "AND candidate_threads.first_generation <= ? "
+        "ORDER BY candidate_threads.archive_state = 'active' DESC, "
+        "candidate_threads.last_generation DESC, "
+        "candidate_threads.thread_key "
+        "LIMIT 1) "
+        "WHERE rollup.generation = ? "
+        "GROUP BY threads.logical_thread_id, canonical_threads.thread_key"
+    )
+    base_query = (
+        f"SELECT {', '.join(selected)} "
+        f"{grouped_rows}"
     )
     if operation is Operation.SHARE:
         share_columns = ", ".join(
@@ -280,16 +301,17 @@ def _compile_thread_rollup(
     order_name = request.order_by or (request.measures[0] if request.measures else "thread")
     direction = "DESC" if request.descending else "ASC"
     sql = f"{base_query} ORDER BY {order_name} {direction}, thread ASC LIMIT ? OFFSET ?"
-    count_sql = "SELECT COUNT(*) FROM rollup_thread WHERE generation = ?"
+    count_sql = f"SELECT COUNT(*) FROM (SELECT 1 {grouped_rows}) AS grouped"
+    generation_parameters = (generation, generation)
     return CompiledPlan(
         plan_id=f"calls.{operation.value}.rollup_thread.v{PLAN_VERSION}",
         sql=sql,
         count_sql=count_sql,
         scan_sql=count_sql,
         coverage_sql=None,
-        parameters=(generation, request.limit + 1, offset),
-        count_parameters=(generation,),
-        scan_parameters=(generation,),
+        parameters=(*generation_parameters, request.limit + 1, offset),
+        count_parameters=generation_parameters,
+        scan_parameters=generation_parameters,
         coverage_parameters=(),
         offset=offset,
     )

--- a/tests/kernel/interfaces/support.py
+++ b/tests/kernel/interfaces/support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from codex_usage_tracker.kernel.application import RuntimePaths
@@ -30,3 +31,119 @@ def active_runtime(root: Path) -> RuntimePaths:
         owner_id="interface-fixture",
     )
     return runtime
+
+
+def logical_split_runtime(root: Path) -> RuntimePaths:
+    """Build one logical thread from active, archived, and copied sources."""
+
+    runtime = RuntimePaths(
+        codex_home=root / "codex-home",
+        cache_root=root / "cache",
+    )
+    shared_session = "00000000-0000-4000-8000-000000000101"
+    sources = (
+        _logical_source(
+            runtime.codex_home / "sessions" / "active-shared.jsonl",
+            session_id=shared_session,
+            nickname="Current logical thread",
+            event_id="shared-active",
+            timestamp="2026-01-02T00:00:03Z",
+            input_tokens=200,
+        ),
+        _logical_source(
+            runtime.codex_home / "archived_sessions" / "archived-shared.jsonl",
+            session_id=shared_session,
+            nickname="Archived physical thread",
+            event_id="shared-archived",
+            timestamp="2026-01-01T00:00:01Z",
+            input_tokens=100,
+        ),
+        _logical_source(
+            runtime.codex_home / "archived_sessions" / "copied-shared.jsonl",
+            session_id=shared_session,
+            nickname="Copied physical thread",
+            event_id="shared-archived",
+            timestamp="2026-01-01T00:00:01Z",
+            input_tokens=100,
+        ),
+        _logical_source(
+            runtime.codex_home / "sessions" / "other.jsonl",
+            session_id="00000000-0000-4000-8000-000000000102",
+            nickname="Other logical thread",
+            event_id="other-active",
+            timestamp="2026-01-02T00:00:02Z",
+            input_tokens=50,
+        ),
+    )
+    KernelIngestor(
+        runtime.kernel.analytical,
+        runtime.kernel.operational,
+        journal=GenerationJournal(runtime.kernel.operational),
+    ).refresh(
+        list(sources),
+        trigger=RefreshTrigger.CLI_REFRESH,
+        owner_id="logical-split-fixture",
+    )
+    return runtime
+
+
+def _logical_source(
+    path: Path,
+    *,
+    session_id: str,
+    nickname: str,
+    event_id: str,
+    timestamp: str,
+    input_tokens: int,
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    envelopes = (
+        {
+            "timestamp": timestamp,
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "thread_source": "subagent",
+                "source": {
+                    "subagent": {
+                        "thread_spawn": {
+                            "agent_nickname": nickname,
+                            "agent_role": "worker",
+                        }
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": timestamp,
+            "type": "turn_context",
+            "payload": {
+                "turn_id": f"turn-{event_id}",
+                "model": "gpt-synthetic",
+                "effort": "low",
+            },
+        },
+        {
+            "event_id": event_id,
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": input_tokens,
+                        "cached_input_tokens": 1,
+                        "output_tokens": 2,
+                        "reasoning_output_tokens": 1,
+                        "total_tokens": input_tokens + 2,
+                    },
+                    "model_context_window": 200_000,
+                },
+            },
+        },
+    )
+    path.write_text(
+        "".join(f"{json.dumps(envelope, separators=(',', ':'))}\n" for envelope in envelopes),
+        encoding="utf-8",
+    )
+    return path

--- a/tests/kernel/interfaces/test_application.py
+++ b/tests/kernel/interfaces/test_application.py
@@ -22,7 +22,12 @@ from codex_usage_tracker.kernel.ingest import (
 from codex_usage_tracker.kernel.lease import RefreshLeaseRepository
 from codex_usage_tracker.kernel.operational import initialize_operational_database
 
-from .support import ORACLE_ROOT, active_runtime, synthetic_sources
+from .support import (
+    ORACLE_ROOT,
+    active_runtime,
+    logical_split_runtime,
+    synthetic_sources,
+)
 
 
 def test_read_use_cases_share_one_generation_and_never_write(tmp_path: Path) -> None:
@@ -158,6 +163,42 @@ def test_named_top_threads_template_matches_the_explicit_fast_path(
     assert repeated["cache"]["hit"] is True
     assert all(row["thread_label"] for row in named["results"][0]["rows"])
     assert named["results"][0]["evidence_selectors"]
+
+
+def test_named_top_threads_keeps_logical_token_and_cost_results_coherent(
+    tmp_path: Path,
+) -> None:
+    app = KernelApplication(
+        logical_split_runtime(tmp_path),
+        worker_launcher=lambda _paths, _preset: None,
+    )
+
+    first = app.query({"requests": [{"template": "top_threads"}]})
+    repeated = app.query({"requests": [{"template": "top_threads"}]})
+    token_result, cost_result = first["results"]
+    token_threads = [str(row["thread"]) for row in token_result["rows"]]
+    cost_threads = [str(row["thread"]) for row in cost_result["rows"]]
+
+    assert token_threads == cost_threads
+    assert len(token_threads) == len(set(token_threads)) == 2
+    assert [row["thread_label"] for row in token_result["rows"]] == [
+        row["thread_label"] for row in cost_result["rows"]
+    ]
+    assert token_result["rows"][0]["thread_label"] == "Current logical thread"
+    assert token_result["rows"][0]["calls"] == 2
+    assert token_result["rows"][0]["uncached_input_tokens"] == 298
+    assert token_result["rows"][0]["cached_input_tokens"] == 2
+    assert token_result["rows"][0]["reasoning_tokens"] == 2
+    assert token_result["rows"][0]["output_tokens"] == 4
+    assert token_result["rows"][0]["total_tokens"] == 304
+    assert all(
+        "configured_cost_usd" in row and "estimated_credits" in row
+        for row in cost_result["rows"]
+    )
+    assert first["cache"]["hit"] is False
+    assert repeated["cache"]["hit"] is True
+    assert repeated["cache"]["key"] == first["cache"]["key"]
+    assert repeated["results"] == first["results"]
 
 
 def test_curated_period_and_latest_change_templates_use_one_snapshot(

--- a/tests/kernel/interfaces/test_mcp.py
+++ b/tests/kernel/interfaces/test_mcp.py
@@ -20,7 +20,7 @@ from codex_usage_tracker.kernel.interfaces.mcp.server import (
 )
 from scripts.smoke_installed_package import _write_mcp
 
-from .support import active_runtime, synthetic_sources
+from .support import active_runtime, logical_split_runtime, synthetic_sources
 
 
 def test_mcp_catalog_and_calls_use_structured_results_without_duplication(
@@ -206,6 +206,40 @@ def test_mcp_executes_named_top_threads_template_in_one_query_call(
     assert len(json.dumps(response, separators=(",", ":")).encode()) <= (
         MAX_MESSAGE_BYTES
     )
+
+
+def test_mcp_top_threads_preserves_logical_identity_across_both_results(
+    tmp_path: Path,
+) -> None:
+    server = McpServer(
+        KernelApplication(
+            logical_split_runtime(tmp_path),
+            worker_launcher=lambda _paths, _preset: None,
+        )
+    )
+
+    response = server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "usage_query",
+                "arguments": {
+                    "requests": [{"template": "top_threads"}],
+                },
+            },
+        }
+    )
+
+    result = response["result"]["structuredContent"]
+    model_content = json.loads(result["model_summary"])
+    token_threads = [row["thread"] for row in result["results"][0]["rows"]]
+    cost_threads = [row["thread"] for row in result["results"][1]["rows"]]
+    assert token_threads == cost_threads
+    assert len(token_threads) == len(set(token_threads)) == 2
+    assert model_content["results"][0]["rows"] == result["results"][0]["rows"]
+    assert model_content["results"][1]["rows"] == result["results"][1]["rows"]
 
 
 @pytest.mark.parametrize(

--- a/tests/kernel/query/test_r4_rollups.py
+++ b/tests/kernel/query/test_r4_rollups.py
@@ -22,7 +22,7 @@ from codex_usage_tracker.kernel.rollups import (
     _LINK_UNRESOLVED_TOOL_CALLS_SQL,
     generation_rollups_ready,
 )
-from tests.kernel.interfaces.support import active_runtime
+from tests.kernel.interfaces.support import active_runtime, logical_split_runtime
 from tests.kernel.test_ingest_pipeline import _token_line
 
 
@@ -72,6 +72,100 @@ def test_top_threads_uses_bounded_rollup_plan(tmp_path: Path) -> None:
     assert result.scanned_count == 2
     assert result.returned_count == 2
     assert sum(int(row["calls"]) for row in result.rows) == 4
+
+
+def test_top_threads_consolidates_physical_rows_by_logical_thread(
+    tmp_path: Path,
+) -> None:
+    runtime = logical_split_runtime(tmp_path)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+    assert control.active_generation is not None
+    request = QueryRequest(
+        dataset="calls",
+        operation=Operation.SHARE,
+        dimensions=("thread",),
+        measures=(
+            "calls",
+            "uncached_input_tokens",
+            "cached_input_tokens",
+            "reasoning_tokens",
+            "output_tokens",
+            "total_tokens",
+        ),
+        order_by="total_tokens",
+        limit=25,
+    )
+    result = QueryService(runtime.kernel.operational).execute(request)
+
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        oracle_rows = connection.execute(
+            """
+            SELECT threads.logical_thread_id,
+                   COUNT(*) AS calls,
+                   SUM(model_calls.input_tokens) AS input_tokens,
+                   SUM(
+                       model_calls.input_tokens
+                       - model_calls.cached_input_tokens
+                   ) AS uncached_input_tokens,
+                   SUM(model_calls.cached_input_tokens)
+                       AS cached_input_tokens,
+                   SUM(model_calls.reasoning_tokens) AS reasoning_tokens,
+                   SUM(model_calls.output_tokens) AS output_tokens,
+                   SUM(
+                       model_calls.input_tokens
+                       + model_calls.output_tokens
+                   ) AS total_tokens
+            FROM model_calls
+            JOIN threads ON threads.thread_id = model_calls.thread_id
+            WHERE model_calls.generation <= ?
+              AND model_calls.duplicate_state = 'canonical'
+            GROUP BY threads.logical_thread_id
+            ORDER BY total_tokens DESC, threads.logical_thread_id
+            """,
+            (control.active_generation,),
+        ).fetchall()
+        copied_calls = connection.execute(
+            "SELECT COUNT(*) FROM model_calls WHERE duplicate_state != 'canonical'"
+        ).fetchone()
+
+    actual_rows = {
+        str(row["thread"]): {
+            measure: int(row[measure])
+            for measure in (
+                "calls",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens",
+                "total_tokens",
+            )
+        }
+        for row in result.rows
+    }
+    oracle = {
+        str(row[0]): {
+            "calls": int(row[1]),
+            "uncached_input_tokens": int(row[3]),
+            "cached_input_tokens": int(row[4]),
+            "reasoning_tokens": int(row[5]),
+            "output_tokens": int(row[6]),
+            "total_tokens": int(row[7]),
+        }
+        for row in oracle_rows
+    }
+
+    assert result.plan_id == "calls.share.rollup_thread.v1"
+    assert copied_calls == (1,)
+    assert actual_rows == oracle
+    assert result.returned_count == len(oracle)
+    assert result.matched_count == len(oracle)
+    assert result.scanned_count == len(oracle)
+    assert len(result.rows) == len({str(row["thread"]) for row in result.rows})
+    assert result.rows[0]["thread_label"] == "Current logical thread"
+    assert sum(float(row["share_total_tokens"]) for row in result.rows) == pytest.approx(
+        1.0
+    )
 
 
 def test_model_effort_and_global_queries_use_small_rollups(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #360

## Summary
- consolidate physical `rollup_thread` rows by logical thread identity
- resolve one active/newest canonical human label for both token and cost/credit plans
- prove canonical copied-call exclusion and every token class through synthetic ingestion
- prove the two-result `top_threads` application/MCP response and cache remain coherent

## Performance
On the unchanged 100,000-call synthetic workload, unprofiled p95 changed:
- common: 1.538 ms -> 1.197 ms
- comparison: 145.494 ms -> 140.182 ms
- concentration: 2.072 ms -> 2.051 ms
- daily: 1.597 ms -> 1.211 ms

Agent-perf attribution: before `20260728T125643Z-c8f7f1d5`, final after `20260728T131552Z-b9a5cfc0`.

## Validation
- `just v`: 444 Python tests and 9 frontend tests passed
- Ruff, MyPy, Pyright, deterministic assets, scope, maintainability, and release safety passed
- focused query/interface set: 129 passed
- single final reviewer: 3 findings, 3 accepted (`R1`, `R2`, `R3`); token attribution pending because the metrics helper still invokes the retired `strict` command
