### PR TITLE
test: freeze agent-kernel logical vectors

### DIFF
--- a/config/agent-kernel/logical-contract-v1.json
+++ b/config/agent-kernel/logical-contract-v1.json
@@ -1,0 +1,1165 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.logical.v1",
+  "version": 1,
+  "database_identity": "codex-usage-tracker.agent-kernel.v1",
+  "authority": [
+    "docs/architecture/LOGICAL_KERNEL_CONTRACT.md",
+    "docs/architecture/ADAPTER_CONTRACT.md",
+    "config/agent-kernel/question-catalog-v1.json"
+  ],
+  "vector_bundle_sha256": "f310f9e6dc6e65e8f1944a347b6d3bfbf18fe68f2f8ddcf9eb0d1c81e9396848",
+  "identity": {
+    "version": "v1",
+    "tuple_encoding": "canonical_cbor",
+    "digest": "sha256",
+    "text_encoding": "lowercase_base32_without_padding",
+    "digest_characters": 52,
+    "shape": "<kind>:v1:<digest>",
+    "collision_policy": "fail_publication_when_one_logical_id_has_distinct_canonical_identity_bytes",
+    "mutable_labels_in_identity": false,
+    "publication_derivation": {
+      "publication_id": "semantic_id('publication', [publication_key])",
+      "artifact_digest": "sha256(canonical_artifact_with_publication_id_and_without_artifact_digest)",
+      "order": [
+        "allocate_publication_key",
+        "derive_publication_id",
+        "assemble_canonical_artifact_without_artifact_digest",
+        "derive_artifact_digest"
+      ]
+    }
+  },
+  "time": {
+    "storage": "signed_64_bit_integer_utc_microseconds",
+    "epoch": "1970-01-01T00:00:00Z",
+    "missing": "null",
+    "calendar_timezone": "required_iana_name",
+    "window_bounds": "[start,end)",
+    "duration_unit": "integer_microseconds",
+    "fractional_precision": "zero_to_six_decimal_digits_only",
+    "total_order": [
+      "event_time_availability",
+      "event_at_us",
+      "source_order",
+      "event_kind_order",
+      "logical_id"
+    ],
+    "missing_time_order": "after_observed_instants_then_source_order",
+    "invalid_duration": "null_with_diagnostic"
+  },
+  "missingness": {
+    "missing_value": null,
+    "zero_is_observed": true,
+    "mask_version": "measurement-mask-v1",
+    "canonical_grades": [
+      "exact",
+      "deterministic",
+      "configured_estimate"
+    ],
+    "result_only_grades": [
+      "model_inference",
+      "unsupported"
+    ],
+    "missing_bases": [
+      "unobserved",
+      "unavailable",
+      "inapplicable",
+      "invalid"
+    ]
+  },
+  "token_accounting": {
+    "classes": [
+      "uncached_input_tokens",
+      "cached_input_tokens",
+      "reasoning_tokens",
+      "output_tokens"
+    ],
+    "input_formula": "uncached_input_tokens + cached_input_tokens",
+    "total_formula": "uncached_input_tokens + cached_input_tokens + output_tokens",
+    "reasoning_in_default_total": false,
+    "partial_total": "null",
+    "negative_value": "invalid"
+  },
+  "decimal_contract": {
+    "encoding": "plain_finite_decimal_without_sign_plus_exponent_trailing_fraction_zeros_or_negative_zero",
+    "zero": "0",
+    "rates": {
+      "minimum": "0",
+      "maximum": null
+    },
+    "percentages": {
+      "minimum": "0",
+      "maximum": "100"
+    },
+    "missing": null
+  },
+  "semantic_operations": [
+    "read",
+    "search",
+    "list",
+    "execute",
+    "write",
+    "patch",
+    "test",
+    "navigate",
+    "delegate",
+    "wait",
+    "unknown"
+  ],
+  "resource_kinds": [
+    "file",
+    "directory",
+    "repository",
+    "command_family",
+    "url_origin_path_template",
+    "mcp_tool",
+    "browser_route",
+    "test_target",
+    "unknown"
+  ],
+  "lifecycle_states": [
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "rolled_back",
+    "open",
+    "unknown"
+  ],
+  "source_states": [
+    "active",
+    "archived",
+    "replaced",
+    "truncated",
+    "missing",
+    "malformed",
+    "deferred"
+  ],
+  "publication_states": [
+    "committed",
+    "rolled_back"
+  ],
+  "logical_primitives": {
+    "allowance_observation": "allowance_observation",
+    "canonical_call": "canonical_call",
+    "compaction_boundary": "compaction_boundary",
+    "context_component": "context_component",
+    "model_profile": "model_profile",
+    "project": "project",
+    "publication": "publication",
+    "publication_delta": "publication_delta",
+    "resource": "resource",
+    "session": "session",
+    "source_manifestation": "source_manifestation",
+    "source_occurrence": "source_occurrence",
+    "state_change": "state_change",
+    "tool_invocation": "tool_invocation",
+    "turn": "turn",
+    "valuation_match": "valuation_match"
+  },
+  "capabilities": {
+    "allowance_observation": {
+      "owner": "allowance",
+      "semantics": "Exact provider allowance observations and compatible intervals are observable."
+    },
+    "completion_lifecycle": {
+      "owner": "facts/lifecycle",
+      "semantics": "Structural start and terminal transitions are observable."
+    },
+    "compaction_boundary": {
+      "owner": "facts/activities",
+      "semantics": "Compaction or context-epoch boundaries are observable."
+    },
+    "context_window": {
+      "owner": "facts/model_calls",
+      "semantics": "A call context-window measurement is structurally observable."
+    },
+    "model_call_usage": {
+      "owner": "facts/model_calls",
+      "semantics": "Canonical calls expose independent token measurements."
+    },
+    "project_identity": {
+      "owner": "identity/projects",
+      "semantics": "Normalized project identity is observable."
+    },
+    "publication_delta": {
+      "owner": "publication",
+      "semantics": "Accepted mutation summaries between committed publications are observable."
+    },
+    "publication_state": {
+      "owner": "publication",
+      "semantics": "Committed truth identity, coverage, and freshness are observable."
+    },
+    "resource_identity": {
+      "owner": "facts/resources",
+      "semantics": "Normalized metadata-only resource identities are observable."
+    },
+    "session_hierarchy": {
+      "owner": "identity/sessions",
+      "semantics": "Direct parent and descendant relationships are structurally observable."
+    },
+    "session_identity": {
+      "owner": "identity/sessions",
+      "semantics": "Stable session identity is observable."
+    },
+    "source_inventory": {
+      "owner": "sources",
+      "semantics": "Bounded source discovery and state are observable."
+    },
+    "source_occurrence": {
+      "owner": "evidence",
+      "semantics": "Physical occurrence provenance for a semantic entity is observable."
+    },
+    "state_change_observation": {
+      "owner": "facts/state_changes",
+      "semantics": "A structured resource mutation is observed without causal attribution."
+    },
+    "structural_context": {
+      "owner": "capabilities/context",
+      "semantics": "Optional structural context components are observable without raw bodies."
+    },
+    "tool_lifecycle": {
+      "owner": "facts/tools",
+      "semantics": "Tool invocation transitions and structured measurements are observable."
+    },
+    "turn_identity": {
+      "owner": "identity/turns",
+      "semantics": "Deterministic user-intent boundaries are observable."
+    },
+    "valuation": {
+      "owner": "valuation",
+      "semantics": "A configured rate-card revision can be applied with explicit coverage."
+    }
+  },
+  "measurements": {
+    "allowance_limit": {
+      "bit": 0,
+      "grade": "exact",
+      "basis": "observed_limit_identity",
+      "missing": "null_when_provider_limit_is_unobserved",
+      "vector_ids": [
+        "allowance.compatible_used"
+      ]
+    },
+    "allowance_percent": {
+      "bit": 1,
+      "grade": "exact",
+      "basis": "observed_decimal_percent",
+      "missing": "null_when_neither_used_nor_remaining_is_observed",
+      "vector_ids": [
+        "allowance.compatible_used",
+        "allowance.compatible_remaining"
+      ]
+    },
+    "cached_input_tokens": {
+      "bit": 2,
+      "grade": "exact",
+      "basis": "observed_or_compatible_deterministic_derivation",
+      "missing": "null_when_upstream_does_not_establish_cached_input",
+      "vector_ids": [
+        "accounting.four_tokens",
+        "accounting.missing_cached"
+      ]
+    },
+    "call_count": {
+      "bit": 3,
+      "grade": "exact",
+      "basis": "canonical_entity_count",
+      "missing": "null_when_call_capability_is_unavailable",
+      "vector_ids": [
+        "identity.source_copy"
+      ]
+    },
+    "completion_state": {
+      "bit": 4,
+      "grade": "deterministic",
+      "basis": "ordered_lifecycle_fold",
+      "missing": "unknown_state_when_no_compatible_transition_exists",
+      "vector_ids": [
+        "lifecycle.cross_publication"
+      ]
+    },
+    "configured_cost_usd": {
+      "bit": 5,
+      "grade": "configured_estimate",
+      "basis": "selected_rate_card_revision",
+      "missing": "null_when_no_tokens_are_rated",
+      "vector_ids": [
+        "valuation.full",
+        "valuation.unmatched"
+      ]
+    },
+    "context_window_tokens": {
+      "bit": 6,
+      "grade": "exact",
+      "basis": "observed_model_call_field",
+      "missing": "null_when_adapter_capability_is_absent",
+      "vector_ids": [
+        "accounting.measurement_missing"
+      ]
+    },
+    "duration_us": {
+      "bit": 7,
+      "grade": "deterministic",
+      "basis": "valid_terminal_time_minus_start_time",
+      "missing": "null_when_boundary_is_missing_or_negative",
+      "vector_ids": [
+        "lifecycle.cross_publication"
+      ]
+    },
+    "estimated_credits": {
+      "bit": 8,
+      "grade": "configured_estimate",
+      "basis": "selected_rate_card_revision",
+      "missing": "null_when_no_credit_rate_applies",
+      "vector_ids": [
+        "valuation.full",
+        "valuation.unmatched"
+      ]
+    },
+    "event_time_us": {
+      "bit": 9,
+      "grade": "exact",
+      "basis": "documented_upstream_timestamp_conversion",
+      "missing": "null_without_timestamp_substitution",
+      "vector_ids": [
+        "time.epoch",
+        "time.missing_order"
+      ]
+    },
+    "hierarchy_depth": {
+      "bit": 10,
+      "grade": "deterministic",
+      "basis": "acyclic_parent_fold",
+      "missing": "null_while_parent_chain_is_unresolved",
+      "vector_ids": [
+        "hierarchy.late_parent",
+        "hierarchy.multilevel"
+      ]
+    },
+    "model_profile": {
+      "bit": 11,
+      "grade": "exact",
+      "basis": "observed_model_effort_tier_tuple_with_unknown_members",
+      "missing": "explicit_unknown_members_not_empty_strings",
+      "vector_ids": [
+        "identity.model_profile"
+      ]
+    },
+    "mutation_count": {
+      "bit": 12,
+      "grade": "exact",
+      "basis": "canonical_state_change_count",
+      "missing": "null_when_state_change_capability_is_absent",
+      "vector_ids": [
+        "accounting.tool_separation"
+      ]
+    },
+    "output_tokens": {
+      "bit": 13,
+      "grade": "exact",
+      "basis": "observed_model_usage",
+      "missing": "null_when_upstream_does_not_establish_output",
+      "vector_ids": [
+        "accounting.four_tokens"
+      ]
+    },
+    "reasoning_tokens": {
+      "bit": 14,
+      "grade": "exact",
+      "basis": "observed_model_usage",
+      "missing": "null_when_upstream_does_not_establish_reasoning",
+      "vector_ids": [
+        "accounting.four_tokens",
+        "valuation.reasoning_overlap"
+      ]
+    },
+    "resource_operation": {
+      "bit": 15,
+      "grade": "deterministic",
+      "basis": "metadata_only_transport_classification",
+      "missing": "unknown_enum_when_unrecognized",
+      "vector_ids": [
+        "accounting.tool_separation"
+      ]
+    },
+    "source_occurrence_count": {
+      "bit": 16,
+      "grade": "exact",
+      "basis": "preserved_occurrence_coordinate_count",
+      "missing": "null_when_occurrence_capability_is_absent",
+      "vector_ids": [
+        "identity.source_copy"
+      ]
+    },
+    "tool_output_bytes": {
+      "bit": 17,
+      "grade": "exact",
+      "basis": "bounded_structural_size_observation",
+      "missing": "null_when_host_does_not_expose_size",
+      "vector_ids": [
+        "accounting.measurement_missing"
+      ]
+    },
+    "tool_status": {
+      "bit": 18,
+      "grade": "deterministic",
+      "basis": "ordered_lifecycle_fold",
+      "missing": "unknown_state_without_transition",
+      "vector_ids": [
+        "lifecycle.cross_publication",
+        "accounting.tool_separation"
+      ]
+    },
+    "turn_count": {
+      "bit": 19,
+      "grade": "exact",
+      "basis": "canonical_turn_count",
+      "missing": "null_when_turn_capability_is_unavailable",
+      "vector_ids": [
+        "hierarchy.multilevel"
+      ]
+    },
+    "uncached_input_tokens": {
+      "bit": 20,
+      "grade": "deterministic",
+      "basis": "observed_value_or_compatible_input_total_minus_cached",
+      "missing": "null_when_required_inputs_are_absent_or_invalid",
+      "vector_ids": [
+        "accounting.four_tokens",
+        "accounting.invalid_negative"
+      ]
+    }
+  },
+  "selector_kinds": {
+    "allowance_interval": {
+      "entity": "allowance_interval",
+      "prefix": "allowance-interval",
+      "identity_kind": "allowance-interval"
+    },
+    "allowance_observation": {
+      "entity": "allowance_observation",
+      "prefix": "allowance-observation",
+      "identity_kind": "allowance-observation"
+    },
+    "call": {
+      "entity": "canonical_call",
+      "prefix": "call",
+      "identity_kind": "call"
+    },
+    "model_profile": {
+      "entity": "model_profile",
+      "prefix": "model-profile",
+      "identity_kind": "model-profile"
+    },
+    "project": {
+      "entity": "project",
+      "prefix": "project",
+      "identity_kind": "project"
+    },
+    "publication": {
+      "entity": "publication",
+      "prefix": "publication",
+      "identity_kind": "publication"
+    },
+    "rate_card": {
+      "entity": "rate_card_revision",
+      "prefix": "rate-card",
+      "identity_kind": "rate-card"
+    },
+    "resource": {
+      "entity": "resource",
+      "prefix": "resource",
+      "identity_kind": "resource"
+    },
+    "session": {
+      "entity": "session",
+      "prefix": "session",
+      "identity_kind": "session"
+    },
+    "source_manifestation": {
+      "entity": "source_manifestation",
+      "prefix": "source-manifestation",
+      "identity_kind": "source-manifestation"
+    },
+    "state_change": {
+      "entity": "state_change",
+      "prefix": "state-change",
+      "identity_kind": "state-change"
+    },
+    "tool": {
+      "entity": "tool_invocation",
+      "prefix": "tool",
+      "identity_kind": "tool"
+    },
+    "turn": {
+      "entity": "turn",
+      "prefix": "turn",
+      "identity_kind": "turn"
+    },
+    "window": {
+      "entity": "query_window",
+      "prefix": "window",
+      "identity_kind": "window"
+    }
+  },
+  "entities": [
+    {
+      "id": "adapter_identity",
+      "identity": {
+        "kind": "adapter",
+        "input_fields": ["adapter_id", "adapter_version", "source_kind", "identity_version"],
+        "derived_id_field": null
+      },
+      "owner": "adapters/contracts",
+      "semantics": "Versioned source-observation family and the capabilities it can establish.",
+      "vector_ids": ["identity.adapter_identity", "field.adapter_identity"],
+      "fields": [
+        {"name": "adapter_id", "semantics": "Stable adapter family.", "identity_participation": "included", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.adapter_identity"]},
+        {"name": "adapter_version", "semantics": "Parser and normalization contract version.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.adapter_identity"]},
+        {"name": "source_kind", "semantics": "Versioned upstream representation kind.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.adapter_identity"]},
+        {"name": "capability_mask", "semantics": "Fields and lifecycle observations this adapter can establish.", "identity_participation": "excluded", "missing": "empty_mask_means_no_capabilities", "basis": "adapter_exact", "vector_ids": ["field.adapter_identity"]},
+        {"name": "identity_version", "semantics": "Identity algorithm suite emitted by the adapter.", "identity_participation": "included", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.adapter_identity"]}
+      ]
+    },
+    {
+      "id": "source",
+      "identity": {
+        "kind": "source",
+        "input_fields": ["adapter_id", "source_kind", "adapter_native_source_key"],
+        "derived_id_field": "source_id"
+      },
+      "owner": "sources",
+      "semantics": "Stable upstream source identity across observed manifestations.",
+      "vector_ids": ["identity.source", "field.source"],
+      "fields": [
+        {"name": "source_id", "semantics": "Versioned semantic source identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source"]},
+        {"name": "adapter_id", "semantics": "Adapter family that owns source interpretation.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.source"]},
+        {"name": "source_kind", "semantics": "Upstream representation family.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.source"]},
+        {"name": "adapter_native_source_key", "semantics": "Stable adapter-native structural source key.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.source"]},
+        {"name": "first_seen_publication", "semantics": "First committed publication that observed the source.", "identity_participation": "excluded", "missing": "null_before_commit", "basis": "publication_exact", "vector_ids": ["field.source"]},
+        {"name": "last_seen_publication", "semantics": "Latest committed publication that observed the source.", "identity_participation": "excluded", "missing": "null_before_commit", "basis": "publication_exact", "vector_ids": ["field.source"]},
+        {"name": "selected_history_coverage", "semantics": "Whether this source was selected, deferred, uncertain, malformed, or missing.", "identity_participation": "excluded", "missing": "forbidden_after_inventory", "basis": "planner_exact", "vector_ids": ["field.source"]}
+      ]
+    },
+    {
+      "id": "source_manifestation",
+      "identity": {
+        "kind": "source-manifestation",
+        "input_fields": ["source_id", "technical_path_key"],
+        "derived_id_field": "manifestation_id"
+      },
+      "owner": "sources",
+      "semantics": "One observed path and revision of a stable source.",
+      "vector_ids": ["identity.source_manifestation", "field.source_manifestation"],
+      "fields": [
+        {"name": "manifestation_id", "semantics": "Stable identity for one adapter manifestation key.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source_manifestation"]},
+        {"name": "source_id", "semantics": "Owning stable source.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source_manifestation"]},
+        {"name": "technical_path_key", "semantics": "Normalized local technical locator.", "identity_participation": "included", "missing": "forbidden_for_file_sources", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "display_label", "semantics": "Mutable local presentation label.", "identity_participation": "excluded", "missing": "null_when_no_label_candidate", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "filesystem_identity", "semantics": "Filesystem identity when the platform exposes one.", "identity_participation": "excluded", "missing": "null_when_unavailable", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "size_bytes", "semantics": "Observed manifestation byte size.", "identity_participation": "excluded", "missing": "null_when_stat_fails", "basis": "filesystem_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "modified_at_us", "semantics": "Filesystem modification time used only for discovery.", "identity_participation": "excluded", "missing": "null_when_stat_fails", "basis": "filesystem_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "content_revision", "semantics": "Observed content-revision fingerprint.", "identity_participation": "excluded", "missing": "null_until_hashed", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "cursor_byte_offset", "semantics": "Offset after the last committed complete record.", "identity_participation": "excluded", "missing": "zero_only_when_observed_at_file_start", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "cursor_record_ordinal", "semantics": "Stable ordinal of the last committed complete record.", "identity_participation": "excluded", "missing": "null_when_no_complete_record", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "state", "semantics": "Current manifestation lifecycle state.", "identity_participation": "excluded", "missing": "forbidden_after_inventory", "basis": "inventory_exact", "vector_ids": ["field.source_manifestation"]},
+        {"name": "parse_diagnostics", "semantics": "Bounded malformed or unsupported ranges.", "identity_participation": "excluded", "missing": "empty_collection_means_no_observed_diagnostic", "basis": "adapter_exact", "vector_ids": ["field.source_manifestation"]}
+      ]
+    },
+    {
+      "id": "project",
+      "identity": {
+        "kind": "project",
+        "input_fields": ["workspace_key"],
+        "derived_id_field": "project_id"
+      },
+      "owner": "identity/projects",
+      "semantics": "Stable normalized workspace grouping with mutable label candidates.",
+      "vector_ids": ["identity.project", "field.project"],
+      "fields": [
+        {"name": "project_id", "semantics": "Versioned normalized project identity.", "identity_participation": "excluded", "missing": "explicit_unknown_project_bucket", "basis": "identity_v1", "vector_ids": ["field.project"]},
+        {"name": "workspace_key", "semantics": "Normalized observed workspace key.", "identity_participation": "included", "missing": "explicit_unknown_key", "basis": "adapter_exact", "vector_ids": ["field.project"]},
+        {"name": "label_candidates", "semantics": "Current human-readable project labels with provenance.", "identity_participation": "excluded", "missing": "empty_collection_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.project"]},
+        {"name": "first_event_at_us", "semantics": "Earliest observed project event time.", "identity_participation": "excluded", "missing": "null_when_all_event_times_missing", "basis": "deterministic_min", "vector_ids": ["field.project"]},
+        {"name": "last_event_at_us", "semantics": "Latest observed project event time.", "identity_participation": "excluded", "missing": "null_when_all_event_times_missing", "basis": "deterministic_max", "vector_ids": ["field.project"]},
+        {"name": "provenance", "semantics": "Occurrence coordinates supporting project observation.", "identity_participation": "excluded", "missing": "forbidden_for_observed_project", "basis": "occurrence_exact", "vector_ids": ["field.project"]}
+      ]
+    },
+    {
+      "id": "session",
+      "identity": {
+        "kind": "session",
+        "input_fields": ["adapter_native_session_key", "identity_version"],
+        "derived_id_field": "session_id"
+      },
+      "owner": "identity/sessions",
+      "semantics": "Stable adapter-native session whose hierarchy may be discovered later.",
+      "vector_ids": ["identity.session", "field.session"],
+      "fields": [
+        {"name": "session_id", "semantics": "Versioned session identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.session"]},
+        {"name": "adapter_native_session_key", "semantics": "Stable upstream session key.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "identity_version", "semantics": "Session identity tuple version.", "identity_participation": "included", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.session"]},
+        {"name": "project_id", "semantics": "Observed project relation.", "identity_participation": "excluded", "missing": "null_until_observed", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "root_session_id", "semantics": "Current resolved hierarchy root.", "identity_participation": "excluded", "missing": "null_while_unresolved", "basis": "deterministic_hierarchy_fold", "vector_ids": ["field.session"]},
+        {"name": "parent_session_id", "semantics": "Current direct parent relation.", "identity_participation": "excluded", "missing": "null_while_unresolved_or_root", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "relationship_basis", "semantics": "Upstream evidence supporting parent relation.", "identity_participation": "excluded", "missing": "null_without_parent", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "delegation_depth", "semantics": "Acyclic distance from resolved root.", "identity_participation": "excluded", "missing": "null_while_chain_unresolved", "basis": "deterministic_hierarchy_fold", "vector_ids": ["field.session"]},
+        {"name": "start_at_us", "semantics": "Earliest valid observed session event.", "identity_participation": "excluded", "missing": "null_without_observed_time", "basis": "deterministic_min", "vector_ids": ["field.session"]},
+        {"name": "end_at_us", "semantics": "Compatible terminal session time.", "identity_participation": "excluded", "missing": "null_while_open_or_unobserved", "basis": "lifecycle_fold", "vector_ids": ["field.session"]},
+        {"name": "lifecycle_state", "semantics": "Current folded session lifecycle state.", "identity_participation": "excluded", "missing": "unknown_without_transition", "basis": "lifecycle_fold", "vector_ids": ["field.session"]},
+        {"name": "completion_basis", "semantics": "Structural evidence for completion state.", "identity_participation": "excluded", "missing": "null_without_terminal_evidence", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "label_candidates", "semantics": "Mutable human-readable session labels.", "identity_participation": "excluded", "missing": "empty_collection_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.session"]},
+        {"name": "evidence_coordinates", "semantics": "First and last structural source coordinates.", "identity_participation": "excluded", "missing": "forbidden_for_observed_session", "basis": "occurrence_exact", "vector_ids": ["field.session"]}
+      ]
+    },
+    {
+      "id": "turn",
+      "identity": {
+        "kind": "turn",
+        "input_fields": ["session_id", "ordinal"],
+        "derived_id_field": "turn_id"
+      },
+      "owner": "identity/turns",
+      "semantics": "Deterministic user-intent boundary through the next intent or explicit terminal event.",
+      "vector_ids": ["identity.turn", "field.turn"],
+      "fields": [
+        {"name": "turn_id", "semantics": "Versioned turn identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.turn"]},
+        {"name": "session_id", "semantics": "Owning canonical session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.turn"]},
+        {"name": "ordinal", "semantics": "One-based deterministic ordinal within session order.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_deterministic", "vector_ids": ["field.turn"]},
+        {"name": "start_at_us", "semantics": "User-intent boundary time.", "identity_participation": "excluded", "missing": "null_without_upstream_time", "basis": "adapter_exact", "vector_ids": ["field.turn"]},
+        {"name": "end_at_us", "semantics": "Next boundary or explicit terminal time.", "identity_participation": "excluded", "missing": "null_while_open", "basis": "lifecycle_fold", "vector_ids": ["field.turn"]},
+        {"name": "source_order_range", "semantics": "First and last stable adapter source order.", "identity_participation": "excluded", "missing": "forbidden_for_observed_turn", "basis": "adapter_exact", "vector_ids": ["field.turn"]},
+        {"name": "lifecycle_state", "semantics": "Current folded turn state.", "identity_participation": "excluded", "missing": "open_without_terminal_evidence", "basis": "lifecycle_fold", "vector_ids": ["field.turn"]},
+        {"name": "completion_basis", "semantics": "Structural basis for terminal state.", "identity_participation": "excluded", "missing": "null_while_open", "basis": "adapter_exact", "vector_ids": ["field.turn"]},
+        {"name": "first_boundary_coordinates", "semantics": "First call, action, success, and mutation coordinates when available.", "identity_participation": "excluded", "missing": "null_per_unobserved_boundary", "basis": "deterministic_order", "vector_ids": ["field.turn"]},
+        {"name": "membership", "semantics": "Exact call, tool, activity, and state-change members.", "identity_participation": "excluded", "missing": "empty_collection_is_observed_zero", "basis": "canonical_relationship", "vector_ids": ["field.turn"]}
+      ]
+    },
+    {
+      "id": "point_event",
+      "identity": {
+        "kind": "event",
+        "input_fields": ["event_kind", "event_at_us", "source_order", "session_id", "turn_id"],
+        "derived_id_field": "event_id"
+      },
+      "owner": "facts/events",
+      "semantics": "Immutable instantaneous observation in the canonical total order.",
+      "vector_ids": ["identity.point_event", "field.point_event"],
+      "fields": [
+        {"name": "event_id", "semantics": "Versioned event identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.point_event"]},
+        {"name": "event_kind", "semantics": "Typed observation kind.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "event_at_us", "semantics": "Observed signed UTC microsecond instant.", "identity_participation": "included", "missing": "null_without_substitution", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "source_order", "semantics": "Stable adapter-provided tie-break tuple.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "session_id", "semantics": "Owning session when observed.", "identity_participation": "included", "missing": "null_for_global_observation", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "turn_id", "semantics": "Containing turn when observed.", "identity_participation": "included", "missing": "null_outside_turn", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "occurrence_coordinate", "semantics": "Physical structural record evidence.", "identity_participation": "excluded", "missing": "forbidden_for_observed_event", "basis": "occurrence_exact", "vector_ids": ["field.point_event"]},
+        {"name": "measurement_mask", "semantics": "Availability bits for optional event measurements.", "identity_participation": "excluded", "missing": "zero_mask_means_none_observed", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "basis", "semantics": "Observation or derivation basis.", "identity_participation": "excluded", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.point_event"]},
+        {"name": "confidence", "semantics": "Structured confidence enum without model inference.", "identity_participation": "excluded", "missing": "null_when_not_applicable", "basis": "adapter_exact", "vector_ids": ["field.point_event"]}
+      ]
+    },
+    {
+      "id": "lifecycle_entity",
+      "identity": {
+        "kind": "lifecycle",
+        "input_fields": ["logical_id", "kind"],
+        "derived_id_field": null
+      },
+      "owner": "facts/lifecycle",
+      "semantics": "Deterministic current state folded from append-only transition observations.",
+      "vector_ids": ["identity.lifecycle_entity", "field.lifecycle_entity"],
+      "fields": [
+        {"name": "logical_id", "semantics": "Identity of the lifecycle-bearing entity.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "kind", "semantics": "Call, tool, activity, or turn lifecycle kind.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "start_coordinate", "semantics": "Earliest compatible start transition.", "identity_participation": "excluded", "missing": "null_without_start", "basis": "ordered_transition_fold", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "last_transition_coordinate", "semantics": "Latest compatible transition in semantic event order.", "identity_participation": "excluded", "missing": "forbidden_when_transition_exists", "basis": "ordered_transition_fold", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "terminal_coordinate", "semantics": "Compatible terminal transition.", "identity_participation": "excluded", "missing": "null_while_nonterminal", "basis": "ordered_transition_fold", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "state", "semantics": "Current deterministic lifecycle state.", "identity_participation": "excluded", "missing": "unknown_without_transition", "basis": "ordered_transition_fold", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "state_basis", "semantics": "Basis from the winning transition.", "identity_participation": "excluded", "missing": "unknown_without_transition", "basis": "adapter_exact", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "transition_version", "semantics": "Lifecycle fold contract version.", "identity_participation": "excluded", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "observed_duration_us", "semantics": "Valid terminal time minus start time.", "identity_participation": "excluded", "missing": "null_without_valid_boundaries", "basis": "deterministic_difference", "vector_ids": ["field.lifecycle_entity"]},
+        {"name": "terminal_error_category", "semantics": "Structural terminal error category.", "identity_participation": "excluded", "missing": "null_when_unobserved_or_not_failed", "basis": "adapter_exact", "vector_ids": ["field.lifecycle_entity"]}
+      ]
+    },
+    {
+      "id": "model_profile",
+      "identity": {
+        "kind": "model-profile",
+        "input_fields": ["model", "reasoning_effort", "service_tier"],
+        "derived_id_field": "model_profile_id"
+      },
+      "owner": "facts/model_calls",
+      "semantics": "Exact observed model, effort, service-tier tuple with explicit unknown members.",
+      "vector_ids": ["identity.model_profile", "field.model_profile"],
+      "fields": [
+        {"name": "model_profile_id", "semantics": "Versioned identity of the exact profile tuple.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.model_profile"]},
+        {"name": "model", "semantics": "Observed model label or explicit unknown.", "identity_participation": "included", "missing": "explicit_unknown_member", "basis": "adapter_exact", "vector_ids": ["field.model_profile"]},
+        {"name": "reasoning_effort", "semantics": "Observed reasoning effort or explicit unknown.", "identity_participation": "included", "missing": "explicit_unknown_member", "basis": "adapter_exact", "vector_ids": ["field.model_profile"]},
+        {"name": "service_tier", "semantics": "Observed service tier or explicit unknown.", "identity_participation": "included", "missing": "explicit_unknown_member", "basis": "adapter_exact", "vector_ids": ["field.model_profile"]}
+      ]
+    },
+    {
+      "id": "canonical_call",
+      "identity": {
+        "kind": "call",
+        "input_fields": ["adapter_native_call_key", "session_id", "turn_id"],
+        "derived_id_field": "call_id"
+      },
+      "owner": "facts/model_calls",
+      "semantics": "Canonical accounting grain for one model call across duplicate occurrences.",
+      "vector_ids": ["identity.canonical_call", "field.canonical_call"],
+      "fields": [
+        {"name": "call_id", "semantics": "Versioned model-call identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.canonical_call"]},
+        {"name": "adapter_native_call_key", "semantics": "Stable upstream call key or deterministic source coordinate.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "session_id", "semantics": "Owning canonical session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.canonical_call"]},
+        {"name": "turn_id", "semantics": "Containing canonical turn.", "identity_participation": "included", "missing": "null_only_when_adapter_cannot_bound_turn", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "model_profile_id", "semantics": "Exact observed model-profile tuple.", "identity_participation": "excluded", "missing": "explicit_unknown_profile", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "context_window_tokens", "semantics": "Observed model context capacity.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "uncached_input_tokens", "semantics": "Uncached input token class.", "identity_participation": "excluded", "missing": "null_when_unobserved_or_invalid", "basis": "observed_or_deterministic", "vector_ids": ["field.canonical_call"]},
+        {"name": "cached_input_tokens", "semantics": "Cached input token class.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "reasoning_tokens", "semantics": "Reasoning token class kept separate from default total.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "output_tokens", "semantics": "Output token class.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "token_basis", "semantics": "Per-class observation or derivation basis.", "identity_participation": "excluded", "missing": "forbidden_for_nonnull_token", "basis": "adapter_exact", "vector_ids": ["field.canonical_call"]},
+        {"name": "lifecycle", "semantics": "Current start and terminal state.", "identity_participation": "excluded", "missing": "unknown_without_transitions", "basis": "lifecycle_fold", "vector_ids": ["field.canonical_call"]},
+        {"name": "evidence_coordinates", "semantics": "All valid physical occurrences for this call.", "identity_participation": "excluded", "missing": "forbidden_for_observed_call", "basis": "occurrence_exact", "vector_ids": ["field.canonical_call"]}
+      ]
+    },
+    {
+      "id": "tool_invocation",
+      "identity": {
+        "kind": "tool",
+        "input_fields": ["adapter_native_invocation_key", "session_id", "turn_id"],
+        "derived_id_field": "tool_id"
+      },
+      "owner": "facts/tools",
+      "semantics": "One tool activity with transport, semantic operation, lifecycle, and target metadata kept distinct.",
+      "vector_ids": ["identity.tool_invocation", "field.tool_invocation"],
+      "fields": [
+        {"name": "tool_id", "semantics": "Versioned tool-invocation identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.tool_invocation"]},
+        {"name": "adapter_native_invocation_key", "semantics": "Stable upstream invocation key or deterministic coordinate.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]},
+        {"name": "session_id", "semantics": "Owning session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.tool_invocation"]},
+        {"name": "turn_id", "semantics": "Containing turn.", "identity_participation": "included", "missing": "null_when_unresolved", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]},
+        {"name": "transport_name", "semantics": "Exact observed callable or host transport.", "identity_participation": "excluded", "missing": "explicit_unknown_transport", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]},
+        {"name": "semantic_operation", "semantics": "Deterministic metadata-only operation enum.", "identity_participation": "excluded", "missing": "unknown_enum_when_unrecognized", "basis": "adapter_deterministic", "vector_ids": ["field.tool_invocation"]},
+        {"name": "tool_family", "semantics": "Stable grouping of equivalent transport purposes.", "identity_participation": "excluded", "missing": "unknown_family_when_unclassified", "basis": "adapter_deterministic", "vector_ids": ["field.tool_invocation"]},
+        {"name": "resource_links", "semantics": "Normalized target identities and relationship roles.", "identity_participation": "excluded", "missing": "empty_collection_when_no_target_observed", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]},
+        {"name": "write_intent", "semantics": "Invocation expressed a write-like intent only.", "identity_participation": "excluded", "missing": "false_only_when_classification_observed", "basis": "adapter_deterministic", "vector_ids": ["field.tool_invocation"]},
+        {"name": "lifecycle", "semantics": "Current tool state and completion basis.", "identity_participation": "excluded", "missing": "unknown_without_transition", "basis": "lifecycle_fold", "vector_ids": ["field.tool_invocation"]},
+        {"name": "output_bytes", "semantics": "Bounded structural output size, not body content.", "identity_participation": "excluded", "missing": "null_when_host_does_not_expose_size", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]},
+        {"name": "duration_us", "semantics": "Valid terminal time minus start time.", "identity_participation": "excluded", "missing": "null_without_valid_boundaries", "basis": "deterministic_difference", "vector_ids": ["field.tool_invocation"]},
+        {"name": "error_category", "semantics": "Structurally observed terminal error category.", "identity_participation": "excluded", "missing": "null_when_unobserved_or_not_failed", "basis": "adapter_exact", "vector_ids": ["field.tool_invocation"]}
+      ]
+    },
+    {
+      "id": "activity",
+      "identity": {
+        "kind": "activity",
+        "input_fields": ["session_id", "turn_id", "activity_kind"],
+        "derived_id_field": "activity_id"
+      },
+      "owner": "facts/activities",
+      "semantics": "Structured host phase or task marker with lifecycle semantics.",
+      "vector_ids": ["identity.activity", "field.activity"],
+      "fields": [
+        {"name": "activity_id", "semantics": "Versioned structured activity identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.activity"]},
+        {"name": "session_id", "semantics": "Owning session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.activity"]},
+        {"name": "turn_id", "semantics": "Containing turn when observed.", "identity_participation": "included", "missing": "null_outside_turn", "basis": "adapter_exact", "vector_ids": ["field.activity"]},
+        {"name": "activity_kind", "semantics": "Structured host phase enum.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.activity"]},
+        {"name": "lifecycle", "semantics": "Current folded activity state.", "identity_participation": "excluded", "missing": "unknown_without_transition", "basis": "lifecycle_fold", "vector_ids": ["field.activity"]}
+      ]
+    },
+    {
+      "id": "compaction_boundary",
+      "identity": {
+        "kind": "compaction",
+        "input_fields": ["session_id", "source_order"],
+        "derived_id_field": "compaction_id"
+      },
+      "owner": "facts/activities",
+      "semantics": "Observed compaction point or lifecycle boundary between context epochs.",
+      "vector_ids": ["identity.compaction_boundary", "field.compaction_boundary"],
+      "fields": [
+        {"name": "compaction_id", "semantics": "Versioned boundary identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.compaction_boundary"]},
+        {"name": "session_id", "semantics": "Owning session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.compaction_boundary"]},
+        {"name": "source_order", "semantics": "Stable adapter boundary coordinate.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.compaction_boundary"]},
+        {"name": "before_context_epoch", "semantics": "Observed pre-boundary epoch identity.", "identity_participation": "excluded", "missing": "null_when_host_does_not_expose_epoch", "basis": "adapter_exact", "vector_ids": ["field.compaction_boundary"]},
+        {"name": "after_context_epoch", "semantics": "Observed post-boundary epoch identity.", "identity_participation": "excluded", "missing": "null_when_host_does_not_expose_epoch", "basis": "adapter_exact", "vector_ids": ["field.compaction_boundary"]}
+      ]
+    },
+    {
+      "id": "resource",
+      "identity": {
+        "kind": "resource",
+        "input_fields": ["project_id", "kind", "normalized_key", "normalization_version"],
+        "derived_id_field": "resource_id"
+      },
+      "owner": "facts/resources",
+      "semantics": "Normalized metadata-only local target without raw body content.",
+      "vector_ids": ["identity.resource", "field.resource"],
+      "fields": [
+        {"name": "resource_id", "semantics": "Versioned resource identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.resource"]},
+        {"name": "project_id", "semantics": "Related project when provable.", "identity_participation": "included", "missing": "explicit_unknown_project", "basis": "identity_v1", "vector_ids": ["field.resource"]},
+        {"name": "kind", "semantics": "Resource-kind enum.", "identity_participation": "included", "missing": "unknown_enum_when_unclassified", "basis": "adapter_deterministic", "vector_ids": ["field.resource"]},
+        {"name": "normalized_key", "semantics": "Versioned project-relative or technical identity key.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_deterministic", "vector_ids": ["field.resource"]},
+        {"name": "normalization_version", "semantics": "Resource normalization rule version.", "identity_participation": "included", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.resource"]},
+        {"name": "display_label", "semantics": "Concise mutable local display label.", "identity_participation": "excluded", "missing": "null_when_no_label_candidate", "basis": "adapter_exact", "vector_ids": ["field.resource"]},
+        {"name": "provenance", "semantics": "Structural extraction basis and occurrence evidence.", "identity_participation": "excluded", "missing": "forbidden_for_observed_resource", "basis": "adapter_exact", "vector_ids": ["field.resource"]}
+      ]
+    },
+    {
+      "id": "state_change",
+      "identity": {
+        "kind": "state-change",
+        "input_fields": ["change_kind", "resource_id", "observation_at_us", "session_id", "turn_id"],
+        "derived_id_field": "change_id"
+      },
+      "owner": "facts/state_changes",
+      "semantics": "Structured observed mutation kept separate from tool intent and success.",
+      "vector_ids": ["identity.state_change", "field.state_change"],
+      "fields": [
+        {"name": "change_id", "semantics": "Versioned observed-change identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.state_change"]},
+        {"name": "change_kind", "semantics": "Structured mutation kind.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.state_change"]},
+        {"name": "resource_id", "semantics": "Affected normalized resource.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.state_change"]},
+        {"name": "observation_at_us", "semantics": "Time the mutation was structurally observed.", "identity_participation": "included", "missing": "null_without_upstream_time", "basis": "adapter_exact", "vector_ids": ["field.state_change"]},
+        {"name": "session_id", "semantics": "Containing session.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.state_change"]},
+        {"name": "turn_id", "semantics": "Containing turn or phase.", "identity_participation": "included", "missing": "null_when_unresolved", "basis": "adapter_exact", "vector_ids": ["field.state_change"]},
+        {"name": "before_revision", "semantics": "Technical resource revision before mutation.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.state_change"]},
+        {"name": "after_revision", "semantics": "Technical resource revision after mutation.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.state_change"]},
+        {"name": "causal_attribution", "semantics": "Always false for canonical state-change facts.", "identity_participation": "excluded", "missing": "forbidden", "basis": "contract_constant", "vector_ids": ["field.state_change"]},
+        {"name": "evidence_coordinates", "semantics": "Structural mutation occurrence evidence.", "identity_participation": "excluded", "missing": "forbidden", "basis": "occurrence_exact", "vector_ids": ["field.state_change"]}
+      ]
+    },
+    {
+      "id": "context_component",
+      "identity": {
+        "kind": "context-component",
+        "input_fields": ["call_id", "turn_id", "category"],
+        "derived_id_field": "component_id"
+      },
+      "owner": "capabilities/context",
+      "semantics": "Optional structural context category measurement without persisted raw body.",
+      "vector_ids": ["identity.context_component", "field.context_component"],
+      "fields": [
+        {"name": "component_id", "semantics": "Versioned component observation identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.context_component"]},
+        {"name": "call_id", "semantics": "Related call when known included.", "identity_participation": "included", "missing": "null_when_inclusion_unknown", "basis": "adapter_exact", "vector_ids": ["field.context_component"]},
+        {"name": "turn_id", "semantics": "Containing turn.", "identity_participation": "included", "missing": "null_when_unresolved", "basis": "adapter_exact", "vector_ids": ["field.context_component"]},
+        {"name": "category", "semantics": "Structural context category.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.context_component"]},
+        {"name": "observed_utf8_bytes", "semantics": "Observed structural byte count.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.context_component"]},
+        {"name": "event_count", "semantics": "Observed structural event count.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.context_component"]},
+        {"name": "estimated_tokens", "semantics": "Optional estimator output.", "identity_participation": "excluded", "missing": "null_without_named_estimator", "basis": "configured_estimate", "vector_ids": ["field.context_component"]},
+        {"name": "inclusion_basis", "semantics": "Observed, selected, known included, or inclusion unknown.", "identity_participation": "excluded", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.context_component"]}
+      ]
+    },
+    {
+      "id": "allowance_limit",
+      "identity": {
+        "kind": "allowance-limit",
+        "input_fields": ["provider", "account_local_identity", "plan_identity", "window_kind"],
+        "derived_id_field": "limit_id"
+      },
+      "owner": "allowance",
+      "semantics": "Provider/account-local allowance window identity and capability basis.",
+      "vector_ids": ["identity.allowance_limit", "field.allowance_limit"],
+      "fields": [
+        {"name": "limit_id", "semantics": "Versioned allowance-limit identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_limit"]},
+        {"name": "provider", "semantics": "Observed allowance provider.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.allowance_limit"]},
+        {"name": "account_local_identity", "semantics": "Opaque local account identity when exposed.", "identity_participation": "included", "missing": "explicit_unknown_account", "basis": "adapter_exact", "vector_ids": ["field.allowance_limit"]},
+        {"name": "plan_identity", "semantics": "Observed plan identity.", "identity_participation": "included", "missing": "explicit_unknown_plan", "basis": "adapter_exact", "vector_ids": ["field.allowance_limit"]},
+        {"name": "window_kind", "semantics": "Provider allowance-window kind.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.allowance_limit"]},
+        {"name": "configured_duration_us", "semantics": "Observed or configured window duration.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "configured_estimate", "vector_ids": ["field.allowance_limit"]},
+        {"name": "capability_basis", "semantics": "Adapter basis for available allowance fields.", "identity_participation": "excluded", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.allowance_limit"]}
+      ]
+    },
+    {
+      "id": "allowance_cycle",
+      "identity": {
+        "kind": "allowance-cycle",
+        "input_fields": ["limit_id", "reset_identity", "start_at_us", "end_at_us"],
+        "derived_id_field": "cycle_id"
+      },
+      "owner": "allowance",
+      "semantics": "Stable reset-bounded allowance cycle.",
+      "vector_ids": ["identity.allowance_cycle", "field.allowance_cycle"],
+      "fields": [
+        {"name": "cycle_id", "semantics": "Versioned allowance-cycle identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "limit_id", "semantics": "Owning allowance limit.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "reset_identity", "semantics": "Provider reset identity or deterministic boundary tuple.", "identity_participation": "included", "missing": "explicit_unknown_reset", "basis": "adapter_exact", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "start_at_us", "semantics": "Cycle start UTC microseconds.", "identity_participation": "included", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "end_at_us", "semantics": "Cycle end UTC microseconds.", "identity_participation": "included", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "reset_basis", "semantics": "Observed or deterministic reset-boundary basis.", "identity_participation": "excluded", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.allowance_cycle"]},
+        {"name": "completion_status", "semantics": "Whether both reset boundaries are established.", "identity_participation": "excluded", "missing": "open_when_end_unobserved", "basis": "deterministic", "vector_ids": ["field.allowance_cycle"]}
+      ]
+    },
+    {
+      "id": "allowance_observation",
+      "identity": {
+        "kind": "allowance-observation",
+        "input_fields": ["limit_id", "cycle_id", "observed_at_us", "source_occurrence"],
+        "derived_id_field": "observation_id"
+      },
+      "owner": "allowance",
+      "semantics": "Every exact provider observation, including repeated identical values.",
+      "vector_ids": ["identity.allowance_observation", "field.allowance_observation"],
+      "fields": [
+        {"name": "observation_id", "semantics": "Versioned observation identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_observation"]},
+        {"name": "limit_id", "semantics": "Owning compatible allowance limit.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_observation"]},
+        {"name": "cycle_id", "semantics": "Owning reset cycle.", "identity_participation": "included", "missing": "explicit_unknown_cycle", "basis": "identity_v1", "vector_ids": ["field.allowance_observation"]},
+        {"name": "observed_at_us", "semantics": "Exact observation UTC microseconds.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "used_percent", "semantics": "Canonical decimal-string used percentage.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "remaining_percent", "semantics": "Canonical decimal-string remaining percentage.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "absolute_fields", "semantics": "Provider absolute allowance measurements when exposed.", "identity_participation": "excluded", "missing": "empty_collection_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "reset_time_us", "semantics": "Observed next reset instant.", "identity_participation": "excluded", "missing": "null_when_unobserved", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "plan_identity", "semantics": "Plan observed with this measurement.", "identity_participation": "excluded", "missing": "explicit_unknown_plan", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "source_occurrence", "semantics": "Exact structural source coordinate.", "identity_participation": "included", "missing": "forbidden", "basis": "occurrence_exact", "vector_ids": ["field.allowance_observation"]},
+        {"name": "measurement_mask", "semantics": "Availability of used, remaining, reset, and absolute fields.", "identity_participation": "excluded", "missing": "zero_mask_means_none_observed", "basis": "adapter_exact", "vector_ids": ["field.allowance_observation"]}
+      ]
+    },
+    {
+      "id": "allowance_interval",
+      "identity": {
+        "kind": "allowance-interval",
+        "input_fields": ["start_observation_id", "end_observation_id"],
+        "derived_id_field": "interval_id"
+      },
+      "owner": "allowance",
+      "semantics": "Deterministic relation between adjacent compatible observations.",
+      "vector_ids": ["identity.allowance_interval", "field.allowance_interval"],
+      "fields": [
+        {"name": "interval_id", "semantics": "Identity of ordered boundary observation pair.", "identity_participation": "excluded", "missing": "forbidden_for_compatible_pair", "basis": "identity_v1", "vector_ids": ["field.allowance_interval"]},
+        {"name": "start_observation_id", "semantics": "Inclusive observation boundary selector.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_interval"]},
+        {"name": "end_observation_id", "semantics": "Exclusive observation boundary selector.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.allowance_interval"]},
+        {"name": "event_bounds", "semantics": "Half-open event interval between observations.", "identity_participation": "excluded", "missing": "forbidden", "basis": "deterministic", "vector_ids": ["field.allowance_interval"]},
+        {"name": "percent_delta", "semantics": "Used increase or remaining decrease as canonical decimal string.", "identity_participation": "excluded", "missing": "null_when_compatible_values_are_unavailable", "basis": "deterministic", "vector_ids": ["field.allowance_interval"]},
+        {"name": "compatibility_basis", "semantics": "Exact joined match of provider, limit_id, plan_identity, window_kind, cycle_id, and reset_identity.", "identity_participation": "excluded", "missing": "no_interval_when_incompatible", "basis": "deterministic", "vector_ids": ["field.allowance_interval"]},
+        {"name": "ratio_eligible", "semantics": "True only for a positive compatible percentage delta.", "identity_participation": "excluded", "missing": "false_for_zero_negative_or_missing_delta", "basis": "deterministic", "vector_ids": ["field.allowance_interval"]},
+        {"name": "coverage", "semantics": "Local fact coverage inside the half-open bounds.", "identity_participation": "excluded", "missing": "null_when_history_is_incomplete", "basis": "publication_exact", "vector_ids": ["field.allowance_interval"]}
+      ]
+    },
+    {
+      "id": "rate_card_revision",
+      "identity": {
+        "kind": "rate-card",
+        "input_fields": ["digest"],
+        "derived_id_field": "rate_card_id"
+      },
+      "owner": "valuation",
+      "semantics": "Immutable configured pricing and credit provenance applied at query time.",
+      "vector_ids": ["identity.rate_card_revision", "field.rate_card_revision"],
+      "fields": [
+        {"name": "rate_card_id", "semantics": "Versioned rate-card identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "digest", "semantics": "Digest of normalized rate-card content.", "identity_participation": "included", "missing": "forbidden", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "source_name", "semantics": "Human-readable pricing source name.", "identity_participation": "excluded", "missing": "null_when_unnamed", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "source_url", "semantics": "Configured source URL when applicable.", "identity_participation": "excluded", "missing": "null_when_local_or_unknown", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "effective_at_us", "semantics": "Configured rate effective time.", "identity_participation": "excluded", "missing": "null_when_unstated", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "fetched_at_us", "semantics": "Time source material was obtained.", "identity_participation": "excluded", "missing": "null_when_unstated", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "currency", "semantics": "Configured valuation currency.", "identity_participation": "excluded", "missing": "forbidden_for_cost_rates", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "model_match_rules", "semantics": "Versioned exact or alias match rules.", "identity_participation": "excluded", "missing": "empty_rules_match_nothing", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "four_class_rates", "semantics": "Per-million decimal-string rates for independent token classes.", "identity_participation": "excluded", "missing": "null_per_unpriced_class", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "credit_rates", "semantics": "Per-million decimal-string credit estimates.", "identity_participation": "excluded", "missing": "null_per_unpriced_class", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "reasoning_in_output", "semantics": "Provider/rate-card provenance declaring reasoning already included in output accounting.", "identity_participation": "excluded", "missing": "forbidden_when_reasoning_or_output_rates_are_configured", "basis": "provider_or_rate_card_provenance", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "confidence", "semantics": "Configured source confidence.", "identity_participation": "excluded", "missing": "null_when_unstated", "basis": "configured_exact", "vector_ids": ["field.rate_card_revision"]},
+        {"name": "validation_status", "semantics": "Contract validation outcome for this revision.", "identity_participation": "excluded", "missing": "forbidden", "basis": "deterministic", "vector_ids": ["field.rate_card_revision"]}
+      ]
+    },
+    {
+      "id": "valuation_match",
+      "identity": {
+        "kind": "valuation",
+        "input_fields": ["call_id", "rate_card_digest"],
+        "derived_id_field": "valuation_id"
+      },
+      "owner": "valuation",
+      "semantics": "Current configured estimate for one call and selected rate-card revision.",
+      "vector_ids": ["identity.valuation_match", "field.valuation_match"],
+      "fields": [
+        {"name": "valuation_id", "semantics": "Identity of call and selected rate-card revision.", "identity_participation": "excluded", "missing": "forbidden_when_match_attempted", "basis": "identity_v1", "vector_ids": ["field.valuation_match"]},
+        {"name": "call_id", "semantics": "Canonical call being valued.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.valuation_match"]},
+        {"name": "rate_card_digest", "semantics": "Selected immutable rate-card revision.", "identity_participation": "included", "missing": "forbidden", "basis": "configured_exact", "vector_ids": ["field.valuation_match"]},
+        {"name": "match_basis", "semantics": "Exact, alias, or no-match basis.", "identity_participation": "excluded", "missing": "forbidden", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "configured_cost_usd", "semantics": "Current configured cost estimate.", "identity_participation": "excluded", "missing": "null_when_no_token_class_is_rated", "basis": "configured_estimate", "vector_ids": ["field.valuation_match"]},
+        {"name": "estimated_credits", "semantics": "Current configured credit estimate.", "identity_participation": "excluded", "missing": "null_when_no_credit_rate_is_applied", "basis": "configured_estimate", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_rated_token_fields", "semantics": "Observed token classes with independently applied cost rates.", "identity_participation": "excluded", "missing": "empty_collection_when_no_cost_rate_applies", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_rated_token_fields", "semantics": "Observed token classes with independently applied credit rates.", "identity_participation": "excluded", "missing": "empty_collection_when_no_credit_rate_applies", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_unpriced_token_fields", "semantics": "Observed eligible token classes without a cost rate.", "identity_participation": "excluded", "missing": "empty_collection_when_all_observed_classes_are_cost_rated", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_unpriced_token_fields", "semantics": "Observed eligible token classes without a credit rate.", "identity_participation": "excluded", "missing": "empty_collection_when_all_observed_classes_are_credit_rated", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "missing_token_fields", "semantics": "Eligible token classes whose measurements are absent.", "identity_participation": "excluded", "missing": "empty_collection_when_all_eligible_classes_are_observed", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_coverage_numerator_tokens", "semantics": "Observed tokens with an applied cost rate.", "identity_participation": "excluded", "missing": "zero_when_observed_but_cost_unpriced", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_coverage_denominator_tokens", "semantics": "Observed eligible tokens for cost coverage.", "identity_participation": "excluded", "missing": "zero_when_no_eligible_tokens_are_observed", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_coverage", "semantics": "Cost-rated token coverage ratio as canonical decimal.", "identity_participation": "excluded", "missing": "null_when_denominator_is_zero", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_coverage_numerator_tokens", "semantics": "Observed tokens with an applied credit rate.", "identity_participation": "excluded", "missing": "zero_when_observed_but_credit_unpriced", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_coverage_denominator_tokens", "semantics": "Observed eligible tokens for credit coverage.", "identity_participation": "excluded", "missing": "zero_when_no_eligible_tokens_are_observed", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_coverage", "semantics": "Credit-rated token coverage ratio as canonical decimal.", "identity_participation": "excluded", "missing": "null_when_denominator_is_zero", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_unpriced_reason", "semantics": "Structured reason for absent or partial cost valuation.", "identity_participation": "excluded", "missing": "null_when_cost_is_fully_priced", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_unpriced_reason", "semantics": "Structured reason for absent or partial credit valuation.", "identity_participation": "excluded", "missing": "null_when_credits_are_fully_priced", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "cost_grade", "semantics": "Configured-estimate or unsupported result grade for cost.", "identity_participation": "excluded", "missing": "unsupported_when_no_cost_rate_applies", "basis": "deterministic", "vector_ids": ["field.valuation_match"]},
+        {"name": "credit_grade", "semantics": "Configured-estimate or unsupported result grade for credits.", "identity_participation": "excluded", "missing": "unsupported_when_no_credit_rate_applies", "basis": "deterministic", "vector_ids": ["field.valuation_match"]}
+      ]
+    },
+    {
+      "id": "publication",
+      "identity": {
+        "kind": "publication",
+        "input_fields": ["publication_key"],
+        "derived_id_field": "publication_id"
+      },
+      "owner": "publication",
+      "semantics": "Only committed queryable truth identity with facts, projections, coverage, and selectors from one snapshot.",
+      "vector_ids": ["identity.publication", "field.publication"],
+      "fields": [
+        {"name": "publication_key", "semantics": "Immutable host-allocated publication-attempt key assigned before artifact assembly.", "identity_participation": "included", "missing": "forbidden", "basis": "host_exact", "vector_ids": ["field.publication"]},
+        {"name": "publication_id", "semantics": "Opaque versioned publication identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.publication"]},
+        {"name": "parent_publication_id", "semantics": "Immediate accepted predecessor.", "identity_participation": "excluded", "missing": "null_for_initial_publication", "basis": "publication_exact", "vector_ids": ["field.publication"]},
+        {"name": "schema_versions", "semantics": "Schema, adapter, identity, derivation, projection, and rate-card versions.", "identity_participation": "excluded", "missing": "forbidden", "basis": "contract_exact", "vector_ids": ["field.publication"]},
+        {"name": "committed_at_us", "semantics": "Commit instant for the truth unit.", "identity_participation": "excluded", "missing": "forbidden_when_committed", "basis": "host_exact", "vector_ids": ["field.publication"]},
+        {"name": "observed_through_us", "semantics": "Latest observed event instant in selected sources.", "identity_participation": "excluded", "missing": "null_when_all_event_times_missing", "basis": "deterministic_max", "vector_ids": ["field.publication"]},
+        {"name": "history_preset", "semantics": "Selected initial or expanded history policy.", "identity_participation": "excluded", "missing": "forbidden", "basis": "planner_exact", "vector_ids": ["field.publication"]},
+        {"name": "requested_cutoff_us", "semantics": "Requested history cutoff.", "identity_participation": "excluded", "missing": "null_for_all_time", "basis": "planner_exact", "vector_ids": ["field.publication"]},
+        {"name": "indexed_from_us", "semantics": "Earliest indexed event time.", "identity_participation": "excluded", "missing": "null_when_no_timed_events", "basis": "deterministic_min", "vector_ids": ["field.publication"]},
+        {"name": "indexed_through_us", "semantics": "Latest indexed event time.", "identity_participation": "excluded", "missing": "null_when_no_timed_events", "basis": "deterministic_max", "vector_ids": ["field.publication"]},
+        {"name": "guaranteed_complete_from_us", "semantics": "Earliest time after which inventory proves selection completeness.", "identity_participation": "excluded", "missing": "null_when_inventory_cannot_guarantee_completeness", "basis": "inventory_exact", "vector_ids": ["field.publication"]},
+        {"name": "source_coverage", "semantics": "Selected, deferred, uncertain, malformed, and missing source counts and bytes.", "identity_participation": "excluded", "missing": "forbidden", "basis": "inventory_exact", "vector_ids": ["field.publication"]},
+        {"name": "capability_coverage", "semantics": "Capabilities and measurement availability in this truth unit.", "identity_participation": "excluded", "missing": "forbidden", "basis": "deterministic", "vector_ids": ["field.publication"]},
+        {"name": "entity_counts", "semantics": "Canonical entity counts by kind.", "identity_participation": "excluded", "missing": "zero_is_observed_empty_kind", "basis": "canonical_exact", "vector_ids": ["field.publication"]},
+        {"name": "publication_delta", "semantics": "Accepted mutation summary from parent.", "identity_participation": "excluded", "missing": "null_for_initial_publication", "basis": "deterministic", "vector_ids": ["field.publication"]},
+        {"name": "artifact_digest", "semantics": "Digest of the complete committed truth artifact.", "identity_participation": "excluded", "missing": "forbidden", "basis": "host_exact", "vector_ids": ["field.publication"]},
+        {"name": "status", "semantics": "Committed or rolled-back publication state.", "identity_participation": "excluded", "missing": "forbidden", "basis": "host_exact", "vector_ids": ["field.publication"]}
+      ]
+    },
+    {
+      "id": "publication_delta",
+      "identity": {
+        "kind": "publication-delta",
+        "input_fields": ["delta_key"],
+        "derived_id_field": "delta_id"
+      },
+      "owner": "publication",
+      "semantics": "Accepted mutation summary between a publication and its parent without calling recanonicalization new activity.",
+      "vector_ids": ["identity.publication_delta", "field.publication_delta"],
+      "fields": [
+        {"name": "delta_key", "semantics": "Immutable host-allocated delta computation key.", "identity_participation": "included", "missing": "forbidden", "basis": "host_exact", "vector_ids": ["field.publication_delta"]},
+        {"name": "delta_id", "semantics": "Identity of parent and child publication pair.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.publication_delta"]},
+        {"name": "publication_id", "semantics": "Child publication.", "identity_participation": "excluded", "missing": "forbidden", "basis": "publication_exact", "vector_ids": ["field.publication_delta"]},
+        {"name": "parent_publication_id", "semantics": "Compared parent publication.", "identity_participation": "excluded", "missing": "null_for_initial_publication", "basis": "publication_exact", "vector_ids": ["field.publication_delta"]},
+        {"name": "inserted_count", "semantics": "New semantic entities accepted.", "identity_participation": "excluded", "missing": "zero_is_observed_none", "basis": "deterministic", "vector_ids": ["field.publication_delta"]},
+        {"name": "corrected_count", "semantics": "Existing entities with accepted canonical corrections.", "identity_participation": "excluded", "missing": "zero_is_observed_none", "basis": "deterministic", "vector_ids": ["field.publication_delta"]},
+        {"name": "terminalized_count", "semantics": "Lifecycle entities newly reaching terminal state.", "identity_participation": "excluded", "missing": "zero_is_observed_none", "basis": "deterministic", "vector_ids": ["field.publication_delta"]},
+        {"name": "recanonicalized_count", "semantics": "Existing semantic owners recomputed after source replacement.", "identity_participation": "excluded", "missing": "zero_is_observed_none", "basis": "deterministic", "vector_ids": ["field.publication_delta"]},
+        {"name": "removed_count", "semantics": "Semantic entities no longer selected after accepted correction.", "identity_participation": "excluded", "missing": "zero_is_observed_none", "basis": "deterministic", "vector_ids": ["field.publication_delta"]},
+        {"name": "token_delta", "semantics": "Exact four-class token change by accepted mutation class.", "identity_participation": "excluded", "missing": "null_per_unavailable_token_class", "basis": "deterministic", "vector_ids": ["field.publication_delta"]}
+      ]
+    },
+    {
+      "id": "source_occurrence",
+      "identity": {
+        "kind": "occurrence",
+        "input_fields": ["semantic_logical_id", "source_manifestation_id", "source_revision", "record_byte_range", "record_ordinal", "adapter_version"],
+        "derived_id_field": "occurrence_id"
+      },
+      "owner": "evidence",
+      "semantics": "Physical provenance coordinate for one occurrence of a semantic entity.",
+      "vector_ids": ["identity.source_occurrence", "field.source_occurrence"],
+      "fields": [
+        {"name": "occurrence_id", "semantics": "Versioned coordinate identity.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source_occurrence"]},
+        {"name": "semantic_logical_id", "semantics": "Canonical entity evidenced by this occurrence.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source_occurrence"]},
+        {"name": "source_manifestation_id", "semantics": "Containing manifestation.", "identity_participation": "included", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.source_occurrence"]},
+        {"name": "source_revision", "semantics": "Revision containing the structural record.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.source_occurrence"]},
+        {"name": "record_byte_range", "semantics": "Half-open complete-record byte range when available.", "identity_participation": "included", "missing": "null_when_stable_ordinal_is_used", "basis": "adapter_exact", "vector_ids": ["field.source_occurrence"]},
+        {"name": "record_ordinal", "semantics": "Stable complete-record ordinal when available.", "identity_participation": "included", "missing": "null_when_byte_range_is_stable", "basis": "adapter_exact", "vector_ids": ["field.source_occurrence"]},
+        {"name": "adapter_version", "semantics": "Adapter needed to interpret the structural record.", "identity_participation": "included", "missing": "forbidden", "basis": "adapter_exact", "vector_ids": ["field.source_occurrence"]}
+      ]
+    },
+    {
+      "id": "query_window",
+      "identity": {
+        "kind": "window",
+        "input_fields": ["start_us", "end_us", "timezone"],
+        "derived_id_field": "window_id"
+      },
+      "owner": "evidence",
+      "semantics": "Stable half-open UTC query window derived once from an IANA calendar request.",
+      "vector_ids": ["identity.query_window", "field.query_window"],
+      "fields": [
+        {"name": "window_id", "semantics": "Versioned identity of normalized bounds and timezone basis.", "identity_participation": "excluded", "missing": "forbidden", "basis": "identity_v1", "vector_ids": ["field.query_window"]},
+        {"name": "start_us", "semantics": "Inclusive UTC microsecond boundary.", "identity_participation": "included", "missing": "forbidden", "basis": "calendar_conversion", "vector_ids": ["field.query_window"]},
+        {"name": "end_us", "semantics": "Exclusive UTC microsecond boundary.", "identity_participation": "included", "missing": "forbidden", "basis": "calendar_conversion", "vector_ids": ["field.query_window"]},
+        {"name": "timezone", "semantics": "IANA timezone used for calendar conversion.", "identity_participation": "included", "missing": "forbidden_for_calendar_window", "basis": "request_exact", "vector_ids": ["field.query_window"]},
+        {"name": "preset", "semantics": "Optional current-session, day, week, month, quarter, year, or all-time label.", "identity_participation": "excluded", "missing": "null_for_explicit_bounds", "basis": "request_exact", "vector_ids": ["field.query_window"]}
+      ]
+    }
+  ],
+  "decisions": [
+    {
+      "id": "CK02-D001",
+      "decision": "Logical IDs use exactly 52 lowercase unpadded base32 SHA-256 characters over restricted canonical-CBOR identity tuples, and publication identity is derived before its nonrecursive artifact digest.",
+      "rationale": "The exact wire grammar and ordered identity inputs make identities portable; deriving a publication from its allocated key before hashing the artifact breaks the publication-ID/artifact-digest cycle.",
+      "vector_ids": ["identity.collision", "identity.publication_artifact"]
+    },
+    {
+      "id": "CK02-D002",
+      "decision": "A NULL event time remains NULL, observed timestamp text accepts at most six fractional digits, and events sort by exact UTC microseconds then stable semantic tie-breakers.",
+      "rationale": "Rejecting submicrosecond source text avoids hidden rounding while preserving missingness and deterministic ordering without ingestion-time or sentinel substitutions.",
+      "vector_ids": ["time.epoch", "time.pre_epoch", "time.offset", "time.submicrosecond", "time.submicrosecond_zero", "time.total_order", "time.late_event", "time.missing_order"]
+    },
+    {
+      "id": "CK02-D003",
+      "decision": "Ambiguous IANA wall times require an explicit fold and nonexistent DST wall times fail closed.",
+      "rationale": "Calendar boundaries must convert once to exact UTC microseconds without silently selecting a DST interpretation.",
+      "vector_ids": ["time.dst_fold_0", "time.dst_fold_1", "time.dst_gap", "time.dst_ambiguous", "time.int64_boundaries"]
+    },
+    {
+      "id": "CK02-D004",
+      "decision": "Lifecycle transitions fold by semantic event order across publications; conflicting terminal states fail closed.",
+      "rationale": "Late observations must reach the same current state as in-order observations without allowing arrival order to overwrite terminal truth.",
+      "vector_ids": ["lifecycle.cross_publication", "lifecycle.late_transition", "lifecycle.invalid_terminal"]
+    },
+    {
+      "id": "CK02-D005",
+      "decision": "Hierarchy links are mutable relationships outside session identity and all three usage scopes reconcile from exclusive session facts.",
+      "rationale": "Late parent discovery must not change session or usage identity and family totals must not double-count descendants.",
+      "vector_ids": ["hierarchy.late_parent", "hierarchy.multilevel", "hierarchy.cycle"]
+    },
+    {
+      "id": "CK02-D006",
+      "decision": "Allowance joins require exact provider, limit_id, plan_identity, window_kind, cycle_id, and reset_identity compatibility; percentages and rates use canonical bounded decimal strings; interval events use [start,end).",
+      "rationale": "Joined-shape compatibility prevents cross-plan, cross-cycle, or cross-reset ratios, while canonical decimal domains and half-open bounds avoid binary drift and boundary double counting.",
+      "vector_ids": ["allowance.compatible_used", "allowance.compatible_remaining", "allowance.repeated", "allowance.negative", "allowance.reset_incompatible", "allowance.plan_incompatible", "allowance.cycle_incompatible", "allowance.time_decrease", "decimal.canonical", "decimal.noncanonical", "decimal.percentage_domain"]
+    },
+    {
+      "id": "CK02-D007",
+      "decision": "Configured cost and credit valuation are independent channels with separate rated fields, estimates, coverage, caveats, and reasoning-overlap controls.",
+      "rationale": "A cost rate does not imply a credit rate (or vice versa), and provider provenance must prevent reasoning/output overlap independently in each channel.",
+      "vector_ids": ["valuation.full", "valuation.partial", "valuation.unmatched", "valuation.cost_only", "valuation.credit_only", "valuation.asymmetric", "valuation.reasoning_overlap", "valuation.reasoning_credit_overlap", "valuation.negative_rate"]
+    },
+    {
+      "id": "CK02-D008",
+      "decision": "Selector registry IDs retain CK-01 underscore names while public selectors require real semantic IDs with exactly 52 lowercase unpadded base32 digest characters.",
+      "rationale": "The wire grammar remains stable and interoperable while rejecting shortened, uppercase, or padded digests that could alias distinct identities.",
+      "vector_ids": ["selector.session", "selector.state_change", "selector.source_manifestation", "selector.invalid_prefix", "selector.invalid_digest_length", "selector.invalid_digest_case", "selector.invalid_digest_padding", "selector.kind_mismatch", "selector.alias_same", "selector.alias_distinct"]
+    },
+    {
+      "id": "CK02-D009",
+      "decision": "Only a committed publication may answer a query and every returned row must name that same publication identity.",
+      "rationale": "Facts, coverage, valuation, and selectors must be read from one truth snapshot.",
+      "vector_ids": ["publication.committed_snapshot", "publication.mixed_snapshot", "publication.rolled_back"]
+    },
+    {
+      "id": "CK02-D010",
+      "decision": "Observed zero, missing NULL, measurement availability, grade, and basis remain mechanically distinct; canonical missing measurements reject result-only grades.",
+      "rationale": "Canonical facts cannot fabricate observations or carry unsupported/model-inference grades that are meaningful only in result envelopes.",
+      "vector_ids": ["accounting.four_tokens", "accounting.missing_cached", "accounting.zero_tokens", "accounting.invalid_negative", "accounting.aggregate_partial", "accounting.aggregate_all_missing", "accounting.measurement_mask", "accounting.measurement_missing", "accounting.measurement_grade", "accounting.measurement_result_grade", "accounting.tool_separation"]
+    },
+    {
+      "id": "CK02-D011",
+      "decision": "Duplicate source occurrences preserve every coordinate while one semantic identity is counted once.",
+      "rationale": "Copied, archived, and replacement manifestations are evidence, not additional user activity.",
+      "vector_ids": ["identity.source_copy", "selector.rebuild_stable"]
+    },
+    {
+      "id": "CK02-D012",
+      "decision": "Every admitted entity field is consumed by one checked-in synthetic record and an executable per-field assertion covering basis, missingness, identity participation, and field semantics.",
+      "rationale": "Traceability tags alone cannot prove the field contract; regenerating and executing the complete matrix makes added or changed fields fail unless their semantics are maintained.",
+      "vector_ids": ["field.adapter_identity", "field.source", "field.source_manifestation", "field.project", "field.session", "field.turn", "field.point_event", "field.lifecycle_entity", "field.model_profile", "field.canonical_call", "field.tool_invocation", "field.activity", "field.compaction_boundary", "field.resource", "field.state_change", "field.context_component", "field.allowance_limit", "field.allowance_cycle", "field.allowance_observation", "field.allowance_interval", "field.rate_card_revision", "field.valuation_match", "field.publication", "field.publication_delta", "field.source_occurrence", "field.query_window"]
+    }
+  ]
+}

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -7,10 +7,10 @@ in the linked files under [`docs/roadmap/tasks/`](tasks/).
 
 ## Overall
 
-- Completed packets: **2 / 17**
+- Completed packets: **3 / 17**
 - In progress: **None**
-- Not started: **15**
-- Critical-path completion: **2 / 16**
+- Not started: **14**
+- Critical-path completion: **3 / 16**
 - Optional packets: **CK-15**
 
 A packet may be checked only after its acceptance criteria and required checks
@@ -21,8 +21,8 @@ line and the milestone accounting below.
 ## Milestones
 
 - [x] **M0 — Authority Ready** · 1 / 1 · CK-00 complete
-- [ ] **M1 — Architecture Selected** · 1 / 4 · CK-01 complete; CK-02–CK-04
-  not started
+- [ ] **M1 — Architecture Selected** · 2 / 4 · CK-01–CK-02 complete;
+  CK-03–CK-04 not started
 - [ ] **M2 — Kernel Alpha** · 0 / 5 · CK-05–CK-09 not started
 - [ ] **M3 — Codex MVP Qualified** · 0 / 3 · CK-10–CK-12 not started
 - [ ] **M4 — Clean Cutover** · 0 / 2 · CK-13–CK-14 not started
@@ -42,7 +42,7 @@ line and the milestone accounting below.
 - [x] **CK-01 — Make the question catalog executable** · **Completed** ·
   depends on CK-00
   · [packet](tasks/ck-01-make-question-catalog-executable.md)
-- [ ] **CK-02 — Freeze logical contract vectors** · Not started ·
+- [x] **CK-02 — Freeze logical contract vectors** · **Completed** ·
   depends on CK-01
   · [packet](tasks/ck-02-freeze-logical-contract-vectors.md)
 - [ ] **CK-03 — Build synthetic fixtures and oracles** · Not started ·

--- a/docs/roadmap/tasks/ck-02-freeze-logical-contract-vectors.md
+++ b/docs/roadmap/tasks/ck-02-freeze-logical-contract-vectors.md
@@ -1,6 +1,6 @@
 # CK-02 — Freeze logical contract vectors
 
-**Status:** Not started
+**Status:** Completed
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
@@ -47,5 +47,44 @@ primitive resolves.
 Breaking a locked decision requires a documented decision amendment.
 
 **Cleanup/docs:** Update logical contract and question mappings together.
+
+## Completion evidence
+
+- The physical-independent contract freezes **26 logical entities**, one
+  ordered exact identity tuple per entity, and **245 admitted fields**. A
+  checked-in synthetic field matrix executes one semantic assertion for every
+  field, including basis, missingness, identity participation, ordered
+  identity-input consumption, and derived-ID validation.
+- The versioned bundle contains **119 unique vectors** in **146,658 bytes**.
+  Its canonical bundle digest is
+  `f310f9e6dc6e65e8f1944a347b6d3bfbf18fe68f2f8ddcf9eb0d1c81e9396848`.
+  Logical IDs use exactly 52 lowercase unpadded base32 digest characters.
+- Exact vectors lock nonrecursive publication-ID/artifact-digest derivation,
+  zero-to-six-digit timestamp precision, canonical decimal domains,
+  result-only grade rejection in canonical missing measurements, joined
+  allowance compatibility, and independent cost/credit valuation coverage.
+- Focused qualification passed with **37 tests in 0.67 seconds**. Final
+  repository qualification passed with **497 tests in 68.58 seconds**, Ruff,
+  MyPy, Pyright, scope/manifests/interfaces, frontend checks,
+  maintainability, release safety, and `git diff --check`.
+- Final review produced **9 findings; 9 were accepted and resolved**.
+  Reviewer-token attribution is **pending** because the required strict usage
+  command is unavailable; tokens per accepted finding remain pending rather
+  than triggering retries.
+
+### Deviations and residual risks
+
+- No production database, parser, query, MCP, or presentation code was added.
+  The packet uses pure reference functions and synthetic fixtures exactly as
+  scoped.
+- The field matrix replaces tag-only completeness as the executable gate.
+  Existing `vector_ids` remain as traceability metadata, but contract
+  completeness now regenerates and executes the exact matrix.
+- Physical implementations in CK-03 onward must prove they reproduce these
+  vectors. Adapter-specific source keys, provider rate-card contents, and
+  real publication storage remain intentionally unresolved here.
+- Independent cost and credit estimates are configured estimates, never
+  observed billing truth. Unsupported channels remain null with explicit
+  grades and reasons.
 
 **Suggested commit:** `test: freeze agent-kernel logical vectors`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ files = [
   "scripts/smoke_installed_package.py",
   "src/codex_usage_tracker/release/artifact_manifest.py",
   "src/codex_usage_tracker/kernel",
+  "tests/agent_kernel/contracts/reference",
 ]
 
 [tool.pyright]
@@ -118,6 +119,7 @@ include = [
   "scripts/smoke_installed_console.py",
   "scripts/smoke_installed_catalog.py",
   "src/codex_usage_tracker/kernel",
+  "tests/agent_kernel/contracts/reference",
 ]
 pythonVersion = "3.10"
 typeCheckingMode = "standard"

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -296,6 +296,34 @@ CK01_AGENT_KERNEL_CONTRACT_ADDITIONS = frozenset(
     }
 )
 
+CK02_LOGICAL_CONTRACT_ADDITIONS = frozenset(
+    {
+        "config/agent-kernel/logical-contract-v1.json",
+        "tests/agent_kernel/contracts/reference/__init__.py",
+        "tests/agent_kernel/contracts/reference/accounting.py",
+        "tests/agent_kernel/contracts/reference/allowance.py",
+        "tests/agent_kernel/contracts/reference/contract.py",
+        "tests/agent_kernel/contracts/reference/field_contract.py",
+        "tests/agent_kernel/contracts/reference/identity.py",
+        "tests/agent_kernel/contracts/reference/lifecycle.py",
+        "tests/agent_kernel/contracts/reference/selectors.py",
+        "tests/agent_kernel/contracts/reference/time.py",
+        "tests/agent_kernel/contracts/test_accounting_vectors.py",
+        "tests/agent_kernel/contracts/test_allowance_vectors.py",
+        "tests/agent_kernel/contracts/test_identity_vectors.py",
+        "tests/agent_kernel/contracts/test_lifecycle_vectors.py",
+        "tests/agent_kernel/contracts/test_selector_vectors.py",
+        "tests/agent_kernel/contracts/test_time_vectors.py",
+        "tests/agent_kernel/contracts/vectors/accounting-v1.json",
+        "tests/agent_kernel/contracts/vectors/allowance-v1.json",
+        "tests/agent_kernel/contracts/vectors/field-contract-v1.json",
+        "tests/agent_kernel/contracts/vectors/identity-v1.json",
+        "tests/agent_kernel/contracts/vectors/lifecycle-v1.json",
+        "tests/agent_kernel/contracts/vectors/selector-v1.json",
+        "tests/agent_kernel/contracts/vectors/time-v1.json",
+    }
+)
+
 INTEGRATION_ADDITIONS = (
     K1A_ADDITIONS
     | K2_ADDITIONS
@@ -319,6 +347,7 @@ INTEGRATION_ADDITIONS = (
     | R4_ADDITIONS
     | R5_ADDITIONS
     | CK01_AGENT_KERNEL_CONTRACT_ADDITIONS
+    | CK02_LOGICAL_CONTRACT_ADDITIONS
 )
 _BLOCKED_TASK_REF = re.compile(r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))")
 

--- a/tests/agent_kernel/contracts/reference/__init__.py
+++ b/tests/agent_kernel/contracts/reference/__init__.py
@@ -1,0 +1,1 @@
+"""Pure, physical-independent reference functions for CK-02 vectors."""

--- a/tests/agent_kernel/contracts/reference/accounting.py
+++ b/tests/agent_kernel/contracts/reference/accounting.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+_TOKEN_FIELDS = (
+    "uncached_input_tokens",
+    "cached_input_tokens",
+    "reasoning_tokens",
+    "output_tokens",
+)
+_CANONICAL_GRADES = frozenset({"exact", "deterministic", "configured_estimate"})
+_RESULT_ONLY_GRADES = frozenset({"model_inference", "unsupported"})
+
+
+class AccountingContractError(ValueError):
+    """Raised when accounting would lose missingness or double-count usage."""
+
+
+def _optional_nonnegative_int(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise AccountingContractError(f"{field} must be a nonnegative integer or null")
+    return value
+
+
+def token_totals(tokens: dict[str, Any]) -> dict[str, int | None]:
+    """Derive default totals while keeping reasoning outside billed total."""
+
+    unknown = set(tokens) - set(_TOKEN_FIELDS)
+    if unknown:
+        raise AccountingContractError(f"unknown token fields: {sorted(unknown)}")
+    normalized = {
+        field: _optional_nonnegative_int(tokens.get(field), field)
+        for field in _TOKEN_FIELDS
+    }
+    uncached = normalized["uncached_input_tokens"]
+    cached = normalized["cached_input_tokens"]
+    output = normalized["output_tokens"]
+    input_tokens = None if uncached is None or cached is None else uncached + cached
+    total_tokens = None if input_tokens is None or output is None else input_tokens + output
+    return {
+        **normalized,
+        "input_tokens": input_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def aggregate_measurement(values: Iterable[int | None]) -> dict[str, Any]:
+    """Sum observed values and expose missing coverage instead of imputing zero."""
+
+    selected = list(values)
+    observed: list[int] = []
+    for value in selected:
+        if value is None:
+            continue
+        normalized = _optional_nonnegative_int(value, "aggregate value")
+        if normalized is not None:
+            observed.append(normalized)
+    missing_count = len(selected) - len(observed)
+    return {
+        "value": sum(observed) if observed else None,
+        "observed_count": len(observed),
+        "missing_count": missing_count,
+        "complete": missing_count == 0,
+    }
+
+
+def measurement_mask(
+    available: Iterable[str],
+    bit_positions: dict[str, int],
+) -> int:
+    """Encode the versioned measurement-availability mask."""
+
+    mask = 0
+    for measurement in available:
+        if measurement not in bit_positions:
+            raise AccountingContractError(f"unknown measurement bit: {measurement}")
+        mask |= 1 << bit_positions[measurement]
+    return mask
+
+
+def validate_measurement_record(
+    record: dict[str, dict[str, Any]],
+    *,
+    mask: int,
+    bit_positions: dict[str, int],
+) -> None:
+    """Validate value/mask/grade/basis consistency for canonical measurements."""
+
+    for measurement, details in record.items():
+        if measurement not in bit_positions:
+            raise AccountingContractError(f"unknown measurement: {measurement}")
+        available = bool(mask & (1 << bit_positions[measurement]))
+        value = details.get("value")
+        grade = details.get("grade")
+        basis = details.get("basis")
+        if grade in _RESULT_ONLY_GRADES:
+            raise AccountingContractError(
+                "canonical measurement has a result-only grade"
+            )
+        if value is None:
+            if available:
+                raise AccountingContractError("missing measurement has availability bit")
+            if grade is not None:
+                raise AccountingContractError("missing measurement has a value grade")
+            if basis not in {"unavailable", "unobserved", "inapplicable", "invalid"}:
+                raise AccountingContractError("missing measurement lacks missing basis")
+            continue
+        if not available:
+            raise AccountingContractError("observed measurement lacks availability bit")
+        if grade not in _CANONICAL_GRADES:
+            raise AccountingContractError("canonical measurement has invalid grade")
+        if not isinstance(basis, str) or basis in {
+            "",
+            "unavailable",
+            "unobserved",
+            "inapplicable",
+            "invalid",
+        }:
+            raise AccountingContractError("observed measurement lacks exact basis")
+
+
+def tool_outcome_counts(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Count intent, lifecycle success, and mutation as independent facts."""
+
+    mutation_ids = {
+        record["state_change_id"]
+        for record in records
+        if record.get("state_change_id") is not None
+    }
+    return {
+        "invocations": len(records),
+        "write_intents": sum(bool(record.get("write_intent")) for record in records),
+        "succeeded": sum(
+            record.get("lifecycle_state") == "succeeded" for record in records
+        ),
+        "observed_mutations": len(mutation_ids),
+        "causal_attribution": False,
+    }

--- a/tests/agent_kernel/contracts/reference/allowance.py
+++ b/tests/agent_kernel/contracts/reference/allowance.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+_TOKEN_FIELDS = (
+    "uncached_input_tokens",
+    "cached_input_tokens",
+    "reasoning_tokens",
+    "output_tokens",
+)
+_COMPATIBILITY_FIELDS = (
+    "provider",
+    "limit_id",
+    "plan_identity",
+    "window_kind",
+    "cycle_id",
+    "reset_identity",
+)
+
+
+class AllowanceContractError(ValueError):
+    """Raised when allowance or valuation facts are logically incompatible."""
+
+
+def _decimal_text(value: Decimal) -> str:
+    if value == 0:
+        return "0"
+    text = format(value.normalize(), "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+def _decimal(
+    value: Any,
+    field: str,
+    *,
+    minimum: Decimal | None = None,
+    maximum: Decimal | None = None,
+) -> Decimal | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AllowanceContractError(f"{field} must be a canonical decimal string")
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise AllowanceContractError(f"{field} is not a decimal") from exc
+    if not parsed.is_finite():
+        raise AllowanceContractError(f"{field} must be finite")
+    if value != _decimal_text(parsed):
+        raise AllowanceContractError(f"{field} is not a canonical decimal string")
+    if minimum is not None and parsed < minimum:
+        raise AllowanceContractError(f"{field} is below its allowed domain")
+    if maximum is not None and parsed > maximum:
+        raise AllowanceContractError(f"{field} is above its allowed domain")
+    return parsed
+
+
+def canonical_decimal(
+    value: Any,
+    field: str,
+    *,
+    minimum: str | None = None,
+    maximum: str | None = None,
+) -> str | None:
+    """Validate and round-trip one canonical finite decimal string."""
+
+    parsed = _decimal(
+        value,
+        field,
+        minimum=None if minimum is None else Decimal(minimum),
+        maximum=None if maximum is None else Decimal(maximum),
+    )
+    return None if parsed is None else _decimal_text(parsed)
+
+
+def allowance_interval(
+    start: dict[str, Any],
+    end: dict[str, Any],
+) -> dict[str, Any]:
+    """Relate adjacent compatible observations with half-open event bounds."""
+
+    incompatible = [
+        field
+        for field in _COMPATIBILITY_FIELDS
+        if start.get(field) != end.get(field)
+    ]
+    if incompatible:
+        raise AllowanceContractError(
+            f"incompatible allowance observations: {','.join(incompatible)}"
+        )
+    missing_compatibility = [
+        field
+        for field in _COMPATIBILITY_FIELDS
+        if start.get(field) is None or end.get(field) is None
+    ]
+    if missing_compatibility:
+        raise AllowanceContractError(
+            "allowance compatibility field is missing: "
+            f"{','.join(missing_compatibility)}"
+        )
+    start_at = start["observed_at_us"]
+    end_at = end["observed_at_us"]
+    if end_at < start_at:
+        raise AllowanceContractError("allowance observation time decreases")
+
+    percentage_minimum = Decimal(0)
+    percentage_maximum = Decimal(100)
+    used_start = _decimal(
+        start.get("used_percent"),
+        "used_percent",
+        minimum=percentage_minimum,
+        maximum=percentage_maximum,
+    )
+    used_end = _decimal(
+        end.get("used_percent"),
+        "used_percent",
+        minimum=percentage_minimum,
+        maximum=percentage_maximum,
+    )
+    remaining_start = _decimal(
+        start.get("remaining_percent"),
+        "remaining_percent",
+        minimum=percentage_minimum,
+        maximum=percentage_maximum,
+    )
+    remaining_end = _decimal(
+        end.get("remaining_percent"),
+        "remaining_percent",
+        minimum=percentage_minimum,
+        maximum=percentage_maximum,
+    )
+    deltas: list[Decimal] = []
+    if used_start is not None and used_end is not None:
+        deltas.append(used_end - used_start)
+    if remaining_start is not None and remaining_end is not None:
+        deltas.append(remaining_start - remaining_end)
+    if not deltas:
+        percent_delta = None
+    else:
+        if any(delta != deltas[0] for delta in deltas[1:]):
+            raise AllowanceContractError("used and remaining percentage deltas disagree")
+        percent_delta = deltas[0]
+    return {
+        "start_selector": f"allowance-observation:{start['observation_id']}",
+        "end_selector": f"allowance-observation:{end['observation_id']}",
+        "event_bounds": {
+            "start_us": start_at,
+            "end_us": end_at,
+            "semantics": "[start,end)",
+        },
+        "percent_delta": (
+            None if percent_delta is None else _decimal_text(percent_delta)
+        ),
+        "ratio_eligible": percent_delta is not None and percent_delta > 0,
+        "compatibility_basis": "exact_identity_tuple_v1",
+    }
+
+
+def _token_value(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise AllowanceContractError(f"{field} must be nonnegative integer or null")
+    return value
+
+
+def current_valuation(
+    tokens: dict[str, Any],
+    rate_card: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply one configured rate-card revision without rewriting canonical calls."""
+
+    normalized = {
+        field: _token_value(tokens.get(field), field) for field in _TOKEN_FIELDS
+    }
+    rates = rate_card.get("rates_per_million", {})
+    credit_rates = rate_card.get("credit_rates_per_million", {})
+    parsed_cost_rates = {
+        field: _decimal(
+            rates.get(field),
+            f"{field} cost rate",
+            minimum=Decimal(0),
+        )
+        for field in _TOKEN_FIELDS
+    }
+    parsed_credit_rates = {
+        field: _decimal(
+            credit_rates.get(field),
+            f"{field} credit rate",
+            minimum=Decimal(0),
+        )
+        for field in _TOKEN_FIELDS
+    }
+    reasoning_in_output = bool(rate_card.get("reasoning_in_output"))
+    if reasoning_in_output:
+        if parsed_cost_rates["reasoning_tokens"] not in {None, Decimal(0)}:
+            raise AllowanceContractError(
+                "reasoning cost rate would double-count output"
+            )
+        if parsed_credit_rates["reasoning_tokens"] not in {None, Decimal(0)}:
+            raise AllowanceContractError(
+                "reasoning credit rate would double-count output"
+            )
+
+    eligible_fields = [
+        field
+        for field in _TOKEN_FIELDS
+        if not (field == "reasoning_tokens" and reasoning_in_output)
+    ]
+    observed_fields = [
+        field for field in eligible_fields if normalized[field] is not None
+    ]
+    matched = bool(rate_card.get("matched", True))
+    cost_rated_fields = (
+        [
+            field
+            for field in observed_fields
+            if parsed_cost_rates[field] is not None
+        ]
+        if matched
+        else []
+    )
+    credit_rated_fields = (
+        [
+            field
+            for field in observed_fields
+            if parsed_credit_rates[field] is not None
+        ]
+        if matched
+        else []
+    )
+    cost_unpriced_fields = [
+        field for field in observed_fields if field not in cost_rated_fields
+    ]
+    credit_unpriced_fields = [
+        field for field in observed_fields if field not in credit_rated_fields
+    ]
+    denominator = sum(normalized[field] or 0 for field in observed_fields)
+    cost_numerator = sum(
+        normalized[field] or 0 for field in cost_rated_fields
+    )
+    credit_numerator = sum(
+        normalized[field] or 0 for field in credit_rated_fields
+    )
+    cost = sum(
+        (
+            Decimal(normalized[field] or 0)
+            * (parsed_cost_rates[field] or Decimal(0))
+            / Decimal(1_000_000)
+            for field in cost_rated_fields
+        ),
+        Decimal(0),
+    )
+    credits = sum(
+        (
+            Decimal(normalized[field] or 0)
+            * (parsed_credit_rates[field] or Decimal(0))
+            / Decimal(1_000_000)
+            for field in credit_rated_fields
+        ),
+        Decimal(0),
+    )
+    missing_fields = [
+        field for field in eligible_fields if normalized[field] is None
+    ]
+    def unpriced_reason(unpriced_fields: list[str]) -> str | None:
+        if not matched:
+            return "model_unmatched"
+        if unpriced_fields:
+            return "partial_rate_card"
+        if missing_fields:
+            return "missing_measurement"
+        return None
+
+    cost_reason = unpriced_reason(cost_unpriced_fields)
+    credit_reason = unpriced_reason(credit_unpriced_fields)
+    return {
+        "rate_card_digest": rate_card["digest"],
+        "match_basis": rate_card["match_basis"],
+        "configured_cost_usd": (
+            None if not cost_rated_fields else _decimal_text(cost)
+        ),
+        "estimated_credits": (
+            None if not credit_rated_fields else _decimal_text(credits)
+        ),
+        "cost_rated_token_fields": cost_rated_fields,
+        "credit_rated_token_fields": credit_rated_fields,
+        "cost_unpriced_token_fields": cost_unpriced_fields,
+        "credit_unpriced_token_fields": credit_unpriced_fields,
+        "missing_token_fields": missing_fields,
+        "cost_coverage_numerator_tokens": cost_numerator,
+        "cost_coverage_denominator_tokens": denominator,
+        "cost_coverage": (
+            None
+            if denominator == 0
+            else _decimal_text(Decimal(cost_numerator) / Decimal(denominator))
+        ),
+        "credit_coverage_numerator_tokens": credit_numerator,
+        "credit_coverage_denominator_tokens": denominator,
+        "credit_coverage": (
+            None
+            if denominator == 0
+            else _decimal_text(Decimal(credit_numerator) / Decimal(denominator))
+        ),
+        "cost_unpriced_reason": cost_reason,
+        "credit_unpriced_reason": credit_reason,
+        "cost_grade": (
+            "configured_estimate" if cost_rated_fields else "unsupported"
+        ),
+        "credit_grade": (
+            "configured_estimate" if credit_rated_fields else "unsupported"
+        ),
+    }

--- a/tests/agent_kernel/contracts/reference/contract.py
+++ b/tests/agent_kernel/contracts/reference/contract.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from tests.agent_kernel.contracts.reference.field_contract import (
+    FieldContractError,
+    build_field_contract_cases,
+    validate_field_contract_cases,
+)
+from tests.agent_kernel.contracts.reference.identity import semantic_id
+
+_FIELD_KEYS = frozenset(
+    {
+        "basis",
+        "identity_participation",
+        "missing",
+        "name",
+        "semantics",
+        "vector_ids",
+    }
+)
+_IDENTITY_PARTICIPATION = frozenset({"included", "excluded"})
+_CANONICAL_GRADES = frozenset({"exact", "deterministic", "configured_estimate"})
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Return the canonical JSON representation used by contract fixtures."""
+
+    return (
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        + "\n"
+    ).encode("utf-8")
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    return payload
+
+
+def vector_bundle_digest(vector_paths: Iterable[Path]) -> str:
+    """Hash names and canonical payloads so file moves or byte drift are visible."""
+
+    digest = hashlib.sha256()
+    for path in sorted(vector_paths, key=lambda item: item.name):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(canonical_json_bytes(_load_object(path)))
+    return digest.hexdigest()
+
+
+def _duplicate_values(values: Iterable[str]) -> set[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return duplicates
+
+
+def _payload_with_schema(
+    payloads: list[dict[str, Any]],
+    schema: str,
+) -> dict[str, Any] | None:
+    matches = [payload for payload in payloads if payload.get("schema") == schema]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def contract_failures(
+    contract: dict[str, Any],
+    question_catalog: dict[str, Any],
+    vector_paths: list[Path],
+) -> list[str]:
+    """Return deterministic logical-contract completeness and linkage failures."""
+
+    failures: list[str] = []
+    if contract.get("schema") != "codex-usage-tracker.agent-kernel.logical.v1":
+        failures.append("logical contract schema identity is not v1")
+    if contract.get("version") != 1:
+        failures.append("logical contract version is not 1")
+    if contract.get("database_identity") != "codex-usage-tracker.agent-kernel.v1":
+        failures.append("replacement database identity is not locked")
+
+    vector_payloads = [_load_object(path) for path in vector_paths]
+    vector_ids = {
+        vector_id
+        for payload in vector_payloads
+        for vector_id in payload.get("vector_ids", [])
+    }
+    duplicate_vector_ids = _duplicate_values(
+        vector_id
+        for payload in vector_payloads
+        for vector_id in payload.get("vector_ids", [])
+    )
+    if duplicate_vector_ids:
+        failures.append(f"duplicate vector IDs: {sorted(duplicate_vector_ids)}")
+    if not vector_paths:
+        failures.append("logical contract has no vector bundles")
+    elif contract.get("vector_bundle_sha256") != vector_bundle_digest(vector_paths):
+        failures.append("logical contract vector bundle digest is stale")
+
+    entities = contract.get("entities", [])
+    entity_ids = [entity.get("id") for entity in entities]
+    if any(not isinstance(entity_id, str) for entity_id in entity_ids):
+        failures.append("every logical entity must have a string ID")
+    duplicate_entity_ids = _duplicate_values(
+        entity_id for entity_id in entity_ids if isinstance(entity_id, str)
+    )
+    if duplicate_entity_ids:
+        failures.append(f"duplicate logical entity IDs: {sorted(duplicate_entity_ids)}")
+    known_entity_ids = {
+        entity_id for entity_id in entity_ids if isinstance(entity_id, str)
+    }
+
+    referenced_vectors: set[str] = set()
+    for entity in entities:
+        entity_id = entity.get("id", "<unknown>")
+        if not entity.get("owner"):
+            failures.append(f"{entity_id} has no logical owner")
+        if not entity.get("semantics"):
+            failures.append(f"{entity_id} has no semantics")
+        entity_vectors = entity.get("vector_ids", [])
+        if not entity_vectors:
+            failures.append(f"{entity_id} has no executable vector")
+        referenced_vectors.update(entity_vectors)
+        fields = entity.get("fields", [])
+        names = [field.get("name") for field in fields]
+        if not fields:
+            failures.append(f"{entity_id} has no field contracts")
+        duplicates = _duplicate_values(name for name in names if isinstance(name, str))
+        if duplicates:
+            failures.append(f"{entity_id} has duplicate fields: {sorted(duplicates)}")
+        field_by_name = {
+            field.get("name"): field
+            for field in fields
+            if isinstance(field.get("name"), str)
+        }
+        identity = entity.get("identity")
+        if not isinstance(identity, dict):
+            failures.append(f"{entity_id} has no identity contract")
+        else:
+            expected_identity_keys = {
+                "derived_id_field",
+                "input_fields",
+                "kind",
+            }
+            if set(identity) != expected_identity_keys:
+                failures.append(f"{entity_id} has incomplete identity metadata")
+            identity_kind = identity.get("kind")
+            identity_inputs = identity.get("input_fields")
+            derived_id_field = identity.get("derived_id_field")
+            if not isinstance(identity_kind, str) or not identity_kind:
+                failures.append(f"{entity_id} has no identity kind")
+            if (
+                not isinstance(identity_inputs, list)
+                or not identity_inputs
+                or any(not isinstance(name, str) for name in identity_inputs)
+            ):
+                failures.append(f"{entity_id} has invalid identity inputs")
+                identity_inputs = []
+            elif len(identity_inputs) != len(set(identity_inputs)):
+                failures.append(f"{entity_id} repeats an identity input")
+            unknown_identity_inputs = set(identity_inputs) - set(field_by_name)
+            if unknown_identity_inputs:
+                failures.append(
+                    f"{entity_id} identity names unknown fields: "
+                    f"{sorted(unknown_identity_inputs)}"
+                )
+            included_fields = [
+                name
+                for name, field in field_by_name.items()
+                if field.get("identity_participation") == "included"
+            ]
+            if included_fields != identity_inputs:
+                failures.append(
+                    f"{entity_id} identity input order differs from included fields"
+                )
+            if derived_id_field is not None:
+                if derived_id_field not in field_by_name:
+                    failures.append(f"{entity_id} derived identity field is unknown")
+                elif derived_id_field in identity_inputs:
+                    failures.append(
+                        f"{entity_id} derived identity participates in its own identity"
+                    )
+                elif (
+                    field_by_name[derived_id_field].get("identity_participation")
+                    != "excluded"
+                ):
+                    failures.append(
+                        f"{entity_id} derived identity field is not excluded"
+                    )
+        for field in fields:
+            field_name = field.get("name", "<unknown>")
+            if set(field) != _FIELD_KEYS:
+                failures.append(f"{entity_id}.{field_name} has incomplete field metadata")
+            if not field.get("semantics"):
+                failures.append(f"{entity_id}.{field_name} has no semantics")
+            if field.get("identity_participation") not in _IDENTITY_PARTICIPATION:
+                failures.append(
+                    f"{entity_id}.{field_name} has invalid identity participation"
+                )
+            if not field.get("missing"):
+                failures.append(f"{entity_id}.{field_name} has no missing-value rule")
+            if not field.get("basis"):
+                failures.append(f"{entity_id}.{field_name} has no basis")
+            field_vectors = field.get("vector_ids", [])
+            referenced_vectors.update(field_vectors)
+
+    identity_payload = _payload_with_schema(
+        vector_payloads,
+        "codex-usage-tracker.agent-kernel.identity-vectors.v1",
+    )
+    if identity_payload is None:
+        failures.append("logical contract needs exactly one identity vector bundle")
+        identity_vectors: list[dict[str, Any]] = []
+    else:
+        identity_vectors = identity_payload.get("identity_vectors", [])
+        identity_vector_entities = [
+            vector.get("entity") for vector in identity_vectors
+        ]
+        if identity_vector_entities != entity_ids:
+            failures.append(
+                "identity vectors must cover every entity once in contract order"
+            )
+        for vector in identity_vectors:
+            entity_id = vector.get("entity")
+            entity = next(
+                (item for item in entities if item.get("id") == entity_id),
+                None,
+            )
+            if entity is None:
+                failures.append(f"identity vector resolves unknown entity {entity_id}")
+                continue
+            identity = entity.get("identity", {})
+            if vector.get("kind") != identity.get("kind"):
+                failures.append(f"{entity_id} identity vector kind drifted")
+            if vector.get("identity_input_fields") != identity.get("input_fields"):
+                failures.append(f"{entity_id} identity vector field order drifted")
+            identity_tuple = vector.get("identity_tuple")
+            if not isinstance(identity_tuple, list):
+                failures.append(f"{entity_id} identity vector tuple is invalid")
+                continue
+            if len(identity_tuple) != len(identity.get("input_fields", [])):
+                failures.append(f"{entity_id} identity vector tuple length drifted")
+                continue
+            try:
+                computed_id = semantic_id(identity["kind"], identity_tuple)
+            except (KeyError, TypeError, ValueError) as exc:
+                failures.append(f"{entity_id} identity vector is invalid: {exc}")
+            else:
+                if computed_id != vector.get("expected_id"):
+                    failures.append(f"{entity_id} exact identity vector drifted")
+
+    field_payload = _payload_with_schema(
+        vector_payloads,
+        "codex-usage-tracker.agent-kernel.field-contract-vectors.v1",
+    )
+    if field_payload is None:
+        failures.append("logical contract needs exactly one field vector bundle")
+    elif identity_payload is not None:
+        field_cases = field_payload.get("field_contract_vectors", [])
+        expected_cases = build_field_contract_cases(entities, identity_vectors)
+        if field_cases != expected_cases:
+            failures.append("checked-in field contract vectors are stale")
+        else:
+            try:
+                assertion_count = validate_field_contract_cases(
+                    entities,
+                    identity_vectors,
+                    field_cases,
+                )
+            except (FieldContractError, KeyError, TypeError, ValueError) as exc:
+                failures.append(f"field contract vector execution failed: {exc}")
+            else:
+                expected_assertion_count = sum(
+                    len(entity.get("fields", [])) for entity in entities
+                )
+                if assertion_count != expected_assertion_count:
+                    failures.append(
+                        "field contract assertions do not cover every field"
+                    )
+
+    primitive_map = contract.get("logical_primitives", {})
+    catalog_primitives = set(question_catalog.get("logical_primitives", []))
+    if set(primitive_map) != catalog_primitives:
+        failures.append(
+            "CK-01/logical primitive IDs differ: "
+            f"catalog_only={sorted(catalog_primitives - set(primitive_map))}, "
+            f"contract_only={sorted(set(primitive_map) - catalog_primitives)}"
+        )
+    for primitive_id, entity_id in primitive_map.items():
+        if entity_id not in known_entity_ids:
+            failures.append(
+                f"logical primitive {primitive_id} resolves to unknown entity {entity_id}"
+            )
+
+    contract_measurements = contract.get("measurements", {})
+    catalog_measurements = set(question_catalog.get("measurements", []))
+    if set(contract_measurements) != catalog_measurements:
+        failures.append("CK-01/logical measurement IDs differ")
+    bit_positions = [
+        measurement.get("bit")
+        for measurement in contract_measurements.values()
+        if isinstance(measurement, dict)
+    ]
+    if bit_positions != list(range(len(bit_positions))):
+        failures.append("measurement-mask bit positions must be contiguous and ordered")
+    for measurement_id, measurement in contract_measurements.items():
+        if measurement.get("grade") not in _CANONICAL_GRADES:
+            failures.append(f"{measurement_id} has an invalid canonical grade")
+        if not measurement.get("basis"):
+            failures.append(f"{measurement_id} has no basis")
+        if not measurement.get("missing"):
+            failures.append(f"{measurement_id} has no missing-value rule")
+        measurement_vectors = measurement.get("vector_ids", [])
+        if not measurement_vectors:
+            failures.append(f"{measurement_id} has no executable vector")
+        referenced_vectors.update(measurement_vectors)
+
+    if set(contract.get("capabilities", {})) != set(
+        question_catalog.get("capabilities", [])
+    ):
+        failures.append("CK-01/logical capability IDs differ")
+    contract_selectors = contract.get("selector_kinds", {})
+    if set(contract_selectors) != set(question_catalog.get("selector_kinds", [])):
+        failures.append("CK-01/logical selector-kind IDs differ")
+    for selector_id, selector in contract_selectors.items():
+        if selector.get("entity") not in known_entity_ids:
+            failures.append(f"{selector_id} resolves unknown selector entity")
+        if not selector.get("prefix") or not selector.get("identity_kind"):
+            failures.append(f"{selector_id} has an incomplete wire contract")
+
+    for decision in contract.get("decisions", []):
+        if not decision.get("id") or not decision.get("rationale"):
+            failures.append("every CK-02 decision needs an ID and rationale")
+        referenced_vectors.update(decision.get("vector_ids", []))
+
+    unknown_vectors = referenced_vectors - vector_ids
+    if unknown_vectors:
+        failures.append(f"contract references unknown vectors: {sorted(unknown_vectors)}")
+    unowned_vectors = vector_ids - referenced_vectors
+    if unowned_vectors:
+        failures.append(f"vectors lack contract ownership: {sorted(unowned_vectors)}")
+    return failures

--- a/tests/agent_kernel/contracts/reference/field_contract.py
+++ b/tests/agent_kernel/contracts/reference/field_contract.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from tests.agent_kernel.contracts.reference.allowance import canonical_decimal
+from tests.agent_kernel.contracts.reference.time import ensure_int64
+
+_LOGICAL_ID = re.compile(r"^[a-z][a-z0-9-]*:v1:[a-z2-7]{52}$")
+_DIGEST = re.compile(r"^(?:sha256:)?[a-f0-9]{64}$")
+_LIFECYCLE_STATES = frozenset(
+    {
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "rolled_back",
+        "open",
+        "unknown",
+    }
+)
+
+
+class FieldContractError(ValueError):
+    """Raised when one locked entity field lacks executable semantic coverage."""
+
+
+def _nonnegative_integer(value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise FieldContractError("expected a nonnegative integer")
+
+
+def _utc_microseconds(value: Any) -> None:
+    if value is not None:
+        ensure_int64(value)
+
+
+def _logical_id(value: Any) -> None:
+    if not isinstance(value, str) or _LOGICAL_ID.fullmatch(value) is None:
+        raise FieldContractError("expected an exact v1 logical ID")
+
+
+def _logical_id_or_null(value: Any) -> None:
+    if value is not None:
+        _logical_id(value)
+
+
+def _nonempty_text(value: Any) -> None:
+    if not isinstance(value, str) or not value:
+        raise FieldContractError("expected nonempty text")
+
+
+def _boolean(value: Any) -> None:
+    if not isinstance(value, bool):
+        raise FieldContractError("expected a boolean")
+
+
+def _mapping(value: Any) -> None:
+    if not isinstance(value, dict):
+        raise FieldContractError("expected a mapping")
+
+
+def _sequence(value: Any) -> None:
+    if not isinstance(value, list):
+        raise FieldContractError("expected a sequence")
+
+
+def _source_order(value: Any) -> None:
+    _sequence(value)
+    if not value:
+        raise FieldContractError("source order must not be empty")
+    if any(isinstance(part, (dict, list)) for part in value):
+        raise FieldContractError("source order parts must be scalar")
+
+
+def _half_open_bounds(value: Any) -> None:
+    if isinstance(value, list):
+        if len(value) != 2:
+            raise FieldContractError("half-open bounds need two members")
+        start, end = value
+    elif isinstance(value, dict):
+        start = value.get("start_us")
+        end = value.get("end_us")
+        if value.get("semantics", "[start,end)") != "[start,end)":
+            raise FieldContractError("bounds must be half-open")
+    else:
+        raise FieldContractError("half-open bounds need a list or mapping")
+    if start is not None:
+        ensure_int64(start)
+    if end is not None:
+        ensure_int64(end)
+    if start is not None and end is not None and end < start:
+        raise FieldContractError("half-open bounds decrease")
+
+
+def _source_coordinate(value: Any) -> None:
+    _mapping(value)
+    required = {
+        "source_manifestation_id",
+        "source_revision",
+        "record_ordinal",
+        "adapter_version",
+    }
+    if not required <= set(value):
+        raise FieldContractError("source coordinate is incomplete")
+    _logical_id(value["source_manifestation_id"])
+    _nonnegative_integer(value["record_ordinal"])
+
+
+def _source_coordinates(value: Any) -> None:
+    _sequence(value)
+    for coordinate in value:
+        _source_coordinate(coordinate)
+
+
+def _measurement_mask(value: Any) -> None:
+    _nonnegative_integer(value)
+
+
+def _lifecycle_state(value: Any) -> None:
+    if value not in _LIFECYCLE_STATES:
+        raise FieldContractError("invalid lifecycle state")
+
+
+def _decimal_percentage(value: Any) -> None:
+    canonical_decimal(value, "percentage", minimum="0", maximum="100")
+
+
+def _decimal_value(value: Any) -> None:
+    canonical_decimal(value, "decimal")
+
+
+def _decimal_rate_map(value: Any) -> None:
+    _mapping(value)
+    for field, rate in value.items():
+        canonical_decimal(rate, f"{field} rate", minimum="0")
+
+
+def _digest_text(value: Any) -> None:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        raise FieldContractError("expected a SHA-256 digest")
+
+
+def _iana_timezone(value: Any) -> None:
+    _nonempty_text(value)
+    try:
+        ZoneInfo(value)
+    except ZoneInfoNotFoundError as exc:
+        raise FieldContractError("expected an IANA timezone") from exc
+
+
+def _token_count(value: Any) -> None:
+    if value is not None:
+        _nonnegative_integer(value)
+
+
+def _status_enum(value: Any) -> None:
+    _nonempty_text(value)
+
+
+def _structural(value: Any) -> None:
+    if value is None:
+        raise FieldContractError("structural sample must be observed")
+
+
+_CHECKS: dict[str, Callable[[Any], None]] = {
+    "boolean": _boolean,
+    "decimal_percentage": _decimal_percentage,
+    "decimal_rate_map": _decimal_rate_map,
+    "decimal_value": _decimal_value,
+    "derived_identity": _logical_id,
+    "digest_text": _digest_text,
+    "half_open_bounds": _half_open_bounds,
+    "identity_input": _structural,
+    "iana_timezone": _iana_timezone,
+    "lifecycle_state": _lifecycle_state,
+    "logical_id": _logical_id,
+    "logical_id_or_null": _logical_id_or_null,
+    "mapping": _mapping,
+    "measurement_mask": _measurement_mask,
+    "nonempty_text": _nonempty_text,
+    "nonnegative_integer": _nonnegative_integer,
+    "sequence": _sequence,
+    "source_coordinate": _source_coordinate,
+    "source_coordinates": _source_coordinates,
+    "source_order": _source_order,
+    "status_enum": _status_enum,
+    "structural": _structural,
+    "token_count": _token_count,
+    "utc_microseconds": _utc_microseconds,
+}
+
+
+def missing_probe_for_rule(rule: str) -> str:
+    """Classify the exact sentinel required by one missingness rule."""
+
+    if rule.startswith("null_"):
+        return "allow_null"
+    if rule.startswith("empty_collection") or rule.startswith("empty_rules"):
+        return "empty_collection"
+    if rule.startswith("empty_mask"):
+        return "zero_mask"
+    if rule.startswith("zero_"):
+        return "zero_observed"
+    if rule.startswith("false_"):
+        return "false_observed"
+    if rule.startswith("open_"):
+        return "open_state"
+    if rule.startswith("unknown_"):
+        return "unknown_state"
+    if rule.startswith("explicit_unknown"):
+        return "explicit_unknown"
+    return "reject_null"
+
+
+_BOOLEAN_FIELDS = frozenset(
+    {"causal_attribution", "ratio_eligible", "reasoning_in_output", "write_intent"}
+)
+_MAPPING_FIELDS = frozenset(
+    {
+        "absolute_fields",
+        "capability_coverage",
+        "coverage",
+        "entity_counts",
+        "filesystem_identity",
+        "first_boundary_coordinates",
+        "membership",
+        "publication_delta",
+        "schema_versions",
+        "source_coverage",
+        "token_delta",
+    }
+)
+_SEQUENCE_FIELDS = frozenset(
+    {
+        "cost_rated_token_fields",
+        "cost_unpriced_token_fields",
+        "credit_rated_token_fields",
+        "credit_unpriced_token_fields",
+        "label_candidates",
+        "missing_token_fields",
+        "model_match_rules",
+        "parse_diagnostics",
+        "resource_links",
+        "source_order_range",
+    }
+)
+_SOURCE_COORDINATE_FIELDS = frozenset(
+    {
+        "last_transition_coordinate",
+        "occurrence_coordinate",
+        "source_occurrence",
+        "start_coordinate",
+        "terminal_coordinate",
+    }
+)
+_SOURCE_COORDINATES_FIELDS = frozenset({"evidence_coordinates", "provenance"})
+_STATUS_FIELDS = frozenset(
+    {
+        "completion_status",
+        "state",
+        "status",
+        "validation_status",
+    }
+)
+_LIFECYCLE_FIELDS = frozenset({"lifecycle", "lifecycle_state"})
+_DIGEST_FIELDS = frozenset(
+    {
+        "after_revision",
+        "artifact_digest",
+        "before_revision",
+        "content_revision",
+        "digest",
+        "rate_card_digest",
+        "source_revision",
+    }
+)
+_DECIMAL_FIELDS = frozenset(
+    {
+        "confidence",
+        "configured_cost_usd",
+        "cost_coverage",
+        "credit_coverage",
+        "estimated_credits",
+        "percent_delta",
+    }
+)
+_NONNEGATIVE_FIELDS = frozenset(
+    {
+        "after_context_epoch",
+        "before_context_epoch",
+        "ordinal",
+        "transition_version",
+    }
+)
+_TEXT_FIELDS = frozenset(
+    {
+        "account_local_identity",
+        "activity_kind",
+        "adapter_id",
+        "adapter_native_call_key",
+        "adapter_native_invocation_key",
+        "adapter_native_session_key",
+        "adapter_native_source_key",
+        "adapter_version",
+        "basis",
+        "capability_basis",
+        "category",
+        "change_kind",
+        "compatibility_basis",
+        "completion_basis",
+        "cost_grade",
+        "cost_unpriced_reason",
+        "credit_grade",
+        "credit_unpriced_reason",
+        "currency",
+        "delta_key",
+        "display_label",
+        "error_category",
+        "event_kind",
+        "history_preset",
+        "identity_version",
+        "inclusion_basis",
+        "kind",
+        "match_basis",
+        "model",
+        "normalization_version",
+        "normalized_key",
+        "plan_identity",
+        "preset",
+        "provider",
+        "publication_key",
+        "reasoning_effort",
+        "relationship_basis",
+        "reset_basis",
+        "reset_identity",
+        "selected_history_coverage",
+        "semantic_operation",
+        "service_tier",
+        "source_kind",
+        "source_name",
+        "source_url",
+        "state_basis",
+        "technical_path_key",
+        "terminal_error_category",
+        "token_basis",
+        "tool_family",
+        "transport_name",
+        "window_kind",
+        "workspace_key",
+    }
+)
+
+
+def semantic_checks_for_field(
+    entity: dict[str, Any],
+    field: dict[str, Any],
+) -> list[str]:
+    """Return the maintained semantic assertions for one admitted field."""
+
+    name = field["name"]
+    checks: list[str] = []
+    if field["identity_participation"] == "included":
+        checks.append("identity_input")
+    if entity["identity"]["derived_id_field"] == name:
+        checks.append("derived_identity")
+    if name in _SOURCE_COORDINATE_FIELDS:
+        checks.append("source_coordinate")
+    elif name in _SOURCE_COORDINATES_FIELDS:
+        checks.append("source_coordinates")
+    elif name == "source_order":
+        checks.append("source_order")
+    elif name in {"event_bounds", "record_byte_range"}:
+        checks.append("half_open_bounds")
+    elif name in _DIGEST_FIELDS:
+        checks.append("digest_text")
+    elif name == "timezone":
+        checks.append("iana_timezone")
+    elif name in {"used_percent", "remaining_percent"}:
+        checks.append("decimal_percentage")
+    elif name in {"four_class_rates", "credit_rates"}:
+        checks.append("decimal_rate_map")
+    elif name in _DECIMAL_FIELDS:
+        checks.append("decimal_value")
+    elif name in _BOOLEAN_FIELDS:
+        checks.append("boolean")
+    elif name in _LIFECYCLE_FIELDS:
+        checks.append("lifecycle_state")
+    elif name in _STATUS_FIELDS:
+        checks.append("status_enum")
+    elif name in _MAPPING_FIELDS:
+        checks.append("mapping")
+    elif name in _SEQUENCE_FIELDS:
+        checks.append("sequence")
+    elif (
+        name.endswith("_id") and name != "adapter_id"
+    ) or name in {
+        "first_seen_publication",
+        "last_seen_publication",
+        "logical_id",
+    }:
+        checks.append("logical_id")
+    elif name.endswith("_duration_us") or name in {
+        "configured_duration_us",
+        "duration_us",
+    }:
+        checks.append("nonnegative_integer")
+    elif name.endswith("_us"):
+        checks.append("utc_microseconds")
+    elif name.endswith("_tokens"):
+        checks.append("token_count")
+    elif (
+        name.endswith("_count")
+        or name.endswith("_bytes")
+        or name.endswith("_ordinal")
+        or name.endswith("_offset")
+        or name.endswith("_depth")
+        or name in _NONNEGATIVE_FIELDS
+    ):
+        checks.append("nonnegative_integer")
+    elif name in {"capability_mask", "measurement_mask"}:
+        checks.append("measurement_mask")
+    elif name in _TEXT_FIELDS:
+        checks.append("nonempty_text")
+    else:
+        raise FieldContractError(
+            f"{entity['id']}.{name} lacks a maintained semantic classifier"
+        )
+    return list(dict.fromkeys(checks))
+
+
+def _sample_for_checks(
+    checks: list[str],
+    *,
+    logical_id: str,
+    coordinate: dict[str, Any],
+) -> Any:
+    if "derived_identity" in checks or "logical_id" in checks:
+        return logical_id
+    if "source_coordinate" in checks:
+        return coordinate
+    if "source_coordinates" in checks:
+        return [coordinate]
+    if "source_order" in checks:
+        return ["fixture", 1]
+    if "half_open_bounds" in checks:
+        return [0, 1]
+    if "digest_text" in checks:
+        return "sha256:" + "a" * 64
+    if "iana_timezone" in checks:
+        return "UTC"
+    if "decimal_percentage" in checks:
+        return "50"
+    if "decimal_rate_map" in checks:
+        return {
+            "uncached_input_tokens": "1",
+            "cached_input_tokens": "0.1",
+            "reasoning_tokens": "1",
+            "output_tokens": "2",
+        }
+    if "decimal_value" in checks:
+        return "1"
+    if "boolean" in checks:
+        return True
+    if "lifecycle_state" in checks:
+        return "succeeded"
+    if "status_enum" in checks:
+        return "active"
+    if "mapping" in checks:
+        return {"fixture": "value"}
+    if "sequence" in checks:
+        return ["fixture"]
+    if "utc_microseconds" in checks:
+        return 100
+    if (
+        "nonnegative_integer" in checks
+        or "measurement_mask" in checks
+        or "token_count" in checks
+    ):
+        return 1
+    if "nonempty_text" in checks:
+        return "fixture"
+    raise FieldContractError(f"no sample builder for checks {checks}")
+
+
+def build_field_contract_cases(
+    entities: list[dict[str, Any]],
+    identity_vectors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build the reviewable table that is checked into the vector bundle."""
+
+    identity_by_entity = {
+        vector["entity"]: vector for vector in identity_vectors
+    }
+    fallback_logical_id = identity_by_entity["session"]["expected_id"]
+    manifestation_id = identity_by_entity["source_manifestation"]["expected_id"]
+    coordinate = {
+        "source_manifestation_id": manifestation_id,
+        "source_revision": "sha256:" + "b" * 64,
+        "record_ordinal": 1,
+        "adapter_version": "codex-jsonl.v1",
+    }
+    cases: list[dict[str, Any]] = []
+    for entity in entities:
+        identity_vector = identity_by_entity[entity["id"]]
+        identity_values = dict(
+            zip(
+                identity_vector["identity_input_fields"],
+                identity_vector["identity_tuple"],
+                strict=True,
+            )
+        )
+        record: dict[str, Any] = {}
+        assertions: dict[str, Any] = {}
+        for field in entity["fields"]:
+            checks = semantic_checks_for_field(entity, field)
+            name = field["name"]
+            if name in identity_values:
+                value = identity_values[name]
+            elif entity["identity"]["derived_id_field"] == name:
+                value = identity_vector["expected_id"]
+            else:
+                value = _sample_for_checks(
+                    checks,
+                    logical_id=fallback_logical_id,
+                    coordinate=coordinate,
+                )
+            record[name] = value
+            assertions[name] = {
+                "checks": checks,
+                "basis": field["basis"],
+                "missing_probe": missing_probe_for_rule(field["missing"]),
+                "identity_participation": field["identity_participation"],
+            }
+        cases.append(
+            {
+                "id": f"field.{entity['id']}",
+                "entity": entity["id"],
+                "record": record,
+                "assertions": assertions,
+            }
+        )
+    return cases
+
+
+def validate_field_contract_cases(
+    entities: list[dict[str, Any]],
+    identity_vectors: list[dict[str, Any]],
+    cases: list[dict[str, Any]],
+) -> int:
+    """Execute every declared semantic assertion exactly once per locked field."""
+
+    entity_by_id = {entity["id"]: entity for entity in entities}
+    identity_by_entity = {
+        vector["entity"]: vector for vector in identity_vectors
+    }
+    case_by_entity = {case["entity"]: case for case in cases}
+    if set(case_by_entity) != set(entity_by_id):
+        raise FieldContractError("field cases do not exactly cover logical entities")
+    assertion_count = 0
+    for entity_id, entity in entity_by_id.items():
+        case = case_by_entity[entity_id]
+        fields = {field["name"]: field for field in entity["fields"]}
+        record = case["record"]
+        assertions = case["assertions"]
+        if set(record) != set(fields) or set(assertions) != set(fields):
+            raise FieldContractError(f"{entity_id} field coverage is not exact")
+        identity = entity["identity"]
+        identity_vector = identity_by_entity[entity_id]
+        extracted_tuple = [
+            record[field_name] for field_name in identity["input_fields"]
+        ]
+        if extracted_tuple != identity_vector["identity_tuple"]:
+            raise FieldContractError(f"{entity_id} identity tuple order drifted")
+        for field_name, field in fields.items():
+            assertion = assertions[field_name]
+            if assertion["basis"] != field["basis"]:
+                raise FieldContractError(f"{entity_id}.{field_name} basis drifted")
+            if assertion["missing_probe"] != missing_probe_for_rule(field["missing"]):
+                raise FieldContractError(
+                    f"{entity_id}.{field_name} missingness drifted"
+                )
+            if (
+                assertion["identity_participation"]
+                != field["identity_participation"]
+            ):
+                raise FieldContractError(
+                    f"{entity_id}.{field_name} identity participation drifted"
+                )
+            checks = assertion["checks"]
+            if not checks:
+                raise FieldContractError(
+                    f"{entity_id}.{field_name} has no semantic assertion"
+                )
+            if field["identity_participation"] == "included":
+                if "identity_input" not in checks:
+                    raise FieldContractError(
+                        f"{entity_id}.{field_name} identity input is not consumed"
+                    )
+            elif "identity_input" in checks:
+                raise FieldContractError(
+                    f"{entity_id}.{field_name} invents identity participation"
+                )
+            if (
+                identity["derived_id_field"] == field_name
+                and "derived_identity" not in checks
+            ):
+                raise FieldContractError(
+                    f"{entity_id}.{field_name} derived identity is not asserted"
+                )
+            for check in checks:
+                validator = _CHECKS.get(check)
+                if validator is None:
+                    raise FieldContractError(
+                        f"{entity_id}.{field_name} has unknown check {check}"
+                    )
+                validator(record[field_name])
+            assertion_count += 1
+    return assertion_count

--- a/tests/agent_kernel/contracts/reference/identity.py
+++ b/tests/agent_kernel/contracts/reference/identity.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+_KIND = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+class IdentityContractError(ValueError):
+    """Base identity-vector failure."""
+
+
+class IdentityCollisionError(IdentityContractError):
+    """Raised when one digest is presented with two normalized tuples."""
+
+    def __init__(self, logical_id: str) -> None:
+        self.logical_id = logical_id
+        super().__init__(f"identity collision for {logical_id}")
+
+
+def _head(major: int, value: int) -> bytes:
+    if value < 0:
+        raise IdentityContractError("canonical CBOR length must be nonnegative")
+    initial = major << 5
+    if value < 24:
+        return bytes((initial | value,))
+    if value <= 0xFF:
+        return bytes((initial | 24, value))
+    if value <= 0xFFFF:
+        return bytes((initial | 25,)) + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return bytes((initial | 26,)) + value.to_bytes(4, "big")
+    if value <= 0xFFFFFFFFFFFFFFFF:
+        return bytes((initial | 27,)) + value.to_bytes(8, "big")
+    raise IdentityContractError("canonical CBOR integer exceeds 64-bit encoding")
+
+
+def canonical_cbor(value: Any) -> bytes:
+    """Encode the restricted identity vocabulary with canonical CBOR ordering."""
+
+    if value is None:
+        return b"\xf6"
+    if value is False:
+        return b"\xf4"
+    if value is True:
+        return b"\xf5"
+    if isinstance(value, int):
+        return _head(0, value) if value >= 0 else _head(1, -1 - value)
+    if isinstance(value, bytes):
+        return _head(2, len(value)) + value
+    if isinstance(value, str):
+        encoded = value.encode("utf-8")
+        return _head(3, len(encoded)) + encoded
+    if isinstance(value, (list, tuple)):
+        encoded_items = b"".join(canonical_cbor(item) for item in value)
+        return _head(4, len(value)) + encoded_items
+    if isinstance(value, dict):
+        pairs = [
+            (canonical_cbor(key), canonical_cbor(item))
+            for key, item in value.items()
+        ]
+        pairs.sort(key=lambda pair: (len(pair[0]), pair[0]))
+        return _head(5, len(pairs)) + b"".join(
+            key + item for key, item in pairs
+        )
+    raise IdentityContractError(
+        f"unsupported canonical CBOR identity type: {type(value).__name__}"
+    )
+
+
+def semantic_id(kind: str, identity_tuple: Any) -> str:
+    """Return the v1 logical ID for a normalized structural identity tuple."""
+
+    if _KIND.fullmatch(kind) is None:
+        raise IdentityContractError(f"invalid identity kind: {kind}")
+    digest = hashlib.sha256(canonical_cbor(identity_tuple)).digest()
+    encoded = base64.b32encode(digest).decode("ascii").rstrip("=").lower()
+    return f"{kind}:v1:{encoded}"
+
+
+@dataclass
+class RegisteredEntity:
+    identity_bytes: bytes
+    occurrences: list[dict[str, Any]] = field(default_factory=list)
+
+
+class IdentityRegistry:
+    """Tiny collision-checking canonicalization oracle."""
+
+    def __init__(self) -> None:
+        self.entities: dict[str, RegisteredEntity] = {}
+
+    def register(
+        self,
+        logical_id: str,
+        identity_tuple: Any,
+        *,
+        occurrence: dict[str, Any] | None = None,
+    ) -> None:
+        normalized = canonical_cbor(identity_tuple)
+        entity = self.entities.get(logical_id)
+        if entity is None:
+            entity = RegisteredEntity(identity_bytes=normalized)
+            self.entities[logical_id] = entity
+        elif entity.identity_bytes != normalized:
+            raise IdentityCollisionError(logical_id)
+        if occurrence is not None and occurrence not in entity.occurrences:
+            entity.occurrences.append(occurrence)

--- a/tests/agent_kernel/contracts/reference/lifecycle.py
+++ b/tests/agent_kernel/contracts/reference/lifecycle.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from tests.agent_kernel.contracts.reference.time import event_order_key
+
+_TERMINAL_STATES = frozenset(
+    {"succeeded", "failed", "cancelled", "rolled_back"}
+)
+_ALLOWED = {
+    "unknown": frozenset(
+        {"unknown", "pending", "open", "running", *_TERMINAL_STATES}
+    ),
+    "pending": frozenset({"pending", "open", "running", *_TERMINAL_STATES}),
+    "open": frozenset({"open", "running", *_TERMINAL_STATES}),
+    "running": frozenset({"running", *_TERMINAL_STATES}),
+    "succeeded": frozenset({"succeeded"}),
+    "failed": frozenset({"failed"}),
+    "cancelled": frozenset({"cancelled"}),
+    "rolled_back": frozenset({"rolled_back"}),
+}
+
+
+class LifecycleContractError(ValueError):
+    """Raised for an invalid lifecycle fold or session hierarchy."""
+
+
+def fold_lifecycle(transitions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold append-only observations by semantic event order, not arrival order."""
+
+    if not transitions:
+        raise LifecycleContractError("lifecycle requires at least one transition")
+    logical_ids = {transition["logical_id"] for transition in transitions}
+    if len(logical_ids) != 1:
+        raise LifecycleContractError("lifecycle transitions mix logical identities")
+    ordered = sorted(transitions, key=event_order_key)
+    state = "unknown"
+    start = None
+    start_at_us: int | None = None
+    terminal = None
+    terminal_at_us: int | None = None
+    basis = "unknown"
+    for transition in ordered:
+        next_state = transition["state"]
+        if next_state not in _ALLOWED:
+            raise LifecycleContractError(f"unknown lifecycle state {next_state}")
+        if next_state not in _ALLOWED[state]:
+            raise LifecycleContractError(
+                f"invalid lifecycle transition {state} -> {next_state}"
+            )
+        state = next_state
+        basis = transition["basis"]
+        if start is None and next_state in {"pending", "open", "running"}:
+            start = transition["coordinate"]
+            start_at_us = transition.get("event_at_us")
+        if next_state in _TERMINAL_STATES:
+            terminal = transition["coordinate"]
+            terminal_at_us = transition.get("event_at_us")
+    duration_us = None
+    diagnostic = None
+    if (
+        start is not None
+        and terminal is not None
+        and start_at_us is not None
+        and terminal_at_us is not None
+    ):
+        if terminal_at_us >= start_at_us:
+            duration_us = terminal_at_us - start_at_us
+        else:
+            diagnostic = "negative_duration"
+    return {
+        "logical_id": next(iter(logical_ids)),
+        "state": state,
+        "state_basis": basis,
+        "start_coordinate": start,
+        "terminal_coordinate": terminal,
+        "observed_duration_us": duration_us,
+        "duration_diagnostic": diagnostic,
+        "transition_count": len(ordered),
+    }
+
+
+def _assert_acyclic(parent_by_session: dict[str, str | None]) -> None:
+    for origin in parent_by_session:
+        seen: set[str] = set()
+        current: str | None = origin
+        while current is not None:
+            if current in seen:
+                raise LifecycleContractError("session hierarchy contains a cycle")
+            seen.add(current)
+            current = parent_by_session.get(current)
+
+
+def hierarchy_usage(
+    session_id: str,
+    parent_by_session: dict[str, str | None],
+    exclusive_usage: dict[str, int],
+) -> dict[str, int]:
+    """Reconcile direct, descendant-exclusive, and family-inclusive scopes."""
+
+    _assert_acyclic(parent_by_session)
+    children: dict[str, list[str]] = defaultdict(list)
+    for child, parent in parent_by_session.items():
+        if parent is not None:
+            children[parent].append(child)
+    descendants: list[str] = []
+    stack = list(children.get(session_id, []))
+    while stack:
+        child = stack.pop()
+        descendants.append(child)
+        stack.extend(children.get(child, []))
+    parent_exclusive = exclusive_usage.get(session_id, 0)
+    descendant_exclusive = sum(exclusive_usage.get(child, 0) for child in descendants)
+    return {
+        "parent_exclusive": parent_exclusive,
+        "descendant_exclusive": descendant_exclusive,
+        "family_inclusive": parent_exclusive + descendant_exclusive,
+        "child_count": len(children.get(session_id, [])),
+        "descendant_count": len(descendants),
+    }

--- a/tests/agent_kernel/contracts/reference/selectors.py
+++ b/tests/agent_kernel/contracts/reference/selectors.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_LOGICAL_ID = re.compile(r"^[a-z][a-z0-9-]*:v1:[a-z2-7]{52}$")
+
+
+class SelectorContractError(ValueError):
+    """Raised when a selector, alias, or publication snapshot is inconsistent."""
+
+
+def format_selector(
+    kind: str,
+    logical_id: str,
+    prefixes: dict[str, str],
+    identity_kinds: dict[str, str],
+) -> str:
+    """Format a stable public selector from a logical identity."""
+
+    if kind not in prefixes or kind not in identity_kinds:
+        raise SelectorContractError(f"unknown selector kind {kind}")
+    if _LOGICAL_ID.fullmatch(logical_id) is None:
+        raise SelectorContractError("selector contains an invalid logical ID")
+    if not logical_id.startswith(f"{identity_kinds[kind]}:v1:"):
+        raise SelectorContractError("selector kind does not match logical ID kind")
+    return f"{prefixes[kind]}:{logical_id}"
+
+
+def parse_selector(
+    selector: str,
+    prefixes: dict[str, str],
+    identity_kinds: dict[str, str],
+) -> tuple[str, str]:
+    """Parse a selector and validate the logical-ID kind contract."""
+
+    prefix, separator, logical_id = selector.partition(":")
+    if not separator:
+        raise SelectorContractError("selector has no kind prefix")
+    inverse = {value: key for key, value in prefixes.items()}
+    if prefix not in inverse:
+        raise SelectorContractError(f"unknown selector prefix {prefix}")
+    kind = inverse[prefix]
+    expected_kind = identity_kinds[kind]
+    if _LOGICAL_ID.fullmatch(logical_id) is None:
+        raise SelectorContractError("selector contains an invalid logical ID")
+    if not logical_id.startswith(f"{expected_kind}:v1:"):
+        raise SelectorContractError("selector kind does not match logical ID kind")
+    return kind, logical_id
+
+
+def resolve_alias(
+    selector: str,
+    aliases: dict[str, str],
+    entities: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Resolve an identity correction only when both selectors name one entity."""
+
+    target = aliases.get(selector, selector)
+    if selector not in entities or target not in entities:
+        raise SelectorContractError("selector alias names an unknown entity")
+    if entities[selector]["entity_key"] != entities[target]["entity_key"]:
+        raise SelectorContractError("selector alias would join distinct entities")
+    return {
+        "requested_selector": selector,
+        "resolved_selector": target,
+        "alias_applied": target != selector,
+        "entity_key": entities[target]["entity_key"],
+    }
+
+
+def validate_publication_snapshot(
+    publication: dict[str, Any],
+    rows: list[dict[str, Any]],
+) -> str:
+    """Ensure facts, coverage, and selectors come from one committed truth unit."""
+
+    if publication.get("status") != "committed":
+        raise SelectorContractError("publication is not committed")
+    publication_id = publication["publication_id"]
+    mismatches = [
+        row for row in rows if row.get("publication_id") != publication_id
+    ]
+    if mismatches:
+        raise SelectorContractError("snapshot mixes publication identities")
+    return publication_id

--- a/tests/agent_kernel/contracts/reference/time.py
+++ b/tests/agent_kernel/contracts/reference/time.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_MIN_INT64 = -(2**63)
+_MAX_INT64 = 2**63 - 1
+_FRACTIONAL_SECONDS = re.compile(
+    r"[.,](?P<digits>[0-9]+)(?:Z|[+-][0-9]{2}:[0-9]{2})?$"
+)
+
+
+class TimeContractError(ValueError):
+    """Raised when a timestamp cannot satisfy the logical time contract."""
+
+
+def ensure_int64(value: int) -> int:
+    """Return a non-boolean signed 64-bit integer or fail closed."""
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TimeContractError("timestamp is not a signed 64-bit integer")
+    if value < _MIN_INT64 or value > _MAX_INT64:
+        raise TimeContractError("timestamp exceeds signed 64-bit range")
+    return value
+
+
+def _datetime_us(value: datetime) -> int:
+    delta = value.astimezone(timezone.utc) - _EPOCH
+    return ensure_int64(
+        (delta.days * 86_400 + delta.seconds) * 1_000_000 + delta.microseconds
+    )
+
+
+def _require_microsecond_precision(value: str) -> None:
+    match = _FRACTIONAL_SECONDS.search(value)
+    if match is not None and len(match.group("digits")) > 6:
+        raise TimeContractError("timestamp exceeds exact microsecond precision")
+
+
+def parse_instant_us(value: str) -> int:
+    """Parse an exact offset-bearing ISO instant without floating-point math."""
+
+    _require_microsecond_precision(value)
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        instant = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise TimeContractError("invalid documented timestamp") from exc
+    if instant.tzinfo is None:
+        raise TimeContractError("timestamp lacks an explicit UTC offset")
+    return _datetime_us(instant)
+
+
+def local_datetime_to_utc_us(
+    value: str,
+    timezone_name: str,
+    *,
+    fold: int | None = None,
+) -> int:
+    """Resolve an IANA-zone wall time, requiring an explicit DST fold when needed."""
+
+    _require_microsecond_precision(value)
+    try:
+        naive = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise TimeContractError("invalid local calendar timestamp") from exc
+    if naive.tzinfo is not None:
+        raise TimeContractError("calendar timestamp must not include an offset")
+    try:
+        zone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise TimeContractError("unknown IANA timezone") from exc
+
+    candidates: list[tuple[int, int]] = []
+    for candidate_fold in (0, 1):
+        aware = naive.replace(tzinfo=zone, fold=candidate_fold)
+        utc = aware.astimezone(timezone.utc)
+        round_trip = utc.astimezone(zone)
+        if round_trip.replace(tzinfo=None) == naive:
+            candidate = (candidate_fold, _datetime_us(utc))
+            if candidate[1] not in {item[1] for item in candidates}:
+                candidates.append(candidate)
+    if not candidates:
+        raise TimeContractError("nonexistent DST local time")
+    if len(candidates) > 1 and fold is None:
+        raise TimeContractError("ambiguous DST local time requires fold")
+    if fold is not None and fold not in {0, 1}:
+        raise TimeContractError("DST fold must be 0 or 1")
+    if fold is None:
+        return candidates[0][1]
+    for candidate_fold, candidate_us in candidates:
+        if candidate_fold == fold:
+            return candidate_us
+    raise TimeContractError("requested DST fold is not valid for local time")
+
+
+def _source_order_key(source_order: list[Any]) -> tuple[tuple[int, Any], ...]:
+    normalized: list[tuple[int, Any]] = []
+    for part in source_order:
+        if isinstance(part, bool):
+            normalized.append((2, int(part)))
+        elif isinstance(part, int):
+            normalized.append((0, part))
+        elif isinstance(part, str):
+            normalized.append((1, part))
+        else:
+            raise TimeContractError("source order contains an unsupported type")
+    return tuple(normalized)
+
+
+def event_order_key(event: dict[str, Any]) -> tuple[Any, ...]:
+    """Return the physical-independent total-order key.
+
+    Missing event time remains missing and sorts after observed instants; source
+    order then preserves deterministic adapter order without inventing a time.
+    """
+
+    event_at_us = event.get("event_at_us")
+    time_key = (
+        (1, 0) if event_at_us is None else (0, ensure_int64(event_at_us))
+    )
+    return (
+        *time_key,
+        _source_order_key(event["source_order"]),
+        int(event["event_kind_order"]),
+        str(event["logical_id"]),
+    )

--- a/tests/agent_kernel/contracts/test_accounting_vectors.py
+++ b/tests/agent_kernel/contracts/test_accounting_vectors.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.agent_kernel.contracts.reference.accounting import (
+    AccountingContractError,
+    aggregate_measurement,
+    measurement_mask,
+    token_totals,
+    tool_outcome_counts,
+    validate_measurement_record,
+)
+
+_VECTOR_PATH = Path(__file__).with_name("vectors") / "accounting-v1.json"
+
+
+def _vectors() -> dict[str, Any]:
+    payload = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_four_token_classes_never_double_count_cached_or_reasoning() -> None:
+    for vector in _vectors()["token_vectors"]:
+        if "error" in vector:
+            with pytest.raises(AccountingContractError, match=vector["error"]):
+                token_totals(vector["tokens"])
+        else:
+            assert token_totals(vector["tokens"]) == vector["expected"]
+
+
+def test_missing_measurements_never_become_zero() -> None:
+    for vector in _vectors()["aggregation_vectors"]:
+        assert aggregate_measurement(vector["values"]) == vector["expected"]
+
+
+def test_measurement_masks_grades_and_bases_are_consistent() -> None:
+    payload = _vectors()
+    bit_positions = payload["measurement_bits"]
+
+    for vector in payload["measurement_vectors"]:
+        mask = measurement_mask(vector["available"], bit_positions)
+        assert mask == vector["expected_mask"]
+        if vector["valid"]:
+            validate_measurement_record(
+                vector["record"],
+                mask=mask,
+                bit_positions=bit_positions,
+            )
+        else:
+            with pytest.raises(AccountingContractError, match=vector["error"]):
+                validate_measurement_record(
+                    vector["record"],
+                    mask=mask,
+                    bit_positions=bit_positions,
+                )
+
+
+def test_tool_intent_completion_and_observed_mutation_stay_separate() -> None:
+    for vector in _vectors()["tool_outcome_vectors"]:
+        assert tool_outcome_counts(vector["records"]) == vector["expected"]

--- a/tests/agent_kernel/contracts/test_allowance_vectors.py
+++ b/tests/agent_kernel/contracts/test_allowance_vectors.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.agent_kernel.contracts.reference.allowance import (
+    AllowanceContractError,
+    allowance_interval,
+    canonical_decimal,
+    current_valuation,
+)
+
+_VECTOR_PATH = Path(__file__).with_name("vectors") / "allowance-v1.json"
+
+
+def _vectors() -> dict[str, Any]:
+    payload = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_allowance_intervals_require_compatible_adjacent_observations() -> None:
+    for vector in _vectors()["interval_vectors"]:
+        if "error" in vector:
+            with pytest.raises(AllowanceContractError, match=vector["error"]):
+                allowance_interval(vector["start"], vector["end"])
+        else:
+            assert allowance_interval(vector["start"], vector["end"]) == vector["expected"]
+
+
+def test_zero_negative_reset_or_incompatible_deltas_have_no_ratio() -> None:
+    for vector in _vectors()["ratio_vectors"]:
+        interval = allowance_interval(vector["start"], vector["end"])
+        assert interval["percent_delta"] == vector["expected_percent_delta"]
+        assert interval["ratio_eligible"] is vector["expected_ratio_eligible"]
+
+
+def test_current_valuation_reports_partial_and_unpriced_coverage() -> None:
+    for vector in _vectors()["valuation_vectors"]:
+        if "error" in vector:
+            with pytest.raises(AllowanceContractError, match=vector["error"]):
+                current_valuation(vector["tokens"], vector["rate_card"])
+        else:
+            assert current_valuation(vector["tokens"], vector["rate_card"]) == vector[
+                "expected"
+            ]
+
+
+def test_decimal_strings_round_trip_and_enforce_domains() -> None:
+    for vector in _vectors()["decimal_vectors"]:
+        if "error" in vector:
+            with pytest.raises(AllowanceContractError, match=vector["error"]):
+                canonical_decimal(
+                    vector["value"],
+                    vector["field"],
+                    minimum=vector.get("minimum"),
+                    maximum=vector.get("maximum"),
+                )
+        else:
+            assert canonical_decimal(
+                vector["value"],
+                vector["field"],
+                minimum=vector.get("minimum"),
+                maximum=vector.get("maximum"),
+            ) == vector["expected"]

--- a/tests/agent_kernel/contracts/test_identity_vectors.py
+++ b/tests/agent_kernel/contracts/test_identity_vectors.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.agent_kernel.contracts.reference.contract import (
+    canonical_json_bytes,
+    contract_failures,
+    vector_bundle_digest,
+)
+from tests.agent_kernel.contracts.reference.field_contract import (
+    build_field_contract_cases,
+    validate_field_contract_cases,
+)
+from tests.agent_kernel.contracts.reference.identity import (
+    IdentityCollisionError,
+    IdentityRegistry,
+    semantic_id,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONTRACT_PATH = (
+    _REPO_ROOT / "config" / "agent-kernel" / "logical-contract-v1.json"
+)
+_CATALOG_PATH = (
+    _REPO_ROOT / "config" / "agent-kernel" / "question-catalog-v1.json"
+)
+_VECTOR_ROOT = Path(__file__).with_name("vectors")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_logical_contract_is_complete_and_reconciles_ck01() -> None:
+    contract = _load(_CONTRACT_PATH)
+    catalog = _load(_CATALOG_PATH)
+    vector_paths = sorted(_VECTOR_ROOT.glob("*.json"))
+
+    assert contract_failures(contract, catalog, vector_paths) == []
+    assert contract["vector_bundle_sha256"] == vector_bundle_digest(vector_paths)
+    assert canonical_json_bytes(contract) == canonical_json_bytes(
+        json.loads(canonical_json_bytes(contract))
+    )
+
+
+def test_versioned_identity_vectors_are_exact() -> None:
+    payload = _load(_VECTOR_ROOT / "identity-v1.json")
+    contract = _load(_CONTRACT_PATH)
+    entities = {entity["id"]: entity for entity in contract["entities"]}
+
+    for vector in payload["identity_vectors"]:
+        entity = entities[vector["entity"]]
+        identity = entity["identity"]
+        assert identity["kind"] == vector["kind"]
+        assert identity["input_fields"] == vector["identity_input_fields"]
+        assert len(identity["input_fields"]) == len(vector["identity_tuple"])
+        field_participation = {
+            field["name"]: field["identity_participation"]
+            for field in entity["fields"]
+        }
+        assert [
+            name
+            for name, participation in field_participation.items()
+            if participation == "included"
+        ] == identity["input_fields"]
+        derived_id_field = identity["derived_id_field"]
+        if derived_id_field is not None:
+            assert derived_id_field not in identity["input_fields"]
+            assert field_participation[derived_id_field] == "excluded"
+        assert semantic_id(vector["kind"], vector["identity_tuple"]) == vector["expected_id"]
+    assert {vector["entity"] for vector in payload["identity_vectors"]} == set(entities)
+
+
+def test_publication_identity_precedes_nonrecursive_artifact_digest() -> None:
+    payload = _load(_VECTOR_ROOT / "identity-v1.json")
+
+    for vector in payload["publication_derivation_vectors"]:
+        assert semantic_id("publication", [vector["publication_key"]]) == vector[
+            "expected_publication_id"
+        ]
+        artifact = vector["artifact_without_digest"]
+        assert artifact["publication_id"] == vector["expected_publication_id"]
+        assert "artifact_digest" not in artifact
+        assert hashlib.sha256(canonical_json_bytes(artifact)).hexdigest() == vector[
+            "expected_artifact_digest"
+        ]
+
+
+def test_every_admitted_field_has_an_executed_semantic_assertion() -> None:
+    contract = _load(_CONTRACT_PATH)
+    identities = _load(_VECTOR_ROOT / "identity-v1.json")
+    payload = _load(_VECTOR_ROOT / "field-contract-v1.json")
+    expected_cases = build_field_contract_cases(
+        contract["entities"],
+        identities["identity_vectors"],
+    )
+
+    assert payload["field_contract_vectors"] == expected_cases
+    assert payload["vector_ids"] == [case["id"] for case in expected_cases]
+    expected_assertions = sum(
+        len(entity["fields"]) for entity in contract["entities"]
+    )
+    assert validate_field_contract_cases(
+        contract["entities"],
+        identities["identity_vectors"],
+        payload["field_contract_vectors"],
+    ) == expected_assertions
+
+
+def test_hash_collision_never_merges_distinct_identity_tuples() -> None:
+    payload = _load(_VECTOR_ROOT / "identity-v1.json")
+
+    for vector in payload["collision_vectors"]:
+        registry = IdentityRegistry()
+        registry.register(vector["logical_id"], vector["first_tuple"])
+        try:
+            registry.register(vector["logical_id"], vector["second_tuple"])
+        except IdentityCollisionError as exc:
+            assert exc.logical_id == vector["logical_id"]
+        else:
+            raise AssertionError("identity collision did not fail closed")
+
+
+def test_source_copies_count_once_but_preserve_occurrences() -> None:
+    payload = _load(_VECTOR_ROOT / "identity-v1.json")
+
+    for vector in payload["occurrence_vectors"]:
+        registry = IdentityRegistry()
+        for occurrence in vector["occurrences"]:
+            registry.register(
+                occurrence["logical_id"],
+                occurrence["identity_tuple"],
+                occurrence=occurrence["coordinate"],
+            )
+        entity = registry.entities[vector["expected_logical_id"]]
+        assert len(registry.entities) == vector["expected_entity_count"]
+        assert entity.occurrences == vector["expected_coordinates"]

--- a/tests/agent_kernel/contracts/test_lifecycle_vectors.py
+++ b/tests/agent_kernel/contracts/test_lifecycle_vectors.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.agent_kernel.contracts.reference.lifecycle import (
+    LifecycleContractError,
+    fold_lifecycle,
+    hierarchy_usage,
+)
+
+_VECTOR_PATH = Path(__file__).with_name("vectors") / "lifecycle-v1.json"
+
+
+def _vectors() -> dict[str, Any]:
+    payload = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_lifecycle_fold_is_deterministic_across_publications() -> None:
+    for vector in _vectors()["lifecycle_vectors"]:
+        if "error" in vector:
+            with pytest.raises(LifecycleContractError, match=vector["error"]):
+                fold_lifecycle(vector["transitions"])
+        else:
+            assert fold_lifecycle(vector["transitions"]) == vector["expected"]
+
+
+def test_late_parent_discovery_preserves_identity_and_reconciles_scopes() -> None:
+    for vector in _vectors()["hierarchy_vectors"]:
+        before = hierarchy_usage(
+            vector["session_id"],
+            vector["before_parent_by_session"],
+            vector["exclusive_usage"],
+        )
+        after = hierarchy_usage(
+            vector["session_id"],
+            vector["after_parent_by_session"],
+            vector["exclusive_usage"],
+        )
+        assert before == vector["expected_before"]
+        assert after == vector["expected_after"]
+        assert vector["session_identity_before"] == vector["session_identity_after"]
+
+
+def test_hierarchy_cycles_fail_closed() -> None:
+    for vector in _vectors()["invalid_hierarchy_vectors"]:
+        with pytest.raises(LifecycleContractError, match=vector["error"]):
+            hierarchy_usage(
+                vector["session_id"],
+                vector["parent_by_session"],
+                vector["exclusive_usage"],
+            )

--- a/tests/agent_kernel/contracts/test_selector_vectors.py
+++ b/tests/agent_kernel/contracts/test_selector_vectors.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.agent_kernel.contracts.reference.selectors import (
+    SelectorContractError,
+    format_selector,
+    parse_selector,
+    resolve_alias,
+    validate_publication_snapshot,
+)
+
+_VECTOR_PATH = Path(__file__).with_name("vectors") / "selector-v1.json"
+
+
+def _vectors() -> dict[str, Any]:
+    payload = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_selectors_round_trip_and_remain_stable_after_rebuild_or_replacement() -> None:
+    for vector in _vectors()["selector_vectors"]:
+        selector = format_selector(
+            vector["kind"],
+            vector["logical_id"],
+            vector["prefixes"],
+            vector["identity_kinds"],
+        )
+        assert selector == vector["expected_selector"]
+        assert parse_selector(
+            selector,
+            vector["prefixes"],
+            vector["identity_kinds"],
+        ) == (vector["kind"], vector["logical_id"])
+        assert selector == vector["selector_after_rebuild"]
+        assert vector["old_coordinate"] != vector["replacement_coordinate"]
+
+
+def test_selector_and_alias_shape_errors_fail_closed() -> None:
+    payload = _vectors()
+    for vector in payload["invalid_selector_vectors"]:
+        with pytest.raises(SelectorContractError, match=vector["error"]):
+            parse_selector(
+                vector["selector"],
+                payload["prefixes"],
+                payload["identity_kinds"],
+            )
+    for vector in payload["alias_vectors"]:
+        if "error" in vector:
+            with pytest.raises(SelectorContractError, match=vector["error"]):
+                resolve_alias(vector["selector"], vector["aliases"], vector["entities"])
+        else:
+            assert resolve_alias(
+                vector["selector"],
+                vector["aliases"],
+                vector["entities"],
+            ) == vector["expected"]
+
+
+def test_publication_snapshot_reads_one_committed_truth_unit() -> None:
+    for vector in _vectors()["publication_vectors"]:
+        if "error" in vector:
+            with pytest.raises(SelectorContractError, match=vector["error"]):
+                validate_publication_snapshot(vector["publication"], vector["rows"])
+        else:
+            assert validate_publication_snapshot(
+                vector["publication"],
+                vector["rows"],
+            ) == vector["expected_publication_id"]

--- a/tests/agent_kernel/contracts/test_time_vectors.py
+++ b/tests/agent_kernel/contracts/test_time_vectors.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.agent_kernel.contracts.reference.time import (
+    TimeContractError,
+    ensure_int64,
+    event_order_key,
+    local_datetime_to_utc_us,
+    parse_instant_us,
+)
+
+_VECTOR_PATH = Path(__file__).with_name("vectors") / "time-v1.json"
+
+
+def _vectors() -> dict[str, Any]:
+    payload = json.loads(_VECTOR_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_exact_instants_use_signed_utc_microseconds() -> None:
+    for vector in _vectors()["instant_vectors"]:
+        if "error" in vector:
+            with pytest.raises(TimeContractError, match=vector["error"]):
+                parse_instant_us(vector["instant"])
+        else:
+            assert parse_instant_us(vector["instant"]) == vector["expected_us"]
+
+
+def test_calendar_conversion_handles_dst_ambiguity_and_gaps_explicitly() -> None:
+    for vector in _vectors()["calendar_vectors"]:
+        if "error" in vector:
+            with pytest.raises(TimeContractError, match=vector["error"]):
+                local_datetime_to_utc_us(
+                    vector["local"],
+                    vector["timezone"],
+                    fold=vector.get("fold"),
+                )
+        else:
+            assert (
+                local_datetime_to_utc_us(
+                    vector["local"],
+                    vector["timezone"],
+                    fold=vector.get("fold"),
+                )
+                == vector["expected_us"]
+            )
+
+
+def test_int64_boundaries_and_overflow_fail_closed() -> None:
+    for vector in _vectors()["integer_vectors"]:
+        if vector["valid"]:
+            assert ensure_int64(vector["value"]) == vector["value"]
+        else:
+            with pytest.raises(TimeContractError, match="signed 64-bit"):
+                ensure_int64(vector["value"])
+
+
+def test_total_order_is_stable_for_ties_late_events_and_missing_time() -> None:
+    for vector in _vectors()["ordering_vectors"]:
+        ordered = sorted(vector["events"], key=event_order_key)
+        assert [event["logical_id"] for event in ordered] == vector["expected_ids"]

--- a/tests/agent_kernel/contracts/vectors/accounting-v1.json
+++ b/tests/agent_kernel/contracts/vectors/accounting-v1.json
@@ -1,0 +1,274 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.accounting-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "accounting.four_tokens",
+    "accounting.missing_cached",
+    "accounting.zero_tokens",
+    "accounting.invalid_negative",
+    "accounting.aggregate_partial",
+    "accounting.aggregate_all_missing",
+    "accounting.measurement_mask",
+    "accounting.measurement_missing",
+    "accounting.measurement_grade",
+    "accounting.measurement_result_grade",
+    "accounting.tool_separation"
+  ],
+  "measurement_bits": {
+    "allowance_limit": 0,
+    "allowance_percent": 1,
+    "cached_input_tokens": 2,
+    "call_count": 3,
+    "completion_state": 4,
+    "configured_cost_usd": 5,
+    "context_window_tokens": 6,
+    "duration_us": 7,
+    "estimated_credits": 8,
+    "event_time_us": 9,
+    "hierarchy_depth": 10,
+    "model_profile": 11,
+    "mutation_count": 12,
+    "output_tokens": 13,
+    "reasoning_tokens": 14,
+    "resource_operation": 15,
+    "source_occurrence_count": 16,
+    "tool_output_bytes": 17,
+    "tool_status": 18,
+    "turn_count": 19,
+    "uncached_input_tokens": 20
+  },
+  "token_vectors": [
+    {
+      "id": "accounting.four_tokens",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 200,
+        "reasoning_tokens": 50,
+        "output_tokens": 25
+      },
+      "expected": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 200,
+        "reasoning_tokens": 50,
+        "output_tokens": 25,
+        "input_tokens": 300,
+        "total_tokens": 325
+      }
+    },
+    {
+      "id": "accounting.missing_cached",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": null,
+        "reasoning_tokens": 50,
+        "output_tokens": 25
+      },
+      "expected": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": null,
+        "reasoning_tokens": 50,
+        "output_tokens": 25,
+        "input_tokens": null,
+        "total_tokens": null
+      }
+    },
+    {
+      "id": "accounting.zero_tokens",
+      "tokens": {
+        "uncached_input_tokens": 0,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "expected": {
+        "uncached_input_tokens": 0,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0,
+        "input_tokens": 0,
+        "total_tokens": 0
+      }
+    },
+    {
+      "id": "accounting.invalid_negative",
+      "tokens": {
+        "uncached_input_tokens": -1,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "error": "uncached_input_tokens must be a nonnegative integer or null"
+    }
+  ],
+  "aggregation_vectors": [
+    {
+      "id": "accounting.aggregate_partial",
+      "values": [
+        10,
+        null,
+        0,
+        5
+      ],
+      "expected": {
+        "value": 15,
+        "observed_count": 3,
+        "missing_count": 1,
+        "complete": false
+      }
+    },
+    {
+      "id": "accounting.aggregate_all_missing",
+      "values": [
+        null,
+        null
+      ],
+      "expected": {
+        "value": null,
+        "observed_count": 0,
+        "missing_count": 2,
+        "complete": false
+      }
+    }
+  ],
+  "measurement_vectors": [
+    {
+      "id": "accounting.measurement_mask",
+      "available": [
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_tokens",
+        "uncached_input_tokens"
+      ],
+      "expected_mask": 1073156,
+      "valid": true,
+      "record": {
+        "cached_input_tokens": {
+          "value": 200,
+          "grade": "exact",
+          "basis": "observed_upstream"
+        },
+        "output_tokens": {
+          "value": 25,
+          "grade": "exact",
+          "basis": "observed_upstream"
+        },
+        "reasoning_tokens": {
+          "value": 50,
+          "grade": "exact",
+          "basis": "observed_upstream"
+        },
+        "uncached_input_tokens": {
+          "value": 100,
+          "grade": "deterministic",
+          "basis": "input_total_minus_cached_v1"
+        }
+      }
+    },
+    {
+      "id": "accounting.measurement_missing",
+      "available": [
+        "cached_input_tokens"
+      ],
+      "expected_mask": 4,
+      "valid": false,
+      "error": "missing measurement has availability bit",
+      "record": {
+        "cached_input_tokens": {
+          "value": null,
+          "grade": null,
+          "basis": "unobserved"
+        }
+      }
+    },
+    {
+      "id": "accounting.measurement_missing",
+      "available": [],
+      "expected_mask": 0,
+      "valid": false,
+      "error": "observed measurement lacks availability bit",
+      "record": {
+        "uncached_input_tokens": {
+          "value": 100,
+          "grade": "exact",
+          "basis": "observed_upstream"
+        }
+      }
+    },
+    {
+      "id": "accounting.measurement_grade",
+      "available": [
+        "cached_input_tokens"
+      ],
+      "expected_mask": 4,
+      "valid": false,
+      "error": "canonical measurement has a result-only grade",
+      "record": {
+        "cached_input_tokens": {
+          "value": 200,
+          "grade": "model_inference",
+          "basis": "model_guess"
+        }
+      }
+    },
+    {
+      "id": "accounting.measurement_result_grade",
+      "available": [],
+      "expected_mask": 0,
+      "valid": false,
+      "error": "canonical measurement has a result-only grade",
+      "record": {
+        "cached_input_tokens": {
+          "value": null,
+          "grade": "unsupported",
+          "basis": "unobserved"
+        }
+      }
+    },
+    {
+      "id": "accounting.measurement_result_grade",
+      "available": [],
+      "expected_mask": 0,
+      "valid": false,
+      "error": "canonical measurement has a result-only grade",
+      "record": {
+        "cached_input_tokens": {
+          "value": null,
+          "grade": "model_inference",
+          "basis": "unobserved"
+        }
+      }
+    }
+  ],
+  "tool_outcome_vectors": [
+    {
+      "id": "accounting.tool_separation",
+      "records": [
+        {
+          "tool_id": "tool:v1:aaaaaaaaaaaaaaaa",
+          "write_intent": true,
+          "lifecycle_state": "succeeded",
+          "state_change_id": null
+        },
+        {
+          "tool_id": "tool:v1:bbbbbbbbbbbbbbbb",
+          "write_intent": false,
+          "lifecycle_state": "succeeded",
+          "state_change_id": null
+        },
+        {
+          "tool_id": "tool:v1:cccccccccccccccc",
+          "write_intent": false,
+          "lifecycle_state": "failed",
+          "state_change_id": "state-change:v1:aaaaaaaaaaaaaaaa"
+        }
+      ],
+      "expected": {
+        "invocations": 3,
+        "write_intents": 1,
+        "succeeded": 2,
+        "observed_mutations": 1,
+        "causal_attribution": false
+      }
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/allowance-v1.json
+++ b/tests/agent_kernel/contracts/vectors/allowance-v1.json
@@ -1,0 +1,745 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.allowance-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "allowance.compatible_used",
+    "allowance.compatible_remaining",
+    "allowance.repeated",
+    "allowance.negative",
+    "allowance.reset_incompatible",
+    "allowance.plan_incompatible",
+    "allowance.cycle_incompatible",
+    "allowance.time_decrease",
+    "valuation.full",
+    "valuation.partial",
+    "valuation.unmatched",
+    "valuation.cost_only",
+    "valuation.credit_only",
+    "valuation.asymmetric",
+    "valuation.reasoning_overlap",
+    "valuation.reasoning_credit_overlap",
+    "valuation.negative_rate",
+    "decimal.canonical",
+    "decimal.noncanonical",
+    "decimal.percentage_domain"
+  ],
+  "interval_vectors": [
+    {
+      "id": "allowance.compatible_used",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "10.5",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "12.75",
+        "remaining_percent": null
+      },
+      "expected": {
+        "start_selector": "allowance-observation:allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "end_selector": "allowance-observation:allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "event_bounds": {
+          "start_us": 100,
+          "end_us": 200,
+          "semantics": "[start,end)"
+        },
+        "percent_delta": "2.25",
+        "ratio_eligible": true,
+        "compatibility_basis": "exact_identity_tuple_v1"
+      }
+    },
+    {
+      "id": "allowance.compatible_remaining",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": null,
+        "remaining_percent": "89.5"
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": null,
+        "remaining_percent": "87.25"
+      },
+      "expected": {
+        "start_selector": "allowance-observation:allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "end_selector": "allowance-observation:allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "event_bounds": {
+          "start_us": 100,
+          "end_us": 200,
+          "semantics": "[start,end)"
+        },
+        "percent_delta": "2.25",
+        "ratio_eligible": true,
+        "compatibility_basis": "exact_identity_tuple_v1"
+      }
+    },
+    {
+      "id": "allowance.reset_incompatible",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "99",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-b",
+        "observed_at_us": 200,
+        "used_percent": "1",
+        "remaining_percent": null
+      },
+      "error": "incompatible allowance observations: reset_identity"
+    },
+    {
+      "id": "allowance.plan_incompatible",
+      "start": {
+        "observation_id": "allowance-observation:v1:6lf2ino7z4ocppmtbjxxqkmhpznuznws3mwzxjc5ylyklejxmqrq",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "10",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:siheoew57wfulrgsapeqrbxvxdcv6gbacjzydze4bicfzmla6u7q",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-b",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "11",
+        "remaining_percent": null
+      },
+      "error": "incompatible allowance observations: plan_identity"
+    },
+    {
+      "id": "allowance.cycle_incompatible",
+      "start": {
+        "observation_id": "allowance-observation:v1:6lf2ino7z4ocppmtbjxxqkmhpznuznws3mwzxjc5ylyklejxmqrq",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "10",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:siheoew57wfulrgsapeqrbxvxdcv6gbacjzydze4bicfzmla6u7q",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-b",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "11",
+        "remaining_percent": null
+      },
+      "error": "incompatible allowance observations: cycle_id"
+    },
+    {
+      "id": "allowance.time_decrease",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "10",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "11",
+        "remaining_percent": null
+      },
+      "error": "allowance observation time decreases"
+    }
+  ],
+  "ratio_vectors": [
+    {
+      "id": "allowance.repeated",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "10",
+        "remaining_percent": "90"
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "10",
+        "remaining_percent": "90"
+      },
+      "expected_percent_delta": "0",
+      "expected_ratio_eligible": false
+    },
+    {
+      "id": "allowance.negative",
+      "start": {
+        "observation_id": "allowance-observation:v1:aaaaaaaaaaaaaaaa",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 100,
+        "used_percent": "20",
+        "remaining_percent": null
+      },
+      "end": {
+        "observation_id": "allowance-observation:v1:bbbbbbbbbbbbbbbb",
+        "provider": "openai",
+        "limit_id": "weekly",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "cycle_id": "cycle-a",
+        "reset_identity": "reset-a",
+        "observed_at_us": 200,
+        "used_percent": "18",
+        "remaining_percent": null
+      },
+      "expected_percent_delta": "-2",
+      "expected_ratio_eligible": false
+    }
+  ],
+  "valuation_vectors": [
+    {
+      "id": "valuation.full",
+      "tokens": {
+        "uncached_input_tokens": 1000,
+        "cached_input_tokens": 2000,
+        "reasoning_tokens": 300,
+        "output_tokens": 500
+      },
+      "rate_card": {
+        "digest": "sha256:full",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": true,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": "1",
+          "reasoning_tokens": null,
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": "0.2",
+          "reasoning_tokens": null,
+          "output_tokens": "4"
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:full",
+        "match_basis": "exact_model_profile",
+        "configured_cost_usd": "0.022",
+        "estimated_credits": "0.0044",
+        "cost_rated_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "output_tokens"
+        ],
+        "credit_rated_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "output_tokens"
+        ],
+        "cost_unpriced_token_fields": [],
+        "credit_unpriced_token_fields": [],
+        "missing_token_fields": [],
+        "cost_coverage_numerator_tokens": 3500,
+        "cost_coverage_denominator_tokens": 3500,
+        "cost_coverage": "1",
+        "credit_coverage_numerator_tokens": 3500,
+        "credit_coverage_denominator_tokens": 3500,
+        "credit_coverage": "1",
+        "cost_unpriced_reason": null,
+        "credit_unpriced_reason": null,
+        "cost_grade": "configured_estimate",
+        "credit_grade": "configured_estimate"
+      }
+    },
+    {
+      "id": "valuation.partial",
+      "tokens": {
+        "uncached_input_tokens": 1000,
+        "cached_input_tokens": 2000,
+        "reasoning_tokens": null,
+        "output_tokens": 1000
+      },
+      "rate_card": {
+        "digest": "sha256:partial",
+        "match_basis": "model_alias",
+        "matched": true,
+        "reasoning_in_output": false,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": null,
+          "reasoning_tokens": "5",
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": null,
+          "reasoning_tokens": "1",
+          "output_tokens": "4"
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:partial",
+        "match_basis": "model_alias",
+        "configured_cost_usd": "0.03",
+        "estimated_credits": "0.006",
+        "cost_rated_token_fields": [
+          "uncached_input_tokens",
+          "output_tokens"
+        ],
+        "credit_rated_token_fields": [
+          "uncached_input_tokens",
+          "output_tokens"
+        ],
+        "cost_unpriced_token_fields": [
+          "cached_input_tokens"
+        ],
+        "credit_unpriced_token_fields": [
+          "cached_input_tokens"
+        ],
+        "missing_token_fields": [
+          "reasoning_tokens"
+        ],
+        "cost_coverage_numerator_tokens": 2000,
+        "cost_coverage_denominator_tokens": 4000,
+        "cost_coverage": "0.5",
+        "credit_coverage_numerator_tokens": 2000,
+        "credit_coverage_denominator_tokens": 4000,
+        "credit_coverage": "0.5",
+        "cost_unpriced_reason": "partial_rate_card",
+        "credit_unpriced_reason": "partial_rate_card",
+        "cost_grade": "configured_estimate",
+        "credit_grade": "configured_estimate"
+      }
+    },
+    {
+      "id": "valuation.unmatched",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "rate_card": {
+        "digest": "sha256:unmatched",
+        "match_basis": "no_match",
+        "matched": false,
+        "reasoning_in_output": false,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": "1",
+          "reasoning_tokens": "5",
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": "0.2",
+          "reasoning_tokens": "1",
+          "output_tokens": "4"
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:unmatched",
+        "match_basis": "no_match",
+        "configured_cost_usd": null,
+        "estimated_credits": null,
+        "cost_rated_token_fields": [],
+        "credit_rated_token_fields": [],
+        "cost_unpriced_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "credit_unpriced_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "missing_token_fields": [],
+        "cost_coverage_numerator_tokens": 0,
+        "cost_coverage_denominator_tokens": 100,
+        "cost_coverage": "0",
+        "credit_coverage_numerator_tokens": 0,
+        "credit_coverage_denominator_tokens": 100,
+        "credit_coverage": "0",
+        "cost_unpriced_reason": "model_unmatched",
+        "credit_unpriced_reason": "model_unmatched",
+        "cost_grade": "unsupported",
+        "credit_grade": "unsupported"
+      }
+    },
+    {
+      "id": "valuation.reasoning_overlap",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 10,
+        "output_tokens": 20
+      },
+      "rate_card": {
+        "digest": "sha256:invalid",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": true,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": "1",
+          "reasoning_tokens": "5",
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": "0.2",
+          "reasoning_tokens": "1",
+          "output_tokens": "4"
+        }
+      },
+      "error": "reasoning cost rate would double-count output"
+    },
+    {
+      "id": "valuation.cost_only",
+      "tokens": {
+        "uncached_input_tokens": 1000,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "rate_card": {
+        "digest": "sha256:cost-only",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": false,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": null,
+          "reasoning_tokens": null,
+          "output_tokens": null
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:cost-only",
+        "match_basis": "exact_model_profile",
+        "configured_cost_usd": "0.01",
+        "estimated_credits": null,
+        "cost_rated_token_fields": [
+          "uncached_input_tokens"
+        ],
+        "credit_rated_token_fields": [],
+        "cost_unpriced_token_fields": [
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "credit_unpriced_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "missing_token_fields": [],
+        "cost_coverage_numerator_tokens": 1000,
+        "cost_coverage_denominator_tokens": 1000,
+        "cost_coverage": "1",
+        "credit_coverage_numerator_tokens": 0,
+        "credit_coverage_denominator_tokens": 1000,
+        "credit_coverage": "0",
+        "cost_unpriced_reason": "partial_rate_card",
+        "credit_unpriced_reason": "partial_rate_card",
+        "cost_grade": "configured_estimate",
+        "credit_grade": "unsupported"
+      }
+    },
+    {
+      "id": "valuation.credit_only",
+      "tokens": {
+        "uncached_input_tokens": 1000,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "rate_card": {
+        "digest": "sha256:credit-only",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": false,
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": null,
+          "reasoning_tokens": null,
+          "output_tokens": null
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:credit-only",
+        "match_basis": "exact_model_profile",
+        "configured_cost_usd": null,
+        "estimated_credits": "0.002",
+        "cost_rated_token_fields": [],
+        "credit_rated_token_fields": [
+          "uncached_input_tokens"
+        ],
+        "cost_unpriced_token_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "credit_unpriced_token_fields": [
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "missing_token_fields": [],
+        "cost_coverage_numerator_tokens": 0,
+        "cost_coverage_denominator_tokens": 1000,
+        "cost_coverage": "0",
+        "credit_coverage_numerator_tokens": 1000,
+        "credit_coverage_denominator_tokens": 1000,
+        "credit_coverage": "1",
+        "cost_unpriced_reason": "partial_rate_card",
+        "credit_unpriced_reason": "partial_rate_card",
+        "cost_grade": "unsupported",
+        "credit_grade": "configured_estimate"
+      }
+    },
+    {
+      "id": "valuation.asymmetric",
+      "tokens": {
+        "uncached_input_tokens": 1000,
+        "cached_input_tokens": 1000,
+        "reasoning_tokens": 1000,
+        "output_tokens": 1000
+      },
+      "rate_card": {
+        "digest": "sha256:asymmetric",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": false,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": null,
+          "reasoning_tokens": null,
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": null,
+          "cached_input_tokens": "0.2",
+          "reasoning_tokens": null,
+          "output_tokens": null
+        }
+      },
+      "expected": {
+        "rate_card_digest": "sha256:asymmetric",
+        "match_basis": "exact_model_profile",
+        "configured_cost_usd": "0.03",
+        "estimated_credits": "0.0002",
+        "cost_rated_token_fields": [
+          "uncached_input_tokens",
+          "output_tokens"
+        ],
+        "credit_rated_token_fields": [
+          "cached_input_tokens"
+        ],
+        "cost_unpriced_token_fields": [
+          "cached_input_tokens",
+          "reasoning_tokens"
+        ],
+        "credit_unpriced_token_fields": [
+          "uncached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "missing_token_fields": [],
+        "cost_coverage_numerator_tokens": 2000,
+        "cost_coverage_denominator_tokens": 4000,
+        "cost_coverage": "0.5",
+        "credit_coverage_numerator_tokens": 1000,
+        "credit_coverage_denominator_tokens": 4000,
+        "credit_coverage": "0.25",
+        "cost_unpriced_reason": "partial_rate_card",
+        "credit_unpriced_reason": "partial_rate_card",
+        "cost_grade": "configured_estimate",
+        "credit_grade": "configured_estimate"
+      }
+    },
+    {
+      "id": "valuation.reasoning_credit_overlap",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 10,
+        "output_tokens": 20
+      },
+      "rate_card": {
+        "digest": "sha256:invalid-credit-overlap",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": true,
+        "rates_per_million": {
+          "uncached_input_tokens": "10",
+          "cached_input_tokens": "1",
+          "reasoning_tokens": null,
+          "output_tokens": "20"
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": "2",
+          "cached_input_tokens": "0.2",
+          "reasoning_tokens": "1",
+          "output_tokens": "4"
+        }
+      },
+      "error": "reasoning credit rate would double-count output"
+    },
+    {
+      "id": "valuation.negative_rate",
+      "tokens": {
+        "uncached_input_tokens": 100,
+        "cached_input_tokens": 0,
+        "reasoning_tokens": 0,
+        "output_tokens": 0
+      },
+      "rate_card": {
+        "digest": "sha256:negative-rate",
+        "match_basis": "exact_model_profile",
+        "matched": true,
+        "reasoning_in_output": false,
+        "rates_per_million": {
+          "uncached_input_tokens": "-1",
+          "cached_input_tokens": null,
+          "reasoning_tokens": null,
+          "output_tokens": null
+        },
+        "credit_rates_per_million": {
+          "uncached_input_tokens": null,
+          "cached_input_tokens": null,
+          "reasoning_tokens": null,
+          "output_tokens": null
+        }
+      },
+      "error": "uncached_input_tokens cost rate is below its allowed domain"
+    }
+  ],
+  "decimal_vectors": [
+    {
+      "id": "decimal.canonical",
+      "field": "used_percent",
+      "value": "2.25",
+      "minimum": "0",
+      "maximum": "100",
+      "expected": "2.25"
+    },
+    {
+      "id": "decimal.noncanonical",
+      "field": "used_percent",
+      "value": "2.250",
+      "minimum": "0",
+      "maximum": "100",
+      "error": "used_percent is not a canonical decimal string"
+    },
+    {
+      "id": "decimal.noncanonical",
+      "field": "rate",
+      "value": "1e1",
+      "minimum": "0",
+      "error": "rate is not a canonical decimal string"
+    },
+    {
+      "id": "decimal.percentage_domain",
+      "field": "used_percent",
+      "value": "101",
+      "minimum": "0",
+      "maximum": "100",
+      "error": "used_percent is above its allowed domain"
+    },
+    {
+      "id": "decimal.percentage_domain",
+      "field": "remaining_percent",
+      "value": "-1",
+      "minimum": "0",
+      "maximum": "100",
+      "error": "remaining_percent is below its allowed domain"
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/field-contract-v1.json
+++ b/tests/agent_kernel/contracts/vectors/field-contract-v1.json
@@ -1,0 +1,2672 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.field-contract-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "field.adapter_identity",
+    "field.source",
+    "field.source_manifestation",
+    "field.project",
+    "field.session",
+    "field.turn",
+    "field.point_event",
+    "field.lifecycle_entity",
+    "field.model_profile",
+    "field.canonical_call",
+    "field.tool_invocation",
+    "field.activity",
+    "field.compaction_boundary",
+    "field.resource",
+    "field.state_change",
+    "field.context_component",
+    "field.allowance_limit",
+    "field.allowance_cycle",
+    "field.allowance_observation",
+    "field.allowance_interval",
+    "field.rate_card_revision",
+    "field.valuation_match",
+    "field.publication",
+    "field.publication_delta",
+    "field.source_occurrence",
+    "field.query_window"
+  ],
+  "field_contract_vectors": [
+    {
+      "id": "field.adapter_identity",
+      "entity": "adapter_identity",
+      "record": {
+        "adapter_id": "codex-jsonl",
+        "adapter_version": "codex-jsonl.v1",
+        "source_kind": "session-jsonl",
+        "capability_mask": 1,
+        "identity_version": "identity-v1"
+      },
+      "assertions": {
+        "adapter_id": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "adapter_version": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "capability_mask": {
+          "checks": [
+            "measurement_mask"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "zero_mask",
+          "identity_participation": "excluded"
+        },
+        "identity_version": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        }
+      }
+    },
+    {
+      "id": "field.source",
+      "entity": "source",
+      "record": {
+        "source_id": "source:v1:cvn6tcrz6bilh3bo33cesif4iiomw5zgbrueh46cszl5uwb23cia",
+        "adapter_id": "codex-jsonl",
+        "source_kind": "session-jsonl",
+        "adapter_native_source_key": "codex-session-store",
+        "first_seen_publication": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "last_seen_publication": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "selected_history_coverage": "fixture"
+      },
+      "assertions": {
+        "source_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "adapter_id": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "adapter_native_source_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "first_seen_publication": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "last_seen_publication": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "selected_history_coverage": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "planner_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.source_manifestation",
+      "entity": "source_manifestation",
+      "record": {
+        "manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+        "source_id": "source:v1:cvn6tcrz6bilh3bo33cesif4iiomw5zgbrueh46cszl5uwb23cia",
+        "technical_path_key": "sessions/2026/07/example.jsonl",
+        "display_label": "fixture",
+        "filesystem_identity": {
+          "fixture": "value"
+        },
+        "size_bytes": 1,
+        "modified_at_us": 100,
+        "content_revision": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "cursor_byte_offset": 1,
+        "cursor_record_ordinal": 1,
+        "state": "active",
+        "parse_diagnostics": [
+          "fixture"
+        ]
+      },
+      "assertions": {
+        "manifestation_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "source_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "technical_path_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "display_label": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "filesystem_identity": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "size_bytes": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "filesystem_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "modified_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "filesystem_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "content_revision": {
+          "checks": [
+            "digest_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "cursor_byte_offset": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "cursor_record_ordinal": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "state": {
+          "checks": [
+            "status_enum"
+          ],
+          "basis": "inventory_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "parse_diagnostics": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.project",
+      "entity": "project",
+      "record": {
+        "project_id": "project:v1:gdmt2ndek24pjiu3m3jfnjyod676cfhczbnobuuq3rqpky67myia",
+        "workspace_key": "workspace/example",
+        "label_candidates": [
+          "fixture"
+        ],
+        "first_event_at_us": 100,
+        "last_event_at_us": 100,
+        "provenance": [
+          {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "record_ordinal": 1,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        ]
+      },
+      "assertions": {
+        "project_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "excluded"
+        },
+        "workspace_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "label_candidates": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "first_event_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_min",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "last_event_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_max",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "provenance": {
+          "checks": [
+            "source_coordinates"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.session",
+      "entity": "session",
+      "record": {
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "adapter_native_session_key": "native-session-001",
+        "identity_version": "identity-v1",
+        "project_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "root_session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "parent_session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "relationship_basis": "fixture",
+        "delegation_depth": 1,
+        "start_at_us": 100,
+        "end_at_us": 100,
+        "lifecycle_state": "succeeded",
+        "completion_basis": "fixture",
+        "label_candidates": [
+          "fixture"
+        ],
+        "evidence_coordinates": [
+          {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "record_ordinal": 1,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        ]
+      },
+      "assertions": {
+        "session_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "adapter_native_session_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "identity_version": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "project_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "root_session_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "deterministic_hierarchy_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "parent_session_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "relationship_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "delegation_depth": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic_hierarchy_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "start_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_min",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "end_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "lifecycle_state": {
+          "checks": [
+            "lifecycle_state"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "completion_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "label_candidates": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "evidence_coordinates": {
+          "checks": [
+            "source_coordinates"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.turn",
+      "entity": "turn",
+      "record": {
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "ordinal": 1,
+        "start_at_us": 100,
+        "end_at_us": 100,
+        "source_order_range": [
+          "fixture"
+        ],
+        "lifecycle_state": "succeeded",
+        "completion_basis": "fixture",
+        "first_boundary_coordinates": {
+          "fixture": "value"
+        },
+        "membership": {
+          "fixture": "value"
+        }
+      },
+      "assertions": {
+        "turn_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "ordinal": {
+          "checks": [
+            "identity_input",
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "start_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "end_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "source_order_range": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "lifecycle_state": {
+          "checks": [
+            "lifecycle_state"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "open_state",
+          "identity_participation": "excluded"
+        },
+        "completion_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "first_boundary_coordinates": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "deterministic_order",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "membership": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "canonical_relationship",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.point_event",
+      "entity": "point_event",
+      "record": {
+        "event_id": "event:v1:vzqemngqig4fsqfgvso4qtjetxe2d5bgltgw24mihiylofrzk6va",
+        "event_kind": "model_call",
+        "event_at_us": 100,
+        "source_order": [
+          "fixture",
+          1
+        ],
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "occurrence_coordinate": {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        "measurement_mask": 1,
+        "basis": "fixture",
+        "confidence": "1"
+      },
+      "assertions": {
+        "event_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "event_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "event_at_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "source_order": {
+          "checks": [
+            "identity_input",
+            "source_order"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "occurrence_coordinate": {
+          "checks": [
+            "source_coordinate"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "measurement_mask": {
+          "checks": [
+            "measurement_mask"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "confidence": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.lifecycle_entity",
+      "entity": "lifecycle_entity",
+      "record": {
+        "logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "kind": "session",
+        "start_coordinate": {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        "last_transition_coordinate": {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        "terminal_coordinate": {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        "state": "active",
+        "state_basis": "fixture",
+        "transition_version": 1,
+        "observed_duration_us": 1,
+        "terminal_error_category": "fixture"
+      },
+      "assertions": {
+        "logical_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "start_coordinate": {
+          "checks": [
+            "source_coordinate"
+          ],
+          "basis": "ordered_transition_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "last_transition_coordinate": {
+          "checks": [
+            "source_coordinate"
+          ],
+          "basis": "ordered_transition_fold",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "terminal_coordinate": {
+          "checks": [
+            "source_coordinate"
+          ],
+          "basis": "ordered_transition_fold",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "state": {
+          "checks": [
+            "status_enum"
+          ],
+          "basis": "ordered_transition_fold",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "state_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "transition_version": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "observed_duration_us": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic_difference",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "terminal_error_category": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.model_profile",
+      "entity": "model_profile",
+      "record": {
+        "model_profile_id": "model-profile:v1:agrmp4vnr5fai7yfnfentlrtpuaeecflb5zacov4ysdr5ymvlebq",
+        "model": "gpt-5.5",
+        "reasoning_effort": "high",
+        "service_tier": "priority"
+      },
+      "assertions": {
+        "model_profile_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "model": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "reasoning_effort": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "service_tier": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        }
+      }
+    },
+    {
+      "id": "field.canonical_call",
+      "entity": "canonical_call",
+      "record": {
+        "call_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q",
+        "adapter_native_call_key": "native-call-001",
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "model_profile_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "context_window_tokens": 1,
+        "uncached_input_tokens": 1,
+        "cached_input_tokens": 1,
+        "reasoning_tokens": 1,
+        "output_tokens": 1,
+        "token_basis": "fixture",
+        "lifecycle": "succeeded",
+        "evidence_coordinates": [
+          {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "record_ordinal": 1,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        ]
+      },
+      "assertions": {
+        "call_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "adapter_native_call_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "model_profile_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "excluded"
+        },
+        "context_window_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "uncached_input_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "observed_or_deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "cached_input_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "reasoning_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "output_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "token_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "lifecycle": {
+          "checks": [
+            "lifecycle_state"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "evidence_coordinates": {
+          "checks": [
+            "source_coordinates"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.tool_invocation",
+      "entity": "tool_invocation",
+      "record": {
+        "tool_id": "tool:v1:jjedz64fn65ld2h4yybfuc5jze7ytmkpujli7ioli3uib6smyfha",
+        "adapter_native_invocation_key": "native-tool-001",
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "transport_name": "fixture",
+        "semantic_operation": "fixture",
+        "tool_family": "fixture",
+        "resource_links": [
+          "fixture"
+        ],
+        "write_intent": true,
+        "lifecycle": "succeeded",
+        "output_bytes": 1,
+        "duration_us": 1,
+        "error_category": "fixture"
+      },
+      "assertions": {
+        "tool_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "adapter_native_invocation_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "transport_name": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "excluded"
+        },
+        "semantic_operation": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "tool_family": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "resource_links": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "write_intent": {
+          "checks": [
+            "boolean"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "false_observed",
+          "identity_participation": "excluded"
+        },
+        "lifecycle": {
+          "checks": [
+            "lifecycle_state"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        },
+        "output_bytes": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "duration_us": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic_difference",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "error_category": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.activity",
+      "entity": "activity",
+      "record": {
+        "activity_id": "activity:v1:isgkkwlqrx5hxfovhdcgyfwviofd5us4gwvnkc3hjaj57lq5xv4a",
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "activity_kind": "compaction",
+        "lifecycle": "succeeded"
+      },
+      "assertions": {
+        "activity_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "activity_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "lifecycle": {
+          "checks": [
+            "lifecycle_state"
+          ],
+          "basis": "lifecycle_fold",
+          "missing_probe": "unknown_state",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.compaction_boundary",
+      "entity": "compaction_boundary",
+      "record": {
+        "compaction_id": "compaction:v1:seerinpi5x7rhrff7fr4dx525msgilx6ha25mxgo75pmkwxowqmq",
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "source_order": [
+          "fixture",
+          8
+        ],
+        "before_context_epoch": 1,
+        "after_context_epoch": 1
+      },
+      "assertions": {
+        "compaction_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_order": {
+          "checks": [
+            "identity_input",
+            "source_order"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "before_context_epoch": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "after_context_epoch": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.resource",
+      "entity": "resource",
+      "record": {
+        "resource_id": "resource:v1:hm3db535gdykbsnhga6t2ylpg3672b27tp35ezssm7aqhtps2y6a",
+        "project_id": "project:v1:gdmt2ndek24pjiu3m3jfnjyod676cfhczbnobuuq3rqpky67myia",
+        "kind": "file",
+        "normalized_key": "src/app.py",
+        "normalization_version": "resource-normalization-v1",
+        "display_label": "fixture",
+        "provenance": [
+          {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "record_ordinal": 1,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        ]
+      },
+      "assertions": {
+        "resource_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "project_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "unknown_state",
+          "identity_participation": "included"
+        },
+        "normalized_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "normalization_version": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "display_label": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "provenance": {
+          "checks": [
+            "source_coordinates"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.state_change",
+      "entity": "state_change",
+      "record": {
+        "change_id": "state-change:v1:d57pzczkqwqlmkfnt32xo4o4xidizu3tttb464px2ogj2gvs77xa",
+        "change_kind": "write",
+        "resource_id": "resource:v1:hm3db535gdykbsnhga6t2ylpg3672b27tp35ezssm7aqhtps2y6a",
+        "observation_at_us": 200,
+        "session_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "before_revision": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "after_revision": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "causal_attribution": true,
+        "evidence_coordinates": [
+          {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "record_ordinal": 1,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        ]
+      },
+      "assertions": {
+        "change_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "change_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "resource_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "observation_at_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "session_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "before_revision": {
+          "checks": [
+            "digest_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "after_revision": {
+          "checks": [
+            "digest_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "causal_attribution": {
+          "checks": [
+            "boolean"
+          ],
+          "basis": "contract_constant",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "evidence_coordinates": {
+          "checks": [
+            "source_coordinates"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.context_component",
+      "entity": "context_component",
+      "record": {
+        "component_id": "context-component:v1:u2f7id3ocldurdhnvaoyk62ma54u7nhof56a2mjlxj4flbv4d64a",
+        "call_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q",
+        "turn_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "category": "tool_output",
+        "observed_utf8_bytes": 1,
+        "event_count": 1,
+        "estimated_tokens": 1,
+        "inclusion_basis": "fixture"
+      },
+      "assertions": {
+        "component_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "call_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "turn_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "category": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "observed_utf8_bytes": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "event_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "estimated_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "configured_estimate",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "inclusion_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.allowance_limit",
+      "entity": "allowance_limit",
+      "record": {
+        "limit_id": "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya",
+        "provider": "openai",
+        "account_local_identity": "account-local-1",
+        "plan_identity": "plan-a",
+        "window_kind": "rolling_week",
+        "configured_duration_us": 1,
+        "capability_basis": "fixture"
+      },
+      "assertions": {
+        "limit_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "provider": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "account_local_identity": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "plan_identity": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "window_kind": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "configured_duration_us": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "configured_estimate",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "capability_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.allowance_cycle",
+      "entity": "allowance_cycle",
+      "record": {
+        "cycle_id": "allowance-cycle:v1:daiagql6qamdpl56ac5vq2gvqed5fn276cbtebyj26n3mjyau7ba",
+        "limit_id": "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya",
+        "reset_identity": "reset-2026-w31",
+        "start_at_us": 1000,
+        "end_at_us": 2000,
+        "reset_basis": "fixture",
+        "completion_status": "active"
+      },
+      "assertions": {
+        "cycle_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "limit_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "reset_identity": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "start_at_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "end_at_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "reset_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "completion_status": {
+          "checks": [
+            "status_enum"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "open_state",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.allowance_observation",
+      "entity": "allowance_observation",
+      "record": {
+        "observation_id": "allowance-observation:v1:dtksjcefe7ttlapfn6mtn4qphqruawelnopydqyrrookorcwpyxa",
+        "limit_id": "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya",
+        "cycle_id": "allowance-cycle:v1:daiagql6qamdpl56ac5vq2gvqed5fn276cbtebyj26n3mjyau7ba",
+        "observed_at_us": 1100,
+        "used_percent": "50",
+        "remaining_percent": "50",
+        "absolute_fields": {
+          "fixture": "value"
+        },
+        "reset_time_us": 100,
+        "plan_identity": "fixture",
+        "source_occurrence": {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        "measurement_mask": 1
+      },
+      "assertions": {
+        "observation_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "limit_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "cycle_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "included"
+        },
+        "observed_at_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "used_percent": {
+          "checks": [
+            "decimal_percentage"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "remaining_percent": {
+          "checks": [
+            "decimal_percentage"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "absolute_fields": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "reset_time_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "plan_identity": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "explicit_unknown",
+          "identity_participation": "excluded"
+        },
+        "source_occurrence": {
+          "checks": [
+            "identity_input",
+            "source_coordinate"
+          ],
+          "basis": "occurrence_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "measurement_mask": {
+          "checks": [
+            "measurement_mask"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.allowance_interval",
+      "entity": "allowance_interval",
+      "record": {
+        "interval_id": "allowance-interval:v1:utrf2l6qkqkkj2dz76tzi3acxnakbb7o5kavv4zmezdzd3qws7xq",
+        "start_observation_id": "allowance-observation:v1:dtksjcefe7ttlapfn6mtn4qphqruawelnopydqyrrookorcwpyxa",
+        "end_observation_id": "allowance-observation:v1:pp2tbni6i2rax2lqiat5npzmnt6xfnsus5q7lzxt3gigtbbppbka",
+        "event_bounds": [
+          0,
+          1
+        ],
+        "percent_delta": "1",
+        "compatibility_basis": "fixture",
+        "ratio_eligible": true,
+        "coverage": {
+          "fixture": "value"
+        }
+      },
+      "assertions": {
+        "interval_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "start_observation_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "end_observation_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "event_bounds": {
+          "checks": [
+            "half_open_bounds"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "percent_delta": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "compatibility_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "ratio_eligible": {
+          "checks": [
+            "boolean"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "false_observed",
+          "identity_participation": "excluded"
+        },
+        "coverage": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.rate_card_revision",
+      "entity": "rate_card_revision",
+      "record": {
+        "rate_card_id": "rate-card:v1:nnz7pn6y5e2tzxsbb4c2duemp2amvjn4nt6vsb6l4377wrm2owda",
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "source_name": "fixture",
+        "source_url": "fixture",
+        "effective_at_us": 100,
+        "fetched_at_us": 100,
+        "currency": "fixture",
+        "model_match_rules": [
+          "fixture"
+        ],
+        "four_class_rates": {
+          "uncached_input_tokens": "1",
+          "cached_input_tokens": "0.1",
+          "reasoning_tokens": "1",
+          "output_tokens": "2"
+        },
+        "credit_rates": {
+          "uncached_input_tokens": "1",
+          "cached_input_tokens": "0.1",
+          "reasoning_tokens": "1",
+          "output_tokens": "2"
+        },
+        "reasoning_in_output": true,
+        "confidence": "1",
+        "validation_status": "active"
+      },
+      "assertions": {
+        "rate_card_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "digest": {
+          "checks": [
+            "identity_input",
+            "digest_text"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_name": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "source_url": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "effective_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "fetched_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "currency": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "model_match_rules": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "four_class_rates": {
+          "checks": [
+            "decimal_rate_map"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "credit_rates": {
+          "checks": [
+            "decimal_rate_map"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "reasoning_in_output": {
+          "checks": [
+            "boolean"
+          ],
+          "basis": "provider_or_rate_card_provenance",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "confidence": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "validation_status": {
+          "checks": [
+            "status_enum"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.valuation_match",
+      "entity": "valuation_match",
+      "record": {
+        "valuation_id": "valuation:v1:mrha4ff5csbeqeucteyzpc644oih5rjhd3g3kc6527p6ttd4pv6q",
+        "call_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q",
+        "rate_card_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "match_basis": "fixture",
+        "configured_cost_usd": "1",
+        "estimated_credits": "1",
+        "cost_rated_token_fields": [
+          "fixture"
+        ],
+        "credit_rated_token_fields": [
+          "fixture"
+        ],
+        "cost_unpriced_token_fields": [
+          "fixture"
+        ],
+        "credit_unpriced_token_fields": [
+          "fixture"
+        ],
+        "missing_token_fields": [
+          "fixture"
+        ],
+        "cost_coverage_numerator_tokens": 1,
+        "cost_coverage_denominator_tokens": 1,
+        "cost_coverage": "1",
+        "credit_coverage_numerator_tokens": 1,
+        "credit_coverage_denominator_tokens": 1,
+        "credit_coverage": "1",
+        "cost_unpriced_reason": "fixture",
+        "credit_unpriced_reason": "fixture",
+        "cost_grade": "fixture",
+        "credit_grade": "fixture"
+      },
+      "assertions": {
+        "valuation_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "call_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "rate_card_digest": {
+          "checks": [
+            "identity_input",
+            "digest_text"
+          ],
+          "basis": "configured_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "match_basis": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "configured_cost_usd": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "configured_estimate",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "estimated_credits": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "configured_estimate",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "cost_rated_token_fields": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "credit_rated_token_fields": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "cost_unpriced_token_fields": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "credit_unpriced_token_fields": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "missing_token_fields": {
+          "checks": [
+            "sequence"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "empty_collection",
+          "identity_participation": "excluded"
+        },
+        "cost_coverage_numerator_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "cost_coverage_denominator_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "cost_coverage": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "credit_coverage_numerator_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "credit_coverage_denominator_tokens": {
+          "checks": [
+            "token_count"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "credit_coverage": {
+          "checks": [
+            "decimal_value"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "cost_unpriced_reason": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "credit_unpriced_reason": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "cost_grade": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "credit_grade": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.publication",
+      "entity": "publication",
+      "record": {
+        "publication_key": "publication-attempt-001",
+        "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+        "parent_publication_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "schema_versions": {
+          "fixture": "value"
+        },
+        "committed_at_us": 100,
+        "observed_through_us": 100,
+        "history_preset": "fixture",
+        "requested_cutoff_us": 100,
+        "indexed_from_us": 100,
+        "indexed_through_us": 100,
+        "guaranteed_complete_from_us": 100,
+        "source_coverage": {
+          "fixture": "value"
+        },
+        "capability_coverage": {
+          "fixture": "value"
+        },
+        "entity_counts": {
+          "fixture": "value"
+        },
+        "publication_delta": {
+          "fixture": "value"
+        },
+        "artifact_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "status": "active"
+      },
+      "assertions": {
+        "publication_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "host_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "publication_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "parent_publication_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "schema_versions": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "contract_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "committed_at_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "host_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "observed_through_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_max",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "history_preset": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "planner_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "requested_cutoff_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "planner_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "indexed_from_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_min",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "indexed_through_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "deterministic_max",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "guaranteed_complete_from_us": {
+          "checks": [
+            "utc_microseconds"
+          ],
+          "basis": "inventory_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "source_coverage": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "inventory_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "capability_coverage": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "entity_counts": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "canonical_exact",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "publication_delta": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "artifact_digest": {
+          "checks": [
+            "digest_text"
+          ],
+          "basis": "host_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "status": {
+          "checks": [
+            "status_enum"
+          ],
+          "basis": "host_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.publication_delta",
+      "entity": "publication_delta",
+      "record": {
+        "delta_key": "publication-delta-001",
+        "delta_id": "publication-delta:v1:oid5bteiazax2bb5bxonzk4mtf3oiaefwm63qwtcrbb6mnfcurfq",
+        "publication_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "parent_publication_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "inserted_count": 1,
+        "corrected_count": 1,
+        "terminalized_count": 1,
+        "recanonicalized_count": 1,
+        "removed_count": 1,
+        "token_delta": {
+          "fixture": "value"
+        }
+      },
+      "assertions": {
+        "delta_key": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "host_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "delta_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "publication_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "parent_publication_id": {
+          "checks": [
+            "logical_id"
+          ],
+          "basis": "publication_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        },
+        "inserted_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "corrected_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "terminalized_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "recanonicalized_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "removed_count": {
+          "checks": [
+            "nonnegative_integer"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "zero_observed",
+          "identity_participation": "excluded"
+        },
+        "token_delta": {
+          "checks": [
+            "mapping"
+          ],
+          "basis": "deterministic",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    },
+    {
+      "id": "field.source_occurrence",
+      "entity": "source_occurrence",
+      "record": {
+        "occurrence_id": "occurrence:v1:ykmjovvykqspyd7wnlup74wqtoluq7hk6gw4l2gtzpnmqbvvmela",
+        "semantic_logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+        "source_revision": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "record_byte_range": [
+          0,
+          128
+        ],
+        "record_ordinal": 1,
+        "adapter_version": "codex-jsonl.v1"
+      },
+      "assertions": {
+        "occurrence_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "semantic_logical_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_manifestation_id": {
+          "checks": [
+            "identity_input",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "source_revision": {
+          "checks": [
+            "identity_input",
+            "digest_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "record_byte_range": {
+          "checks": [
+            "identity_input",
+            "half_open_bounds"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "record_ordinal": {
+          "checks": [
+            "identity_input",
+            "nonnegative_integer"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "included"
+        },
+        "adapter_version": {
+          "checks": [
+            "identity_input",
+            "nonempty_text"
+          ],
+          "basis": "adapter_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        }
+      }
+    },
+    {
+      "id": "field.query_window",
+      "entity": "query_window",
+      "record": {
+        "window_id": "window:v1:45zbxkpom4tqf7jerpd22cqnwcx74gbdrwwc56gniprax5struyq",
+        "start_us": 0,
+        "end_us": 86400000000,
+        "timezone": "UTC",
+        "preset": "fixture"
+      },
+      "assertions": {
+        "window_id": {
+          "checks": [
+            "derived_identity",
+            "logical_id"
+          ],
+          "basis": "identity_v1",
+          "missing_probe": "reject_null",
+          "identity_participation": "excluded"
+        },
+        "start_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "calendar_conversion",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "end_us": {
+          "checks": [
+            "identity_input",
+            "utc_microseconds"
+          ],
+          "basis": "calendar_conversion",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "timezone": {
+          "checks": [
+            "identity_input",
+            "iana_timezone"
+          ],
+          "basis": "request_exact",
+          "missing_probe": "reject_null",
+          "identity_participation": "included"
+        },
+        "preset": {
+          "checks": [
+            "nonempty_text"
+          ],
+          "basis": "request_exact",
+          "missing_probe": "allow_null",
+          "identity_participation": "excluded"
+        }
+      }
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/identity-v1.json
+++ b/tests/agent_kernel/contracts/vectors/identity-v1.json
@@ -1,0 +1,546 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.identity-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "identity.adapter_identity",
+    "identity.source",
+    "identity.source_manifestation",
+    "identity.project",
+    "identity.session",
+    "identity.turn",
+    "identity.point_event",
+    "identity.lifecycle_entity",
+    "identity.model_profile",
+    "identity.canonical_call",
+    "identity.tool_invocation",
+    "identity.activity",
+    "identity.compaction_boundary",
+    "identity.resource",
+    "identity.state_change",
+    "identity.context_component",
+    "identity.allowance_limit",
+    "identity.allowance_cycle",
+    "identity.allowance_observation",
+    "identity.allowance_interval",
+    "identity.rate_card_revision",
+    "identity.valuation_match",
+    "identity.publication",
+    "identity.publication_delta",
+    "identity.source_occurrence",
+    "identity.query_window",
+    "identity.publication_artifact",
+    "identity.collision",
+    "identity.source_copy"
+  ],
+  "identity_vectors": [
+    {
+      "id": "identity.adapter_identity",
+      "entity": "adapter_identity",
+      "kind": "adapter",
+      "identity_input_fields": [
+        "adapter_id",
+        "adapter_version",
+        "source_kind",
+        "identity_version"
+      ],
+      "identity_tuple": [
+        "codex-jsonl",
+        "codex-jsonl.v1",
+        "session-jsonl",
+        "identity-v1"
+      ],
+      "expected_id": "adapter:v1:hc5336lztbvfctvohv3kk5s5xznqwf6m5zcqvwnfhd4iareqnrna"
+    },
+    {
+      "id": "identity.source",
+      "entity": "source",
+      "kind": "source",
+      "identity_input_fields": [
+        "adapter_id",
+        "source_kind",
+        "adapter_native_source_key"
+      ],
+      "identity_tuple": [
+        "codex-jsonl",
+        "session-jsonl",
+        "codex-session-store"
+      ],
+      "expected_id": "source:v1:cvn6tcrz6bilh3bo33cesif4iiomw5zgbrueh46cszl5uwb23cia"
+    },
+    {
+      "id": "identity.source_manifestation",
+      "entity": "source_manifestation",
+      "kind": "source-manifestation",
+      "identity_input_fields": [
+        "source_id",
+        "technical_path_key"
+      ],
+      "identity_tuple": [
+        "source:v1:cvn6tcrz6bilh3bo33cesif4iiomw5zgbrueh46cszl5uwb23cia",
+        "sessions/2026/07/example.jsonl"
+      ],
+      "expected_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea"
+    },
+    {
+      "id": "identity.project",
+      "entity": "project",
+      "kind": "project",
+      "identity_input_fields": [
+        "workspace_key"
+      ],
+      "identity_tuple": [
+        "workspace/example"
+      ],
+      "expected_id": "project:v1:gdmt2ndek24pjiu3m3jfnjyod676cfhczbnobuuq3rqpky67myia"
+    },
+    {
+      "id": "identity.session",
+      "entity": "session",
+      "kind": "session",
+      "identity_input_fields": [
+        "adapter_native_session_key",
+        "identity_version"
+      ],
+      "identity_tuple": [
+        "native-session-001",
+        "identity-v1"
+      ],
+      "expected_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna"
+    },
+    {
+      "id": "identity.turn",
+      "entity": "turn",
+      "kind": "turn",
+      "identity_input_fields": [
+        "session_id",
+        "ordinal"
+      ],
+      "identity_tuple": [
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        1
+      ],
+      "expected_id": "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a"
+    },
+    {
+      "id": "identity.point_event",
+      "entity": "point_event",
+      "kind": "event",
+      "identity_input_fields": [
+        "event_kind",
+        "event_at_us",
+        "source_order",
+        "session_id",
+        "turn_id"
+      ],
+      "identity_tuple": [
+        "model_call",
+        100,
+        [
+          "fixture",
+          1
+        ],
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a"
+      ],
+      "expected_id": "event:v1:vzqemngqig4fsqfgvso4qtjetxe2d5bgltgw24mihiylofrzk6va"
+    },
+    {
+      "id": "identity.lifecycle_entity",
+      "entity": "lifecycle_entity",
+      "kind": "lifecycle",
+      "identity_input_fields": [
+        "logical_id",
+        "kind"
+      ],
+      "identity_tuple": [
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "session"
+      ],
+      "expected_id": "lifecycle:v1:cwv5mbs7rxid7ri2oyfgldv76wm5rmeu6dnr44g4ja2rnlgbzhxa"
+    },
+    {
+      "id": "identity.model_profile",
+      "entity": "model_profile",
+      "kind": "model-profile",
+      "identity_input_fields": [
+        "model",
+        "reasoning_effort",
+        "service_tier"
+      ],
+      "identity_tuple": [
+        "gpt-5.5",
+        "high",
+        "priority"
+      ],
+      "expected_id": "model-profile:v1:agrmp4vnr5fai7yfnfentlrtpuaeecflb5zacov4ysdr5ymvlebq"
+    },
+    {
+      "id": "identity.canonical_call",
+      "entity": "canonical_call",
+      "kind": "call",
+      "identity_input_fields": [
+        "adapter_native_call_key",
+        "session_id",
+        "turn_id"
+      ],
+      "identity_tuple": [
+        "native-call-001",
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a"
+      ],
+      "expected_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q"
+    },
+    {
+      "id": "identity.tool_invocation",
+      "entity": "tool_invocation",
+      "kind": "tool",
+      "identity_input_fields": [
+        "adapter_native_invocation_key",
+        "session_id",
+        "turn_id"
+      ],
+      "identity_tuple": [
+        "native-tool-001",
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a"
+      ],
+      "expected_id": "tool:v1:jjedz64fn65ld2h4yybfuc5jze7ytmkpujli7ioli3uib6smyfha"
+    },
+    {
+      "id": "identity.activity",
+      "entity": "activity",
+      "kind": "activity",
+      "identity_input_fields": [
+        "session_id",
+        "turn_id",
+        "activity_kind"
+      ],
+      "identity_tuple": [
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "compaction"
+      ],
+      "expected_id": "activity:v1:isgkkwlqrx5hxfovhdcgyfwviofd5us4gwvnkc3hjaj57lq5xv4a"
+    },
+    {
+      "id": "identity.compaction_boundary",
+      "entity": "compaction_boundary",
+      "kind": "compaction",
+      "identity_input_fields": [
+        "session_id",
+        "source_order"
+      ],
+      "identity_tuple": [
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        [
+          "fixture",
+          8
+        ]
+      ],
+      "expected_id": "compaction:v1:seerinpi5x7rhrff7fr4dx525msgilx6ha25mxgo75pmkwxowqmq"
+    },
+    {
+      "id": "identity.resource",
+      "entity": "resource",
+      "kind": "resource",
+      "identity_input_fields": [
+        "project_id",
+        "kind",
+        "normalized_key",
+        "normalization_version"
+      ],
+      "identity_tuple": [
+        "project:v1:gdmt2ndek24pjiu3m3jfnjyod676cfhczbnobuuq3rqpky67myia",
+        "file",
+        "src/app.py",
+        "resource-normalization-v1"
+      ],
+      "expected_id": "resource:v1:hm3db535gdykbsnhga6t2ylpg3672b27tp35ezssm7aqhtps2y6a"
+    },
+    {
+      "id": "identity.state_change",
+      "entity": "state_change",
+      "kind": "state-change",
+      "identity_input_fields": [
+        "change_kind",
+        "resource_id",
+        "observation_at_us",
+        "session_id",
+        "turn_id"
+      ],
+      "identity_tuple": [
+        "write",
+        "resource:v1:hm3db535gdykbsnhga6t2ylpg3672b27tp35ezssm7aqhtps2y6a",
+        200,
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a"
+      ],
+      "expected_id": "state-change:v1:d57pzczkqwqlmkfnt32xo4o4xidizu3tttb464px2ogj2gvs77xa"
+    },
+    {
+      "id": "identity.context_component",
+      "entity": "context_component",
+      "kind": "context-component",
+      "identity_input_fields": [
+        "call_id",
+        "turn_id",
+        "category"
+      ],
+      "identity_tuple": [
+        "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q",
+        "turn:v1:5rcoyph6igf36vxn3jyv26ixsxygtdahr6mestu3tnk6bbad2i7a",
+        "tool_output"
+      ],
+      "expected_id": "context-component:v1:u2f7id3ocldurdhnvaoyk62ma54u7nhof56a2mjlxj4flbv4d64a"
+    },
+    {
+      "id": "identity.allowance_limit",
+      "entity": "allowance_limit",
+      "kind": "allowance-limit",
+      "identity_input_fields": [
+        "provider",
+        "account_local_identity",
+        "plan_identity",
+        "window_kind"
+      ],
+      "identity_tuple": [
+        "openai",
+        "account-local-1",
+        "plan-a",
+        "rolling_week"
+      ],
+      "expected_id": "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya"
+    },
+    {
+      "id": "identity.allowance_cycle",
+      "entity": "allowance_cycle",
+      "kind": "allowance-cycle",
+      "identity_input_fields": [
+        "limit_id",
+        "reset_identity",
+        "start_at_us",
+        "end_at_us"
+      ],
+      "identity_tuple": [
+        "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya",
+        "reset-2026-w31",
+        1000,
+        2000
+      ],
+      "expected_id": "allowance-cycle:v1:daiagql6qamdpl56ac5vq2gvqed5fn276cbtebyj26n3mjyau7ba"
+    },
+    {
+      "id": "identity.allowance_observation",
+      "entity": "allowance_observation",
+      "kind": "allowance-observation",
+      "identity_input_fields": [
+        "limit_id",
+        "cycle_id",
+        "observed_at_us",
+        "source_occurrence"
+      ],
+      "identity_tuple": [
+        "allowance-limit:v1:eu5ip4ofpzmqt3r2dw2rzh2mk4xywgixiaofvt5tk4y2cqaixlya",
+        "allowance-cycle:v1:daiagql6qamdpl56ac5vq2gvqed5fn276cbtebyj26n3mjyau7ba",
+        1100,
+        {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "record_ordinal": 1,
+          "adapter_version": "codex-jsonl.v1"
+        }
+      ],
+      "expected_id": "allowance-observation:v1:dtksjcefe7ttlapfn6mtn4qphqruawelnopydqyrrookorcwpyxa"
+    },
+    {
+      "id": "identity.allowance_interval",
+      "entity": "allowance_interval",
+      "kind": "allowance-interval",
+      "identity_input_fields": [
+        "start_observation_id",
+        "end_observation_id"
+      ],
+      "identity_tuple": [
+        "allowance-observation:v1:dtksjcefe7ttlapfn6mtn4qphqruawelnopydqyrrookorcwpyxa",
+        "allowance-observation:v1:pp2tbni6i2rax2lqiat5npzmnt6xfnsus5q7lzxt3gigtbbppbka"
+      ],
+      "expected_id": "allowance-interval:v1:utrf2l6qkqkkj2dz76tzi3acxnakbb7o5kavv4zmezdzd3qws7xq"
+    },
+    {
+      "id": "identity.rate_card_revision",
+      "entity": "rate_card_revision",
+      "kind": "rate-card",
+      "identity_input_fields": [
+        "digest"
+      ],
+      "identity_tuple": [
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      ],
+      "expected_id": "rate-card:v1:nnz7pn6y5e2tzxsbb4c2duemp2amvjn4nt6vsb6l4377wrm2owda"
+    },
+    {
+      "id": "identity.valuation_match",
+      "entity": "valuation_match",
+      "kind": "valuation",
+      "identity_input_fields": [
+        "call_id",
+        "rate_card_digest"
+      ],
+      "identity_tuple": [
+        "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q",
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      ],
+      "expected_id": "valuation:v1:mrha4ff5csbeqeucteyzpc644oih5rjhd3g3kc6527p6ttd4pv6q"
+    },
+    {
+      "id": "identity.publication",
+      "entity": "publication",
+      "kind": "publication",
+      "identity_input_fields": [
+        "publication_key"
+      ],
+      "identity_tuple": [
+        "publication-attempt-001"
+      ],
+      "expected_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka"
+    },
+    {
+      "id": "identity.publication_delta",
+      "entity": "publication_delta",
+      "kind": "publication-delta",
+      "identity_input_fields": [
+        "delta_key"
+      ],
+      "identity_tuple": [
+        "publication-delta-001"
+      ],
+      "expected_id": "publication-delta:v1:oid5bteiazax2bb5bxonzk4mtf3oiaefwm63qwtcrbb6mnfcurfq"
+    },
+    {
+      "id": "identity.source_occurrence",
+      "entity": "source_occurrence",
+      "kind": "occurrence",
+      "identity_input_fields": [
+        "semantic_logical_id",
+        "source_manifestation_id",
+        "source_revision",
+        "record_byte_range",
+        "record_ordinal",
+        "adapter_version"
+      ],
+      "identity_tuple": [
+        "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        [
+          0,
+          128
+        ],
+        1,
+        "codex-jsonl.v1"
+      ],
+      "expected_id": "occurrence:v1:ykmjovvykqspyd7wnlup74wqtoluq7hk6gw4l2gtzpnmqbvvmela"
+    },
+    {
+      "id": "identity.query_window",
+      "entity": "query_window",
+      "kind": "window",
+      "identity_input_fields": [
+        "start_us",
+        "end_us",
+        "timezone"
+      ],
+      "identity_tuple": [
+        0,
+        86400000000,
+        "UTC"
+      ],
+      "expected_id": "window:v1:45zbxkpom4tqf7jerpd22cqnwcx74gbdrwwc56gniprax5struyq"
+    }
+  ],
+  "publication_derivation_vectors": [
+    {
+      "id": "identity.publication_artifact",
+      "publication_key": "publication-attempt-001",
+      "expected_publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+      "artifact_without_digest": {
+        "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+        "database_identity": "codex-usage-tracker.agent-kernel.v1",
+        "status": "committed",
+        "entity_counts": {
+          "session": 1
+        }
+      },
+      "expected_artifact_digest": "6f461e2badb0d84abd7aaf41e415831451ff805cc87a10a87b9781ada22a4841",
+      "derivation_order": [
+        "allocate_publication_key",
+        "derive_publication_id",
+        "assemble_canonical_artifact_without_artifact_digest",
+        "derive_artifact_digest"
+      ]
+    }
+  ],
+  "collision_vectors": [
+    {
+      "id": "identity.collision",
+      "logical_id": "session:v1:eriwi3rtswlcz6ap5k2jt7ywypijkhi6hcxdwxgoaoev2jepaita",
+      "first_tuple": [
+        "native-session-collision-a",
+        "identity-v1"
+      ],
+      "second_tuple": [
+        "native-session-collision-b",
+        "identity-v1"
+      ]
+    }
+  ],
+  "occurrence_vectors": [
+    {
+      "id": "identity.source_copy",
+      "occurrences": [
+        {
+          "logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+          "identity_tuple": [
+            "native-session-001",
+            "identity-v1"
+          ],
+          "coordinate": {
+            "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+            "source_revision": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+            "record_ordinal": 7,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        },
+        {
+          "logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+          "identity_tuple": [
+            "native-session-001",
+            "identity-v1"
+          ],
+          "coordinate": {
+            "source_manifestation_id": "source-manifestation:v1:xf7ybcedaztxb5bcray7ufhpe2tntltawxsdhbmemp5fqvpjdrsa",
+            "source_revision": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+            "record_ordinal": 7,
+            "adapter_version": "codex-jsonl.v1"
+          }
+        }
+      ],
+      "expected_logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "expected_entity_count": 1,
+      "expected_coordinates": [
+        {
+          "source_manifestation_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+          "source_revision": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "record_ordinal": 7,
+          "adapter_version": "codex-jsonl.v1"
+        },
+        {
+          "source_manifestation_id": "source-manifestation:v1:xf7ybcedaztxb5bcray7ufhpe2tntltawxsdhbmemp5fqvpjdrsa",
+          "source_revision": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "record_ordinal": 7,
+          "adapter_version": "codex-jsonl.v1"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/lifecycle-v1.json
+++ b/tests/agent_kernel/contracts/vectors/lifecycle-v1.json
@@ -1,0 +1,234 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.lifecycle-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "lifecycle.cross_publication",
+    "lifecycle.late_transition",
+    "lifecycle.invalid_terminal",
+    "hierarchy.late_parent",
+    "hierarchy.multilevel",
+    "hierarchy.cycle"
+  ],
+  "lifecycle_vectors": [
+    {
+      "id": "lifecycle.cross_publication",
+      "transitions": [
+        {
+          "logical_id": "tool:v1:aaaaaaaaaaaaaaaa",
+          "state": "running",
+          "basis": "observed_start",
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "publication_id": "publication:v1:aaaaaaaaaaaaaaaa",
+            "record_ordinal": 1
+          }
+        },
+        {
+          "logical_id": "tool:v1:aaaaaaaaaaaaaaaa",
+          "state": "succeeded",
+          "basis": "observed_terminal",
+          "event_at_us": 250,
+          "source_order": [
+            "source-a",
+            2
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "publication_id": "publication:v1:bbbbbbbbbbbbbbbb",
+            "record_ordinal": 2
+          }
+        }
+      ],
+      "expected": {
+        "logical_id": "tool:v1:aaaaaaaaaaaaaaaa",
+        "state": "succeeded",
+        "state_basis": "observed_terminal",
+        "start_coordinate": {
+          "publication_id": "publication:v1:aaaaaaaaaaaaaaaa",
+          "record_ordinal": 1
+        },
+        "terminal_coordinate": {
+          "publication_id": "publication:v1:bbbbbbbbbbbbbbbb",
+          "record_ordinal": 2
+        },
+        "observed_duration_us": 150,
+        "duration_diagnostic": null,
+        "transition_count": 2
+      }
+    },
+    {
+      "id": "lifecycle.late_transition",
+      "transitions": [
+        {
+          "logical_id": "call:v1:aaaaaaaaaaaaaaaa",
+          "state": "succeeded",
+          "basis": "observed_terminal",
+          "event_at_us": 300,
+          "source_order": [
+            "source-a",
+            3
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "publication_id": "publication:v1:aaaaaaaaaaaaaaaa",
+            "record_ordinal": 3
+          }
+        },
+        {
+          "logical_id": "call:v1:aaaaaaaaaaaaaaaa",
+          "state": "running",
+          "basis": "late_observed_start",
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "publication_id": "publication:v1:bbbbbbbbbbbbbbbb",
+            "record_ordinal": 1
+          }
+        }
+      ],
+      "expected": {
+        "logical_id": "call:v1:aaaaaaaaaaaaaaaa",
+        "state": "succeeded",
+        "state_basis": "observed_terminal",
+        "start_coordinate": {
+          "publication_id": "publication:v1:bbbbbbbbbbbbbbbb",
+          "record_ordinal": 1
+        },
+        "terminal_coordinate": {
+          "publication_id": "publication:v1:aaaaaaaaaaaaaaaa",
+          "record_ordinal": 3
+        },
+        "observed_duration_us": 200,
+        "duration_diagnostic": null,
+        "transition_count": 2
+      }
+    },
+    {
+      "id": "lifecycle.invalid_terminal",
+      "transitions": [
+        {
+          "logical_id": "tool:v1:bbbbbbbbbbbbbbbb",
+          "state": "succeeded",
+          "basis": "observed_terminal",
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "record_ordinal": 1
+          }
+        },
+        {
+          "logical_id": "tool:v1:bbbbbbbbbbbbbbbb",
+          "state": "failed",
+          "basis": "conflicting_terminal",
+          "event_at_us": 200,
+          "source_order": [
+            "source-a",
+            2
+          ],
+          "event_kind_order": 1,
+          "coordinate": {
+            "record_ordinal": 2
+          }
+        }
+      ],
+      "error": "invalid lifecycle transition succeeded -> failed"
+    }
+  ],
+  "hierarchy_vectors": [
+    {
+      "id": "hierarchy.late_parent",
+      "session_id": "root",
+      "before_parent_by_session": {
+        "root": null,
+        "child": null
+      },
+      "after_parent_by_session": {
+        "root": null,
+        "child": "root"
+      },
+      "exclusive_usage": {
+        "root": 100,
+        "child": 50
+      },
+      "session_identity_before": "session:v1:aaaaaaaaaaaaaaaa",
+      "session_identity_after": "session:v1:aaaaaaaaaaaaaaaa",
+      "expected_before": {
+        "parent_exclusive": 100,
+        "descendant_exclusive": 0,
+        "family_inclusive": 100,
+        "child_count": 0,
+        "descendant_count": 0
+      },
+      "expected_after": {
+        "parent_exclusive": 100,
+        "descendant_exclusive": 50,
+        "family_inclusive": 150,
+        "child_count": 1,
+        "descendant_count": 1
+      }
+    },
+    {
+      "id": "hierarchy.multilevel",
+      "session_id": "root",
+      "before_parent_by_session": {
+        "root": null,
+        "child": "root",
+        "grandchild": "child"
+      },
+      "after_parent_by_session": {
+        "root": null,
+        "child": "root",
+        "grandchild": "child"
+      },
+      "exclusive_usage": {
+        "root": 100,
+        "child": 50,
+        "grandchild": 25
+      },
+      "session_identity_before": "session:v1:aaaaaaaaaaaaaaaa",
+      "session_identity_after": "session:v1:aaaaaaaaaaaaaaaa",
+      "expected_before": {
+        "parent_exclusive": 100,
+        "descendant_exclusive": 75,
+        "family_inclusive": 175,
+        "child_count": 1,
+        "descendant_count": 2
+      },
+      "expected_after": {
+        "parent_exclusive": 100,
+        "descendant_exclusive": 75,
+        "family_inclusive": 175,
+        "child_count": 1,
+        "descendant_count": 2
+      }
+    }
+  ],
+  "invalid_hierarchy_vectors": [
+    {
+      "id": "hierarchy.cycle",
+      "session_id": "a",
+      "parent_by_session": {
+        "a": "b",
+        "b": "a"
+      },
+      "exclusive_usage": {
+        "a": 10,
+        "b": 20
+      },
+      "error": "session hierarchy contains a cycle"
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/selector-v1.json
+++ b/tests/agent_kernel/contracts/vectors/selector-v1.json
@@ -1,0 +1,230 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.selector-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "selector.session",
+    "selector.state_change",
+    "selector.source_manifestation",
+    "selector.rebuild_stable",
+    "selector.invalid_prefix",
+    "selector.invalid_digest_length",
+    "selector.invalid_digest_case",
+    "selector.invalid_digest_padding",
+    "selector.kind_mismatch",
+    "selector.alias_same",
+    "selector.alias_distinct",
+    "publication.committed_snapshot",
+    "publication.mixed_snapshot",
+    "publication.rolled_back"
+  ],
+  "prefixes": {
+    "allowance_interval": "allowance-interval",
+    "allowance_observation": "allowance-observation",
+    "call": "call",
+    "model_profile": "model-profile",
+    "project": "project",
+    "publication": "publication",
+    "rate_card": "rate-card",
+    "resource": "resource",
+    "session": "session",
+    "source_manifestation": "source-manifestation",
+    "state_change": "state-change",
+    "tool": "tool",
+    "turn": "turn",
+    "window": "window"
+  },
+  "identity_kinds": {
+    "allowance_interval": "allowance-interval",
+    "allowance_observation": "allowance-observation",
+    "call": "call",
+    "model_profile": "model-profile",
+    "project": "project",
+    "publication": "publication",
+    "rate_card": "rate-card",
+    "resource": "resource",
+    "session": "session",
+    "source_manifestation": "source-manifestation",
+    "state_change": "state-change",
+    "tool": "tool",
+    "turn": "turn",
+    "window": "window"
+  },
+  "selector_vectors": [
+    {
+      "id": "selector.session",
+      "kind": "session",
+      "logical_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "expected_selector": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "selector_after_rebuild": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "old_coordinate": {
+        "source_revision": "sha256:old",
+        "record_ordinal": 1
+      },
+      "replacement_coordinate": {
+        "source_revision": "sha256:new",
+        "record_ordinal": 7
+      },
+      "prefixes": {
+        "session": "session"
+      },
+      "identity_kinds": {
+        "session": "session"
+      }
+    },
+    {
+      "id": "selector.state_change",
+      "kind": "state_change",
+      "logical_id": "state-change:v1:acys4xwbzjqqoolyxvrr6h22mdahlmqw7tyqj27tlrxwqi6p2cqa",
+      "expected_selector": "state-change:state-change:v1:acys4xwbzjqqoolyxvrr6h22mdahlmqw7tyqj27tlrxwqi6p2cqa",
+      "selector_after_rebuild": "state-change:state-change:v1:acys4xwbzjqqoolyxvrr6h22mdahlmqw7tyqj27tlrxwqi6p2cqa",
+      "old_coordinate": {
+        "source_revision": "sha256:old",
+        "record_ordinal": 2
+      },
+      "replacement_coordinate": {
+        "source_revision": "sha256:new",
+        "record_ordinal": 8
+      },
+      "prefixes": {
+        "state_change": "state-change"
+      },
+      "identity_kinds": {
+        "state_change": "state-change"
+      }
+    },
+    {
+      "id": "selector.source_manifestation",
+      "kind": "source_manifestation",
+      "logical_id": "source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+      "expected_selector": "source-manifestation:source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+      "selector_after_rebuild": "source-manifestation:source-manifestation:v1:lyhp3de3mn7xwdn7amv6vnkjjabw3y2bczicu7pfhg5t3a4cxsea",
+      "old_coordinate": {
+        "source_revision": "sha256:old",
+        "record_ordinal": 3
+      },
+      "replacement_coordinate": {
+        "source_revision": "sha256:new",
+        "record_ordinal": 9
+      },
+      "prefixes": {
+        "source_manifestation": "source-manifestation"
+      },
+      "identity_kinds": {
+        "source_manifestation": "source-manifestation"
+      }
+    }
+  ],
+  "invalid_selector_vectors": [
+    {
+      "id": "selector.invalid_prefix",
+      "selector": "unknown:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "error": "unknown selector prefix unknown"
+    },
+    {
+      "id": "selector.invalid_digest_length",
+      "selector": "session:session:v1:ly4h5wl3xcwosiub",
+      "error": "selector contains an invalid logical ID"
+    },
+    {
+      "id": "selector.invalid_digest_case",
+      "selector": "session:session:v1:Ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "error": "selector contains an invalid logical ID"
+    },
+    {
+      "id": "selector.invalid_digest_padding",
+      "selector": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna=",
+      "error": "selector contains an invalid logical ID"
+    },
+    {
+      "id": "selector.kind_mismatch",
+      "selector": "session:tool:v1:jjedz64fn65ld2h4yybfuc5jze7ytmkpujli7ioli3uib6smyfha",
+      "error": "selector kind does not match logical ID kind"
+    }
+  ],
+  "alias_vectors": [
+    {
+      "id": "selector.alias_same",
+      "selector": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "aliases": {
+        "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna": "session:session:v1:dpf63lfge2y2nt7dpyywmlwklnwh4wrrx2b4cxnujxvtqusuropq"
+      },
+      "entities": {
+        "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna": {
+          "entity_key": "native-session-1"
+        },
+        "session:session:v1:dpf63lfge2y2nt7dpyywmlwklnwh4wrrx2b4cxnujxvtqusuropq": {
+          "entity_key": "native-session-1"
+        }
+      },
+      "expected": {
+        "requested_selector": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+        "resolved_selector": "session:session:v1:dpf63lfge2y2nt7dpyywmlwklnwh4wrrx2b4cxnujxvtqusuropq",
+        "alias_applied": true,
+        "entity_key": "native-session-1"
+      }
+    },
+    {
+      "id": "selector.alias_distinct",
+      "selector": "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna",
+      "aliases": {
+        "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna": "session:session:v1:dpf63lfge2y2nt7dpyywmlwklnwh4wrrx2b4cxnujxvtqusuropq"
+      },
+      "entities": {
+        "session:session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna": {
+          "entity_key": "native-session-1"
+        },
+        "session:session:v1:dpf63lfge2y2nt7dpyywmlwklnwh4wrrx2b4cxnujxvtqusuropq": {
+          "entity_key": "native-session-2"
+        }
+      },
+      "error": "selector alias would join distinct entities"
+    }
+  ],
+  "publication_vectors": [
+    {
+      "id": "publication.committed_snapshot",
+      "publication": {
+        "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+        "status": "committed"
+      },
+      "rows": [
+        {
+          "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+          "entity_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna"
+        },
+        {
+          "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+          "entity_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q"
+        }
+      ],
+      "expected_publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka"
+    },
+    {
+      "id": "publication.mixed_snapshot",
+      "publication": {
+        "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+        "status": "committed"
+      },
+      "rows": [
+        {
+          "publication_id": "publication:v1:rhvnzju6icrcrt2geso6ocup2nl33swccs3y4fncbdgsunm7rdka",
+          "entity_id": "session:v1:ly4h5wl3xcwosiubv36cztq7pxkh3gi5yx447fl5dddtgcpnbnna"
+        },
+        {
+          "publication_id": "publication:v1:s2dvctcs3wzjhj5cnc43japv7acxg2vheqgyucc4zuyjsjrsu5wa",
+          "entity_id": "call:v1:qalvn2ajqkevrjnkcuccriwuvhd6oxffwetrrau3ea5gzmqmh32q"
+        }
+      ],
+      "error": "snapshot mixes publication identities"
+    },
+    {
+      "id": "publication.rolled_back",
+      "publication": {
+        "publication_id": "publication:v1:laniwk2dhjeojyl4u7fir5w2qjo56wjiz4fz7hy4r6xz5shvuw5a",
+        "status": "rolled_back"
+      },
+      "rows": [],
+      "error": "publication is not committed"
+    }
+  ]
+}

--- a/tests/agent_kernel/contracts/vectors/time-v1.json
+++ b/tests/agent_kernel/contracts/vectors/time-v1.json
@@ -1,0 +1,199 @@
+{
+  "schema": "codex-usage-tracker.agent-kernel.time-vectors.v1",
+  "version": 1,
+  "vector_ids": [
+    "time.epoch",
+    "time.pre_epoch",
+    "time.offset",
+    "time.submicrosecond",
+    "time.submicrosecond_zero",
+    "time.dst_fold_0",
+    "time.dst_fold_1",
+    "time.dst_gap",
+    "time.dst_ambiguous",
+    "time.int64_boundaries",
+    "time.total_order",
+    "time.late_event",
+    "time.missing_order"
+  ],
+  "instant_vectors": [
+    {
+      "id": "time.epoch",
+      "instant": "1970-01-01T00:00:00Z",
+      "expected_us": 0
+    },
+    {
+      "id": "time.pre_epoch",
+      "instant": "1969-12-31T23:59:59.999999Z",
+      "expected_us": -1
+    },
+    {
+      "id": "time.offset",
+      "instant": "2026-07-28T17:00:00-04:00",
+      "expected_us": 1785272400000000
+    },
+    {
+      "id": "time.submicrosecond",
+      "instant": "2026-07-28T17:00:00.1234567Z",
+      "error": "timestamp exceeds exact microsecond precision"
+    },
+    {
+      "id": "time.submicrosecond_zero",
+      "instant": "2026-07-28T17:00:00.1234560Z",
+      "error": "timestamp exceeds exact microsecond precision"
+    }
+  ],
+  "calendar_vectors": [
+    {
+      "id": "time.dst_fold_0",
+      "local": "2026-11-01T01:30:00",
+      "timezone": "America/New_York",
+      "fold": 0,
+      "expected_us": 1793511000000000
+    },
+    {
+      "id": "time.dst_fold_1",
+      "local": "2026-11-01T01:30:00",
+      "timezone": "America/New_York",
+      "fold": 1,
+      "expected_us": 1793514600000000
+    },
+    {
+      "id": "time.dst_gap",
+      "local": "2026-03-08T02:30:00",
+      "timezone": "America/New_York",
+      "error": "nonexistent DST local time"
+    },
+    {
+      "id": "time.dst_ambiguous",
+      "local": "2026-11-01T01:30:00",
+      "timezone": "America/New_York",
+      "error": "ambiguous DST local time requires fold"
+    }
+  ],
+  "integer_vectors": [
+    {
+      "id": "time.int64_boundaries",
+      "value": -9223372036854775808,
+      "valid": true
+    },
+    {
+      "id": "time.int64_boundaries",
+      "value": 9223372036854775807,
+      "valid": true
+    },
+    {
+      "id": "time.int64_boundaries",
+      "value": -9223372036854775809,
+      "valid": false
+    },
+    {
+      "id": "time.int64_boundaries",
+      "value": 9223372036854775808,
+      "valid": false
+    }
+  ],
+  "ordering_vectors": [
+    {
+      "id": "time.total_order",
+      "events": [
+        {
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            2
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:bbbbbbbbbbbbbbbb"
+        },
+        {
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 2,
+          "logical_id": "event:v1:aaaaaaaaaaaaaaaa"
+        },
+        {
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:cccccccccccccccc"
+        }
+      ],
+      "expected_ids": [
+        "event:v1:cccccccccccccccc",
+        "event:v1:aaaaaaaaaaaaaaaa",
+        "event:v1:bbbbbbbbbbbbbbbb"
+      ]
+    },
+    {
+      "id": "time.late_event",
+      "events": [
+        {
+          "event_at_us": 300,
+          "source_order": [
+            "source-a",
+            3
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:cccccccccccccccc"
+        },
+        {
+          "event_at_us": 100,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:aaaaaaaaaaaaaaaa"
+        },
+        {
+          "event_at_us": 200,
+          "source_order": [
+            "source-a",
+            2
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:bbbbbbbbbbbbbbbb"
+        }
+      ],
+      "expected_ids": [
+        "event:v1:aaaaaaaaaaaaaaaa",
+        "event:v1:bbbbbbbbbbbbbbbb",
+        "event:v1:cccccccccccccccc"
+      ]
+    },
+    {
+      "id": "time.missing_order",
+      "events": [
+        {
+          "event_at_us": null,
+          "source_order": [
+            "source-a",
+            1
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:missingmissingmiss"
+        },
+        {
+          "event_at_us": 0,
+          "source_order": [
+            "source-a",
+            2
+          ],
+          "event_kind_order": 1,
+          "logical_id": "event:v1:observedobserved"
+        }
+      ],
+      "expected_ids": [
+        "event:v1:observedobserved",
+        "event:v1:missingmissingmiss"
+      ]
+    }
+  ]
+}

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from scripts.check_kernel_scope import (
     CK01_AGENT_KERNEL_CONTRACT_ADDITIONS,
+    CK02_LOGICAL_CONTRACT_ADDITIONS,
     CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS,
     INTEGRATION_ADDITIONS,
     K1A_ADDITIONS,
@@ -265,6 +266,31 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/contracts/__init__.py",
         "tests/agent_kernel/contracts/test_question_catalog.py",
     } == CK01_AGENT_KERNEL_CONTRACT_ADDITIONS
+    assert {
+        "config/agent-kernel/logical-contract-v1.json",
+        "tests/agent_kernel/contracts/reference/__init__.py",
+        "tests/agent_kernel/contracts/reference/accounting.py",
+        "tests/agent_kernel/contracts/reference/allowance.py",
+        "tests/agent_kernel/contracts/reference/contract.py",
+        "tests/agent_kernel/contracts/reference/field_contract.py",
+        "tests/agent_kernel/contracts/reference/identity.py",
+        "tests/agent_kernel/contracts/reference/lifecycle.py",
+        "tests/agent_kernel/contracts/reference/selectors.py",
+        "tests/agent_kernel/contracts/reference/time.py",
+        "tests/agent_kernel/contracts/test_accounting_vectors.py",
+        "tests/agent_kernel/contracts/test_allowance_vectors.py",
+        "tests/agent_kernel/contracts/test_identity_vectors.py",
+        "tests/agent_kernel/contracts/test_lifecycle_vectors.py",
+        "tests/agent_kernel/contracts/test_selector_vectors.py",
+        "tests/agent_kernel/contracts/test_time_vectors.py",
+        "tests/agent_kernel/contracts/vectors/accounting-v1.json",
+        "tests/agent_kernel/contracts/vectors/allowance-v1.json",
+        "tests/agent_kernel/contracts/vectors/field-contract-v1.json",
+        "tests/agent_kernel/contracts/vectors/identity-v1.json",
+        "tests/agent_kernel/contracts/vectors/lifecycle-v1.json",
+        "tests/agent_kernel/contracts/vectors/selector-v1.json",
+        "tests/agent_kernel/contracts/vectors/time-v1.json",
+    } == CK02_LOGICAL_CONTRACT_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -288,6 +314,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | R4_ADDITIONS
         | R5_ADDITIONS
         | CK01_AGENT_KERNEL_CONTRACT_ADDITIONS
+        | CK02_LOGICAL_CONTRACT_ADDITIONS
     )
 
 


### PR DESCRIPTION
## Summary

- freeze physical-independent logical semantics for 26 entities and 245 admitted fields
- add exact identities and 119 executable vectors across time, accounting, lifecycle, allowance/valuation, selectors/publication, and field contracts
- execute one semantic assertion for every admitted field through pure test-only references
- close CK-02 accounting at 3/17 without adding production, schema, MCP, or frontend code

## Validation

- focused contract/docs/scope: 60 passed
- `just vp`: passed
- `just v`: 497 tests passed
- Ruff, MyPy, Pyright, scope, release-safety, diff and secret scans passed
- vector bundle: 146,658 bytes
- bundle SHA-256: `f310f9e6dc6e65e8f1944a347b6d3bfbf18fe68f2f8ddcf9eb0d1c81e9396848`

## Review

One final review produced 9 findings; all 9 were accepted and resolved. Reviewer-token attribution remains pending because the installed Usage Tracker CLI lacks the metrics helper's expected `strict` command.