### PR TITLE
test: synchronize console e2e results

### DIFF
--- a/tests/e2e/kernel-console.spec.mjs
+++ b/tests/e2e/kernel-console.spec.mjs
@@ -261,6 +261,7 @@ test("each result row links to its own most-specific evidence", async ({ page },
   await page.getByLabel("Measures").fill("total_tokens");
   await page.getByRole("button", { name: "Run bounded query" }).click();
   const result = page.locator(".query-result").first();
+  await expect(result.getByRole("heading", { name: "calls · rows" })).toBeVisible();
   await expect(result.getByRole("columnheader", { name: "call" })).toHaveCount(0);
   const rows = result.locator("tbody tr");
   expect(await rows.count()).toBeGreaterThan(1);
@@ -525,6 +526,7 @@ test("limits graph uses elapsed time and labels reset boundaries", async ({ page
     });
   });
   await page.goto("/limits");
+  await expect(page.locator(".allowance-chart .chart-point")).toHaveCount(3);
   const positions = await page.locator(".allowance-chart .chart-point").evaluateAll(
     (nodes) => nodes.map((node) => Number(node.getAttribute("cx"))),
   );


### PR DESCRIPTION
## Summary

- wait for the bounded-query result heading before asserting table rows
- wait for all mocked allowance points before checking elapsed-time spacing
- preserve the existing correctness assertions and leave product code unchanged

## Root cause

Two negative/data assertions could run while the asynchronous result DOM was still empty. The main-branch failure reproduced once in 380 pre-fix executions.

## Validation

- pre-fix: 1 failure / 380 executions
- repaired cases: 100/100 passed with two workers
- normal E2E: 35 passed, 3 intentional skips
- Console build/lint/type/unit: 9/9 passed
- `git diff --check` and secret review passed