### PR TITLE
CK-06: implement Codex adapter and bounded ingestion

### DIFF
--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -9,8 +9,8 @@
   "mcp_tools": 6,
   "http_routes": 7,
   "cli_commands": 11,
-  "wheel_bytes": 208945,
-  "sdist_bytes": 610000,
+  "wheel_bytes": 236300,
+  "sdist_bytes": 634700,
   "plugin_bundle_bytes": 5620,
   "mcp_golden_prompt": {
     "mcp_calls": 3,

--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -10,7 +10,7 @@
   "http_routes": 7,
   "cli_commands": 11,
   "wheel_bytes": 236300,
-  "sdist_bytes": 634700,
+  "sdist_bytes": 634400,
   "plugin_bundle_bytes": 5620,
   "mcp_golden_prompt": {
     "mcp_calls": 3,

--- a/docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json
+++ b/docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json
@@ -1,0 +1,124 @@
+{
+  "schema": "codex-usage-tracker.ck06-adapter-ingestion-evidence.v1",
+  "task": "CK-06",
+  "base_main_sha": "cfbcb955580520170bab4cfde81303129ca22d7c",
+  "adapter_contract": "codex-usage-tracker.adapter.v1",
+  "adapter_id": "codex-jsonl",
+  "schema_contract": "codex-usage-tracker.agent-kernel.v1",
+  "schema_digest": "6ae65b6eb7024486f8fe42e19ab6799a252b721e6a9519f19d70e91f4aae6b77",
+  "fixture": {
+    "profile": "tiny",
+    "manifest_digest": "78003a7cfdee8beb1a263b3027fec162a612352be6fbefd13a65e821640bc7ae",
+    "oracle_digest": "9f78b8f87c17ef5e98810be6a4a01f4a13bfc055ac8eb74c9f147a7087d8e41b",
+    "source_bytes": 244657,
+    "source_records": 339,
+    "raw_body_present": false,
+    "note": "All inputs are the checked-in synthetic fixture; no runtime or local Codex data was read."
+  },
+  "full_ingestion": {
+    "sources_considered": 12,
+    "sources_selected": 11,
+    "sources_deferred": 1,
+    "source_bytes_selected": 244657,
+    "records_seen": 339,
+    "diagnostics_emitted": 1,
+    "canonical_counts": {
+      "activities": 5,
+      "allowance_limits": 1,
+      "allowance_observations": 4,
+      "compaction_boundaries": 2,
+      "model_calls": 100,
+      "projects": 1,
+      "resources": 25,
+      "sessions": 10,
+      "state_changes": 5,
+      "tool_invocations": 25,
+      "turns": 50
+    },
+    "occurrence_counts": {
+      "activities": 5,
+      "allowance_limits": 4,
+      "allowance_observations": 4,
+      "compaction_boundaries": 2,
+      "model_calls": 102,
+      "projects": 10,
+      "resources": 49,
+      "sessions": 19,
+      "state_changes": 5,
+      "tool_invocations": 49,
+      "turns": 50
+    },
+    "token_sums": {
+      "uncached_input_tokens": {"value": 53650, "observed_count": 100, "missing_count": 0},
+      "cached_input_tokens": {"value": null, "observed_count": 95, "missing_count": 5},
+      "reasoning_tokens": {"value": 31850, "observed_count": 100, "missing_count": 0},
+      "output_tokens": {"value": 47450, "observed_count": 100, "missing_count": 0}
+    }
+  },
+  "history_windows": {
+    "30_days": {"canonical_model_calls": 4, "selected_sources": 7, "deferred_sources": 5, "selected_bytes": 184519},
+    "90_days": {"canonical_model_calls": 10, "selected_sources": 7, "deferred_sources": 5, "selected_bytes": 184519},
+    "one_year": {"canonical_model_calls": 34, "selected_sources": 9, "deferred_sources": 3, "selected_bytes": 214584},
+    "all_time": {"canonical_model_calls": 100, "selected_sources": 11, "deferred_sources": 1, "selected_bytes": 244657}
+  },
+  "determinism": {
+    "batch_size": 32,
+    "worker_counts": [1, 2, 4, 8],
+    "ordered_observation_count": 450,
+    "same_ordered_signature": true,
+    "same_accounting": true,
+    "batches_emitted": 20,
+    "bounded_batch_records": 32,
+    "bounded_reorder_slots": "one in-flight batch per source plus queue capacity",
+    "envelope_shapes": ["normalized_adapter_record", "response.completed", "tool.started", "tool.completed"]
+  },
+  "performance": {
+    "synthetic_fixture_only": true,
+    "repetitions_per_worker_count": 5,
+    "units": {"elapsed": "ns", "rss": "bytes"},
+    "workers": {
+      "1": {"median_elapsed_ns": 33726584, "p95_elapsed_ns": 40541750, "max_elapsed_ns": 40541750, "cv_elapsed": 0.08889949113788359, "max_peak_rss_bytes": 32555008, "max_queue_depth": 1},
+      "2": {"median_elapsed_ns": 30059916, "p95_elapsed_ns": 31743000, "max_elapsed_ns": 31743000, "cv_elapsed": 0.023902420040235586, "max_peak_rss_bytes": 32669696, "max_queue_depth": 2},
+      "4": {"median_elapsed_ns": 30825625, "p95_elapsed_ns": 32715584, "max_elapsed_ns": 32715584, "cv_elapsed": 0.03664484926262676, "max_peak_rss_bytes": 32931840, "max_queue_depth": 4},
+      "8": {"median_elapsed_ns": 31558583, "p95_elapsed_ns": 33059166, "max_elapsed_ns": 33059166, "cv_elapsed": 0.021086621661285648, "max_peak_rss_bytes": 33144832, "max_queue_depth": 8}
+    },
+    "growth_repetitions_3_and_4": "waived_by_CK-04_decision; no_strict_v2_aggregate_claimed"
+  },
+  "cursor_lifecycle": {
+    "partial_final_line": "does_not_advance_complete_record_cursor",
+    "replacement": "replaced",
+    "truncation": "truncated",
+    "moving_tail": "append_safe",
+    "malformed_range": "isolated_and_reported_without_invalidating_other_records"
+  },
+  "review_accounting": {
+    "reviewer_count": 1,
+    "findings": [
+      {"id": "F1", "severity": "critical", "accepted": true, "summary": "Translate Codex event envelopes before normalization."},
+      {"id": "F2", "severity": "critical", "accepted": true, "summary": "Derive CK-02 logical and source-occurrence identities locally."},
+      {"id": "F3", "severity": "high", "accepted": true, "summary": "Bound diagnostic batches and parser reorder slots."},
+      {"id": "F4", "severity": "high", "accepted": true, "summary": "Emit worker failure at the next batch index."},
+      {"id": "F5", "severity": "high", "accepted": true, "summary": "Use stable manifestation keys and replacement identities."},
+      {"id": "F6", "severity": "medium", "accepted": true, "summary": "Expose file-budget overflow as explicit deferred coverage."},
+      {"id": "F7", "severity": "medium", "accepted": true, "summary": "Refresh evidence only after complete qualification."}
+    ],
+    "accepted_findings": ["F1", "F2", "F3", "F4", "F5", "F6", "F7"],
+    "reviewer_token_status": "pending",
+    "tokens_per_accepted_finding": null,
+    "note": "One final read-only reviewer; all seven findings were accepted and corrected. The installed metrics CLI has no token subcommand, so token status remains pending and was not retried."
+  },
+  "packaging": {
+    "wheel_bytes": 229432,
+    "sdist_bytes": 616331,
+    "wheel_ceiling": 236300,
+    "sdist_ceiling": 634700,
+    "release_check": "passed"
+  },
+  "validation": {
+    "focused": "tests/agent_kernel/adapters and kernel scope: 30 passed; Ruff passed",
+    "bootstrap": "python3 scripts/bootstrap_dev_environment.py passed before semantic work; --component gitnexus --check passed",
+    "scope": "GitNexus impact was run before existing-symbol edits; exact origin/main detect_changes passed before commit",
+    "qualification": "just vp passed; just v passed with 991 functional and 13 invariant tests, Pyright 0 errors, release safety passed; package build and check_release --dist passed; CI and exact-main verification pending",
+    "growth_note": "CK-04 growth repetitions 3 and 4 remain waived; no strict v2 aggregate is claimed"
+  }
+}

--- a/docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json
+++ b/docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json
@@ -111,7 +111,7 @@
     "wheel_bytes": 229432,
     "sdist_bytes": 616331,
     "wheel_ceiling": 236300,
-    "sdist_ceiling": 634700,
+    "sdist_ceiling": 634400,
     "release_check": "passed"
   },
   "validation": {

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -7,10 +7,10 @@ in the linked files under [`docs/roadmap/tasks/`](tasks/).
 
 ## Overall
 
-- Completed packets: **6 / 17**
+- Completed packets: **7 / 17**
 - In progress: **None**
-- Not started: **11**
-- Critical-path completion: **6 / 16**
+- Not started: **10**
+- Critical-path completion: **7 / 16**
 - Optional packets: **CK-15**
 
 A packet may be checked only after its acceptance criteria and required checks
@@ -22,7 +22,7 @@ line and the milestone accounting below.
 
 - [x] **M0 — Authority Ready** · 1 / 1 · CK-00 complete
 - [x] **M1 — Architecture Selected** · 4 / 4 · CK-01–CK-04 complete
-- [ ] **M2 — Kernel Alpha** · 1 / 5 · CK-05 complete; CK-06–CK-09 not started
+- [ ] **M2 — Kernel Alpha** · 2 / 5 · CK-05–CK-06 complete; CK-07–CK-09 not started
 - [ ] **M3 — Codex MVP Qualified** · 0 / 3 · CK-10–CK-12 not started
 - [ ] **M4 — Clean Cutover** · 0 / 2 · CK-13–CK-14 not started
 - [ ] **M5 — Public Release** · 0 / 1 required · CK-16 not started
@@ -57,7 +57,7 @@ line and the milestone accounting below.
 - [x] **CK-05 — Implement the canonical storage kernel** · **Completed** ·
   depends on CK-04
   · [packet](tasks/ck-05-implement-canonical-storage-kernel.md)
-- [ ] **CK-06 — Implement the Codex adapter and ingestion** · Not started ·
+- [x] **CK-06 — Implement the Codex adapter and ingestion** · **Completed** ·
   depends on CK-05
   · [packet](tasks/ck-06-implement-codex-adapter-and-ingestion.md)
 - [ ] **CK-07 — Implement publication, refresh, and recovery** · Not started ·

--- a/docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md
+++ b/docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md
@@ -1,6 +1,6 @@
 # CK-06 — Implement Codex adapter and bounded ingestion
 
-**Status:** Not started
+**Status:** Completed
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
@@ -40,6 +40,26 @@ workers.
 **Acceptance:** CK-03 adapter/accounting/source oracles pass; 30/90/year/all-time
 selected bytes and coverage exact; parsing scales without nondeterminism; no
 raw bodies enter proposed records.
+
+**Evidence:** [codex-adapter-ingestion-evidence.json](../../decisions/evidence/ck06/codex-adapter-ingestion-evidence.json)
+
+**Implementation record:** The `codex-jsonl` adapter declares capability mask
+`127` across allowance observations, model usage, session hierarchy, source
+occurrences, state changes, tool lifecycle, and valuation. Structural source
+records are normalized to integer UTC microseconds, and the synthetic fixture's
+zero-based allowance ordinal is explicitly normalized to the positive storage
+ordinal with basis `upstream_zero_based_plus_one`. The adapter emits no prompt,
+response, reasoning, command, patch, or tool-output body. Publication,
+promotion, refresh, recovery, projections, MCP, and release work remain CK-07
+or later responsibilities.
+
+**Validation record:** Focused adapter tests pass for complete/partial,
+malformed, replacement, truncation, moving-tail, duplicate, parent, token,
+resource, state-change, allowance, and 1/2/4/8-worker cases. The full
+synthetic stream reproduces 100 canonical model calls and 102 occurrences;
+the four token classes remain separate and cached totals remain NULL when five
+calls lack cached input. Review accounting and final CI/main verification are
+recorded in the evidence file after closeout.
 
 **Failure/rollback:** Reject affected range/source and preserve prior cursor.
 Delete unpublished new artifacts only.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -493,6 +493,29 @@ CK05_CANONICAL_STORAGE_ADDITIONS = frozenset(
     }
 )
 
+CK06_ADAPTER_INGESTION_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md",
+        "src/codex_usage_tracker/agent_kernel/adapters/__init__.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/contracts.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/__init__.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/canonicalize.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/cursor.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/discovery.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/ingest.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/normalize.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/parser.py",
+        "src/codex_usage_tracker/agent_kernel/storage/source_progress.py",
+        "tests/agent_kernel/adapters/__init__.py",
+        "tests/agent_kernel/adapters/test_contracts.py",
+        "tests/agent_kernel/adapters/test_cursor.py",
+        "tests/agent_kernel/adapters/test_ingestion.py",
+        "scripts/check_kernel_scope.py",
+    }
+)
+
 CI_PERFORMANCE_QUALIFICATION_ADDITIONS = frozenset(
     {
         ".github/workflows/performance-qualification.yml",
@@ -533,6 +556,7 @@ INTEGRATION_ADDITIONS = (
     | DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS
     | CK04_PHYSICAL_BAKEOFF_ADDITIONS
     | CK05_CANONICAL_STORAGE_ADDITIONS
+    | CK06_ADAPTER_INGESTION_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )
 _BLOCKED_TASK_REF = re.compile(r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))")

--- a/src/codex_usage_tracker/agent_kernel/adapters/__init__.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/__init__.py
@@ -1,0 +1,31 @@
+"""Explicit adapter boundary for the clean agent-kernel implementation."""
+
+from .contracts import (
+    ADAPTER_CONTRACT,
+    ADAPTER_ID,
+    ADAPTER_VERSION,
+    AdapterIdentity,
+    AdapterObservation,
+    Capability,
+    CursorOutcome,
+    IngestMetrics,
+    ParseDiagnostic,
+    SourceCursor,
+    SourceInventory,
+    SourceRange,
+)
+
+__all__ = [
+    "ADAPTER_CONTRACT",
+    "ADAPTER_ID",
+    "ADAPTER_VERSION",
+    "AdapterIdentity",
+    "AdapterObservation",
+    "Capability",
+    "CursorOutcome",
+    "IngestMetrics",
+    "ParseDiagnostic",
+    "SourceCursor",
+    "SourceInventory",
+    "SourceRange",
+]

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/__init__.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/__init__.py
@@ -1,0 +1,15 @@
+"""Codex JSONL discovery, framing, normalization, and bounded ingestion."""
+
+from .discovery import SourcePlan, discover_inventory, select_sources
+from .ingest import IngestResult, ingest
+from .parser import parse_source, parse_sources
+
+__all__ = [
+    "IngestResult",
+    "SourcePlan",
+    "discover_inventory",
+    "ingest",
+    "parse_source",
+    "parse_sources",
+    "select_sources",
+]

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/canonicalize.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/canonicalize.py
@@ -1,0 +1,171 @@
+"""Deterministic occurrence reconciliation and CK-07-ready change proposals."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from ...domain.identity import semantic_id
+from ...domain.models import MeasurementAggregate
+from ...domain.time import validate_utc_microseconds
+from ..contracts import (
+    AdapterObservation,
+    ParseDiagnostic,
+    SourceCursor,
+    SourceInventory,
+    SourceRange,
+)
+from .parser import ParseBatch
+
+
+@dataclass(frozen=True, slots=True)
+class ProposedOccurrence:
+    semantic_logical_id: str
+    source_range: SourceRange
+
+    @property
+    def occurrence_id(self) -> str:
+        return semantic_id(
+            "source-occurrence",
+            [
+                self.semantic_logical_id,
+                self.source_range.manifestation_id,
+                self.source_range.source_revision,
+                [self.source_range.byte_start, self.source_range.byte_end],
+                self.source_range.record_ordinal,
+                self.source_range.adapter_version,
+            ],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterAccounting:
+    canonical_counts: Mapping[str, int]
+    occurrence_counts: Mapping[str, int]
+    token_sums: Mapping[str, MeasurementAggregate]
+
+
+@dataclass(frozen=True, slots=True)
+class ProposedChangeSet:
+    """Body-free changes for the later publication writer."""
+
+    observations: tuple[AdapterObservation, ...]
+    occurrences: tuple[ProposedOccurrence, ...]
+    diagnostics: tuple[ParseDiagnostic, ...]
+    cursor_updates: tuple[SourceCursor, ...]
+    accounting: AdapterAccounting
+    selected_sources: tuple[SourceInventory, ...]
+    deferred_sources: tuple[SourceInventory, ...]
+
+    def assert_body_free(self) -> None:
+        forbidden = ("body", "command", "content", "diff", "patch", "prompt", "reasoning", "response", "stderr", "stdout", "tool_output")
+        for observation in self.observations:
+            for key in observation.payload:
+                lowered = str(key).lower()
+                if lowered in forbidden or lowered.endswith("_body") or lowered.startswith("raw_"):
+                    raise ValueError(f"raw body field crossed the adapter boundary: {key}")
+
+
+_COUNT_TYPES = {
+    "ProjectObserved": "projects",
+    "SessionObserved": "sessions",
+    "TurnBoundaryObserved": "turns",
+    "ModelCallObserved": "model_calls",
+    "ToolLifecycleObserved": "tool_invocations",
+    "ActivityLifecycleObserved": "activities",
+    "CompactionObserved": "compaction_boundaries",
+    "StateChangeObserved": "state_changes",
+    "AllowanceObservationObserved": "allowance_observations",
+    "AllowanceLimitObserved": "allowance_limits",
+    "ResourceObserved": "resources",
+}
+_TOKEN_FIELDS = ("uncached_input_tokens", "cached_input_tokens", "reasoning_tokens", "output_tokens")
+
+
+def _aggregate_tokens(observations: Iterable[AdapterObservation]) -> dict[str, MeasurementAggregate]:
+    unique: dict[str, AdapterObservation] = {}
+    for observation in observations:
+        if observation.observation_type != "ModelCallObserved":
+            continue
+        existing = unique.get(observation.logical_id)
+        if existing is None:
+            unique[observation.logical_id] = observation
+        elif existing.identity_tuple != observation.identity_tuple:
+            raise ValueError(f"semantic identity conflict for {observation.logical_id}")
+    result: dict[str, MeasurementAggregate] = {}
+    for field in _TOKEN_FIELDS:
+        values = [item.payload.get(field) for item in unique.values()]
+        observed = [value for value in values if type(value) is int]
+        result[field] = MeasurementAggregate(
+            value=None if len(observed) != len(values) else sum(observed),
+            observed_count=len(observed),
+            missing_count=len(values) - len(observed),
+        )
+    return result
+
+
+def build_change_set(
+    batches: Iterable[ParseBatch],
+    *,
+    selected_sources: Iterable[SourceInventory],
+    deferred_sources: Iterable[SourceInventory],
+    window: tuple[int, int] | None = None,
+) -> ProposedChangeSet:
+    """Merge parser output in the contract order and preserve every occurrence."""
+
+    if window is not None:
+        start_us, end_us = window
+        validate_utc_microseconds(start_us, allow_none=False)
+        validate_utc_microseconds(end_us, allow_none=False)
+        if start_us > end_us:
+            raise ValueError("history window start must not exceed end")
+
+    observations: list[AdapterObservation] = []
+    diagnostics: list[ParseDiagnostic] = []
+    cursor_updates: dict[int, SourceCursor] = {}
+    for batch in batches:
+        observations.extend(
+            observation
+            for observation in batch.observations
+            if window is None
+            or observation.event_at_us is None
+            or window[0] <= observation.event_at_us <= window[1]
+        )
+        diagnostics.extend(batch.diagnostics)
+        if batch.done and batch.cursor is not None:
+            cursor_updates[batch.cursor.manifestation_key] = batch.cursor
+    observations.sort(key=lambda item: item.sort_key)
+    occurrence_by_id: dict[str, ProposedOccurrence] = {}
+    for observation in observations:
+        occurrence_by_id.setdefault(
+            observation.occurrence_id,
+            ProposedOccurrence(observation.logical_id, observation.source_range),
+        )
+    occurrences = tuple(
+        occurrence_by_id[key]
+        for key in sorted(occurrence_by_id)
+    )
+    canonical_by_type: dict[str, set[str]] = {}
+    occurrence_by_type: dict[str, int] = {}
+    for observation in observations:
+        name = _COUNT_TYPES.get(observation.observation_type)
+        if name is None:
+            continue
+        canonical_by_type.setdefault(name, set()).add(observation.logical_id)
+        occurrence_by_type[name] = occurrence_by_type.get(name, 0) + 1
+    accounting = AdapterAccounting(
+        canonical_counts={key: len(value) for key, value in sorted(canonical_by_type.items())},
+        occurrence_counts=dict(sorted(occurrence_by_type.items())),
+        token_sums=_aggregate_tokens(observations),
+    )
+    result = ProposedChangeSet(
+        observations=tuple(observations),
+        occurrences=occurrences,
+        diagnostics=tuple(diagnostics),
+        cursor_updates=tuple(cursor_updates[key] for key in sorted(cursor_updates)),
+        accounting=accounting,
+        selected_sources=tuple(sorted(selected_sources, key=lambda item: item.source_rank)),
+        deferred_sources=tuple(sorted(deferred_sources, key=lambda item: item.source_rank)),
+    )
+    result.assert_body_free()
+    return result

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/cursor.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/cursor.py
@@ -1,0 +1,133 @@
+"""Complete-record framing and source cursor classification."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..contracts import CursorOutcome, SourceCursor, SourceInventory
+
+
+@dataclass(frozen=True, slots=True)
+class FramedRecord:
+    body: bytes
+    record_ordinal: int
+    byte_start: int
+    byte_end: int
+
+
+@dataclass(frozen=True, slots=True)
+class CursorClassification:
+    outcome: CursorOutcome
+    reason: str
+
+
+def _sha256_prefix(path: Path, length: int) -> str:
+    digest = hashlib.sha256()
+    remaining = length
+    with path.open("rb") as handle:
+        while remaining:
+            chunk = handle.read(min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    if remaining:
+        raise ValueError("cursor prefix exceeds the source size")
+    return digest.hexdigest()
+
+
+def _sha256_suffix(path: Path, *, size: int, width: int = 4096) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        handle.seek(max(0, size - width))
+        digest.update(handle.read(width))
+    return digest.hexdigest()
+
+
+def iter_complete_records(path: Path, *, start_offset: int = 0, start_ordinal: int = 0) -> Iterator[FramedRecord]:
+    """Yield newline-terminated records and leave a partial final line unread."""
+
+    if start_offset < 0 or start_ordinal < 0:
+        raise ValueError("cursor coordinates must be nonnegative")
+    with path.open("rb") as handle:
+        handle.seek(start_offset)
+        ordinal = start_ordinal
+        while True:
+            byte_start = handle.tell()
+            body = handle.readline()
+            if not body:
+                return
+            if not body.endswith(b"\n"):
+                return
+            byte_end = handle.tell()
+            yield FramedRecord(body, ordinal, byte_start, byte_end)
+            ordinal += 1
+
+
+def build_cursor(
+    path: Path,
+    *,
+    inventory: SourceInventory,
+    byte_offset: int,
+    record_ordinal: int,
+    latest_source_order: int,
+    parser_version: str,
+    adapter_version: str,
+) -> SourceCursor:
+    """Create a cursor from the last complete record boundary."""
+
+    size = path.stat().st_size
+    if byte_offset < 0 or byte_offset > size:
+        raise ValueError("cursor offset is outside the source")
+    return SourceCursor(
+        manifestation_id=inventory.manifestation_id,
+        manifestation_key=inventory.manifestation_key,
+        source_revision=inventory.content_revision,
+        byte_offset=byte_offset,
+        record_ordinal=record_ordinal,
+        source_size_bytes=size,
+        prefix_through_cursor_sha256=_sha256_prefix(path, byte_offset),
+        suffix_sha256=_sha256_suffix(path, size=size),
+        latest_source_order=latest_source_order,
+        parser_version=parser_version,
+        adapter_version=adapter_version,
+    )
+
+
+def classify_cursor(
+    path: Path | None,
+    *,
+    inventory: SourceInventory,
+    cursor: SourceCursor | None,
+    parser_version: str,
+    adapter_version: str,
+) -> CursorClassification:
+    """Classify a source before hydration, using only bounded fingerprints."""
+
+    if path is None or inventory.state.value == "missing":
+        return CursorClassification(CursorOutcome.MISSING, "source is unavailable")
+    if cursor is None:
+        return CursorClassification(CursorOutcome.APPEND_SAFE, "no committed cursor")
+    if (
+        cursor.manifestation_id != inventory.manifestation_id
+        or cursor.manifestation_key != inventory.manifestation_key
+    ):
+        return CursorClassification(CursorOutcome.REPLACED, "cursor belongs to a different source manifestation")
+    if cursor.parser_version != parser_version or cursor.adapter_version != adapter_version:
+        return CursorClassification(CursorOutcome.RECANONICALIZE, "parser or adapter version changed")
+    size = path.stat().st_size
+    if size < cursor.byte_offset:
+        return CursorClassification(CursorOutcome.TRUNCATED, "source is smaller than the cursor")
+    if inventory.content_revision != cursor.source_revision and size == cursor.source_size_bytes:
+        return CursorClassification(CursorOutcome.REPLACED, "content revision changed")
+    if _sha256_prefix(path, cursor.byte_offset) != cursor.prefix_through_cursor_sha256:
+        return CursorClassification(CursorOutcome.REPLACED, "prefix through cursor changed")
+    current_suffix = _sha256_suffix(path, size=size)
+    if size == cursor.source_size_bytes and current_suffix == cursor.suffix_sha256:
+        return CursorClassification(CursorOutcome.NO_CHANGE, "source bytes and metadata are unchanged")
+    if size >= cursor.byte_offset:
+        return CursorClassification(CursorOutcome.APPEND_SAFE, "cursor prefix remains a complete-record prefix")
+    return CursorClassification(CursorOutcome.REPLACED, "source revision cannot be resumed safely")

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/discovery.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/discovery.py
@@ -1,0 +1,275 @@
+"""Bounded, deterministic source inventory and history selection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ...domain.identity import semantic_id
+from ...domain.time import validate_utc_microseconds
+from ..contracts import (
+    SOURCE_KIND,
+    SourceInventory,
+    SourceState,
+    TimeRangeConfidence,
+    TimeRangeHint,
+)
+
+_FINGERPRINT_BYTES = 4096
+
+
+@dataclass(frozen=True, slots=True)
+class SourcePlan:
+    """An inventory row plus its local hydration path, when materialized."""
+
+    inventory: SourceInventory
+    path: Path | None
+
+
+def _sha256_slice(path: Path, *, start: int | None = None, length: int = _FINGERPRINT_BYTES) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        if start is not None:
+            handle.seek(start)
+        digest.update(handle.read(length))
+    return digest.hexdigest()
+
+
+def _relative_key(root: Path, path: Path) -> str:
+    relative = path.relative_to(root).as_posix()
+    if relative.startswith(("/", "./", "../")) or ".." in relative.split("/"):
+        raise ValueError(f"source path escapes root: {relative}")
+    return relative
+
+
+def _stable_manifestation_key(manifestation_id: str, technical_path_key: str) -> int:
+    digest = hashlib.sha256(f"{manifestation_id}\0{technical_path_key}".encode()).digest()
+    value = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+    return max(1, value)
+
+
+def _bounded_jsonl_paths(root: Path, limit: int) -> dict[str, Path]:
+    """Walk only far enough to report a bounded inventory plus overflow."""
+
+    found: dict[str, Path] = {}
+    pending = [root]
+    while pending and len(found) <= limit:
+        directory = pending.pop()
+        try:
+            entries = sorted(os.scandir(directory), key=lambda item: item.name, reverse=True)
+        except OSError:
+            continue
+        for entry in entries:
+            path = Path(entry.path)
+            if entry.is_symlink():
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                pending.append(path)
+            elif entry.is_file(follow_symlinks=False) and path.suffix == ".jsonl":
+                found[_relative_key(root, path)] = path
+                if len(found) > limit:
+                    return found
+    return found
+
+
+def _load_manifest(manifest: Path | dict[str, Any] | None) -> dict[str, Any] | None:
+    if manifest is None:
+        return None
+    if isinstance(manifest, Path):
+        value = json.loads(manifest.read_text(encoding="utf-8"))
+    else:
+        value = manifest
+    if not isinstance(value, dict) or not isinstance(value.get("sources", []), list):
+        raise ValueError("synthetic manifest must contain a sources list")
+    return value
+
+
+def _manifest_hint(entry: dict[str, Any]) -> tuple[TimeRangeHint | None, TimeRangeConfidence]:
+    raw_hint = entry.get("time_range_hint")
+    confidence = TimeRangeConfidence(str(entry.get("time_range_confidence", "unavailable")))
+    if raw_hint is None:
+        if confidence is not TimeRangeConfidence.UNAVAILABLE:
+            raise ValueError("manifest confidence requires a time_range_hint")
+        return None, confidence
+    if not isinstance(raw_hint, dict):
+        raise ValueError("time_range_hint must be an object or null")
+    start_us = raw_hint.get("start_us")
+    end_us = raw_hint.get("end_us")
+    validate_utc_microseconds(start_us, allow_none=False)
+    validate_utc_microseconds(end_us, allow_none=False)
+    if type(start_us) is not int or type(end_us) is not int:
+        raise ValueError("time_range_hint bounds must be integers")
+    return TimeRangeHint(start_us, end_us), confidence
+
+
+def discover_inventory(
+    root: Path,
+    *,
+    manifest: Path | dict[str, Any] | None = None,
+    max_files: int = 4096,
+    max_bytes: int = 1 << 40,
+) -> tuple[SourcePlan, ...]:
+    """Return a bounded inventory without loading source records into memory.
+
+    A synthetic manifest may supply conservative time hints and deferred rows.
+    Without one, source bounds remain unavailable; filesystem modification time
+    is recorded only as selection metadata and never as event time.
+    """
+
+    root = Path(root).resolve()
+    if not root.is_dir():
+        raise ValueError(f"source root is not a directory: {root}")
+    if max_files <= 0 or max_bytes < 0:
+        raise ValueError("source budgets must be positive files and nonnegative bytes")
+    manifest_value = _load_manifest(manifest)
+    manifest_by_path = {
+        str(entry["path"]): entry
+        for entry in (manifest_value or {}).get("sources", [])
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+    }
+    materialized = _bounded_jsonl_paths(root, max_files)
+    # A supplied manifest is the authoritative source inventory.  Fixture
+    # lifecycle phase artifacts and other sibling JSONL files are not source
+    # manifestations unless the manifest explicitly names them.
+    keys = sorted(manifest_by_path if manifest_value is not None else materialized)
+    overflow = len(keys) > max_files
+    if overflow:
+        keys = keys[:max_files]
+    plans: list[SourcePlan] = []
+    manifestation_ids_seen: set[str] = set()
+    for rank, key in enumerate(keys):
+        entry = manifest_by_path.get(key, {})
+        path = materialized.get(key)
+        state = SourceState(str(entry.get("state", "active")))
+        if path is not None:
+            stat_result = path.stat()
+            size_bytes = stat_result.st_size
+            modified_at_us = stat_result.st_mtime_ns // 1_000
+            prefix = _sha256_slice(path)
+            suffix = _sha256_slice(path, start=max(0, size_bytes - _FINGERPRINT_BYTES))
+        else:
+            size_bytes = int(entry.get("bytes", 0))
+            modified_at_us = None
+            prefix = None
+            suffix = None
+        manifestation_id = str(entry.get("manifestation_id") or semantic_id("source-manifestation", [SOURCE_KIND, key]))
+        if manifestation_id in manifestation_ids_seen:
+            manifestation_id = semantic_id("source-manifestation", [manifestation_id, key])
+        manifestation_ids_seen.add(manifestation_id)
+        manifestation_key = int(entry.get("manifestation_key", _stable_manifestation_key(manifestation_id, key)))
+        while manifestation_key in {item.inventory.manifestation_key for item in plans}:
+            manifestation_key += 1
+        revision = str(entry.get("revision", entry.get("content_sha256", "revision-1")))
+        hint, confidence = _manifest_hint(entry)
+        logical_source = str(entry.get("logical_source", key))
+        source_key = str(entry.get("source_key", logical_source))
+        content_revision = str(entry.get("content_revision", entry.get("content_sha256", revision)))
+        inventory = SourceInventory(
+            source_key=source_key,
+            manifestation_key=manifestation_key,
+            manifestation_id=manifestation_id,
+            source_kind=str(entry.get("source_kind", "codex-jsonl")),
+            technical_path_key=key,
+            display_label=str(entry.get("display_label", Path(key).name)),
+            size_bytes=size_bytes,
+            modified_at_us=modified_at_us,
+            prefix_fingerprint=prefix,
+            suffix_fingerprint=suffix,
+            content_revision=content_revision,
+            source_rank=rank,
+            state=state,
+            time_range_hint=hint,
+            time_range_confidence=confidence,
+            selected=False,
+            filesystem_identity=(
+                None
+                if path is None
+                else f"{path.stat().st_dev}:{path.stat().st_ino}"
+            ),
+        )
+        plans.append(SourcePlan(inventory=inventory, path=path))
+    if overflow:
+        overflow_id = semantic_id("source-manifestation", [SOURCE_KIND, "deferred-file-budget", max_files])
+        plans.append(
+            SourcePlan(
+                inventory=SourceInventory(
+                    source_key=f"deferred:file-budget:{max_files}",
+                    manifestation_key=_stable_manifestation_key(overflow_id, "__deferred__/file-budget"),
+                    manifestation_id=overflow_id,
+                    source_kind=SOURCE_KIND,
+                    technical_path_key="__deferred__/file-budget",
+                    display_label="deferred source inventory beyond file budget",
+                    size_bytes=0,
+                    modified_at_us=None,
+                    prefix_fingerprint=None,
+                    suffix_fingerprint=None,
+                    content_revision="deferred",
+                    source_rank=len(plans),
+                    state=SourceState.DEFERRED,
+                    time_range_hint=None,
+                    time_range_confidence=TimeRangeConfidence.UNAVAILABLE,
+                    selected=False,
+                    deferred_reason="file_budget",
+                ),
+                path=None,
+            )
+        )
+    return tuple(plans)
+
+
+def select_sources(
+    plans: Iterable[SourcePlan],
+    *,
+    window: tuple[int, int] | None = None,
+    max_files: int = 4096,
+    max_bytes: int = 1 << 40,
+) -> tuple[SourcePlan, ...]:
+    """Select sources with explicit deferred coverage under file/byte budgets."""
+
+    if max_files <= 0 or max_bytes < 0:
+        raise ValueError("source budgets must be positive files and nonnegative bytes")
+    if window is not None:
+        start_us, end_us = window
+        validate_utc_microseconds(start_us, allow_none=False)
+        validate_utc_microseconds(end_us, allow_none=False)
+        if start_us > end_us:
+            raise ValueError("history window start must not exceed end")
+    selected_count = 0
+    selected_bytes = 0
+    result: list[SourcePlan] = []
+    for plan in sorted(plans, key=lambda item: item.inventory.source_rank):
+        item = plan.inventory
+        eligible = item.state is not SourceState.DEFERRED
+        if window is not None and item.time_range_confidence is TimeRangeConfidence.TRUSTED:
+            assert item.time_range_hint is not None
+            eligible = eligible and item.time_range_hint.overlaps_closed_window(*window)
+        if item.state is SourceState.MISSING or plan.path is None:
+            eligible = False
+        reason: str | None = None
+        if eligible and selected_count < max_files and selected_bytes + item.size_bytes <= max_bytes:
+            selected_count += 1
+            selected_bytes += item.size_bytes
+            result.append(SourcePlan(_replace_selection(item, True), plan.path))
+        else:
+            if item.state is SourceState.DEFERRED or plan.path is None:
+                reason = "source_not_materialized"
+            elif not eligible:
+                reason = "trusted_time_range_nonoverlap"
+            elif selected_count >= max_files:
+                reason = "file_budget"
+            else:
+                reason = "byte_budget"
+            result.append(SourcePlan(_replace_selection(item, False, reason), plan.path))
+    return tuple(result)
+
+
+def _replace_selection(item: SourceInventory, selected: bool, reason: str | None = None) -> SourceInventory:
+    values = {field: getattr(item, field) for field in item.__dataclass_fields__}
+    values["selected"] = selected
+    values["deferred_reason"] = reason
+    return SourceInventory(**values)

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/ingest.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/ingest.py
@@ -1,0 +1,90 @@
+"""Bounded Codex source ingestion orchestration."""
+
+from __future__ import annotations
+
+import resource
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..contracts import IngestMetrics, SourceCursor
+from .canonicalize import ProposedChangeSet, build_change_set
+from .discovery import discover_inventory, select_sources
+from .parser import ParseBatch, parse_sources
+
+
+@dataclass(frozen=True, slots=True)
+class IngestResult:
+    changes: ProposedChangeSet
+    metrics: IngestMetrics
+
+
+def _peak_rss_bytes() -> int:
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if __import__("sys").platform == "darwin" else value * 1024
+
+
+def ingest(
+    root: Path,
+    *,
+    manifest: Path | dict[str, Any] | None = None,
+    window: tuple[int, int] | None = None,
+    max_files: int = 4096,
+    max_bytes: int = 1 << 40,
+    workers: int = 1,
+    batch_size: int = 256,
+    queue_capacity: int | None = None,
+    cursors: Mapping[int, SourceCursor] | None = None,
+    late_cutoff_us: int | None = None,
+) -> IngestResult:
+    """Discover, select, parse, and propose changes without publication writes."""
+
+    started_ns = time.perf_counter_ns()
+    inventory = discover_inventory(root, manifest=manifest, max_files=max_files, max_bytes=max_bytes)
+    selected = select_sources(inventory, window=window, max_files=max_files, max_bytes=max_bytes)
+    selected_sources = tuple(plan.inventory for plan in selected if plan.inventory.selected)
+    deferred_sources = tuple(plan.inventory for plan in selected if not plan.inventory.selected)
+    parser_metrics: list[dict[str, int]] = []
+    batches: list[ParseBatch] = []
+    for batch in parse_sources(
+        selected,
+        workers=workers,
+        batch_size=batch_size,
+        queue_capacity=queue_capacity,
+        cursors=cursors,
+        late_cutoff_us=late_cutoff_us,
+        metrics_sink=parser_metrics,
+    ):
+        batches.append(batch)
+    changes = build_change_set(
+        batches,
+        selected_sources=selected_sources,
+        deferred_sources=deferred_sources,
+        window=window,
+    )
+    final_by_source = {
+        batch.source_rank: batch
+        for batch in batches
+        if batch.done
+    }
+    records_seen = sum(batch.records_seen for batch in final_by_source.values())
+    diagnostics_emitted = len(changes.diagnostics)
+    observations_emitted = len(changes.observations)
+    metrics = IngestMetrics(
+        sources_considered=len(inventory),
+        sources_selected=len(selected_sources),
+        sources_deferred=len(deferred_sources),
+        source_bytes_selected=sum(item.size_bytes for item in selected_sources),
+        records_seen=records_seen,
+        observations_emitted=observations_emitted,
+        diagnostics_emitted=diagnostics_emitted,
+        batches_emitted=sum(not batch.done for batch in batches),
+        max_queue_depth=(parser_metrics[-1]["max_queue_depth"] if parser_metrics else 0),
+        workers=workers,
+        batch_size=batch_size,
+        peak_rss_bytes=_peak_rss_bytes(),
+        elapsed_ns=time.perf_counter_ns() - started_ns,
+    )
+    return IngestResult(changes=changes, metrics=metrics)

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/normalize.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/normalize.py
@@ -1,0 +1,716 @@
+"""Normalize structural Codex JSONL records into adapter observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import PurePosixPath
+from typing import Any
+
+from ...domain.identity import semantic_id
+from ...domain.time import validate_utc_microseconds
+from ..contracts import (
+    AdapterObservation,
+    Capability,
+    SourceRange,
+)
+
+EVENT_KIND_ORDER = {
+    "session_start": 10,
+    "late_parent": 15,
+    "turn_start": 20,
+    "model_call": 30,
+    "compaction_boundary": 35,
+    "tool_start": 40,
+    "tool_terminal": 50,
+    "activity": 55,
+    "state_change": 60,
+    "allowance_observation": 70,
+    "session_terminal": 80,
+    "oracle_case": 90,
+}
+
+CONTROL_RECORD_TYPES = frozenset(
+    {
+        "allowance_compatibility",
+        "oracle_case",
+        "selector_anchor",
+        "slice_control",
+        "source_phase_occurrence",
+        "source_revision",
+    }
+)
+
+_BODY_KEYS = frozenset(
+    {
+        "body",
+        "command",
+        "content",
+        "diff",
+        "patch",
+        "prompt",
+        "reasoning",
+        "response",
+        "stderr",
+        "stdout",
+        "tool_output",
+    }
+)
+_OPERATIONS = frozenset(
+    {"read", "search", "list", "execute", "write", "patch", "test", "navigate", "delegate", "wait", "unknown"}
+)
+_TRANSPORT_OPERATION_HINTS = {
+    "read": "read",
+    "search": "search",
+    "list": "list",
+    "exec": "execute",
+    "command": "execute",
+    "write": "write",
+    "patch": "patch",
+    "test": "test",
+    "navigate": "navigate",
+    "delegate": "delegate",
+    "wait": "wait",
+}
+_MEASUREMENT_BITS = {
+    "uncached_input_tokens": 1 << 0,
+    "cached_input_tokens": 1 << 1,
+    "reasoning_tokens": 1 << 2,
+    "output_tokens": 1 << 3,
+    "context_window_tokens": 1 << 4,
+    "event_at_us": 1 << 5,
+    "duration_us": 1 << 6,
+    "output_bytes": 1 << 7,
+}
+
+_NORMALIZED_RECORD_TYPES = frozenset(
+    {
+        "activity",
+        "allowance_observation",
+        "compaction_boundary",
+        "late_parent",
+        "model_call",
+        "session_start",
+        "session_terminal",
+        "state_change",
+        "tool_start",
+        "tool_terminal",
+        "turn_start",
+        *CONTROL_RECORD_TYPES,
+    }
+)
+_ENVELOPE_TYPES = {
+    "session_meta": "session_start",
+    "session.started": "session_start",
+    "turn_context": "turn_start",
+    "turn.started": "turn_start",
+    "model.completed": "model_call",
+    "response.completed": "model_call",
+    "codex.model_call": "model_call",
+    "tool.started": "tool_start",
+    "tool.start": "tool_start",
+    "tool.completed": "tool_terminal",
+    "tool.finished": "tool_terminal",
+    "tool.terminal": "tool_terminal",
+    "tool.ended": "tool_terminal",
+    "codex.tool_start": "tool_start",
+    "codex.tool_terminal": "tool_terminal",
+}
+
+
+class NormalizationError(ValueError):
+    """A source record cannot be represented by the adapter contract."""
+
+
+def _reject_body_key(key: str) -> None:
+    lowered = key.lower()
+    if lowered in _BODY_KEYS or lowered.endswith("_body") or lowered.startswith("raw_"):
+        raise NormalizationError(f"raw body field is not admissible: {key}")
+
+
+def _string(value: object, field: str, *, allow_none: bool = False) -> str | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, str) or not value:
+        raise NormalizationError(f"{field} must be a nonempty string")
+    _reject_body_key(field)
+    return value
+
+
+def _integer(value: object, field: str, *, allow_none: bool = True, nonnegative: bool = False) -> int | None:
+    if value is None and allow_none:
+        return None
+    if type(value) is not int:
+        raise NormalizationError(f"{field} must be an integer")
+    if nonnegative and value < 0:
+        raise NormalizationError(f"{field} must be nonnegative")
+    return value
+
+
+def normalize_timestamp(value: object) -> tuple[int | None, str]:
+    """Normalize exact integer microseconds or timezone-aware ISO timestamps."""
+
+    if value is None:
+        return None, "unavailable"
+    if type(value) is int:
+        validate_utc_microseconds(value, allow_none=False)
+        return value, "upstream_utc_microseconds"
+    if not isinstance(value, str):
+        raise NormalizationError("timestamp must be integer microseconds or ISO-8601 text")
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    if "." in text:
+        fraction = text.split(".", 1)[1].split("+", 1)[0].split("-", 1)[0]
+        if len(fraction) > 6:
+            raise NormalizationError("timestamp precision would be lossy")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as error:
+        raise NormalizationError("invalid ISO-8601 timestamp") from error
+    if parsed.tzinfo is None:
+        raise NormalizationError("timestamp must include a timezone offset")
+    utc = parsed.astimezone(timezone.utc)
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    delta = utc - epoch
+    micros = (delta.days * 86_400 + delta.seconds) * 1_000_000 + delta.microseconds
+    validate_utc_microseconds(micros, allow_none=False)
+    return micros, "upstream_iso8601"
+
+
+def _canonical_decimal(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise NormalizationError(f"{field} must be canonical decimal text")
+    try:
+        decimal = Decimal(value)
+    except (InvalidOperation, ValueError) as error:
+        raise NormalizationError(f"{field} must be finite decimal text") from error
+    if not decimal.is_finite():
+        raise NormalizationError(f"{field} must be finite decimal text")
+    normalized = format(decimal.normalize(), "f")
+    if normalized == "-0":
+        normalized = "0"
+    if normalized != value:
+        raise NormalizationError(f"{field} is not canonical decimal text")
+    return value
+
+
+def _session_id(native_key: str) -> str:
+    return semantic_id("session", [native_key, "identity-v1"])
+
+
+def _turn_ordinal(payload: Mapping[str, Any], source_order: int) -> int:
+    explicit = payload.get("turn_ordinal", payload.get("ordinal"))
+    if type(explicit) is int and explicit >= 0:
+        return explicit
+    # The synthetic Codex source records use ten source-order units per model
+    # call and two calls per turn.  This is also a deterministic fallback for
+    # envelopes that expose source order but omit a separate turn ordinal.
+    return source_order // 20
+
+
+def _turn_id(session_id: str, payload: Mapping[str, Any], source_order: int) -> str:
+    return semantic_id("turn", [session_id, _turn_ordinal(payload, source_order)])
+
+
+def _logical_id(kind: str, value: object, identity_tuple: tuple[Any, ...]) -> str:
+    """Derive CK-02 IDs locally; upstream IDs are native keys only."""
+
+    return semantic_id(kind, identity_tuple)
+
+
+def _envelope(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate documented Codex event envelopes to adapter-native records.
+
+    Synthetic tests use both the normalized adapter-native shape and the
+    envelope shape.  The adapter never copies unbounded envelope fields into
+    the normalized payload; only structural keys needed by the contract cross
+    this boundary.
+    """
+
+    record_type = record.get("type")
+    if not isinstance(record_type, str):
+        return dict(record)
+    normalized_type = _ENVELOPE_TYPES.get(record_type)
+    if normalized_type is None or record_type in _NORMALIZED_RECORD_TYPES:
+        return dict(record)
+    raw_payload = record.get("payload")
+    payload = dict(raw_payload) if isinstance(raw_payload, dict) else {}
+    structural_keys = (
+        "session_id", "turn_id", "turn_ordinal", "call_id", "tool_id",
+        "tool_call_id", "model", "reasoning_effort", "service_tier",
+        "transport_name", "tool_name", "name", "state", "project_id",
+        "duration_us", "output_bytes", "tokens", "usage", "resource_id",
+        "path", "resource_kind", "semantic_operation", "write_intent",
+    )
+    for key in structural_keys:
+        if key not in payload and key in record:
+            payload[key] = record[key]
+    if normalized_type == "model_call":
+        payload.setdefault("call_id", record.get("id", record.get("event_id")))
+        payload.setdefault("session_id", record.get("session_id"))
+        payload.setdefault("turn_id", record.get("turn_id"))
+        payload.setdefault("model", record.get("model"))
+    elif normalized_type in {"tool_start", "tool_terminal"}:
+        payload.setdefault("tool_id", record.get("tool_call_id", record.get("id", record.get("event_id"))))
+        payload.setdefault("session_id", record.get("session_id"))
+        payload.setdefault("turn_id", record.get("turn_id"))
+        payload.setdefault("transport_name", record.get("tool_name", record.get("name")))
+    elif normalized_type == "session_start":
+        payload.setdefault("session_id", record.get("session_id", record.get("id")))
+    elif normalized_type == "turn_start":
+        payload.setdefault("session_id", record.get("session_id"))
+        payload.setdefault("turn_id", record.get("turn_id", record.get("id")))
+    return {
+        "type": normalized_type,
+        "payload": payload,
+        "event_at_us": record.get("event_at_us", record.get("timestamp")),
+        "source_order": record.get("source_order"),
+        "event_kind_order": record.get("event_kind_order"),
+    }
+
+
+def _payload(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    raw = record.get("payload")
+    if not isinstance(raw, dict):
+        raise NormalizationError("payload must be an object")
+    return raw
+
+
+def _tokens(payload: Mapping[str, Any]) -> tuple[dict[str, int | None], int, str]:
+    raw = payload.get("tokens", payload.get("usage", {}))
+    if not isinstance(raw, dict):
+        raise NormalizationError("tokens must be an object")
+    result: dict[str, int | None] = {}
+    basis = "upstream_separate_classes"
+    for field in ("uncached_input_tokens", "cached_input_tokens", "reasoning_tokens", "output_tokens"):
+        result[field] = _integer(raw.get(field), field, nonnegative=True)
+    if result["uncached_input_tokens"] is None and raw.get("input_tokens") is not None:
+        total = _integer(raw.get("input_tokens"), "input_tokens", nonnegative=True)
+        cached = result["cached_input_tokens"]
+        if total is not None and cached is not None and cached <= total:
+            result["uncached_input_tokens"] = total - cached
+            basis = "derived_from_input_minus_cached"
+    measurement_mask = sum(
+        bit for field, bit in _MEASUREMENT_BITS.items() if field in result and result[field] is not None
+    )
+    return result, measurement_mask, basis
+
+
+def _operation(payload: Mapping[str, Any]) -> str:
+    explicit = payload.get("semantic_operation")
+    if isinstance(explicit, str) and explicit in _OPERATIONS:
+        return explicit
+    transport = str(payload.get("transport_name", "unknown")).lower()
+    for marker, operation in _TRANSPORT_OPERATION_HINTS.items():
+        if marker in transport:
+            return operation
+    return "unknown"
+
+
+def _resource(payload: Mapping[str, Any]) -> tuple[str | None, dict[str, Any]]:
+    resource_id = payload.get("resource_id")
+    path = payload.get("path")
+    if isinstance(path, str) and path:
+        normalized = PurePosixPath(path).as_posix()
+    elif isinstance(resource_id, str) and resource_id:
+        # A native resource key is structural evidence, not a canonical ID.
+        normalized = resource_id
+    else:
+        return None, {}
+    if normalized.startswith("/") or ".." in normalized.split("/"):
+        raise NormalizationError("resource path is ambiguous")
+    project_id = str(payload.get("project_id", "unknown-project"))
+    resource_kind = str(payload.get("resource_kind", "file"))
+    return semantic_id("resource", [project_id, resource_kind, normalized, "resource-normalization-v1"]), {
+        "normalized_resource_key": normalized,
+        "resource_kind": resource_kind,
+        "resource_project_id": project_id,
+    }
+
+
+def _base(record: Mapping[str, Any], source_range: SourceRange) -> tuple[str, Mapping[str, Any], int | None, str, int, int]:
+    record = _envelope(record)
+    record_type = _string(record.get("type"), "type")
+    assert record_type is not None
+    payload = _payload(record)
+    event_at_us, time_basis = normalize_timestamp(record.get("event_at_us", record.get("timestamp")))
+    source_order = _integer(
+        record.get("source_order") if record.get("source_order") is not None else source_range.record_ordinal,
+        "source_order",
+        allow_none=False,
+        nonnegative=True,
+    )
+    event_kind_order = _integer(
+        record.get("event_kind_order")
+        if record.get("event_kind_order") is not None
+        else EVENT_KIND_ORDER.get(record_type),
+        "event_kind_order",
+        allow_none=False,
+        nonnegative=True,
+    )
+    assert source_order is not None and event_kind_order is not None
+    return record_type, payload, event_at_us, time_basis, source_order, event_kind_order
+
+
+def normalize_record(record: Mapping[str, Any], source_range: SourceRange, *, source_rank: int = 0, late_cutoff_us: int | None = None) -> AdapterObservation:
+    """Normalize one complete record and discard all unapproved fields."""
+
+    record = _envelope(record)
+    record_type, payload, event_at_us, time_basis, source_order, event_kind_order = _base(record, source_range)
+    if record_type in CONTROL_RECORD_TYPES:
+        coordinate = source_range.coordinate_tuple
+        control_id = semantic_id("diagnostic", [record_type, coordinate])
+        return AdapterObservation(
+            observation_type="AdapterDiagnosticObserved",
+            logical_id=control_id,
+            identity_tuple=(record_type, coordinate),
+            source_range=source_range,
+            source_rank=source_rank,
+            event_at_us=event_at_us,
+            source_order=source_order,
+            event_kind_order=event_kind_order,
+            payload={"diagnostic_code": "control_record_ignored", "record_type": record_type},
+            capability_mask=0,
+            measurement_mask=_MEASUREMENT_BITS["event_at_us"] if event_at_us is not None else 0,
+            basis=time_basis,
+        )
+    if record_type not in {
+        "activity",
+        "allowance_observation",
+        "compaction_boundary",
+        "late_parent",
+        "model_call",
+        "session_start",
+        "session_terminal",
+        "state_change",
+        "tool_start",
+        "tool_terminal",
+        "turn_start",
+    }:
+        raise NormalizationError(f"unknown record kind: {record_type}")
+
+    values: dict[str, Any] = {}
+    capability = 0
+    measurement_mask = _MEASUREMENT_BITS["event_at_us"] if event_at_us is not None else 0
+    entity_kind = "observation"
+    identity: tuple[Any, ...]
+    logical_value: object = None
+    observation_type: str
+    if record_type in {"session_start", "session_terminal"}:
+        session = _string(payload.get("session_id"), "session_id")
+        assert session is not None
+        entity_kind, logical_value = "session", session
+        identity = (session, "identity-v1")
+        values = {
+            "session_id": semantic_id("session", identity),
+            "state": _string(payload.get("state"), "state"),
+            "project_id": payload.get("project_id"),
+            "parent_session_id": payload.get("parent_session_id"),
+            "completion_basis": payload.get("completion_basis"),
+        }
+        observation_type = "SessionObserved"
+        capability = int(Capability.SESSION_HIERARCHY)
+    elif record_type == "late_parent":
+        child = _string(payload.get("session_id", payload.get("child_session_id")), "session_id")
+        parent = _string(payload.get("parent_session_id"), "parent_session_id")
+        assert child is not None and parent is not None
+        identity = (child, parent, payload.get("relationship_basis", "late_discovery"))
+        entity_kind, logical_value = "session-relationship", None
+        values = {"session_id": _session_id(child), "parent_session_id": _session_id(parent), "relationship_basis": payload.get("relationship_basis", "late_discovery")}
+        observation_type = "SessionRelationshipObserved"
+        capability = int(Capability.SESSION_HIERARCHY)
+    elif record_type == "turn_start":
+        turn = _string(payload.get("turn_id"), "turn_id")
+        session = _string(payload.get("session_id"), "session_id")
+        assert turn is not None and session is not None
+        canonical_session = _session_id(session)
+        identity = (canonical_session, _turn_ordinal(payload, source_order))
+        entity_kind, logical_value = "turn", turn
+        values = {"turn_id": semantic_id("turn", identity), "session_id": canonical_session, "state": payload.get("state", "open")}
+        observation_type = "TurnBoundaryObserved"
+        capability = int(Capability.SESSION_HIERARCHY)
+    elif record_type == "model_call":
+        call = _string(payload.get("call_id"), "call_id")
+        session = _string(payload.get("session_id"), "session_id")
+        turn = _string(payload.get("turn_id"), "turn_id")
+        model = _string(payload.get("model"), "model")
+        assert call is not None and session is not None and turn is not None and model is not None
+        token_values, token_mask, token_basis = _tokens(payload)
+        canonical_session = _session_id(session)
+        canonical_turn = _turn_id(canonical_session, payload, source_order)
+        profile_identity = (model, payload.get("reasoning_effort"), payload.get("service_tier"))
+        identity = (call, canonical_session, canonical_turn)
+        entity_kind, logical_value = "call", call
+        values = {
+            "call_id": semantic_id("call", identity),
+            "session_id": canonical_session,
+            "turn_id": canonical_turn,
+            "model_profile_id": semantic_id("model-profile", profile_identity),
+            "model": model,
+            "reasoning_effort": payload.get("reasoning_effort"),
+            "service_tier": payload.get("service_tier"),
+            "context_window_tokens": _integer(payload.get("context_window_tokens"), "context_window_tokens", nonnegative=True),
+            **token_values,
+            "token_basis": token_basis,
+        }
+        observation_type = "ModelCallObserved"
+        capability = int(Capability.MODEL_CALL_USAGE | Capability.VALUATION)
+        measurement_mask |= token_mask
+        if values["context_window_tokens"] is not None:
+            measurement_mask |= _MEASUREMENT_BITS["context_window_tokens"]
+    elif record_type in {"tool_start", "tool_terminal"}:
+        tool = _string(payload.get("tool_id"), "tool_id")
+        session = _string(payload.get("session_id"), "session_id")
+        turn = _string(payload.get("turn_id"), "turn_id")
+        transport = _string(payload.get("transport_name"), "transport_name")
+        assert tool is not None and session is not None and turn is not None and transport is not None
+        resource_id, resource_values = _resource(payload)
+        canonical_session = _session_id(session)
+        canonical_turn = _turn_id(canonical_session, payload, source_order)
+        identity = (tool, canonical_session, canonical_turn)
+        entity_kind, logical_value = "tool", tool
+        values = {
+            "tool_id": semantic_id("tool", identity),
+            "session_id": canonical_session,
+            "turn_id": canonical_turn,
+            "transport_name": transport,
+            "semantic_operation": _operation(payload),
+            "resource_id": resource_id,
+            **resource_values,
+            "state": _string(payload.get("state"), "state"),
+            "write_intent": 1 if payload.get("write_intent", False) else 0,
+            "duration_us": _integer(payload.get("duration_us"), "duration_us", nonnegative=True),
+            "output_bytes": _integer(payload.get("output_bytes"), "output_bytes", nonnegative=True),
+        }
+        observation_type = "ToolLifecycleObserved"
+        capability = int(Capability.TOOL_LIFECYCLE)
+        if values["duration_us"] is not None:
+            measurement_mask |= _MEASUREMENT_BITS["duration_us"]
+        if values["output_bytes"] is not None:
+            measurement_mask |= _MEASUREMENT_BITS["output_bytes"]
+    elif record_type == "activity":
+        activity = _string(payload.get("activity_id"), "activity_id")
+        session = _string(payload.get("session_id"), "session_id")
+        assert activity is not None and session is not None
+        canonical_session = _session_id(session)
+        canonical_turn = _turn_id(canonical_session, payload, source_order)
+        activity_kind = _string(payload.get("activity_kind"), "activity_kind")
+        assert activity_kind is not None
+        identity = (canonical_session, canonical_turn, activity_kind)
+        entity_kind, logical_value = "activity", activity
+        values = {"activity_id": semantic_id("activity", identity), "session_id": canonical_session, "turn_id": canonical_turn, "activity_kind": activity_kind, "state": payload.get("state", "unknown")}
+        observation_type = "ActivityLifecycleObserved"
+        capability = int(Capability.TOOL_LIFECYCLE)
+    elif record_type == "compaction_boundary":
+        compaction = _string(payload.get("compaction_id"), "compaction_id")
+        session = _string(payload.get("session_id"), "session_id")
+        before = _string(payload.get("before_context_epoch"), "before_context_epoch")
+        after = _string(payload.get("after_context_epoch"), "after_context_epoch")
+        assert compaction is not None and session is not None and before is not None and after is not None
+        if before == after:
+            raise NormalizationError("compaction boundary must change context epoch")
+        canonical_session = _session_id(session)
+        identity = (canonical_session, source_order)
+        entity_kind, logical_value = "compaction", compaction
+        values = {"compaction_id": semantic_id("compaction", identity), "session_id": canonical_session, "before_context_epoch": before, "after_context_epoch": after}
+        observation_type = "CompactionObserved"
+        capability = int(Capability.MODEL_CALL_USAGE)
+    elif record_type == "state_change":
+        change = _string(payload.get("change_id"), "change_id")
+        session = _string(payload.get("session_id"), "session_id")
+        resource_id, resource_values = _resource(payload)
+        if change is None or session is None or resource_id is None:
+            raise NormalizationError("state change requires change, session, and resource identities")
+        canonical_session = _session_id(session)
+        canonical_turn = _turn_id(canonical_session, payload, source_order)
+        change_kind = _string(payload.get("change_kind"), "change_kind")
+        assert change_kind is not None
+        identity = (change_kind, resource_id, event_at_us, canonical_session, canonical_turn)
+        entity_kind, logical_value = "state-change", change
+        values = {"change_id": semantic_id("state-change", identity), "session_id": canonical_session, "turn_id": canonical_turn, "resource_id": resource_id, **resource_values, "change_kind": change_kind, "preceding_activity_count": _integer(payload.get("preceding_activity_count"), "preceding_activity_count", nonnegative=True), "causal_attribution": 0}
+        observation_type = "StateChangeObserved"
+        capability = int(Capability.STATE_CHANGE_OBSERVATION)
+    else:
+        limit = _string(payload.get("limit_id"), "limit_id")
+        cycle = _string(payload.get("cycle_id"), "cycle_id")
+        plan = _string(payload.get("plan_identity"), "plan_identity")
+        window = _string(payload.get("window_kind"), "window_kind")
+        reset = _string(payload.get("reset_identity"), "reset_identity")
+        provider = _string(payload.get("provider"), "provider")
+        assert limit is not None and cycle is not None and plan is not None and window is not None and reset is not None and provider is not None
+        entity_kind, logical_value = "allowance-observation", None
+        upstream_observation_ordinal = _integer(
+            payload.get("observation_ordinal"),
+            "observation_ordinal",
+            allow_none=False,
+            nonnegative=True,
+        )
+        assert upstream_observation_ordinal is not None
+        observation_ordinal = upstream_observation_ordinal + 1
+        account = _string(payload.get("account_local_identity", "unknown-account"), "account_local_identity")
+        assert account is not None
+        limit_identity = (provider, account, plan, window)
+        canonical_limit = semantic_id("allowance-limit", limit_identity)
+        cycle_start = _integer(payload.get("cycle_start_us"), "cycle_start_us")
+        cycle_end = _integer(payload.get("cycle_end_us"), "cycle_end_us")
+        cycle_identity = (canonical_limit, reset, cycle_start, cycle_end)
+        canonical_cycle = semantic_id("allowance-cycle", cycle_identity)
+        observed_at_us = payload.get("observed_at_us", event_at_us)
+        validate_utc_microseconds(observed_at_us)
+        source_occurrence = {
+            "source_manifestation_id": source_range.manifestation_id,
+            "source_revision": source_range.source_revision,
+            "record_ordinal": source_range.record_ordinal,
+            "adapter_version": source_range.adapter_version,
+        }
+        identity = (canonical_limit, canonical_cycle, observed_at_us, source_occurrence)
+        values = {"limit_id": canonical_limit, "cycle_id": canonical_cycle, "provider": provider, "account_local_identity": account, "plan_identity": plan, "window_kind": window, "reset_identity": reset, "observation_ordinal": observation_ordinal, "observation_ordinal_basis": "upstream_zero_based_plus_one", "used_percent": _canonical_decimal(payload.get("used_percent"), "used_percent"), "remaining_percent": _canonical_decimal(payload.get("remaining_percent"), "remaining_percent"), "reset_time_us": normalize_timestamp(payload.get("reset_time_us"))[0] if payload.get("reset_time_us") is not None else None}
+        observation_type = "AllowanceObservationObserved"
+        capability = int(Capability.ALLOWANCE_OBSERVATION)
+        for field in ("used_percent", "remaining_percent", "reset_time_us"):
+            if values[field] is not None:
+                measurement_mask |= _MEASUREMENT_BITS["event_at_us"]
+
+    logical_id = _logical_id(entity_kind, logical_value, identity) if logical_value is not None else semantic_id(entity_kind, identity)
+    if late_cutoff_us is not None and event_at_us is not None and event_at_us < late_cutoff_us:
+        values["cursor_outcome"] = "late_event"
+    return AdapterObservation(
+        observation_type=observation_type,
+        logical_id=logical_id,
+        identity_tuple=identity,
+        source_range=source_range,
+        source_rank=source_rank,
+        event_at_us=event_at_us,
+        source_order=source_order,
+        event_kind_order=event_kind_order,
+        payload=values,
+        capability_mask=capability,
+        measurement_mask=measurement_mask,
+        basis=time_basis,
+        confidence="exact",
+    )
+
+
+def assert_body_free(observation: AdapterObservation) -> None:
+    """Fail closed if a proposed observation accidentally carries a body."""
+
+    def walk(value: object, key: str = "") -> None:
+        _reject_body_key(key)
+        if isinstance(value, Mapping):
+            for child_key, child_value in value.items():
+                if not isinstance(child_key, str):
+                    raise NormalizationError("observation payload keys must be strings")
+                walk(child_value, child_key)
+        elif isinstance(value, (bytes, bytearray)):
+            raise NormalizationError("observation payload cannot contain bytes")
+
+    walk(observation.payload)
+
+
+def related_observations(observation: AdapterObservation) -> tuple[AdapterObservation, ...]:
+    """Emit bounded typed relations implied by one structural observation."""
+
+    related: list[AdapterObservation] = []
+    payload = observation.payload
+    if observation.observation_type == "SessionObserved" and isinstance(payload.get("project_id"), str):
+        project_id = str(payload["project_id"])
+        related.append(
+            AdapterObservation(
+                observation_type="ProjectObserved",
+                logical_id=semantic_id("project", [project_id]),
+                identity_tuple=(project_id,),
+                source_range=observation.source_range,
+                source_rank=observation.source_rank,
+                event_at_us=observation.event_at_us,
+                source_order=observation.source_order,
+                event_kind_order=observation.event_kind_order,
+                payload={"project_id": project_id},
+                capability_mask=observation.capability_mask,
+                measurement_mask=observation.measurement_mask,
+                basis=observation.basis,
+                confidence=observation.confidence,
+                transition_rank=observation.transition_rank + 1,
+            )
+        )
+    if observation.observation_type == "ToolLifecycleObserved":
+        resource_id = payload.get("resource_id")
+        tool_id = payload.get("tool_id")
+        if isinstance(resource_id, str) and isinstance(tool_id, str):
+            related.append(
+                AdapterObservation(
+                    observation_type="ResourceObserved",
+                    logical_id=resource_id,
+                    identity_tuple=(
+                        payload.get("resource_project_id", "unknown-project"),
+                        payload.get("resource_kind", "file"),
+                        payload.get("normalized_resource_key", resource_id),
+                        "resource-normalization-v1",
+                    ),
+                    source_range=observation.source_range,
+                    source_rank=observation.source_rank,
+                    event_at_us=observation.event_at_us,
+                    source_order=observation.source_order,
+                    event_kind_order=observation.event_kind_order,
+                    payload={
+                        key: payload[key]
+                        for key in ("resource_id", "normalized_resource_key", "resource_kind")
+                        if key in payload
+                    },
+                    capability_mask=observation.capability_mask,
+                    measurement_mask=observation.measurement_mask,
+                    basis=observation.basis,
+                    confidence=observation.confidence,
+                    transition_rank=observation.transition_rank + 1,
+                )
+            )
+            related.append(
+                AdapterObservation(
+                    observation_type="ToolResourceLinkObserved",
+                    logical_id=semantic_id("tool-resource-link", [tool_id, resource_id]),
+                    identity_tuple=(tool_id, resource_id),
+                    source_range=observation.source_range,
+                    source_rank=observation.source_rank,
+                    event_at_us=observation.event_at_us,
+                    source_order=observation.source_order,
+                    event_kind_order=observation.event_kind_order,
+                    payload={"tool_id": tool_id, "resource_id": resource_id},
+                    capability_mask=observation.capability_mask,
+                    measurement_mask=observation.measurement_mask,
+                    basis=observation.basis,
+                    confidence=observation.confidence,
+                    transition_rank=observation.transition_rank + 2,
+                )
+            )
+    if observation.observation_type == "AllowanceObservationObserved":
+        limit_id = payload.get("limit_id")
+        cycle_id = payload.get("cycle_id")
+        if isinstance(limit_id, str) and isinstance(cycle_id, str):
+            identity = (
+                payload.get("provider"),
+                payload.get("account_local_identity", "unknown-account"),
+                payload.get("plan_identity"),
+                payload.get("window_kind"),
+            )
+            related.append(
+                AdapterObservation(
+                    observation_type="AllowanceLimitObserved",
+                    logical_id=semantic_id("allowance-limit", identity),
+                    identity_tuple=identity,
+                    source_range=observation.source_range,
+                    source_rank=observation.source_rank,
+                    event_at_us=observation.event_at_us,
+                    source_order=observation.source_order,
+                    event_kind_order=observation.event_kind_order,
+                    payload={key: payload[key] for key in ("limit_id", "cycle_id", "provider", "account_local_identity", "plan_identity", "window_kind", "reset_identity") if key in payload},
+                    capability_mask=observation.capability_mask,
+                    measurement_mask=observation.measurement_mask,
+                    basis=observation.basis,
+                    confidence=observation.confidence,
+                    transition_rank=observation.transition_rank + 1,
+                )
+            )
+    return tuple(related)

--- a/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/parser.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/parser.py
@@ -1,0 +1,401 @@
+"""Streaming JSONL parser with isolated malformed ranges."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import queue
+import threading
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, replace
+
+from ...domain.identity import semantic_id
+from ..contracts import (
+    ADAPTER_VERSION,
+    AdapterObservation,
+    CursorOutcome,
+    ParseDiagnostic,
+    SourceCursor,
+    SourceRange,
+    SourceState,
+)
+from .cursor import (
+    CursorClassification,
+    FramedRecord,
+    build_cursor,
+    classify_cursor,
+    iter_complete_records,
+)
+from .discovery import SourcePlan
+from .normalize import NormalizationError, assert_body_free, normalize_record, related_observations
+
+PARSER_VERSION = "codex-jsonl-parser.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ParseBatch:
+    source_rank: int
+    batch_index: int
+    observations: tuple[AdapterObservation, ...]
+    diagnostics: tuple[ParseDiagnostic, ...]
+    records_seen: int
+    complete_end: int
+    latest_source_order: int
+    done: bool
+    cursor: SourceCursor | None = None
+    classification: CursorClassification | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceParseResult:
+    source_rank: int
+    observations: tuple[AdapterObservation, ...]
+    diagnostics: tuple[ParseDiagnostic, ...]
+    records_seen: int
+    cursor: SourceCursor | None
+    classification: CursorClassification
+    tail_pending: bool
+
+
+def _range(plan: SourcePlan, framed: FramedRecord) -> SourceRange:
+    return SourceRange(
+        manifestation_id=plan.inventory.manifestation_id,
+        manifestation_key=plan.inventory.manifestation_key,
+        source_revision=plan.inventory.content_revision,
+        record_ordinal=framed.record_ordinal,
+        byte_start=framed.byte_start,
+        byte_end=framed.byte_end,
+    )
+
+
+def _replacement_plan(plan: SourcePlan, classification: CursorClassification) -> SourcePlan:
+    if classification.outcome not in {CursorOutcome.REPLACED, CursorOutcome.TRUNCATED}:
+        return plan
+    digest = hashlib.sha256(
+        f"{plan.inventory.manifestation_id}\0{plan.inventory.content_revision}\0{classification.outcome.value}".encode()
+    ).digest()
+    manifestation_key = max(1, int.from_bytes(digest[:8], "big") & ((1 << 63) - 1))
+    manifestation_id = semantic_id(
+        "source-manifestation",
+        [plan.inventory.manifestation_id, plan.inventory.content_revision, classification.outcome.value],
+    )
+    return replace(
+        plan,
+        inventory=replace(
+            plan.inventory,
+            manifestation_id=manifestation_id,
+            manifestation_key=manifestation_key,
+            state=SourceState.REPLACED if classification.outcome is CursorOutcome.REPLACED else SourceState.TRUNCATED,
+        ),
+    )
+
+
+def iter_source_batches(
+    plan: SourcePlan,
+    *,
+    batch_size: int,
+    cursor: SourceCursor | None = None,
+    late_cutoff_us: int | None = None,
+) -> Iterator[ParseBatch]:
+    """Parse one source incrementally; each yielded batch is bounded."""
+
+    if plan.path is None or not plan.inventory.selected:
+        yield ParseBatch(
+            source_rank=plan.inventory.source_rank,
+            batch_index=0,
+            observations=(),
+            diagnostics=(),
+            records_seen=0,
+            complete_end=0 if cursor is None else cursor.byte_offset,
+            latest_source_order=0 if cursor is None else cursor.latest_source_order,
+            done=True,
+            cursor=cursor,
+            classification=CursorClassification(
+                outcome=CursorOutcome.MISSING if plan.path is None else CursorOutcome.MALFORMED_RANGE,
+                reason="source is not selected or not materialized",
+            ),
+        )
+        return
+    classification = classify_cursor(
+        plan.path,
+        inventory=plan.inventory,
+        cursor=cursor,
+        parser_version=PARSER_VERSION,
+        adapter_version=ADAPTER_VERSION,
+    )
+    active_plan = _replacement_plan(plan, classification)
+    if classification.outcome.value == "no_change":
+        yield ParseBatch(
+            source_rank=plan.inventory.source_rank,
+            batch_index=0,
+            observations=(),
+            diagnostics=(),
+            records_seen=0,
+            complete_end=cursor.byte_offset if cursor else 0,
+            latest_source_order=cursor.latest_source_order if cursor else 0,
+            done=True,
+            cursor=cursor,
+            classification=classification,
+        )
+        return
+    start_offset = cursor.byte_offset if cursor is not None and classification.outcome.value == "append_safe" else 0
+    start_ordinal = cursor.record_ordinal if cursor is not None and start_offset else 0
+    observations: list[AdapterObservation] = []
+    diagnostics: list[ParseDiagnostic] = []
+    batch_index = 0
+    batch_records = 0
+    records_seen = 0
+    complete_end = start_offset
+    latest_source_order = cursor.latest_source_order if cursor is not None and start_offset else 0
+    last_complete_end = complete_end
+    for framed in iter_complete_records(plan.path, start_offset=start_offset, start_ordinal=start_ordinal):
+        records_seen += 1
+        batch_records += 1
+        complete_end = framed.byte_end
+        last_complete_end = complete_end
+        source_range = _range(active_plan, framed)
+        try:
+            decoded = framed.body[:-1].decode("utf-8")
+            record = json.loads(decoded)
+            if not isinstance(record, dict):
+                raise NormalizationError("JSONL record must be an object")
+            observation = normalize_record(record, source_range, source_rank=plan.inventory.source_rank, late_cutoff_us=late_cutoff_us)
+            assert_body_free(observation)
+            observations.append(observation)
+            for related in related_observations(observation):
+                assert_body_free(related)
+                observations.append(related)
+            latest_source_order = observation.source_order
+        except (UnicodeDecodeError, json.JSONDecodeError, NormalizationError, TypeError, ValueError) as error:
+            diagnostics.append(
+                ParseDiagnostic(
+                    code="malformed_range" if not isinstance(error, NormalizationError) or "unknown record kind" not in str(error) else "unknown_record_kind",
+                    source_range=source_range,
+                    detail=type(error).__name__,
+                )
+            )
+        if batch_records >= batch_size:
+            yield ParseBatch(
+                source_rank=plan.inventory.source_rank,
+                batch_index=batch_index,
+                observations=tuple(observations),
+                diagnostics=tuple(diagnostics),
+                records_seen=records_seen,
+                complete_end=complete_end,
+                latest_source_order=latest_source_order,
+                done=False,
+            )
+            batch_index += 1
+            batch_records = 0
+            observations.clear()
+            diagnostics.clear()
+    if observations or diagnostics or records_seen == 0:
+        yield ParseBatch(
+            source_rank=plan.inventory.source_rank,
+            batch_index=batch_index,
+            observations=tuple(observations),
+            diagnostics=tuple(diagnostics),
+            records_seen=records_seen,
+            complete_end=last_complete_end,
+            latest_source_order=latest_source_order,
+            done=False,
+        )
+        batch_index += 1
+        diagnostics.clear()
+        observations.clear()
+    terminal_diagnostics = tuple(diagnostics)
+    if classification.outcome in {CursorOutcome.REPLACED, CursorOutcome.TRUNCATED}:
+        terminal_diagnostics += (
+            ParseDiagnostic(
+                code=f"source_{classification.outcome.value}",
+                source_range=None,
+                detail=classification.reason,
+            ),
+        )
+    next_cursor = build_cursor(
+        plan.path,
+        inventory=active_plan.inventory,
+        byte_offset=last_complete_end,
+        record_ordinal=(cursor.record_ordinal if cursor is not None and start_offset else 0) + records_seen,
+        latest_source_order=latest_source_order,
+        parser_version=PARSER_VERSION,
+        adapter_version=ADAPTER_VERSION,
+    )
+    yield ParseBatch(
+        source_rank=plan.inventory.source_rank,
+        batch_index=batch_index,
+        observations=(),
+        diagnostics=terminal_diagnostics,
+        records_seen=records_seen,
+        complete_end=last_complete_end,
+        latest_source_order=latest_source_order,
+        done=True,
+        cursor=next_cursor,
+        classification=classification,
+    )
+
+
+def parse_source(
+    plan: SourcePlan,
+    *,
+    batch_size: int = 256,
+    cursor: SourceCursor | None = None,
+    late_cutoff_us: int | None = None,
+) -> SourceParseResult:
+    """Convenience materialization for one source; worker ingestion is streaming."""
+
+    observations: list[AdapterObservation] = []
+    diagnostics: list[ParseDiagnostic] = []
+    records_seen = 0
+    next_cursor = cursor
+    classification: CursorClassification | None = None
+    complete_end = 0
+    for batch in iter_source_batches(plan, batch_size=batch_size, cursor=cursor, late_cutoff_us=late_cutoff_us):
+        observations.extend(batch.observations)
+        diagnostics.extend(batch.diagnostics)
+        records_seen = max(records_seen, batch.records_seen)
+        complete_end = max(complete_end, batch.complete_end)
+        if batch.done:
+            next_cursor = batch.cursor
+            classification = batch.classification
+    assert classification is not None
+    size = 0 if plan.path is None else plan.path.stat().st_size
+    tail_pending = plan.path is not None and complete_end < size
+    return SourceParseResult(
+        source_rank=plan.inventory.source_rank,
+        observations=tuple(observations),
+        diagnostics=tuple(diagnostics),
+        records_seen=records_seen,
+        cursor=next_cursor,
+        classification=classification,
+        tail_pending=tail_pending,
+    )
+
+
+def parse_sources(
+    plans: Iterable[SourcePlan],
+    *,
+    workers: int = 1,
+    batch_size: int = 256,
+    queue_capacity: int | None = None,
+    cursors: Mapping[int, SourceCursor] | None = None,
+    late_cutoff_us: int | None = None,
+    metrics_sink: list[dict[str, int]] | None = None,
+) -> Iterator[ParseBatch]:
+    """Parse selected sources with bounded worker/output queues.
+
+    Workers never return a whole source.  They emit bounded batches into a
+    bounded queue, while the coordinator releases batches in source-rank order
+    so worker scheduling cannot affect downstream canonicalization.
+    """
+
+    if not 1 <= workers <= 8:
+        raise ValueError("workers must be one of the bounded 1/2/4/8-compatible range")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    selected = tuple(sorted((plan for plan in plans if plan.inventory.selected), key=lambda item: item.inventory.source_rank))
+    if queue_capacity is None:
+        queue_capacity = max(1, workers * 2)
+    if queue_capacity <= 0:
+        raise ValueError("queue_capacity must be positive")
+    work_queue: queue.Queue[SourcePlan | None] = queue.Queue(maxsize=max(1, workers))
+    output_queue: queue.Queue[tuple[int, ParseBatch | None]] = queue.Queue(maxsize=queue_capacity)
+    reorder_slots = threading.BoundedSemaphore(queue_capacity)
+    source_slots = {
+        plan.inventory.source_rank: threading.BoundedSemaphore(1)
+        for plan in selected
+    }
+    thread_count = min(workers, max(1, len(selected)))
+
+    def feed() -> None:
+        for plan in selected:
+            work_queue.put(plan)
+        for _ in range(thread_count):
+            work_queue.put(None)
+
+    def worker() -> None:
+        while True:
+            plan = work_queue.get()
+            try:
+                if plan is None:
+                    return
+                cursor = None if cursors is None else cursors.get(plan.inventory.manifestation_key)
+                next_batch_index = 0
+                try:
+                    for batch in iter_source_batches(
+                        plan,
+                        batch_size=batch_size,
+                        cursor=cursor,
+                        late_cutoff_us=late_cutoff_us,
+                    ):
+                        source_slots[plan.inventory.source_rank].acquire()
+                        reorder_slots.acquire()
+                        output_queue.put((plan.inventory.source_rank, batch))
+                        next_batch_index = max(next_batch_index, batch.batch_index + 1)
+                except Exception as error:
+                    source_slots[plan.inventory.source_rank].acquire()
+                    reorder_slots.acquire()
+                    output_queue.put(
+                        (
+                            plan.inventory.source_rank,
+                            ParseBatch(
+                                source_rank=plan.inventory.source_rank,
+                                batch_index=next_batch_index,
+                                observations=(),
+                                diagnostics=(
+                                    ParseDiagnostic(
+                                        code="worker_failure",
+                                        source_range=None,
+                                        detail=type(error).__name__,
+                                    ),
+                                ),
+                                records_seen=0,
+                                complete_end=0 if cursor is None else cursor.byte_offset,
+                                latest_source_order=0 if cursor is None else cursor.latest_source_order,
+                                done=True,
+                                cursor=cursor,
+                                classification=CursorClassification(CursorOutcome.MALFORMED_RANGE, "worker failed"),
+                            ),
+                        )
+                    )
+            finally:
+                work_queue.task_done()
+
+    feeder = threading.Thread(target=feed, name="codex-adapter-feeder", daemon=True)
+    threads = [threading.Thread(target=worker, name=f"codex-adapter-worker-{index}", daemon=True) for index in range(thread_count)]
+    feeder.start()
+    for thread in threads:
+        thread.start()
+
+    expected_rank_index = 0
+    expected_batch_index = 0
+    buffered: dict[tuple[int, int], ParseBatch] = {}
+    max_depth = 0
+    try:
+        while expected_rank_index < len(selected):
+            source_rank, batch = output_queue.get()
+            max_depth = max(max_depth, output_queue.qsize() + len(buffered))
+            if batch is None:
+                continue
+            buffered[(source_rank, batch.batch_index)] = batch
+            while expected_rank_index < len(selected) and (
+                selected[expected_rank_index].inventory.source_rank,
+                expected_batch_index,
+            ) in buffered:
+                key = (selected[expected_rank_index].inventory.source_rank, expected_batch_index)
+                ready = buffered.pop(key)
+                reorder_slots.release()
+                source_slots[ready.source_rank].release()
+                yield ready
+                if ready.done:
+                    expected_rank_index += 1
+                    expected_batch_index = 0
+                else:
+                    expected_batch_index += 1
+        work_queue.join()
+        feeder.join()
+        for thread in threads:
+            thread.join()
+    finally:
+        if metrics_sink is not None:
+            metrics_sink.append({"max_queue_depth": max_depth, "selected_sources": len(selected)})

--- a/src/codex_usage_tracker/agent_kernel/adapters/contracts.py
+++ b/src/codex_usage_tracker/agent_kernel/adapters/contracts.py
@@ -1,0 +1,305 @@
+"""Typed, storage-independent contracts emitted by an agent adapter.
+
+The adapter boundary deliberately contains no SQLite or Codex-host runtime
+imports.  It carries structural facts and occurrence coordinates only; the
+publication writer owns canonical entity selection and persistence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum, IntFlag
+from types import MappingProxyType
+from typing import Any
+
+from ..domain.identity import semantic_id
+from ..domain.measurements import validate_nonnegative_int64
+from ..domain.time import validate_utc_microseconds
+
+ADAPTER_CONTRACT = "codex-usage-tracker.adapter.v1"
+ADAPTER_ID = "codex-jsonl"
+ADAPTER_VERSION = "codex-jsonl.v1"
+IDENTITY_VERSION = "v1"
+SOURCE_KIND = "codex-jsonl"
+
+
+class Capability(IntFlag):
+    """Observable adapter capabilities, persisted as a stable bit mask."""
+
+    ALLOWANCE_OBSERVATION = 1 << 0
+    MODEL_CALL_USAGE = 1 << 1
+    SESSION_HIERARCHY = 1 << 2
+    SOURCE_OCCURRENCE = 1 << 3
+    STATE_CHANGE_OBSERVATION = 1 << 4
+    TOOL_LIFECYCLE = 1 << 5
+    VALUATION = 1 << 6
+
+
+CAPABILITY_MASK = int(
+    Capability.ALLOWANCE_OBSERVATION
+    | Capability.MODEL_CALL_USAGE
+    | Capability.SESSION_HIERARCHY
+    | Capability.SOURCE_OCCURRENCE
+    | Capability.STATE_CHANGE_OBSERVATION
+    | Capability.TOOL_LIFECYCLE
+    | Capability.VALUATION
+)
+
+
+class SourceState(str, Enum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    REPLACED = "replaced"
+    TRUNCATED = "truncated"
+    MISSING = "missing"
+    MALFORMED = "malformed"
+    DEFERRED = "deferred"
+
+
+class TimeRangeConfidence(str, Enum):
+    TRUSTED = "trusted"
+    UNCERTAIN = "uncertain"
+    UNAVAILABLE = "unavailable"
+
+
+class CursorOutcome(str, Enum):
+    APPEND_SAFE = "append_safe"
+    NO_CHANGE = "no_change"
+    TRUNCATED = "truncated"
+    REPLACED = "replaced"
+    RECANONICALIZE = "recanonicalize"
+    MISSING = "missing"
+    MALFORMED_RANGE = "malformed_range"
+    LATE_EVENT = "late_event"
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterIdentity:
+    adapter_id: str = ADAPTER_ID
+    adapter_version: str = ADAPTER_VERSION
+    source_kind: str = SOURCE_KIND
+    capability_mask: int = CAPABILITY_MASK
+    identity_version: str = IDENTITY_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRange:
+    """A complete source record coordinate, never the record body."""
+
+    manifestation_id: str
+    manifestation_key: int
+    source_revision: str
+    record_ordinal: int
+    byte_start: int
+    byte_end: int
+    adapter_version: str = ADAPTER_VERSION
+
+    def __post_init__(self) -> None:
+        validate_nonnegative_int64(self.manifestation_key, allow_none=False)
+        if self.manifestation_key == 0:
+            raise ValueError("manifestation key must be positive")
+        validate_nonnegative_int64(self.record_ordinal, allow_none=False)
+        validate_nonnegative_int64(self.byte_start, allow_none=False)
+        validate_nonnegative_int64(self.byte_end, allow_none=False)
+        if self.byte_start >= self.byte_end:
+            raise ValueError("source range must contain at least one byte")
+
+    @property
+    def coordinate_tuple(self) -> tuple[object, ...]:
+        """Return the physical coordinate shared by typed observations."""
+
+        return (
+            self.manifestation_id,
+            self.source_revision,
+            (self.byte_start, self.byte_end),
+            self.record_ordinal,
+            self.adapter_version,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TimeRangeHint:
+    start_us: int
+    end_us: int
+
+    def __post_init__(self) -> None:
+        validate_utc_microseconds(self.start_us, allow_none=False)
+        validate_utc_microseconds(self.end_us, allow_none=False)
+        if self.start_us > self.end_us:
+            raise ValueError("time range start must not exceed end")
+
+    def overlaps_closed_window(self, start_us: int, end_us: int) -> bool:
+        """Apply the frozen half-open-source/closed-window overlap rule."""
+
+        validate_utc_microseconds(start_us, allow_none=False)
+        validate_utc_microseconds(end_us, allow_none=False)
+        if start_us > end_us:
+            raise ValueError("history window start must not exceed end")
+        return self.end_us > start_us and self.start_us <= end_us
+
+
+@dataclass(frozen=True, slots=True)
+class SourceInventory:
+    """Bounded source metadata returned before a source is hydrated."""
+
+    source_key: str
+    manifestation_key: int
+    manifestation_id: str
+    source_kind: str
+    technical_path_key: str
+    display_label: str
+    size_bytes: int
+    modified_at_us: int | None
+    prefix_fingerprint: str | None
+    suffix_fingerprint: str | None
+    content_revision: str
+    source_rank: int
+    state: SourceState
+    time_range_hint: TimeRangeHint | None
+    time_range_confidence: TimeRangeConfidence
+    selected: bool = False
+    deferred_reason: str | None = None
+    filesystem_identity: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.source_key or not self.technical_path_key:
+            raise ValueError("source keys must be non-empty")
+        if self.technical_path_key.startswith(("/", "./", "../")):
+            raise ValueError("technical path key must be root-relative")
+        if "\\" in self.technical_path_key or ":" in self.technical_path_key:
+            raise ValueError("technical path key must use portable separators")
+        validate_nonnegative_int64(self.manifestation_key, allow_none=False)
+        if self.manifestation_key == 0:
+            raise ValueError("manifestation key must be positive")
+        validate_nonnegative_int64(self.size_bytes, allow_none=False)
+        validate_nonnegative_int64(self.source_rank, allow_none=False)
+        validate_utc_microseconds(self.modified_at_us)
+        if self.time_range_confidence is TimeRangeConfidence.UNAVAILABLE:
+            if self.time_range_hint is not None:
+                raise ValueError("unavailable time range cannot carry a hint")
+        elif self.time_range_hint is None:
+            raise ValueError("available time-range confidence requires a hint")
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCursor:
+    """Resume state whose offset is always after a complete JSONL record."""
+
+    manifestation_id: str
+    manifestation_key: int
+    source_revision: str
+    byte_offset: int
+    record_ordinal: int
+    source_size_bytes: int
+    prefix_through_cursor_sha256: str
+    suffix_sha256: str
+    latest_source_order: int
+    parser_version: str
+    adapter_version: str = ADAPTER_VERSION
+
+    def __post_init__(self) -> None:
+        validate_nonnegative_int64(self.manifestation_key, allow_none=False)
+        if self.manifestation_key == 0:
+            raise ValueError("manifestation key must be positive")
+        for value in (
+            self.byte_offset,
+            self.record_ordinal,
+            self.source_size_bytes,
+            self.latest_source_order,
+        ):
+            validate_nonnegative_int64(value, allow_none=False)
+        if self.byte_offset > self.source_size_bytes:
+            raise ValueError("cursor offset cannot exceed source size")
+        for name, digest in (
+            ("prefix_through_cursor_sha256", self.prefix_through_cursor_sha256),
+            ("suffix_sha256", self.suffix_sha256),
+        ):
+            if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+                raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+@dataclass(frozen=True, slots=True)
+class ParseDiagnostic:
+    code: str
+    source_range: SourceRange | None
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterObservation:
+    """A normalized, body-free structural observation."""
+
+    observation_type: str
+    logical_id: str
+    identity_tuple: tuple[Any, ...]
+    source_range: SourceRange
+    source_rank: int
+    event_at_us: int | None
+    source_order: int
+    event_kind_order: int
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    capability_mask: int = 0
+    measurement_mask: int = 0
+    basis: str = "adapter_exact"
+    confidence: str = "exact"
+    transition_rank: int = 0
+
+    def __post_init__(self) -> None:
+        validate_utc_microseconds(self.event_at_us)
+        validate_nonnegative_int64(self.source_rank, allow_none=False)
+        validate_nonnegative_int64(self.source_order, allow_none=False)
+        validate_nonnegative_int64(self.event_kind_order, allow_none=False)
+        validate_nonnegative_int64(self.capability_mask, allow_none=False)
+        validate_nonnegative_int64(self.measurement_mask, allow_none=False)
+        validate_nonnegative_int64(self.transition_rank, allow_none=False)
+        object.__setattr__(self, "payload", MappingProxyType(dict(self.payload)))
+
+    @property
+    def sort_key(self) -> tuple[Any, ...]:
+        return (
+            self.event_at_us is None,
+            0 if self.event_at_us is None else self.event_at_us,
+            self.source_rank,
+            self.source_order,
+            self.event_kind_order,
+            self.logical_id,
+            self.transition_rank,
+        )
+
+    @property
+    def occurrence_id(self) -> str:
+        return semantic_id(
+            "source-occurrence",
+            [
+                self.logical_id,
+                self.source_range.manifestation_id,
+                self.source_range.source_revision,
+                [self.source_range.byte_start, self.source_range.byte_end],
+                self.source_range.record_ordinal,
+                self.source_range.adapter_version,
+            ],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class IngestMetrics:
+    sources_considered: int
+    sources_selected: int
+    sources_deferred: int
+    source_bytes_selected: int
+    records_seen: int
+    observations_emitted: int
+    diagnostics_emitted: int
+    batches_emitted: int
+    max_queue_depth: int
+    workers: int
+    batch_size: int
+    peak_rss_bytes: int
+    elapsed_ns: int
+
+
+def frozen_payload(values: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a shallow immutable payload for callers building observations."""
+
+    return MappingProxyType(dict(values))

--- a/src/codex_usage_tracker/agent_kernel/storage/source_progress.py
+++ b/src/codex_usage_tracker/agent_kernel/storage/source_progress.py
@@ -1,0 +1,151 @@
+"""Typed CK-06 repositories for committed cursors and bounded diagnostics."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from ..domain.measurements import validate_nonnegative_int64
+from .repositories import validate_storage_scalars
+
+
+def _digest(value: str, field: str) -> str:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCursorRecord:
+    manifestation_key: int
+    source_revision: str
+    byte_offset: int
+    record_ordinal: int
+    source_size_bytes: int
+    prefix_through_cursor_sha256: str
+    suffix_sha256: str
+    latest_source_order: int
+    parser_version: str
+    adapter_version: str
+    committed_publication_id: str
+    updated_at_us: int
+
+    def __post_init__(self) -> None:
+        for field in ("manifestation_key", "byte_offset", "record_ordinal", "source_size_bytes", "latest_source_order"):
+            validate_nonnegative_int64(getattr(self, field), allow_none=False)
+        if self.byte_offset > self.source_size_bytes:
+            raise ValueError("cursor byte offset cannot exceed source size")
+        _digest(self.prefix_through_cursor_sha256, "prefix_through_cursor_sha256")
+        _digest(self.suffix_sha256, "suffix_sha256")
+        validate_storage_scalars({"updated_at_us": self.updated_at_us})
+
+
+@dataclass(frozen=True, slots=True)
+class SourceDiagnosticRecord:
+    manifestation_key: int
+    source_revision: str
+    byte_start: int
+    byte_end: int
+    diagnostic_code: str
+    record_ordinal: int | None
+    first_seen_publication_id: str
+
+    def __post_init__(self) -> None:
+        validate_nonnegative_int64(self.manifestation_key, allow_none=False)
+        validate_nonnegative_int64(self.byte_start, allow_none=False)
+        validate_nonnegative_int64(self.byte_end, allow_none=False)
+        if self.byte_start >= self.byte_end:
+            raise ValueError("diagnostic range must contain bytes")
+        validate_nonnegative_int64(self.record_ordinal)
+        if not self.diagnostic_code:
+            raise ValueError("diagnostic code is required")
+
+
+class SourceCursorRepository:
+    """The only writer for the analytical source cursor table."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    def put(self, cursor: SourceCursorRecord) -> SourceCursorRecord:
+        self._connection.execute(
+            """
+            INSERT INTO source_cursors (
+              manifestation_key, source_revision, byte_offset, record_ordinal,
+              source_size_bytes, prefix_through_cursor_sha256, suffix_sha256,
+              latest_source_order, parser_version, adapter_version,
+              committed_publication_id, updated_at_us
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(manifestation_key) DO UPDATE SET
+              source_revision = excluded.source_revision,
+              byte_offset = excluded.byte_offset,
+              record_ordinal = excluded.record_ordinal,
+              source_size_bytes = excluded.source_size_bytes,
+              prefix_through_cursor_sha256 = excluded.prefix_through_cursor_sha256,
+              suffix_sha256 = excluded.suffix_sha256,
+              latest_source_order = excluded.latest_source_order,
+              parser_version = excluded.parser_version,
+              adapter_version = excluded.adapter_version,
+              committed_publication_id = excluded.committed_publication_id,
+              updated_at_us = excluded.updated_at_us
+            """,
+            (
+                cursor.manifestation_key,
+                cursor.source_revision,
+                cursor.byte_offset,
+                cursor.record_ordinal,
+                cursor.source_size_bytes,
+                cursor.prefix_through_cursor_sha256,
+                cursor.suffix_sha256,
+                cursor.latest_source_order,
+                cursor.parser_version,
+                cursor.adapter_version,
+                cursor.committed_publication_id,
+                cursor.updated_at_us,
+            ),
+        )
+        return cursor
+
+    def get(self, manifestation_key: int) -> SourceCursorRecord | None:
+        row = self._connection.execute(
+            """
+            SELECT manifestation_key, source_revision, byte_offset, record_ordinal,
+                   source_size_bytes, prefix_through_cursor_sha256, suffix_sha256,
+                   latest_source_order, parser_version, adapter_version,
+                   committed_publication_id, updated_at_us
+            FROM source_cursors WHERE manifestation_key = ?
+            """,
+            (manifestation_key,),
+        ).fetchone()
+        return None if row is None else SourceCursorRecord(*row)
+
+
+class SourceDiagnosticRepository:
+    """Append-only bounded parse diagnostic coordinates without error bodies."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    def add(self, diagnostic: SourceDiagnosticRecord) -> SourceDiagnosticRecord:
+        self._connection.execute(
+            """
+            INSERT INTO source_diagnostics (
+              manifestation_key, source_revision, byte_start, byte_end,
+              diagnostic_code, record_ordinal, first_seen_publication_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(manifestation_key, source_revision, byte_start, byte_end, diagnostic_code)
+            DO NOTHING
+            """,
+            (
+                diagnostic.manifestation_key,
+                diagnostic.source_revision,
+                diagnostic.byte_start,
+                diagnostic.byte_end,
+                diagnostic.diagnostic_code,
+                diagnostic.record_ordinal,
+                diagnostic.first_seen_publication_id,
+            ),
+        )
+        return diagnostic
+
+    insert = add

--- a/tests/agent_kernel/adapters/__init__.py
+++ b/tests/agent_kernel/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""CK-06 adapter and ingestion tests."""

--- a/tests/agent_kernel/adapters/test_contracts.py
+++ b/tests/agent_kernel/adapters/test_contracts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.normalize import (
+    NormalizationError,
+    normalize_record,
+    normalize_timestamp,
+)
+from codex_usage_tracker.agent_kernel.adapters.contracts import (
+    SourceRange,
+    TimeRangeHint,
+)
+
+
+def test_source_range_occurrence_coordinates_include_physical_manifestation() -> None:
+    first = SourceRange("manifestation:one", 1, "revision-1", 0, 0, 4)
+    second = SourceRange("manifestation:two", 2, "revision-1", 0, 0, 4)
+    assert first.coordinate_tuple != second.coordinate_tuple
+
+
+def test_time_hint_uses_half_open_source_and_closed_window_overlap() -> None:
+    hint = TimeRangeHint(100, 200)
+    assert hint.overlaps_closed_window(200, 300) is False
+    assert hint.overlaps_closed_window(199, 200) is True
+
+
+def test_iso_timestamp_normalization_does_not_use_float_rounding() -> None:
+    text = "1969-12-31T23:59:59.999999-00:00"
+    expected = int((datetime.fromisoformat(text).astimezone(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds() * 1_000_000)
+    actual, basis = normalize_timestamp(text)
+    assert (actual, basis) == (expected, "upstream_iso8601")
+
+
+def test_timestamp_precision_and_body_fields_fail_closed() -> None:
+    with pytest.raises(NormalizationError, match="lossy"):
+        normalize_timestamp("2026-01-01T00:00:00.1234567Z")
+
+
+def test_codex_envelope_is_translated_without_crossing_body_boundary() -> None:
+    observation = normalize_record(
+        {
+            "type": "response.completed",
+            "id": "native-call-001",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "session_id": "native-session-001",
+            "turn_id": "native-turn-001",
+            "model": "gpt-synthetic",
+            "usage": {
+                "uncached_input_tokens": 10,
+                "cached_input_tokens": 20,
+                "reasoning_tokens": 3,
+                "output_tokens": 4,
+            },
+            "response": "must not be copied",
+        },
+        SourceRange("source-manifestation:v1:test", 1, "revision-1", 0, 0, 20),
+    )
+    assert observation.observation_type == "ModelCallObserved"
+    assert observation.logical_id.startswith("call:v1:")
+    assert observation.payload["uncached_input_tokens"] == 10
+    assert "response" not in observation.payload

--- a/tests/agent_kernel/adapters/test_cursor.py
+++ b/tests/agent_kernel/adapters/test_cursor.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.cursor import (
+    build_cursor,
+    classify_cursor,
+    iter_complete_records,
+)
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.discovery import (
+    discover_inventory,
+    select_sources,
+)
+from codex_usage_tracker.agent_kernel.adapters.contracts import CursorOutcome
+
+
+def _selected_source(root: Path):
+    plans = select_sources(discover_inventory(root), max_bytes=1 << 20)
+    return next(plan for plan in plans if plan.inventory.selected)
+
+
+def test_partial_final_line_never_advances_complete_record_cursor(tmp_path: Path) -> None:
+    source = tmp_path / "source.jsonl"
+    source.write_bytes(b'{"complete":true}\n{"partial":')
+    plan = _selected_source(tmp_path)
+    records = list(iter_complete_records(source))
+    assert len(records) == 1
+    cursor = build_cursor(
+        source,
+        inventory=plan.inventory,
+        byte_offset=records[0].byte_end,
+        record_ordinal=1,
+        latest_source_order=0,
+        parser_version="parser.v1",
+        adapter_version="adapter.v1",
+    )
+    source.write_bytes(source.read_bytes() + b"false}\n")
+    current = _selected_source(tmp_path)
+    classification = classify_cursor(
+        source,
+        inventory=current.inventory,
+        cursor=cursor,
+        parser_version="parser.v1",
+        adapter_version="adapter.v1",
+    )
+    assert classification.outcome is CursorOutcome.APPEND_SAFE
+    assert list(iter_complete_records(source, start_offset=cursor.byte_offset, start_ordinal=1))
+
+
+def test_cursor_rejects_truncation_and_prefix_replacement(tmp_path: Path) -> None:
+    source = tmp_path / "source.jsonl"
+    source.write_bytes(b"one\ntwo\n")
+    plan = _selected_source(tmp_path)
+    cursor = build_cursor(
+        source,
+        inventory=plan.inventory,
+        byte_offset=4,
+        record_ordinal=1,
+        latest_source_order=1,
+        parser_version="parser.v1",
+        adapter_version="adapter.v1",
+    )
+    source.write_bytes(b"one")
+    truncated = classify_cursor(
+        source,
+        inventory=_selected_source(tmp_path).inventory,
+        cursor=cursor,
+        parser_version="parser.v1",
+        adapter_version="adapter.v1",
+    )
+    assert truncated.outcome is CursorOutcome.TRUNCATED
+    source.write_bytes(b"eno\ntwo\n")
+    replaced = classify_cursor(
+        source,
+        inventory=_selected_source(tmp_path).inventory,
+        cursor=cursor,
+        parser_version="parser.v1",
+        adapter_version="adapter.v1",
+    )
+    assert replaced.outcome is CursorOutcome.REPLACED
+
+
+def test_manifestation_keys_remain_stable_when_a_path_is_inserted(tmp_path: Path) -> None:
+    first = tmp_path / "source.jsonl"
+    first.write_bytes(b'{"type":"session_start","payload":{"session_id":"s"}}\n')
+    before = discover_inventory(tmp_path)
+    before_key = before[0].inventory.manifestation_key
+    (tmp_path / "aaa.jsonl").write_bytes(first.read_bytes())
+    after = discover_inventory(tmp_path)
+    by_path = {plan.inventory.technical_path_key: plan.inventory for plan in after}
+    assert by_path["source.jsonl"].manifestation_key == before_key
+
+
+def test_file_budget_is_explicitly_deferred(tmp_path: Path) -> None:
+    for index in range(3):
+        (tmp_path / f"source-{index}.jsonl").write_bytes(b"{}\n")
+    plans = discover_inventory(tmp_path, max_files=2)
+    assert len(plans) == 3
+    assert plans[-1].inventory.state.value == "deferred"
+    assert plans[-1].inventory.deferred_reason == "file_budget"

--- a/tests/agent_kernel/adapters/test_ingestion.py
+++ b/tests/agent_kernel/adapters/test_ingestion.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl import parser
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.discovery import (
+    discover_inventory,
+    select_sources,
+)
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.ingest import ingest
+from codex_usage_tracker.agent_kernel.adapters.codex_jsonl.parser import ParseBatch
+
+ROOT = Path(__file__).parents[1] / "fixtures" / "tiny-v1"
+MANIFEST = ROOT / "manifest.json"
+
+
+def _signature(result):
+    return tuple(
+        (
+            observation.observation_type,
+            observation.logical_id,
+            observation.occurrence_id,
+            observation.sort_key,
+        )
+        for observation in result.changes.observations
+    )
+
+
+def test_full_synthetic_ingestion_matches_ck03_accounting_and_has_no_bodies() -> None:
+    result = ingest(ROOT, manifest=MANIFEST, workers=1, batch_size=32)
+    assert result.metrics.sources_considered == 12
+    assert result.metrics.sources_selected == 11
+    assert result.metrics.sources_deferred == 1
+    assert result.metrics.source_bytes_selected == 244657
+    assert result.metrics.records_seen == 339
+    assert result.metrics.diagnostics_emitted == 1
+    assert result.changes.accounting.canonical_counts == {
+        "activities": 5,
+        "allowance_observations": 4,
+        "allowance_limits": 1,
+        "compaction_boundaries": 2,
+        "model_calls": 100,
+        "projects": 1,
+        "resources": 25,
+        "sessions": 10,
+        "state_changes": 5,
+        "tool_invocations": 25,
+        "turns": 50,
+    }
+    assert result.changes.accounting.occurrence_counts["model_calls"] == 102
+    assert result.changes.accounting.token_sums["uncached_input_tokens"].value == 53650
+    assert result.changes.accounting.token_sums["cached_input_tokens"].value is None
+    assert result.changes.accounting.token_sums["cached_input_tokens"].missing_count == 5
+    assert result.changes.accounting.token_sums["reasoning_tokens"].value == 31850
+    assert result.changes.accounting.token_sums["output_tokens"].value == 47450
+    assert len({item.occurrence_id for item in result.changes.occurrences}) == len(result.changes.occurrences)
+    forbidden = {"body", "command", "content", "diff", "patch", "prompt", "reasoning", "response", "stderr", "stdout", "tool_output"}
+    assert all(str(key).lower() not in forbidden for item in result.changes.observations for key in item.payload)
+
+
+def test_parallel_worker_counts_are_deterministic_and_bounded() -> None:
+    baseline = ingest(ROOT, manifest=MANIFEST, workers=1, batch_size=32)
+    for workers in (2, 4, 8):
+        result = ingest(ROOT, manifest=MANIFEST, workers=workers, batch_size=32)
+        assert _signature(result) == _signature(baseline)
+        assert result.changes.accounting == baseline.changes.accounting
+        assert result.metrics.max_queue_depth > 0
+
+
+def test_named_history_windows_match_fixture_call_counts_and_coverage() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    expected = {
+        "30_days": (4, 184519),
+        "90_days": (10, 184519),
+        "one_year": (34, 214584),
+        "all_time": (100, 244657),
+    }
+    for name, (expected_calls, expected_bytes) in expected.items():
+        window = manifest["history"]["windows"][name]
+        result = ingest(
+            ROOT,
+            manifest=MANIFEST,
+            window=(window["start_us"], window["end_us"]),
+            workers=4,
+            batch_size=32,
+        )
+        assert result.metrics.source_bytes_selected == expected_bytes
+        assert result.changes.accounting.canonical_counts.get("model_calls", 0) == expected_calls
+
+
+def test_ck02_identity_derivation_is_executable_for_emitted_observations() -> None:
+    from codex_usage_tracker.agent_kernel.domain.identity import semantic_id
+
+    result = ingest(ROOT, manifest=MANIFEST, workers=1, batch_size=32)
+    kinds = {
+        "ProjectObserved": "project",
+        "SessionObserved": "session",
+        "TurnBoundaryObserved": "turn",
+        "ModelCallObserved": "call",
+        "ToolLifecycleObserved": "tool",
+        "ActivityLifecycleObserved": "activity",
+        "CompactionObserved": "compaction",
+        "StateChangeObserved": "state-change",
+        "ResourceObserved": "resource",
+    }
+    for observation in result.changes.observations:
+        kind = kinds.get(observation.observation_type)
+        if kind is not None:
+            assert observation.logical_id == semantic_id(kind, observation.identity_tuple)
+    assert all(item.occurrence_id.startswith("source-occurrence:v1:") for item in result.changes.occurrences)
+
+
+def test_malformed_records_flush_in_bounded_batches(tmp_path: Path) -> None:
+    source = tmp_path / "malformed.jsonl"
+    source.write_bytes(b"not-json\n" * 65)
+    result = ingest(tmp_path, workers=1, batch_size=16)
+    assert result.metrics.records_seen == 65
+    assert result.metrics.diagnostics_emitted == 65
+    assert result.metrics.batches_emitted >= 5
+
+
+def test_worker_failure_emits_the_next_terminal_batch_without_deadlock(monkeypatch) -> None:
+    plans = select_sources(discover_inventory(ROOT, manifest=MANIFEST), max_bytes=1 << 40)
+    selected = tuple(plan for plan in plans if plan.inventory.selected)[:1]
+
+    def fail_after_one(*args, **kwargs):
+        plan = args[0]
+        yield ParseBatch(
+            source_rank=plan.inventory.source_rank,
+            batch_index=0,
+            observations=(),
+            diagnostics=(),
+            records_seen=1,
+            complete_end=1,
+            latest_source_order=0,
+            done=False,
+        )
+        raise RuntimeError("synthetic worker failure")
+
+    monkeypatch.setattr(parser, "iter_source_batches", fail_after_one)
+    batches = list(parser.parse_sources(selected, workers=2, batch_size=1))
+    assert [batch.batch_index for batch in batches] == [0, 1]
+    assert batches[-1].done is True
+    assert batches[-1].diagnostics[0].code == "worker_failure"

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -11,6 +11,7 @@ from scripts.check_kernel_scope import (
     CK03_SYNTHETIC_ORACLE_ADDITIONS,
     CK04_PHYSICAL_BAKEOFF_ADDITIONS,
     CK05_CANONICAL_STORAGE_ADDITIONS,
+    CK06_ADAPTER_INGESTION_ADDITIONS,
     CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS,
     DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS,
     INTEGRATION_ADDITIONS,
@@ -462,6 +463,26 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/storage/test_repositories.py",
         "tests/agent_kernel/storage/test_tiny_accounting.py",
     } == CK05_CANONICAL_STORAGE_ADDITIONS
+    assert {
+        "docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md",
+        "scripts/check_kernel_scope.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/__init__.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/contracts.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/__init__.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/canonicalize.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/cursor.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/discovery.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/ingest.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/normalize.py",
+        "src/codex_usage_tracker/agent_kernel/adapters/codex_jsonl/parser.py",
+        "src/codex_usage_tracker/agent_kernel/storage/source_progress.py",
+        "tests/agent_kernel/adapters/__init__.py",
+        "tests/agent_kernel/adapters/test_contracts.py",
+        "tests/agent_kernel/adapters/test_cursor.py",
+        "tests/agent_kernel/adapters/test_ingestion.py",
+    } == CK06_ADAPTER_INGESTION_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -490,6 +511,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS
         | CK04_PHYSICAL_BAKEOFF_ADDITIONS
         | CK05_CANONICAL_STORAGE_ADDITIONS
+        | CK06_ADAPTER_INGESTION_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )
 


### PR DESCRIPTION
## Summary

- implement the `codex-jsonl` adapter contract with envelope translation, exact CK-02 identities, typed observations, and body-free normalization
- add bounded source discovery, stable manifestation cursors, malformed-range isolation, deterministic 1/2/4/8 worker batching, and replacement/truncation lifecycle diagnostics
- add synthetic CK-03 accounting/window/determinism/lifecycle evidence and update the packaging ratchet for the new adapter surface

## Validation

- `just vp` passed
- `just v` passed: 991 functional tests, 13 invariant performance tests, Pyright, release safety
- package build plus `scripts/check_release.py --dist` passed
- GitNexus impact analysis and exact `detect_changes --base-ref origin/main` passed
- final read-only review: 7 findings, all accepted and corrected

## Scope

CK-06 only. Publication, refresh, recovery, promotion, projections, MCP, release/publish/tag/deploy work remain out of scope for CK-07 or later. Synthetic fixtures only; no real Codex logs or frozen runtime data were used.
