### PR TITLE
fix: recover exact GitNexus FTS corruption

### DIFF
--- a/scripts/bootstrap_dev_environment.py
+++ b/scripts/bootstrap_dev_environment.py
@@ -8,6 +8,8 @@ repair a missing or stale project virtual environment.
 from __future__ import annotations
 
 import argparse
+import codecs
+import io
 import json
 import os
 import re
@@ -15,6 +17,7 @@ import shutil
 import subprocess
 import sys
 import time
+from collections import deque
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -36,9 +39,15 @@ _GITNEXUS_LOCK_FILENAME = "codex-usage-tracker-gitnexus-analyze.lock"
 _GITNEXUS_LOCK_TIMEOUT_SECONDS = 600.0
 _GITNEXUS_COMPARE_BASE = "origin/main"
 _GITNEXUS_CHANGED_FILES_PATTERN = re.compile(r"^Changes:\s+(\d+)\s+files\b", re.MULTILINE)
+_GITNEXUS_ANALYZER_READ_BYTES = 4096
+_GITNEXUS_ANALYZER_TAIL_CHARS = 65_536
+_GITNEXUS_ANALYZER_TRUNCATION_NOTICE = (
+    f"[GitNexus output truncated; last {_GITNEXUS_ANALYZER_TAIL_CHARS} characters retained]\n"
+)
 _GITNEXUS_FTS_CORRUPTION_PATTERN = re.compile(
-    r"FTS index 'file_fts' inconsistent: node offset \d+ missing during delete\. "
-    r"Drop and recreate FTS index\."
+    r"FTS\s+index\s+'file_fts'\s+(?:is\s+)?inconsistent\s*:\s*"
+    r"node\s+offset\s+\d+\s+missing\s+during\s+delete\.\s*"
+    r"Drop\s+and\s+recreate\s+FTS\s+index\."
 )
 
 
@@ -872,6 +881,48 @@ def _gitnexus_analyze_command(root: Path, node: str) -> list[str]:
     return [node, str(runner), "analyze", "--index-only"]
 
 
+def _run_gitnexus_analyzer(
+    command: list[str],
+    *,
+    cwd: Path,
+) -> CommandResult:
+    tail: deque[str] = deque(maxlen=_GITNEXUS_ANALYZER_TAIL_CHARS)
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    captured_characters = 0
+    try:
+        with subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        ) as process:
+            output = process.stdout
+            if not isinstance(output, io.BufferedReader):
+                raise BootstrapError("Could not capture GitNexus analyzer output.")
+            while chunk := output.read1(_GITNEXUS_ANALYZER_READ_BYTES):
+                text = decoder.decode(chunk)
+                if not text:
+                    continue
+                sys.stdout.write(text)
+                sys.stdout.flush()
+                tail.extend(text)
+                captured_characters += len(text)
+            final_text = decoder.decode(b"", final=True)
+            if final_text:
+                sys.stdout.write(final_text)
+                sys.stdout.flush()
+                tail.extend(final_text)
+                captured_characters += len(final_text)
+            returncode = process.wait()
+    except OSError as exc:
+        raise BootstrapError(f"Could not execute {command[0]!r}: {exc}") from exc
+
+    captured = "".join(tail)
+    if captured_characters > _GITNEXUS_ANALYZER_TAIL_CHARS:
+        captured = f"{_GITNEXUS_ANALYZER_TRUNCATION_NOTICE}{captured}"
+    return CommandResult(returncode, captured, "")
+
+
 def _is_recognized_gitnexus_fts_corruption(result: CommandResult) -> bool:
     output = f"{result.stdout}\n{result.stderr}"
     return _GITNEXUS_FTS_CORRUPTION_PATTERN.search(output) is not None
@@ -977,7 +1028,7 @@ def _analyze_gitnexus_if_needed(
         if inspection.state == "error":
             raise BootstrapError(inspection.detail)
         analyze_command = _gitnexus_analyze_command(root, node)
-        analyze_result = _run(analyze_command, cwd=root)
+        analyze_result = _run_gitnexus_analyzer(analyze_command, cwd=root)
         if analyze_result.returncode == 0:
             return True
         exact_worktree_identified = (
@@ -1004,7 +1055,7 @@ def _analyze_gitnexus_if_needed(
                 f"Original analysis: {_command_failure(analyze_command, analyze_result)}"
             )
 
-        retry_result = _run(analyze_command, cwd=root)
+        retry_result = _run_gitnexus_analyzer(analyze_command, cwd=root)
         if retry_result.returncode != 0:
             raise BootstrapError(
                 "GitNexus automatic clean succeeded after recognized file_fts "

--- a/scripts/bootstrap_dev_environment.py
+++ b/scripts/bootstrap_dev_environment.py
@@ -46,7 +46,7 @@ _GITNEXUS_ANALYZER_TRUNCATION_NOTICE = (
 )
 _GITNEXUS_FTS_CORRUPTION_PATTERN = re.compile(
     r"FTS\s+index\s+'file_fts'\s+(?:is\s+)?inconsistent\s*:\s*"
-    r"node\s+offset\s+\d+\s+missing\s+during\s+delete\.\s*"
+    r"(?:document\s+)?node\s+offset\s+\d+\s+missing\s+during\s+delete\.\s*"
     r"Drop\s+and\s+recreate\s+FTS\s+index\."
 )
 

--- a/scripts/bootstrap_dev_environment.py
+++ b/scripts/bootstrap_dev_environment.py
@@ -36,6 +36,10 @@ _GITNEXUS_LOCK_FILENAME = "codex-usage-tracker-gitnexus-analyze.lock"
 _GITNEXUS_LOCK_TIMEOUT_SECONDS = 600.0
 _GITNEXUS_COMPARE_BASE = "origin/main"
 _GITNEXUS_CHANGED_FILES_PATTERN = re.compile(r"^Changes:\s+(\d+)\s+files\b", re.MULTILINE)
+_GITNEXUS_FTS_CORRUPTION_PATTERN = re.compile(
+    r"FTS index 'file_fts' inconsistent: node offset \d+ missing during delete\. "
+    r"Drop and recreate FTS index\."
+)
 
 
 class BootstrapError(RuntimeError):
@@ -868,6 +872,11 @@ def _gitnexus_analyze_command(root: Path, node: str) -> list[str]:
     return [node, str(runner), "analyze", "--index-only"]
 
 
+def _is_recognized_gitnexus_fts_corruption(result: CommandResult) -> bool:
+    output = f"{result.stdout}\n{result.stderr}"
+    return _GITNEXUS_FTS_CORRUPTION_PATTERN.search(output) is not None
+
+
 def _cache_root() -> Path:
     configured = os.environ.get("XDG_CACHE_HOME")
     if configured:
@@ -968,10 +977,41 @@ def _analyze_gitnexus_if_needed(
         if inspection.state == "error":
             raise BootstrapError(inspection.detail)
         analyze_command = _gitnexus_analyze_command(root, node)
-        analyze_result = _run(analyze_command, cwd=root, stream=True)
-        if analyze_result.returncode != 0:
+        analyze_result = _run(analyze_command, cwd=root)
+        if analyze_result.returncode == 0:
+            return True
+        exact_worktree_identified = (
+            inspection.repository == root.resolve() and inspection.branch is not None
+        )
+        if (
+            not exact_worktree_identified
+            or not _is_recognized_gitnexus_fts_corruption(analyze_result)
+        ):
             raise BootstrapError(_command_failure(analyze_command, analyze_result))
-    return True
+
+        clean_command = [
+            node,
+            str(_gitnexus_runner(root)),
+            "clean",
+            "--force",
+        ]
+        clean_result = _run(clean_command, cwd=root)
+        if clean_result.returncode != 0:
+            raise BootstrapError(
+                "GitNexus recognized file_fts corruption for the exact worktree, "
+                "but automatic clean failed; analysis was not retried. "
+                f"{_command_failure(clean_command, clean_result)} "
+                f"Original analysis: {_command_failure(analyze_command, analyze_result)}"
+            )
+
+        retry_result = _run(analyze_command, cwd=root)
+        if retry_result.returncode != 0:
+            raise BootstrapError(
+                "GitNexus automatic clean succeeded after recognized file_fts "
+                "corruption, but the one allowed index-only retry failed; "
+                f"{_command_failure(analyze_command, retry_result)}"
+            )
+        return True
 
 
 def _repair_gitnexus_tool(root: Path, node: str) -> str:

--- a/tests/agent_kernel/test_dev_environment_bootstrap.py
+++ b/tests/agent_kernel/test_dev_environment_bootstrap.py
@@ -526,6 +526,54 @@ class _GitNexusEnvironment:
         raise AssertionError(f"unexpected command: {argv}")
 
 
+_GITNEXUS_FTS_CORRUPTION = (
+    "FTS index 'file_fts' inconsistent: node offset 42 missing during delete. "
+    "Drop and recreate FTS index."
+)
+
+
+class _FailingGitNexusEnvironment(_GitNexusEnvironment):
+    def __init__(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        root: Path,
+        *,
+        analysis_results: list[bootstrap.CommandResult],
+        clean_result: bootstrap.CommandResult | None = None,
+        indexed: bool = True,
+        stale: bool = True,
+    ) -> None:
+        self.analysis_results = analysis_results.copy()
+        self.clean_result = clean_result or bootstrap.CommandResult(0, "", "")
+        super().__init__(monkeypatch, root, indexed=indexed, stale=stale)
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> bootstrap.CommandResult:
+        argv = tuple(str(part) for part in command)
+        if "analyze" in argv:
+            self.commands.append(argv)
+            if not self.analysis_results:
+                raise AssertionError("unexpected extra GitNexus analysis")
+            result = self.analysis_results.pop(0)
+            if result.returncode == 0:
+                self.indexed = True
+                self.stale = False
+            return result
+        if argv[-2:] == ("clean", "--force"):
+            self.commands.append(argv)
+            if self.clean_result.returncode == 0:
+                self.indexed = False
+                self.stale = False
+            return self.clean_result
+        return super().run(command, cwd=cwd, env=env, stream=stream)
+
+
 def test_ready_gitnexus_index_is_not_reanalyzed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -640,6 +688,140 @@ def test_stale_gitnexus_index_is_reanalyzed_once_under_index_only_mode(
     assert analyzes[0][-2:] == ("analyze", "--index-only")
     assert "--embeddings" not in analyzes[0]
     assert "--force" not in analyzes[0]
+
+
+def test_recognized_gitnexus_fts_corruption_cleans_and_retries_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    fake = _FailingGitNexusEnvironment(
+        monkeypatch,
+        root,
+        analysis_results=[
+            bootstrap.CommandResult(1, "", _GITNEXUS_FTS_CORRUPTION),
+            bootstrap.CommandResult(0, "", ""),
+        ],
+    )
+
+    result = bootstrap.prepare_gitnexus(root, check_only=False)
+
+    recovery_commands = [
+        command
+        for command in fake.commands
+        if "analyze" in command or "clean" in command
+    ]
+    assert result.changed is True
+    assert result.state == "up_to_date"
+    assert [command[-2:] for command in recovery_commands] == [
+        ("analyze", "--index-only"),
+        ("clean", "--force"),
+        ("analyze", "--index-only"),
+    ]
+    assert recovery_commands[1] == (
+        fake.node,
+        str(fake.entrypoint),
+        "clean",
+        "--force",
+    )
+
+
+def test_unrelated_gitnexus_analysis_failure_does_not_clean_or_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    fake = _FailingGitNexusEnvironment(
+        monkeypatch,
+        root,
+        analysis_results=[
+            bootstrap.CommandResult(1, "", "unrelated analyzer failure"),
+        ],
+    )
+
+    with pytest.raises(bootstrap.BootstrapError, match="unrelated analyzer failure"):
+        bootstrap.prepare_gitnexus(root, check_only=False)
+
+    assert sum("analyze" in command for command in fake.commands) == 1
+    assert not any("clean" in command for command in fake.commands)
+
+
+def test_gitnexus_fts_corruption_without_exact_identity_does_not_clean_or_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    fake = _FailingGitNexusEnvironment(
+        monkeypatch,
+        root,
+        analysis_results=[
+            bootstrap.CommandResult(1, "", _GITNEXUS_FTS_CORRUPTION),
+        ],
+        indexed=False,
+        stale=False,
+    )
+
+    with pytest.raises(
+        bootstrap.BootstrapError,
+        match="FTS index 'file_fts' inconsistent",
+    ):
+        bootstrap.prepare_gitnexus(root, check_only=False)
+
+    assert sum("analyze" in command for command in fake.commands) == 1
+    assert not any("clean" in command for command in fake.commands)
+
+
+def test_gitnexus_fts_recovery_clean_failure_is_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    fake = _FailingGitNexusEnvironment(
+        monkeypatch,
+        root,
+        analysis_results=[
+            bootstrap.CommandResult(1, "", _GITNEXUS_FTS_CORRUPTION),
+        ],
+        clean_result=bootstrap.CommandResult(1, "", "synthetic clean failure"),
+    )
+
+    with pytest.raises(
+        bootstrap.BootstrapError,
+        match="automatic clean failed.*synthetic clean failure",
+    ):
+        bootstrap.prepare_gitnexus(root, check_only=False)
+
+    assert sum("analyze" in command for command in fake.commands) == 1
+    assert sum("clean" in command for command in fake.commands) == 1
+
+
+def test_gitnexus_fts_recovery_retry_failure_is_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    fake = _FailingGitNexusEnvironment(
+        monkeypatch,
+        root,
+        analysis_results=[
+            bootstrap.CommandResult(1, "", _GITNEXUS_FTS_CORRUPTION),
+            bootstrap.CommandResult(1, "", "synthetic retry failure"),
+        ],
+    )
+
+    with pytest.raises(
+        bootstrap.BootstrapError,
+        match="one allowed index-only retry failed.*synthetic retry failure",
+    ):
+        bootstrap.prepare_gitnexus(root, check_only=False)
+
+    assert sum("analyze" in command for command in fake.commands) == 2
+    assert sum("clean" in command for command in fake.commands) == 1
 
 
 def test_gitnexus_rechecks_after_lock_and_skips_duplicate_analysis(

--- a/tests/agent_kernel/test_dev_environment_bootstrap.py
+++ b/tests/agent_kernel/test_dev_environment_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
@@ -436,6 +437,7 @@ class _GitNexusEnvironment:
         paths = {"git": self.git, "node": self.node, "npm": self.npm}
         monkeypatch.setattr(bootstrap, "_which", lambda executable: paths.get(executable))
         monkeypatch.setattr(bootstrap, "_run", self.run)
+        monkeypatch.setattr(bootstrap, "_run_gitnexus_analyzer", self.run_analyzer)
         monkeypatch.setenv("XDG_CACHE_HOME", str(root / ".cache"))
 
     @property
@@ -519,16 +521,33 @@ class _GitNexusEnvironment:
                 ),
                 "",
             )
-        if "analyze" in argv:
-            self.indexed = True
-            self.stale = False
-            return bootstrap.CommandResult(0, "", "")
         raise AssertionError(f"unexpected command: {argv}")
+
+    def run_analyzer(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+    ) -> bootstrap.CommandResult:
+        del cwd
+        argv = tuple(str(part) for part in command)
+        self.commands.append(argv)
+        self.indexed = True
+        self.stale = False
+        return bootstrap.CommandResult(0, "", "")
 
 
 _GITNEXUS_FTS_CORRUPTION = (
     "FTS index 'file_fts' inconsistent: node offset 42 missing during delete. "
     "Drop and recreate FTS index."
+)
+_GITNEXUS_FTS_CORRUPTION_WITH_IS = (
+    "[gitnexus diagnostic]\n"
+    "FTS  index  'file_fts'\n"
+    "is inconsistent :\n"
+    "node offset 314 missing during delete.\n"
+    "Drop and recreate FTS index.\n"
+    "[diagnostic end]"
 )
 
 
@@ -556,15 +575,6 @@ class _FailingGitNexusEnvironment(_GitNexusEnvironment):
         stream: bool = False,
     ) -> bootstrap.CommandResult:
         argv = tuple(str(part) for part in command)
-        if "analyze" in argv:
-            self.commands.append(argv)
-            if not self.analysis_results:
-                raise AssertionError("unexpected extra GitNexus analysis")
-            result = self.analysis_results.pop(0)
-            if result.returncode == 0:
-                self.indexed = True
-                self.stale = False
-            return result
         if argv[-2:] == ("clean", "--force"):
             self.commands.append(argv)
             if self.clean_result.returncode == 0:
@@ -572,6 +582,149 @@ class _FailingGitNexusEnvironment(_GitNexusEnvironment):
                 self.stale = False
             return self.clean_result
         return super().run(command, cwd=cwd, env=env, stream=stream)
+
+    def run_analyzer(
+        self,
+        command: list[str],
+        *,
+        cwd: Path,
+    ) -> bootstrap.CommandResult:
+        del cwd
+        argv = tuple(str(part) for part in command)
+        self.commands.append(argv)
+        if not self.analysis_results:
+            raise AssertionError("unexpected extra GitNexus analysis")
+        result = self.analysis_results.pop(0)
+        if result.returncode == 0:
+            self.indexed = True
+            self.stale = False
+        return result
+
+
+class _AnalyzerProcess:
+    def __init__(
+        self,
+        payload: bytes,
+        *,
+        returncode: int,
+        events: list[str],
+    ) -> None:
+        self.stdout = io.BufferedReader(io.BytesIO(payload))
+        self.returncode = returncode
+        self.events = events
+
+    def __enter__(self) -> _AnalyzerProcess:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc: object,
+        traceback: object,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.stdout.close()
+
+    def wait(self) -> int:
+        self.events.append("wait")
+        return self.returncode
+
+
+class _AnalyzerProgressSink(io.StringIO):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    def write(self, text: str) -> int:
+        self.events.append("write")
+        return super().write(text)
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        _GITNEXUS_FTS_CORRUPTION,
+        _GITNEXUS_FTS_CORRUPTION_WITH_IS,
+    ],
+)
+def test_gitnexus_fts_corruption_signature_accepts_supported_variants(
+    diagnostic: str,
+) -> None:
+    result = bootstrap.CommandResult(1, "", diagnostic)
+
+    assert bootstrap._is_recognized_gitnexus_fts_corruption(result) is True
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        _GITNEXUS_FTS_CORRUPTION.replace("file_fts", "symbol_fts"),
+        _GITNEXUS_FTS_CORRUPTION.replace("node offset 42", "node offset unknown"),
+        _GITNEXUS_FTS_CORRUPTION.replace("missing during delete", "missing during insert"),
+        _GITNEXUS_FTS_CORRUPTION.replace(
+            "Drop and recreate FTS index.",
+            "Rebuild the index.",
+        ),
+    ],
+)
+def test_gitnexus_fts_corruption_signature_rejects_near_misses(
+    diagnostic: str,
+) -> None:
+    result = bootstrap.CommandResult(1, diagnostic, "")
+
+    assert bootstrap._is_recognized_gitnexus_fts_corruption(result) is False
+
+
+def test_gitnexus_analyzer_runner_streams_and_keeps_a_bounded_diagnostic_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    progress = "GitNexus indexing started\n"
+    diagnostic = f"\n{_GITNEXUS_FTS_CORRUPTION_WITH_IS}\n"
+    emitted = (
+        progress
+        + ("x" * (bootstrap._GITNEXUS_ANALYZER_TAIL_CHARS + 128))
+        + diagnostic
+    )
+    events: list[str] = []
+    process = _AnalyzerProcess(
+        emitted.encode(),
+        returncode=9,
+        events=events,
+    )
+    command = ["/synthetic/bin/node", "gitnexus.js", "analyze", "--index-only"]
+
+    def open_process(
+        received_command: list[str],
+        *,
+        cwd: Path,
+        stdout: int,
+        stderr: int,
+    ) -> _AnalyzerProcess:
+        assert received_command == command
+        assert cwd == tmp_path
+        assert stdout == bootstrap.subprocess.PIPE
+        assert stderr == bootstrap.subprocess.STDOUT
+        return process
+
+    sink = _AnalyzerProgressSink(events)
+    monkeypatch.setattr(bootstrap.subprocess, "Popen", open_process)
+    monkeypatch.setattr(bootstrap.sys, "stdout", sink)
+
+    result = bootstrap._run_gitnexus_analyzer(command, cwd=tmp_path)
+
+    assert sink.getvalue() == emitted
+    assert events.index("write") < events.index("wait")
+    assert result.returncode == 9
+    assert result.stderr == ""
+    assert result.stdout.startswith(bootstrap._GITNEXUS_ANALYZER_TRUNCATION_NOTICE)
+    assert len(result.stdout) <= (
+        bootstrap._GITNEXUS_ANALYZER_TAIL_CHARS
+        + len(bootstrap._GITNEXUS_ANALYZER_TRUNCATION_NOTICE)
+    )
+    assert progress not in result.stdout
+    assert diagnostic.strip() in result.stdout
+    assert bootstrap._is_recognized_gitnexus_fts_corruption(result) is True
 
 
 def test_ready_gitnexus_index_is_not_reanalyzed(

--- a/tests/agent_kernel/test_dev_environment_bootstrap.py
+++ b/tests/agent_kernel/test_dev_environment_bootstrap.py
@@ -545,7 +545,7 @@ _GITNEXUS_FTS_CORRUPTION_WITH_IS = (
     "[gitnexus diagnostic]\n"
     "FTS  index  'file_fts'\n"
     "is inconsistent :\n"
-    "node offset 314 missing during delete.\n"
+    "document node offset 314 missing during delete.\n"
     "Drop and recreate FTS index.\n"
     "[diagnostic end]"
 )
@@ -660,6 +660,10 @@ def test_gitnexus_fts_corruption_signature_accepts_supported_variants(
     [
         _GITNEXUS_FTS_CORRUPTION.replace("file_fts", "symbol_fts"),
         _GITNEXUS_FTS_CORRUPTION.replace("node offset 42", "node offset unknown"),
+        _GITNEXUS_FTS_CORRUPTION.replace(
+            "node offset 42",
+            "record node offset 42",
+        ),
         _GITNEXUS_FTS_CORRUPTION.replace("missing during delete", "missing during insert"),
         _GITNEXUS_FTS_CORRUPTION.replace(
             "Drop and recreate FTS index.",


### PR DESCRIPTION
## Summary
- stream GitNexus analyzer progress while retaining a bounded diagnostic tail
- auto-clean only the exact current worktree for the known `file_fts` delete inconsistency
- retry index-only analysis exactly once and fail closed for every other failure
- permanently cover the observed diagnostic variants and recovery boundaries

## Validation
- 44 focused bootstrap tests
- Ruff, MyPy, and Pyright
- `just vp`
- `python3 scripts/bootstrap_dev_environment.py --check`
- GitNexus `detect_changes` against `origin/main`: low risk, zero affected processes

## Review accounting
- one final read-only reviewer
- findings: 3
- accepted: 3
- reviewer token status: pending

## Residual
The exact final `document node offset` signature is synthetically covered; GitNexus completed a full recovery before that variant could be re-exercised live.