### PR TITLE
fix: normalize GitNexus terminal diagnostics

### DIFF
--- a/scripts/bootstrap_dev_environment.py
+++ b/scripts/bootstrap_dev_environment.py
@@ -44,6 +44,19 @@ _GITNEXUS_ANALYZER_TAIL_CHARS = 65_536
 _GITNEXUS_ANALYZER_TRUNCATION_NOTICE = (
     f"[GitNexus output truncated; last {_GITNEXUS_ANALYZER_TAIL_CHARS} characters retained]\n"
 )
+_GITNEXUS_TERMINAL_ESCAPE_PATTERN = re.compile(
+    r"(?:"
+    r"\x1B(?:"
+    r"\[[0-?]*[ -/]*[@-~]"
+    r"|\][\s\S]*?(?:\x07|\x1B\\|\Z)"
+    r"|[PX^_][\s\S]*?(?:\x1B\\|\Z)"
+    r"|[78]"
+    r"|[@-Z\\-_]"
+    r")"
+    r"|\x9B[0-?]*[ -/]*[@-~]"
+    r")"
+)
+_GITNEXUS_TERMINAL_CONTROL_PATTERN = re.compile(r"[\x00-\x08\x0B-\x1F\x7F-\x9F]")
 _GITNEXUS_FTS_CORRUPTION_PATTERN = re.compile(
     r"FTS\s+index\s+'file_fts'\s+(?:is\s+)?inconsistent\s*:\s*"
     r"(?:document\s+)?node\s+offset\s+\d+\s+missing\s+during\s+delete\.\s*"
@@ -925,7 +938,9 @@ def _run_gitnexus_analyzer(
 
 def _is_recognized_gitnexus_fts_corruption(result: CommandResult) -> bool:
     output = f"{result.stdout}\n{result.stderr}"
-    return _GITNEXUS_FTS_CORRUPTION_PATTERN.search(output) is not None
+    without_escapes = _GITNEXUS_TERMINAL_ESCAPE_PATTERN.sub("", output)
+    normalized = _GITNEXUS_TERMINAL_CONTROL_PATTERN.sub("", without_escapes)
+    return _GITNEXUS_FTS_CORRUPTION_PATTERN.search(normalized) is not None
 
 
 def _cache_root() -> Path:

--- a/tests/agent_kernel/test_dev_environment_bootstrap.py
+++ b/tests/agent_kernel/test_dev_environment_bootstrap.py
@@ -679,6 +679,44 @@ def test_gitnexus_fts_corruption_signature_rejects_near_misses(
     assert bootstrap._is_recognized_gitnexus_fts_corruption(result) is False
 
 
+def test_gitnexus_fts_corruption_signature_ignores_terminal_control_framing() -> None:
+    diagnostic = (
+        "\x1b[2K\r\x1b[31mAnalysis failed:\x1b[0m "
+        "COPY failed for File: Runtime exception: "
+        "FTS ind\x1b[36mex\x1b[0m 'file_\rfts' "
+        "is incon\x1b[2Ksistent: "
+        "document node off\x00set 281 missing during dele\x08te. "
+        "\x1b]8;;https://example.invalid\x1b\\Drop\x1b]8;;\x1b\\ "
+        "and recreate FTS index.\x07"
+    )
+    result = bootstrap.CommandResult(1, "", diagnostic)
+
+    assert bootstrap._is_recognized_gitnexus_fts_corruption(result) is True
+    assert result.stderr == diagnostic
+
+
+def test_gitnexus_fts_corruption_signature_rejects_terminal_metadata_and_near_miss() -> None:
+    terminal_title = f"\x1b]0;{_GITNEXUS_FTS_CORRUPTION}\x07unrelated failure"
+    ansi_near_miss = (
+        "\x1b[31mFTS index 'symbol_fts' inconsistent:\x1b[0m "
+        "node offset 281 missing during delete. "
+        "Drop and recreate FTS index."
+    )
+
+    assert (
+        bootstrap._is_recognized_gitnexus_fts_corruption(
+            bootstrap.CommandResult(1, terminal_title, "")
+        )
+        is False
+    )
+    assert (
+        bootstrap._is_recognized_gitnexus_fts_corruption(
+            bootstrap.CommandResult(1, "", ansi_near_miss)
+        )
+        is False
+    )
+
+
 def test_gitnexus_analyzer_runner_streams_and_keeps_a_bounded_diagnostic_tail(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- normalize terminal control framing before matching the already-narrow `file_fts` corruption signature
- cover realistic CSI, OSC, carriage-return, NUL, and backspace interleaving
- preserve exact-worktree targeting, bounded streaming, one clean, one retry, and fail-closed behavior

## Why
The merged recovery path encountered the exact known diagnostic live in the CK-04 worktree, but GitNexus terminal framing prevented the semantic signature from matching. A manual second analysis then succeeded, confirming the remaining gap was recognition rather than a broader recovery failure.

## Validation
- 46 focused bootstrap tests
- Ruff, MyPy, Pyright
- `just vp`
- bootstrap readiness check
- GitNexus compare: low risk, two files, zero affected processes

## Review accounting
This is the bounded live-evidence follow-up to the already-reviewed PR #375; no second reviewer was used. PR #375 review accounting remains 3 findings / 3 accepted / token status pending.