### PR TITLE
fix: bound top threads cost context

### DIFF
--- a/docs/roadmap/product-recovery-execution.md
+++ b/docs/roadmap/product-recovery-execution.md
@@ -883,8 +883,51 @@ LOW impact from final-diff MEDIUM risk. Review totals are three findings and
 three accepted findings (`R1`, `R2`, `R3`); reviewer-token status and tokens
 per accepted finding are `pending` because the metrics helper invokes the
 retired `strict` command. No retry or second review was run. Branch:
-`fix/logical-thread-rollup`. PR CI, merge identity, and repeated installed
-fresh-task confirmation remain pending.
+`fix/logical-thread-rollup`. PR #361 merged as `44ca2d1`; Python 3.10 passed
+in 1m11s, Python 3.14 in 2m30s, and the focused Console job in 1m29s.
+Repeated installed fresh-task confirmation then exposed issue #362 below.
+
+### R7 qualification correction — issue #362
+
+The first fresh local Codex Desktop task after issue #360 used exactly one
+`usage_query` batch and returned coherent five-row token and cost/credit
+results: both contained five unique logical threads, their identity sets
+matched, all human labels were non-empty, all four token classes and exact
+selectors were present, and no refresh or poll occurred. The structured tracker
+call still took 4,990.064 ms on the maintainer aggregate index, however, and
+the complete Desktop turn took 53.332 seconds. No private labels, identities,
+selectors, or usage values were persisted.
+
+The cost/credit companion still evaluated query-time pricing across the full
+canonical call table. Its existing cost-aware direct path measured 615.058 ms
+p95 on the maintained 100,000-call synthetic workload. The corrected curated
+request first ranks logical threads from `rollup_thread`, then evaluates
+configured cost and estimated credits only for canonical calls belonging to
+the bounded selected threads. Pricing coverage comes from the small
+model/effort rollup, so rate-card semantics remain query-time correct without a
+full call-table pricing scan.
+
+The dedicated five-thread companion measures 10.955 ms p95 on the unchanged
+100,000-call workload, a 98.2 percent reduction from the direct-path baseline.
+Its ordered logical identities, canonical labels, token totals, configured
+costs, estimated credits, and exact/estimated coverage match the full direct
+oracle. The broader caller-authored cost-aware share plan remains available and
+unchanged. Agent-perf runs `20260728T135034Z-311a97b6` before and
+`20260728T135106Z-8429ac5d` after provide CPU attribution only. Branch:
+`fix/top-threads-cost-fast-path`. The specialized compiler is isolated in its
+own K4-owned module; maintainability, Ruff, MyPy, 56 focused
+query/interface/performance tests, and the complete 444-test `just v` gate
+pass. After the accepted regression tests were added, the complete gate passed
+again with 451 tests. One intervening allowance timing sample exceeded its
+550 ms ceiling at 608.861 ms; the isolated prescribed retry passed at
+404.132 ms and the complete rerun passed. GitNexus reports MEDIUM final-diff
+risk across three query execution
+processes. The one final read-only review returned two findings and both were
+accepted: generation-bound canonical-label selection and focused
+fallback/pagination/partial-coverage/logical-split tests. Reviewer-token status
+and tokens per accepted finding are `pending` because the metrics helper still
+invokes the retired `strict` command; it was not retried. PR CI, merge identity,
+rebuilt installed candidate, and fresh Desktop confirmation remain pending.
 
 ## R4 — Build Persisted Rollups And Fast MCP/API Paths
 

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -62,6 +62,7 @@ K4_ADDITIONS = frozenset(
         "src/codex_usage_tracker/kernel/query/phases.py",
         "src/codex_usage_tracker/kernel/query/plans.py",
         "src/codex_usage_tracker/kernel/query/service.py",
+        "src/codex_usage_tracker/kernel/query/thread_cost_plan.py",
         "tests/kernel/query/__init__.py",
         "tests/kernel/query/test_contracts.py",
         "tests/kernel/query/test_performance.py",

--- a/src/codex_usage_tracker/kernel/query/catalog.py
+++ b/src/codex_usage_tracker/kernel/query/catalog.py
@@ -615,7 +615,7 @@ _TOP_THREADS_EXACT_REQUEST = {
 }
 _TOP_THREADS_COST_REQUEST = {
     "dataset": "calls",
-    "operation": "share",
+    "operation": "aggregate",
     "dimensions": ["thread"],
     "measures": [
         "total_tokens",

--- a/src/codex_usage_tracker/kernel/query/plans.py
+++ b/src/codex_usage_tracker/kernel/query/plans.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .catalog import DATASETS, DatasetSpec
 from .contracts import Filter, Operation, QueryRequest
+from .thread_cost_plan import compile_thread_cost_plan
 
 PLAN_VERSION = 1
 
@@ -31,6 +32,14 @@ def compile_plan(
     generation: int,
     offset: int,
 ) -> CompiledPlan:
+    thread_cost_plan = compile_thread_cost_plan(
+        request,
+        generation=generation,
+        offset=offset,
+        plan_version=PLAN_VERSION,
+    )
+    if thread_cost_plan is not None:
+        return CompiledPlan(**thread_cost_plan)
     rollup = _compile_thread_rollup(
         request,
         generation=generation,

--- a/src/codex_usage_tracker/kernel/query/thread_cost_plan.py
+++ b/src/codex_usage_tracker/kernel/query/thread_cost_plan.py
@@ -1,0 +1,202 @@
+"""Compile the bounded logical-thread cost rollup plan."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from .contracts import Operation, QueryRequest
+
+
+class CompiledPlanParts(TypedDict):
+    """Arguments required to construct the public compiled-plan value."""
+
+    plan_id: str
+    sql: str
+    count_sql: str
+    scan_sql: str
+    coverage_sql: str | None
+    parameters: tuple[Any, ...]
+    count_parameters: tuple[Any, ...]
+    scan_parameters: tuple[Any, ...]
+    coverage_parameters: tuple[Any, ...]
+    offset: int
+
+
+def compile_thread_cost_plan(
+    request: QueryRequest,
+    *,
+    generation: int,
+    offset: int,
+    plan_version: int,
+) -> CompiledPlanParts | None:
+    """Return the ranked-thread cost plan when the request is eligible."""
+
+    if not _is_supported_request(request):
+        return None
+    selected = [
+        "ranked_threads.thread AS thread",
+        (
+            "resolved_thread_label("
+            "canonical_threads.session_identity_hash, "
+            "canonical_threads.display_label) AS thread_label"
+        ),
+        *(_MEASURE_SQL[measure] for measure in request.measures),
+        "ranked_threads.matched_count AS __matched_count",
+        "ranked_threads.scanned_count AS __scanned_count",
+    ]
+    return CompiledPlanParts(
+        plan_id=f"calls.aggregate.rollup_thread_cost.v{plan_version}",
+        sql=_result_sql(selected),
+        count_sql=_GROUPED_COUNT_SQL,
+        scan_sql=_SCAN_SQL,
+        coverage_sql=_coverage_sql(request.measures),
+        parameters=(
+            generation,
+            request.limit + 1,
+            offset,
+            generation,
+            generation,
+        ),
+        count_parameters=(generation,),
+        scan_parameters=(generation,),
+        coverage_parameters=(generation,),
+        offset=offset,
+    )
+
+
+def _is_supported_request(request: QueryRequest) -> bool:
+    requested_measures = set(request.measures)
+    return (
+        request.dataset == "calls"
+        and Operation(request.operation) is Operation.AGGREGATE
+        and request.dimensions == ("thread",)
+        and not request.filters
+        and request.comparison is None
+        and request.descending is True
+        and (request.order_by or "total_tokens") == "total_tokens"
+        and requested_measures.issubset(_MEASURE_SQL)
+        and bool(
+            requested_measures.intersection(
+                {"configured_cost_usd", "estimated_credits"}
+            )
+        )
+    )
+
+
+def _coverage_sql(measures: tuple[str, ...]) -> str:
+    selected = ["SUM(calls) AS coverage_total"]
+    for measure in measures:
+        expression = _COVERAGE_FIELDS.get(measure)
+        if expression is None:
+            continue
+        selected.extend(
+            (
+                (
+                    f"SUM(CASE WHEN {expression} IS NOT NULL "
+                    f"THEN calls ELSE 0 END) AS observed_{measure}"
+                ),
+                (
+                    f"SUM(CASE WHEN {expression} IS NULL "
+                    f"THEN calls ELSE 0 END) AS missing_{measure}"
+                ),
+            )
+        )
+    return (
+        f"SELECT {', '.join(selected)} "
+        "FROM rollup_model_effort WHERE generation = ?"
+    )
+
+
+def _result_sql(selected: list[str]) -> str:
+    return (
+        f"{_RANKED_THREADS_SQL} SELECT {', '.join(selected)} "
+        "FROM ranked_threads "
+        "JOIN canonical_threads "
+        "ON canonical_threads.logical_thread_id = ranked_threads.thread "
+        "AND canonical_threads.canonical_rank = 1 "
+        "JOIN threads AS physical_threads "
+        "ON physical_threads.logical_thread_id = ranked_threads.thread "
+        "JOIN model_call_facts AS facts INDEXED BY idx_model_calls_thread_time "
+        "ON facts.thread_key = physical_threads.thread_key "
+        "JOIN model_profiles AS profiles "
+        "ON profiles.model_profile_key = facts.model_profile_key "
+        "WHERE facts.generation <= ? "
+        "AND facts.duplicate_state = 'canonical' "
+        "GROUP BY ranked_threads.thread, canonical_threads.logical_thread_id "
+        "ORDER BY total_tokens DESC, thread"
+    )
+
+
+_MEASURE_SQL = {
+    "total_tokens": "ranked_threads.total_tokens AS total_tokens",
+    "configured_cost_usd": (
+        "SUM(configured_cost_usd("
+        "profiles.model, facts.input_tokens, "
+        "facts.cached_input_tokens, facts.output_tokens"
+        ")) AS configured_cost_usd"
+    ),
+    "estimated_credits": (
+        "SUM(estimated_credits("
+        "profiles.model, facts.input_tokens, "
+        "facts.cached_input_tokens, facts.output_tokens"
+        ")) AS estimated_credits"
+    ),
+}
+
+_COVERAGE_FIELDS = {
+    "configured_cost_usd": (
+        "configured_cost_usd("
+        "model, input_tokens, cached_input_tokens, output_tokens)"
+    ),
+    "estimated_credits": (
+        "estimated_credits("
+        "model, input_tokens, cached_input_tokens, output_tokens)"
+    ),
+}
+
+_RANKED_THREADS_SQL = """
+    WITH grouped_threads AS (
+        SELECT threads.logical_thread_id AS thread,
+               SUM(rollup.calls) AS calls,
+               SUM(rollup.input_tokens) + SUM(rollup.output_tokens) AS total_tokens
+        FROM rollup_thread AS rollup
+        JOIN threads USING (thread_key)
+        WHERE rollup.generation = ?
+        GROUP BY threads.logical_thread_id
+    ),
+    ranked_threads AS (
+        SELECT grouped_threads.*,
+               COUNT(*) OVER () AS matched_count,
+               SUM(calls) OVER () AS scanned_count
+        FROM grouped_threads
+        ORDER BY total_tokens DESC, thread
+        LIMIT ? OFFSET ?
+    ),
+    canonical_threads AS (
+        SELECT threads.logical_thread_id,
+               threads.session_identity_hash,
+               threads.display_label,
+               ROW_NUMBER() OVER (
+                   PARTITION BY threads.logical_thread_id
+                   ORDER BY threads.archive_state = 'active' DESC,
+                            threads.last_generation DESC,
+                            threads.thread_key
+               ) AS canonical_rank
+        FROM threads
+        WHERE threads.first_generation <= ?
+    )
+"""
+
+_GROUPED_COUNT_SQL = (
+    "SELECT COUNT(*) FROM ("
+    "SELECT 1 FROM rollup_thread AS rollup "
+    "JOIN threads USING (thread_key) "
+    "WHERE rollup.generation = ? "
+    "GROUP BY threads.logical_thread_id"
+    ") AS grouped"
+)
+
+_SCAN_SQL = (
+    "SELECT COALESCE(SUM(calls), 0) "
+    "FROM rollup_thread WHERE generation = ?"
+)

--- a/tests/kernel/query/test_performance.py
+++ b/tests/kernel/query/test_performance.py
@@ -192,7 +192,20 @@ def test_100k_r5_analytical_primitive_budgets(
             "configured_cost_usd",
             "estimated_credits",
         ),
+        order_by="total_tokens",
         limit=25,
+    )
+    top_thread_costs = QueryRequest(
+        "calls",
+        Operation.AGGREGATE,
+        ("thread",),
+        (
+            "total_tokens",
+            "configured_cost_usd",
+            "estimated_credits",
+        ),
+        order_by="total_tokens",
+        limit=5,
     )
     tool_impact = QueryRequest(
         "tools",
@@ -213,11 +226,16 @@ def test_100k_r5_analytical_primitive_budgets(
         lambda: large_service.execute(top_threads),
         repeats=12,
     )
+    top_thread_costs_p95 = _p95(
+        lambda: large_service.execute(top_thread_costs),
+        repeats=12,
+    )
     tool_impact_p95 = _p95(
         lambda: large_service.execute(tool_impact),
         repeats=12,
     )
     top_threads_result = large_service.execute(top_threads)
+    top_thread_costs_result = large_service.execute(top_thread_costs)
     tool_impact_result = large_service.execute(tool_impact)
     top_threads_bytes = len(
         json.dumps(
@@ -243,15 +261,43 @@ def test_100k_r5_analytical_primitive_budgets(
                 "tool_impact_p95_ms": round(tool_impact_p95, 3),
                 "top_threads_bytes": top_threads_bytes,
                 "top_threads_p95_ms": round(top_threads_p95, 3),
+                "top_thread_costs_p95_ms": round(
+                    top_thread_costs_p95,
+                    3,
+                ),
             },
             sort_keys=True,
         )
     )
     assert top_threads_p95 <= 1_000.0
+    assert top_thread_costs_p95 <= 100.0
     assert tool_impact_p95 <= 500.0
     assert top_threads_bytes <= 64_000
     assert tool_impact_bytes <= 64_000
     assert top_threads_result.returned_count == 25
+    assert top_thread_costs_result.returned_count == 5
+    assert top_thread_costs_result.plan_id == (
+        "calls.aggregate.rollup_thread_cost.v1"
+    )
+    for direct_row, fast_row in zip(
+        top_threads_result.rows[:5],
+        top_thread_costs_result.rows,
+        strict=True,
+    ):
+        assert fast_row["thread"] == direct_row["thread"]
+        assert fast_row["thread_label"] == direct_row["thread_label"]
+        assert fast_row["total_tokens"] == direct_row["total_tokens"]
+        assert fast_row["configured_cost_usd"] == pytest.approx(
+            direct_row["configured_cost_usd"]
+        )
+        assert fast_row["estimated_credits"] == pytest.approx(
+            direct_row["estimated_credits"]
+        )
+    for measure in ("configured_cost_usd", "estimated_credits"):
+        assert (
+            top_thread_costs_result.coverage["measures"][measure]
+            == top_threads_result.coverage["measures"][measure]
+        )
     assert tool_impact_result.returned_count == 25
     assert tool_impact_result.plan_id == "tools.rows.direct_tool_impact.v1"
     assert all("thread_label" in row for row in top_threads_result.rows)

--- a/tests/kernel/query/test_r4_rollups.py
+++ b/tests/kernel/query/test_r4_rollups.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,7 +18,13 @@ from codex_usage_tracker.kernel.operational import (
     kernel_paths,
     load_cutover_control,
 )
-from codex_usage_tracker.kernel.query import Operation, QueryRequest, QueryService
+from codex_usage_tracker.kernel.query import (
+    Filter,
+    Operation,
+    QueryRequest,
+    QueryService,
+)
+from codex_usage_tracker.kernel.query.plans import compile_plan
 from codex_usage_tracker.kernel.rollups import (
     _LINK_UNRESOLVED_TOOL_CALLS_SQL,
     generation_rollups_ready,
@@ -166,6 +173,212 @@ def test_top_threads_consolidates_physical_rows_by_logical_thread(
     assert sum(float(row["share_total_tokens"]) for row in result.rows) == pytest.approx(
         1.0
     )
+
+
+@pytest.mark.parametrize(
+    "query_request",
+    (
+        QueryRequest(
+            "calls",
+            Operation.SHARE,
+            ("thread",),
+            ("total_tokens", "configured_cost_usd"),
+            order_by="total_tokens",
+            limit=5,
+        ),
+        QueryRequest(
+            "calls",
+            Operation.AGGREGATE,
+            ("thread",),
+            ("total_tokens", "configured_cost_usd"),
+            filters=(Filter("model", "eq", "gpt-synthetic"),),
+            order_by="total_tokens",
+            limit=5,
+        ),
+        QueryRequest(
+            "calls",
+            Operation.AGGREGATE,
+            ("thread",),
+            ("total_tokens", "configured_cost_usd"),
+            order_by="configured_cost_usd",
+            limit=5,
+        ),
+    ),
+)
+def test_thread_cost_plan_preserves_direct_fallbacks(
+    query_request: QueryRequest,
+) -> None:
+    plan = compile_plan(query_request, generation=1, offset=0)
+
+    assert plan.plan_id != "calls.aggregate.rollup_thread_cost.v1"
+
+
+def test_thread_cost_plan_paginates_tied_threads_deterministically(
+    tmp_path: Path,
+) -> None:
+    runtime = active_runtime(tmp_path)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+    assert control.active_generation is not None
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        connection.execute(
+            """
+            UPDATE rollup_thread
+            SET input_tokens = 100, output_tokens = 0
+            WHERE generation = ?
+            """,
+            (control.active_generation,),
+        )
+        connection.commit()
+    service = QueryService(runtime.kernel.operational)
+    request = _thread_cost_request(limit=1)
+
+    first = service.execute(request)
+    second = service.execute(
+        QueryRequest(
+            dataset=request.dataset,
+            operation=request.operation,
+            dimensions=request.dimensions,
+            measures=request.measures,
+            order_by=request.order_by,
+            limit=request.limit,
+            cursor=first.next_cursor,
+        )
+    )
+
+    assert first.truncated is True
+    assert first.next_cursor is not None
+    assert second.next_cursor is None
+    assert str(first.rows[0]["thread"]) < str(second.rows[0]["thread"])
+
+
+def test_thread_cost_plan_preserves_partial_pricing_coverage(
+    tmp_path: Path,
+) -> None:
+    runtime = active_runtime(tmp_path)
+    rate_card = tmp_path / "rates.json"
+    _write_rate_card(rate_card, models=("gpt-5.3-codex",))
+
+    result = QueryService(
+        runtime.kernel.operational,
+        rate_card_path=rate_card,
+    ).execute(_thread_cost_request())
+
+    for measure in ("configured_cost_usd", "estimated_credits"):
+        coverage = result.coverage["measures"][measure]
+        assert coverage["observed_count"] > 0
+        assert coverage["missing_count"] > 0
+        assert 0.0 < coverage["coverage_percent"] < 100.0
+
+
+def test_thread_cost_plan_matches_direct_logical_split_oracle(
+    tmp_path: Path,
+) -> None:
+    runtime = logical_split_runtime(tmp_path)
+    rate_card = tmp_path / "rates.json"
+    _write_rate_card(rate_card, models=("gpt-synthetic",))
+    service = QueryService(
+        runtime.kernel.operational,
+        rate_card_path=rate_card,
+    )
+    direct = service.execute(
+        QueryRequest(
+            "calls",
+            Operation.SHARE,
+            ("thread",),
+            (
+                "total_tokens",
+                "configured_cost_usd",
+                "estimated_credits",
+            ),
+            order_by="total_tokens",
+            limit=5,
+        )
+    )
+    fast = service.execute(_thread_cost_request())
+
+    assert fast.plan_id == "calls.aggregate.rollup_thread_cost.v1"
+    assert fast.returned_count == direct.returned_count == 2
+    for direct_row, fast_row in zip(direct.rows, fast.rows, strict=True):
+        assert fast_row["thread"] == direct_row["thread"]
+        assert fast_row["thread_label"] == direct_row["thread_label"]
+        assert fast_row["total_tokens"] == direct_row["total_tokens"]
+        assert fast_row["configured_cost_usd"] == pytest.approx(
+            direct_row["configured_cost_usd"]
+        )
+        assert fast_row["estimated_credits"] == pytest.approx(
+            direct_row["estimated_credits"]
+        )
+    assert fast.coverage == direct.coverage
+
+
+def test_thread_cost_plan_label_is_bound_to_requested_generation(
+    tmp_path: Path,
+) -> None:
+    runtime = logical_split_runtime(tmp_path)
+    control = load_cutover_control(runtime.kernel.operational)
+    assert control.active_kernel_path is not None
+    assert control.active_generation == 1
+    with sqlite3.connect(control.active_kernel_path) as connection:
+        logical_thread_id = str(
+            connection.execute(
+                """
+                SELECT logical_thread_id
+                FROM threads
+                WHERE display_label = 'Current logical thread'
+                """
+            ).fetchone()[0]
+        )
+        connection.execute(
+            """
+            INSERT INTO generations VALUES (
+                2, 'future-revision', '2026-01-03T00:00:00Z',
+                'future-high-water', 0, 0, 0, 3, 1,
+                '2026-01-03T00:00:00Z', 'synthetic:1', 'valid'
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO threads(
+                thread_id, source_key, source_id, logical_thread_id,
+                session_identity_hash, display_label, archive_state,
+                first_generation, last_generation, identity_basis,
+                identity_confidence
+            )
+            SELECT
+                'future-physical-thread', source_key, source_id,
+                logical_thread_id, 'future-session-hash',
+                'Future logical thread label', 'active',
+                2, 2, 'synthetic', 'exact'
+            FROM threads
+            WHERE logical_thread_id = ?
+            LIMIT 1
+            """,
+            (logical_thread_id,),
+        )
+        connection.commit()
+    service = QueryService(runtime.kernel.operational)
+    tokens = service.execute(
+        QueryRequest(
+            "calls",
+            Operation.SHARE,
+            ("thread",),
+            ("total_tokens",),
+            order_by="total_tokens",
+            limit=5,
+        )
+    )
+    costs = service.execute(_thread_cost_request())
+    token_row = next(
+        row for row in tokens.rows if row["thread"] == logical_thread_id
+    )
+    cost_row = next(
+        row for row in costs.rows if row["thread"] == logical_thread_id
+    )
+
+    assert token_row["thread_label"] == "Current logical thread"
+    assert cost_row["thread_label"] == token_row["thread_label"]
 
 
 def test_model_effort_and_global_queries_use_small_rollups(tmp_path: Path) -> None:
@@ -500,6 +713,51 @@ def _source(root: Path) -> Path:
         encoding="utf-8",
     )
     return source
+
+
+def _thread_cost_request(*, limit: int = 5) -> QueryRequest:
+    return QueryRequest(
+        "calls",
+        Operation.AGGREGATE,
+        ("thread",),
+        (
+            "total_tokens",
+            "configured_cost_usd",
+            "estimated_credits",
+        ),
+        order_by="total_tokens",
+        limit=limit,
+    )
+
+
+def _write_rate_card(path: Path, *, models: tuple[str, ...]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "codex-usage-tracker.kernel-rate-card.v1",
+                "source": {
+                    "name": "Synthetic thread-cost rates",
+                    "url": "https://example.invalid/thread-cost-rates",
+                    "effective_at": "2026-01-01",
+                    "fetched_at": "2026-01-01T00:00:00Z",
+                },
+                "models": {
+                    model: {
+                        "input_per_million": 1.0,
+                        "cached_input_per_million": 0.5,
+                        "output_per_million": 2.0,
+                        "credits_input_per_million": 3.0,
+                        "credits_cached_input_per_million": 1.0,
+                        "credits_output_per_million": 4.0,
+                        "confidence": "estimated",
+                    }
+                    for model in models
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_cross_preset_retry_recovers_appended_generation(


### PR DESCRIPTION
## Summary

- rank logical threads from the persisted thread rollup before evaluating query-time pricing
- price only canonical calls belonging to the bounded selected threads while preserving exact cost, credit, label, and coverage semantics
- retain the general caller-authored share/filter/order paths as direct-query fallbacks
- add generation-bound labels and focused fallback, cursor, partial-coverage, logical-split, and 100k performance regressions

## Why

The curated top-threads query ranked tokens from the fast rollup but calculated its cost/credit companion across the entire canonical call table. On the maintained aggregate index this made an otherwise common one-call agent request take about five seconds.

## Performance

The production-shaped 100,000-call cost companion improves from 615.058 ms p95 to 10.955 ms p95, a 98.2% reduction. The broader direct path remains unchanged.

## Validation

- `just v`: 451 tests plus Ruff, MyPy, maintainability, frontend, release, and deterministic-asset gates
- focused query/interface/performance suite: 56 passed
- exact parity: logical identities, canonical labels, token totals, configured cost, estimated credits, and coverage
- GitNexus final-diff risk: MEDIUM across three query execution processes
- one final read-only review: 2 findings, 2 accepted and fixed; reviewer-token attribution pending because the helper invokes the retired `strict` command

Closes #362