### PR TITLE
docs: record CK-08 fact-backed oracle blocker

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,11 +9,15 @@ and none of the archived documents may override them.
 CK-07 is complete with its
 [publication, refresh, and recovery evidence](decisions/evidence/ck07/publication-refresh-recovery-evidence.json)
 recorded. CK-05 canonical storage and CK-06 adapter/ingestion remain its
-verified dependencies. The CK-04 growth exception remains explicit and the
-strict v2 aggregate is not claimed. After the CK-07 merge is verified,
-execution may transfer to
-[CK-08](roadmap/tasks/ck-08-implement-query-and-evidence.md) in a separate
-Codex task; CK-08 is not part of this packet. The authority set below wins over
+verified dependencies. CK-08 began from the verified CK-07 merge and found a
+missing fact-backed oracle prerequisite: the frozen CK-03 question rows do not
+equal the canonical database-v1 facts for their own requests, while the CK-04
+query proof obtained those rows from a candidate-only `question_cases` table
+that database-v1 explicitly forbids. CK-08 is therefore blocked at its packet
+boundary with the exact
+[prerequisite evidence](decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)
+recorded. CK-09 is not admitted. The CK-04 growth exception remains explicit
+and the strict v2 aggregate is not claimed. The authority set below wins over
 historical operational checkpoints.
 
 ## Authority set

--- a/docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json
+++ b/docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json
@@ -1,0 +1,144 @@
+{
+  "schema": "codex-usage-tracker.ck08-fact-backed-oracle-prerequisite-gap.v1",
+  "task": "CK-08",
+  "status": "blocked",
+  "recorded_at": "2026-07-30",
+  "base_main_sha": "7ff3eaa268def98dfbff0693160211ffb0c2cedc",
+  "boundary": {
+    "implementation_added": false,
+    "public_api_added": false,
+    "projection_added": false,
+    "ck09_started": false,
+    "reason": "The frozen CK-03 question oracle rows are not derivable from the canonical database-v1 facts emitted for the same typed requests."
+  },
+  "authority": {
+    "question_catalog": {
+      "path": "config/agent-kernel/question-catalog-v1.json",
+      "sha256": "51f9008297cf9cccd24dcc41b43f0e0285c71af1301090796951ba3367836824",
+      "foundation_cutover_named_plans": 21,
+      "foundation_cutover_oracle_variants": 42
+    },
+    "fixture_manifest": {
+      "path": "tests/agent_kernel/fixtures/tiny-v1/manifest.json",
+      "sha256": "6cb0425f6a6fb755e87b5bbdf1144c7d9eca49c889577c8c9a0ec0961fe4e45e",
+      "synthetic_only": true
+    },
+    "oracle_bundle": {
+      "path": "tests/agent_kernel/fixtures/tiny-v1/oracle-bundle.json",
+      "sha256": "9f78b8f87c17ef5e98810be6a4a01f4a13bfc055ac8eb74c9f147a7087d8e41b"
+    },
+    "database_v1_ddl": {
+      "path": "src/codex_usage_tracker/agent_kernel/storage/analytical.sql",
+      "sha256": "50c94bf6da492d3bc5a366bf17f6f0ba989018a505539526413bf01b1b1be934",
+      "question_cases_table_present": false
+    }
+  },
+  "reproduction": {
+    "oracle_id": "oracle:q-acc-01:boundaries",
+    "plan_id": "current_usage",
+    "request_window": {
+      "start_us": 1767225600000000,
+      "end_us": 1767312000000000,
+      "timezone": "UTC",
+      "interval": "[start,end)"
+    },
+    "frozen_ck03_expected_row": {
+      "cached_input_tokens": 12500,
+      "calls": 18,
+      "configured_cost_usd": "62.5",
+      "estimated_credits": "312.5",
+      "output_tokens": 3125,
+      "reasoning_tokens": 2083,
+      "total_tokens": 21875,
+      "uncached_input_tokens": 6250
+    },
+    "database_v1_fact_query": {
+      "source": "model_calls_visible",
+      "predicate": "event_at_us >= :start_us AND event_at_us < :end_us",
+      "result": {
+        "cached_input_tokens": 9885,
+        "calls": 2,
+        "output_tokens": 263,
+        "reasoning_tokens": 1267,
+        "total_tokens": 12021,
+        "uncached_input_tokens": 1873
+      }
+    },
+    "publication_path": [
+      "codex_jsonl.ingest on the checked-in tiny-v1 synthetic fixture",
+      "prepare_write_set_from_changes",
+      "PublicationWriter.publish",
+      "read model_calls_visible from the committed publication"
+    ],
+    "mismatch": {
+      "calls": {
+        "expected": 18,
+        "canonical_facts": 2
+      },
+      "uncached_input_tokens": {
+        "expected": 6250,
+        "canonical_facts": 1873
+      },
+      "total_tokens": {
+        "expected": 21875,
+        "canonical_facts": 12021
+      }
+    }
+  },
+  "ck04_proof_limitation": {
+    "candidate_schema_path": "experiments/physical-architecture/candidate_a/schema.py",
+    "candidate_schema_sha256": "363f95a90e476ad1081dab17939138b081460687040b0afe1498131b8d32f13a",
+    "candidate_query_path": "experiments/physical-architecture/candidate_a/queries.py",
+    "candidate_query_sha256": "bd6959c11d12b0baff7f379603d529696b05377c9628b48d1da66e86a627fe5f",
+    "answer_source": "question_cases.observed_facts_json",
+    "ingest_source": "oracle_case payload observed_facts",
+    "production_disposition": "forbidden",
+    "contract_basis": "AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md states that Candidate A question_cases are harness-only and forbidden in the production package."
+  },
+  "rejected_workarounds": [
+    "Add question_cases or another oracle-answer table to database-v1.",
+    "Read oracle_case records or the oracle bundle from the runtime query path.",
+    "Return frozen expected values instead of executing a canonical fact plan.",
+    "Add a CK-09 projection to hide the mismatch.",
+    "Silently weaken or replace the unchanged CK-03 oracle."
+  ],
+  "required_prerequisite": {
+    "decision": "Freeze fact-backed Foundation/Cutover question cases before CK-08 resumes.",
+    "acceptance": [
+      "All 21 named Foundation/Cutover plans retain their contract IDs, grades, formulas, limits, and prohibited claims.",
+      "All 42 variants emit canonical typed facts that independently reconcile to the expected row for the exact typed request.",
+      "Expected rows are calculated by a reference oracle that does not read production query output.",
+      "Every required logical selector resolves to an actual database-v1 entity and occurrence coordinate.",
+      "The proof contains no question_cases table, oracle_case runtime read, projection, generic SQL surface, or frozen 0.28 dependency."
+    ],
+    "ownership": "A contract and fixture amendment is required before CK-08 implementation can resume; CK-08 must not invent that semantic change inside the query compiler."
+  },
+  "review_accounting": {
+    "reviewer_count": 1,
+    "total_findings": 0,
+    "accepted_findings": 0,
+    "accepted_finding_ids": [],
+    "reviewer_token_status": "pending",
+    "reviewer_tokens": null,
+    "tokens_per_accepted_finding": null,
+    "attribution": "unavailable",
+    "measurement_error": "The installed codex-usage-tracker CLI does not expose the historical strict reviewer-token subcommand; the measurement was not retried."
+  },
+  "validation": {
+    "focused_scope_tests": "15 passed",
+    "agent_kernel_contracts": "passed: 40 questions and 14,459 guidance bytes",
+    "release_safety": "passed",
+    "just_vp": "passed after lockfile-pinned root development dependencies were installed",
+    "git_diff_check": "passed",
+    "review": "one final comprehensive read-only reviewer; no findings",
+    "broader_profiles": "just v and just vc were not run because this is a blocker-only documentation and scope-allowlist change with no package, schema, runtime, or public-contract implementation"
+  },
+  "growth_waiver": "CK-04 growth repetitions 3 and 4 remain waived; the strict v2 aggregate is not claimed.",
+  "privacy": {
+    "synthetic_fixture_only": true,
+    "real_codex_logs_read": false,
+    "raw_bodies_read_or_committed": false,
+    "local_tracker_database_read": false,
+    "secrets_read_or_committed": false
+  }
+}

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -8,8 +8,8 @@ in the linked files under [`docs/roadmap/tasks/`](tasks/).
 ## Overall
 
 - Completed packets: **8 / 17**
-- In progress: **None**
-- Not started: **9**
+- In progress: **CK-08 blocked on a fact-backed oracle prerequisite**
+- Not started: **8**
 - Critical-path completion: **8 / 16**
 - Optional packets: **CK-15**
 
@@ -22,7 +22,8 @@ line and the milestone accounting below.
 
 - [x] **M0 — Authority Ready** · 1 / 1 · CK-00 complete
 - [x] **M1 — Architecture Selected** · 4 / 4 · CK-01–CK-04 complete
-- [ ] **M2 — Kernel Alpha** · 3 / 5 · CK-05–CK-07 complete; CK-08–CK-09 not started
+- [ ] **M2 — Kernel Alpha** · 3 / 5 · CK-05–CK-07 complete; CK-08 blocked;
+  CK-09 not started
 - [ ] **M3 — Codex MVP Qualified** · 0 / 3 · CK-10–CK-12 not started
 - [ ] **M4 — Clean Cutover** · 0 / 2 · CK-13–CK-14 not started
 - [ ] **M5 — Public Release** · 0 / 1 required · CK-16 not started
@@ -63,7 +64,9 @@ line and the milestone accounting below.
 - [x] **CK-07 — Implement publication, refresh, and recovery** · **Completed** ·
   depends on CK-06
   · [packet](tasks/ck-07-implement-publication-refresh-recovery.md)
-- [ ] **CK-08 — Implement query and evidence** · Not started ·
+- [ ] **CK-08 — Implement query and evidence** · **Blocked — the frozen CK-03
+  question oracle rows are not derivable from database-v1 canonical facts;
+  [evidence](../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)** ·
   depends on CK-07
   · [packet](tasks/ck-08-implement-query-and-evidence.md)
 - [ ] **CK-09 — Admit projections and named plans** · Not started ·

--- a/docs/roadmap/tasks/ck-08-implement-query-and-evidence.md
+++ b/docs/roadmap/tasks/ck-08-implement-query-and-evidence.md
@@ -1,6 +1,6 @@
 # CK-08 — Implement fact-backed query and evidence services
 
-**Status:** Not started
+**Status:** Blocked — fact-backed oracle prerequisite missing
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
@@ -42,6 +42,33 @@ a CK-09 projection.
 returning incomplete data. No API is public yet.
 
 **Cleanup/docs:** Produce measured projection-admission list.
+
+## Blocking prerequisite found
+
+CK-08 cannot implement or accept the named plans against the unchanged CK-03
+question oracles without violating the fact-backed runtime boundary. The
+checked-in `Q-ACC-01` boundaries case asks for one exact half-open window and
+expects 18 calls and 6,250 uncached-input tokens. Publishing the same synthetic
+fixture through the CK-06 adapter and CK-07 writer produces 2 canonical calls
+and 1,873 uncached-input tokens in that window.
+
+The CK-04 Candidate A proof does not resolve this mismatch. Its query reads a
+candidate-only `question_cases` table populated from `oracle_case` grading
+records. The database-v1 contract explicitly forbids that table in the
+production package. Adding an equivalent table, reading `oracle_case` records
+at runtime, or changing a query to return the frozen expected row would make
+the grading truth the answer source instead of deriving the answer from
+canonical facts.
+
+The exact inputs, hashes, SQL result, and contract references are recorded in
+[`fact-backed-oracle-prerequisite-gap.json`](../../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json).
+Before CK-08 can resume, the authority set must freeze Foundation/Cutover
+question cases whose expected rows are independently calculated from the
+canonical facts emitted for the same typed requests. The replacement must keep
+all 21 named plans, 42 variants, grades, formulas, selectors, and limits, and
+must prove the oracle without a candidate-only answer table. This packet
+remains unchecked; no registry entry, query/evidence implementation,
+projection, public API, or CK-09 work is admitted by this blocker record.
 
 **Suggested commits:**
 

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -541,6 +541,12 @@ CK07_PUBLICATION_RECOVERY_ADDITIONS = frozenset(
     }
 )
 
+CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
+    }
+)
+
 CI_PERFORMANCE_QUALIFICATION_ADDITIONS = frozenset(
     {
         ".github/workflows/performance-qualification.yml",
@@ -583,6 +589,7 @@ INTEGRATION_ADDITIONS = (
     | CK05_CANONICAL_STORAGE_ADDITIONS
     | CK06_ADAPTER_INGESTION_ADDITIONS
     | CK07_PUBLICATION_RECOVERY_ADDITIONS
+    | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )
 _BLOCKED_TASK_REF = re.compile(r"^refs/heads/kernel/(?:0\.26-integration|k(?:1a|[2-9])(?:-|$))")

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -13,6 +13,7 @@ from scripts.check_kernel_scope import (
     CK05_CANONICAL_STORAGE_ADDITIONS,
     CK06_ADAPTER_INGESTION_ADDITIONS,
     CK07_PUBLICATION_RECOVERY_ADDITIONS,
+    CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS,
     DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS,
     INTEGRATION_ADDITIONS,
@@ -506,6 +507,9 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/publication/test_writer.py",
         "tests/kernel/test_kernel_scope.py",
     } == CK07_PUBLICATION_RECOVERY_ADDITIONS
+    assert {
+        "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
+    } == CK08_PREREQUISITE_BLOCKER_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
         K1A_ADDITIONS
         | K2_ADDITIONS
@@ -536,6 +540,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK05_CANONICAL_STORAGE_ADDITIONS
         | CK06_ADAPTER_INGESTION_ADDITIONS
         | CK07_PUBLICATION_RECOVERY_ADDITIONS
+        | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )
 


### PR DESCRIPTION
## Summary

- records a reproducible CK-08 stop-condition finding: the frozen CK-03 question rows do not match canonical database-v1 facts for the same typed request
- documents that CK-04 Candidate A sourced those rows from the production-forbidden `question_cases` harness table
- marks CK-08 blocked and keeps CK-09 unstarted, with no query/evidence runtime, projection, schema, or public API added
- admits only the new bounded evidence file in the repository scope guard

## Validation

- `python -m pytest -q tests/kernel/test_kernel_scope.py` — 15 passed
- `python scripts/check_agent_kernel_contracts.py` — passed
- `python scripts/check_release.py` — passed
- `just vp` — passed
- `git diff --check` — passed
- repository-private GitNexus exact `origin/main` comparison — low risk, 0 affected processes
- one final comprehensive read-only reviewer — 0 findings; token status pending (historical strict subcommand unavailable, not retried)

## Boundary

CK-08 remains unchecked. Resumption requires a contract/fixture amendment that freezes independently calculated fact-backed expected rows for all 21 Foundation/Cutover plans and 42 variants. This PR does not begin CK-09.