### PR TITLE
docs: add cross-packet seam governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,35 @@ its prerequisites are checked complete. Update the packet status, master
 checkbox ledger, measurements, deviations, and residual risks in the same
 change that completes a packet.
 
+## Cross-packet semantic continuity
+
+A packet is connected to its prerequisites by executable semantics, not only
+by document links, identifiers, hashes, counts, or a prior `Completed` status.
+Before a packet may consume an upstream artifact as truth, its contract must
+name:
+
+- the producer artifact and exact identity;
+- the consumer path that uses it;
+- an independent truth source or reference evaluator;
+- the executable seam check that compares producer meaning with consumer
+  behavior;
+- the downstream packets and evidence that require requalification if the seam
+  changes.
+
+For fact-backed behavior, preserve a three-way proof: one scenario declaration
+emits canonical typed facts, an independent reference evaluator calculates the
+expected result for the exact typed request, and the production consumer
+calculates the same result from its permitted facts. A database table
+containing expected answers, a copied oracle row, internal formula
+consistency, or a matching digest does not prove fact lineage.
+
+When a downstream packet exposes an upstream semantic mismatch, stop the
+affected packet, record exact reproduction evidence, and add a corrective
+packet to the dependency graph. Preserve historical packet evidence; amend it
+through a linked requalification record rather than silently changing its
+meaning. Do not resume dependents until the corrective packet replays every
+affected seam against the actual downstream implementation.
+
 ## Packet task handoff
 
 Keep each CK packet in its own Codex task. After a packet is fully accepted,
@@ -31,7 +60,8 @@ remaining approval gates, relevant commands, and any known risks or
 pre-existing failures. Verify that the new task started in the intended project
 folder with the handoff before ending the completing task. The completing task
 must not begin implementation of the next packet; ownership transfers at the
-packet boundary.
+packet boundary. The handoff must also name the admitted producer artifacts,
+consumer seam checks, independent truth source, and requalification set.
 
 ## Implementation boundary
 
@@ -87,13 +117,15 @@ packet boundary.
 ## Working method
 
 1. Read the current packet and only its controlling authority documents.
-2. Name the observable contract and add or select the failing synthetic oracle.
-3. Implement the smallest complete change inside the packet's ownership.
-4. Run focused checks, then the smallest complete repository profile covering
+2. Name the observable contract, upstream producer artifact, consumer path,
+   independent truth source, and executable seam check.
+3. Add or select the failing synthetic oracle.
+4. Implement the smallest complete change inside the packet's ownership.
+5. Run focused checks, then the smallest complete repository profile covering
    every touched contract.
-5. Record correctness, latency, storage, response-byte, MCP-call, and model-token
+6. Record correctness, latency, storage, response-byte, MCP-call, and model-token
    measurements required by the packet.
-6. Stabilize the diff, then use at most one final read-only reviewer.
+7. Stabilize the diff, then use at most one final read-only reviewer.
 
 Prefer direct functions, explicit data structures, cohesive modules, and clear
 dependency direction. Add abstraction only when it removes present

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ Keep the branch and pull request focused on that packet, and update the
 [checkbox ledger](docs/roadmap/TASK_PACKETS.md) only after every acceptance
 criterion and required measurement passes.
 
+For every upstream artifact consumed as truth, the packet must name and execute
+its producer-to-consumer seam check: exact producer identity, consumer path,
+independent truth source, and requalification set. Matching hashes or a prior
+packet's completion do not prove semantic compatibility. If a downstream
+consumer exposes a mismatch, stop it and add a corrective packet rather than
+silently changing expected output or historical evidence.
+
 The replacement belongs under `src/codex_usage_tracker/agent_kernel/`. Do not
 import, migrate, or extend the frozen 0.28 spike under
 `src/codex_usage_tracker/kernel/`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,8 +16,13 @@ query proof obtained those rows from a candidate-only `question_cases` table
 that database-v1 explicitly forbids. CK-08 is therefore blocked at its packet
 boundary with the exact
 [prerequisite evidence](decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)
-recorded. CK-09 is not admitted. The CK-04 growth exception remains explicit
-and the strict v2 aggregate is not claimed. The authority set below wins over
+recorded. Corrective packet
+[CK-07A](roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md)
+is now the admitted critical-path work: it repairs CK-03 oracle lineage,
+replaces CK-04's candidate-only answer proof, and requalifies the unchanged
+CK-05–CK-07 consumer seams before CK-08 may resume. CK-08 remains blocked and
+CK-09 is not admitted. The CK-04 growth exception remains explicit and the
+strict v2 aggregate is not claimed. The authority set below wins over
 historical operational checkpoints.
 
 ## Authority set
@@ -66,6 +71,9 @@ historical operational checkpoints.
 4. Read the qualification cases and budgets before writing code.
 5. Consult archived spike evidence only for the exact oracle or lesson named by
    the packet.
+6. For every upstream artifact consumed as truth, run the packet's executable
+   seam check against the actual consumer path and independent reference
+   evaluator; a digest or prior completion status is not sufficient.
 
 ### Changing a product contract
 
@@ -109,6 +117,11 @@ If two active documents appear inconsistent:
 4. the qualification plan decides whether a claim is proven;
 5. stop the affected packet and record a decision amendment rather than
    silently choosing the spike behavior.
+
+If an already completed packet's artifact fails in a downstream consumer,
+preserve the historical completion record, add a corrective packet to the
+dependency graph, and require linked requalification evidence for every
+affected downstream seam before dependent work resumes.
 
 Archived documents, old branch names, current spike schemas, and historical
 release notes never resolve an active-contract conflict.

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -72,6 +72,28 @@ Registry changes require contract tests, qualification updates, and a version
 change. A plan may not silently fall back to a broad generic scan that exceeds
 its declared budget.
 
+### Fact-backed plan admission
+
+A named plan is admitted to implementation only after its exact typed request
+has an executable fact-lineage triangle:
+
+1. a scenario declaration emits canonical typed facts and selector
+   occurrences;
+2. an independent reference evaluator derives the expected row from those
+   facts without calling the production compiler;
+3. the permitted database-v1 fact plan produces the same row from one read
+   snapshot.
+
+The scenario, reference evaluator, and production plan may share versioned
+formulas and contracts, but they cannot share computed answer rows. Candidate
+or grading tables such as `question_cases`, `oracle_case` runtime reads, and
+equivalent expected-answer caches are forbidden. A matching digest, formula
+check, or database round trip alone does not admit a plan.
+
+Every plan records its producer artifact identity, consumer seam check, and
+requalification set. If any of those inputs change, the plan returns to
+unimplemented until its seam qualification passes again.
+
 ## Typed compositional boundary
 
 The generic query grammar is allowlisted:

--- a/docs/decisions/PHYSICAL_ARCHITECTURE_DECISION.md
+++ b/docs/decisions/PHYSICAL_ARCHITECTURE_DECISION.md
@@ -33,12 +33,14 @@ experimental candidates or the spike runtime.
 
 The first qualification pass selected Candidate A after eliminating Candidates
 C and D. The final read-only review found seven gaps that prevented acceptance.
-All seven remediations are implemented:
+Six remediations remain accepted. The query-correctness remediation is pending
+CK-07A because its database-resident answer source did not prove canonical-fact
+lineage:
 
 | Review gap | Remediation |
 | --- | --- |
 | Recovery used simulated outcomes | The 25-case matrix now observes real termination or injected faults, inspects persistent state, proves rollback, and performs a subsequent publication. |
-| Query results were assembled from oracle rows | Candidate A now returns database-derived rows; fixture-oracle rows are comparison truth only. |
+| Query results were assembled from oracle rows | The original remediation persisted `oracle_case.observed_facts` in candidate-only `question_cases` and read it through SQL. CK-08 later proved this was database-resident grading truth, not canonical-fact derivation. CK-07A replaces and requalifies this proof before CK-08 resumes. |
 | Planner checks were aggregate-only | Every query case now fails on unapproved full scans, automatic indexes, or temporary sorts. |
 | Parser-worker cases ignored worker count | The worker cases now execute bounded spawned 1/2/4/8-worker parsing with deterministic parent-writer merge. |
 | CPU profile did not match the speed workload | Agent Perf now profiles the exact checked-in standard-build workload; repeated unprofiled runs remain the speed authority. |
@@ -50,7 +52,10 @@ Candidate C did not perform the required process termination, and Candidate D
 exceeded the production 30-day `5 s` hard gate.
 
 Candidate A passed the current-commit standard, production, history, expansion,
-query, ordinary-tail, crash/recovery, Agent Perf, and DBHub lanes. The
+ordinary-tail, crash/recovery, Agent Perf, and DBHub lanes. Its query planner
+and performance measurements completed, but query correctness is not accepted
+until CK-07A replays the corrected fixture and recomputes affected selection
+evidence. The
 maintainer directed CK-04 to stop after growth repetition 2, yielding three
 successful current-commit growth samples. Repetitions 3 and 4 are explicitly
 waived because their additional runtime was disproportionate to the remaining
@@ -76,6 +81,7 @@ The accepted evidence at
 | Short history | 15 / 15 passed | `147a00de01af36a7349259582c81654fb4f5a3709ab9262a36da907d5ee30d9b` |
 | All-time history | 5 / 5 passed | `4a531a455b35b5b6d7f09b12bd4be242abb73fd41f1192646cf7e2c34b1c5157` |
 | History expansion | 15 / 15 passed | `2d65a5f2b420e14b496acf50ba45f1e9fcab5a0c3803e9f23076d597c5955ba2` |
+| Query correctness | Not accepted; pending CK-07A canonical-fact replay and affected score recomputation | historical query measurements retained only |
 | Crash and recovery | 25 / 25 passed | `9b697b6f882056a3cb393d3f10ac9f3954f933f6b74a86c23a39e4d3c0c1fc71` |
 | Candidate C elimination | Expected process-termination observation absent | retained current-commit artifact |
 | Candidate D elimination | Expected production build watchdog failure | retained current-commit artifact |
@@ -199,15 +205,17 @@ fsync, rollback, reconciliation, and protected-cleanup behavior.
 
 ## Query qualification
 
-The bake-off query adapter executes and profiles real Candidate A SQL and
-constructs its returned envelope only from persisted, source-derived facts.
-CK-03 fixture-oracle rows remain independent comparison truth used to grade
-answer equivalence. Per-case planner allowances fail closed on unapproved full
-scans, automatic indexes, and temporary sorts.
+The bake-off query adapter executes and profiles real Candidate A SQL, but its
+answer path reads candidate-only `question_cases` rows populated from
+`oracle_case.observed_facts`. Those rows are source-persisted grading metadata,
+not answers derived from canonical database-v1 facts. The planner and
+performance measurements remain historical physical evidence, but the query
+correctness claim is not accepted as a fact-lineage proof.
 
-Candidate A remains an experimental physical-plan reference. CK-08 and CK-09
-must implement production query code independently and rerun the unchanged
-oracles; a false-zero or oracle-backed runtime answer remains a release
+Candidate A remains an experimental physical-plan reference. CK-07A must
+replace this proof with permitted fact-backed qualification and requalify
+CK-05–CK-07 before CK-08 may implement production query code. A false-zero,
+expected-answer table, or oracle-backed runtime answer remains a release
 blocker.
 
 ## Agent Perf result
@@ -269,7 +277,7 @@ Typed contracts and adapter boundaries are retained ideas, not a dependency.
 | --- | --- |
 | Growth-scale build cost and I/O variance | Three current-commit repetitions and one prior complete bundle passed, but two current repetitions were waived. CK-05/CK-06 benchmark streaming, batching, compact SQLite, and truthful progress against the same fixture. |
 | Build RSS | CK-06 proves bounded streaming and queue depth; no whole-history materialization. |
-| Production query implementation | CK-08/CK-09 independently return database-derived rows and rerun every CK-03 oracle. |
+| Fact-backed query qualification | CK-07A replaces Candidate A's `question_cases` proof, reconciles independent expected rows to canonical published facts, and requalifies CK-03–CK-07 before CK-08/CK-09. |
 | Tail overlay has no production fold path | CK-07 implements and crash-qualifies threshold-driven fold or isolated-artifact selection. |
 | Experimental promotion is not durably atomic | CK-07 implements fsync, pointer, lease, rollback, reconciliation, and protected cleanup. |
 | Installed-model DBHub operability is deferred | CK-11 records exact model identity, host/runtime versions, reasoning effort, synthetic-prompt artifact identity/hash, token source, and authorization before any billed call. |

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -22,6 +22,38 @@ user installs.
 
 No lower level substitutes for a required higher level.
 
+### Evidence claim classes
+
+Evidence must state the exact class proved; these claims are not
+interchangeable:
+
+| Claim | Required proof |
+| --- | --- |
+| Structural validity | Schema, identity, ordering, and digest checks pass. |
+| Formula consistency | Values inside one oracle record satisfy its declared formulas. |
+| Canonical-fact lineage | The exact typed request selects canonical typed facts emitted by its scenario, and an independent evaluator derives the expected result from those facts. |
+| Consumer replay | The actual downstream adapter, storage, publication, or query path produces the same result from only its permitted inputs. |
+
+A packet may claim only the classes it executed. A prior packet's completion,
+matching hashes, or internal oracle reconciliation cannot substitute for
+canonical-fact lineage or consumer replay.
+
+Every dependency edge used as truth records a seam contract with:
+
+```text
+producer artifact path, schema, revision, and digest
+consumer packet and executable path
+independent truth source or reference evaluator
+executable seam check
+exact request/result comparison
+affected evidence and packets to requalify after change
+```
+
+If consumer replay disproves an upstream claim, the dependent packet stops.
+The roadmap admits a corrective packet, preserves the historical record, and
+requires current requalification evidence before the dependency may be
+consumed again.
+
 ## Synthetic fixture strategy
 
 Fixtures contain no real local usage records or raw content. A deterministic
@@ -138,6 +170,23 @@ Every catalog ID has:
 - default and hard byte limits;
 - less-capable-model expected behavior.
 
+Every question variant also has a fact-lineage triangle:
+
+1. one scenario declaration emits its canonical typed facts and real selector
+   occurrences;
+2. an independent reference evaluator calculates the expected row for the
+   exact typed request without production SQL or copied grading output;
+3. the downstream consumer calculates the same row from its permitted
+   canonical facts.
+
+The reference evaluator and production consumer may share locked formulas and
+typed contracts, but they must not share computed answer rows. `oracle_case`
+records, the oracle bundle, `question_cases`, or an equivalent expected-answer
+table are grading metadata only and cannot appear in a runtime answer path.
+Mutation qualification proves both directions: changing grading output cannot
+change the consumer result, while changing canonical facts changes the
+consumer result and causes oracle comparison to fail.
+
 ## Performance workloads
 
 Use the scales, history ranges, workloads, hard gates, and early-stop rules in
@@ -218,6 +267,7 @@ start promptly and no long analytical lock is held.
 For each named plan:
 
 - exact oracle;
+- current producer/consumer seam evidence;
 - plan/compiler ID;
 - required index/projection;
 - `EXPLAIN QUERY PLAN`;

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -16,6 +16,14 @@ spike and Console before the new public release.
 - Implement under `src/codex_usage_tracker/agent_kernel/`.
 - Never import the spike root or open/migrate its database.
 - Freeze a contract and failing oracle before production implementation.
+- Connect every dependency edge with an executable seam contract naming the
+  producer artifact, consumer path, independent truth source, and
+  requalification set.
+- A copied expected row, formula-consistent oracle, matching digest, or
+  database-resident answer table does not prove canonical-fact lineage.
+- If downstream work disproves an upstream semantic claim, stop the dependent,
+  add a corrective packet, preserve the historical evidence, and requalify
+  every affected seam before resuming.
 - Use synthetic fixtures only.
 - Query never refreshes.
 - The host waits; the model never polls.
@@ -36,7 +44,7 @@ spike and Console before the new public release.
 | 0. Authority cleanup and spike freeze | CK-00 | 0.28 main and accepted direction | One docs index/roadmap, disposition, frozen oracle ref | No active contradictory docs or obsolete workflow artifacts |
 | 1. Question and logical contracts | CK-01–CK-03 | Authority docs and catalog | Executable question registry, logical vectors, shared fixtures/oracles | Every supported question maps to facts, plans, evidence, budgets |
 | 2. Physical decision | CK-04 | Shared contracts/harness | A/C/D results and architecture decision | One candidate passes hard gates and selection rule |
-| 3. Canonical kernel | CK-05–CK-07 | Selected design | Storage, identity, Codex adapter, ingestion, publication/recovery | Exact facts and bounded tails survive lifecycle/crash matrix |
+| 3. Canonical kernel | CK-05–CK-07, CK-07A correction | Selected design and executable seam contracts | Storage, identity, Codex adapter, ingestion, publication/recovery, fact-lineage requalification | Exact facts and bounded tails survive lifecycle/crash matrix; published facts independently reconcile to question truth |
 | 4. Answers and evidence | CK-08–CK-09 | Published canonical kernel | Query/evidence grammar, projections, Foundation/Cutover named plans | Question oracles and performance gates pass |
 | 5. Installed agent experience | CK-10–CK-12 | Queryable kernel | Setup, MCP/skill/CLI, exact installed harness, full qualification | Fresh CLI/Desktop tasks pass accuracy/call/token/latency gates |
 | 6. Clean cutover and retirement | CK-13–CK-14 | Fully qualified candidate | Cutover decision, clean package, spike/Console deletion | Replacement selected; prior public release remains reinstall rollback |
@@ -46,7 +54,7 @@ spike and Console before the new public release.
 
 ```text
 CK-00 -> CK-01 -> CK-02 -> CK-03 -> CK-04 -> CK-05 -> CK-06
-      -> CK-07 -> CK-08 -> CK-09 -> CK-10 -> CK-11 -> CK-12
+      -> CK-07 -> CK-07A -> CK-08 -> CK-09 -> CK-10 -> CK-11 -> CK-12
       -> CK-13 -> CK-14 -> CK-16
 ```
 
@@ -67,7 +75,8 @@ flowchart LR
     DEC --> K[CK-05 Selected kernel]
     K --> AD[CK-06 Codex adapter and ingest]
     AD --> P[CK-07 Publication and recovery]
-    P --> Q[CK-08 Query and evidence]
+    P --> SEAM[CK-07A Fact-lineage seam repair]
+    SEAM --> Q[CK-08 Query and evidence]
     Q --> PR[CK-09 Projections and named plans]
     PR --> UX[CK-10 Setup, MCP, skill]
     UX --> IH[CK-11 Installed harness]
@@ -88,7 +97,8 @@ Parallel work is optional and never changes dependency order.
 | After CK-02 | Fixture generator, oracle case authoring, benchmark measurement schema | CK-03 integrator owns manifest and expected-answer schema. |
 | CK-04 | Candidate A, C, and D implementations in separate experiment directories | One integrator owns shared harness/fixture/query/evidence contracts and final scoring. |
 | After CK-05 | Codex adapter parser cases; storage failure-injection harness | Identity/domain/schema interfaces have one owner. |
-| After CK-07 | Fact-backed query compiler; evidence cursor service; installed harness skeleton | Public request/result schemas and registry have one owner. |
+| CK-07A | Scenario/canonical-fact generation; independent reference evaluator; CK-04 proof replacement; CK-05–CK-07 requalification | One integrator freezes scenario, expected-row, selector, and seam-evidence schemas before disjoint lanes begin. |
+| After CK-07A | Fact-backed query compiler; evidence cursor service; installed harness skeleton | Public request/result schemas and registry have one owner. |
 | CK-09 | Disjoint projection families after dirty-key registry is frozen | Projection registry and publication call site have one owner. |
 | CK-12 | CLI and Desktop fresh-task runs; performance repetitions; crash matrix | Candidate artifacts, fixture digest, and scorecard schema are immutable. |
 | CK-14 | Runtime deletion; frontend/Node removal; package/CI cleanup | Package manifest and release checker have one owner. |
@@ -117,6 +127,9 @@ Rollback: revert the planning branch; no runtime behavior changed.
 - logical identity/time/missing/token/lifecycle/allowance/valuation vectors
   pass independently of physical storage;
 - fixture manifests are deterministic.
+- every question case emits canonical typed facts for its exact typed request;
+- an independent reference evaluator derives expected rows without production
+  SQL, an answer table, or copied grading output.
 
 Rollback: contract changes only. Resolve ambiguity before physical candidates.
 
@@ -125,6 +138,9 @@ Rollback: contract changes only. Resolve ambiguity before physical candidates.
 - all candidates implement all five vertical slices;
 - identical fixtures and harness;
 - hard correctness/recovery/performance gates applied;
+- query correctness is derived from permitted candidate facts; an
+  `oracle_case`, `question_cases`, or equivalent expected-answer table cannot
+  satisfy the gate;
 - early failures recorded without long waits;
 - DBHub dev-only comparison complete;
 - one signed decision artifact selects tables/indexes and rejects alternatives.
@@ -140,11 +156,15 @@ empty.
 - reads stay available during build;
 - source lifecycle and crash matrix pass;
 - no raw bodies and no spike imports.
+- consumer-side replay proves that the exact published database-v1 facts
+  reconcile to independent expected rows for every admitted upstream question
+  case.
 
 Rollback: candidate database path is independent; spike remains untouched.
 
 ### Gate G4: answer kernel
 
+- CK-07A fact-lineage and downstream seam requalification evidence is complete;
 - Foundation and Cutover named plans pass exact oracles;
 - admitted projections name consumers and bounded dirty updates;
 - evidence selectors/cursors survive rebuild/replacement/late events;
@@ -262,6 +282,8 @@ The clean-cutover program is complete when:
 - fresh installed Codex tasks are the release gate;
 - public artifacts are verified and released;
 - the roadmap ledger and Linear backlog mark all blocking packets complete;
+- every dependency used as truth has producer identity, consumer replay,
+  independent truth, and current requalification evidence;
 - optional future seams add no current runtime burden.
 
 ## Explicit future items

--- a/docs/roadmap/LINEAR_BACKLOG.md
+++ b/docs/roadmap/LINEAR_BACKLOG.md
@@ -33,7 +33,7 @@ Projects:
 | --- | --- |
 | M0 Authority Ready | CK-00 merged; one authority set and roadmap. |
 | M1 Architecture Selected | CK-01–CK-04 complete; physical decision recorded. |
-| M2 Kernel Alpha | CK-05–CK-09 complete; exact published facts and named plans pass. |
+| M2 Kernel Alpha | CK-05–CK-09 plus corrective CK-07A complete; exact published facts independently reconcile to named-plan truth. |
 | M3 Codex MVP Qualified | CK-10–CK-12 complete; installed fresh tasks pass. |
 | M4 Clean Cutover | CK-13–CK-14 complete; spike/Console absent. |
 | M5 Public Release | CK-16 complete; CK-15 included only if independently admitted. |
@@ -75,7 +75,8 @@ complete contract and `TASK_PACKETS.md` as the completion ledger.
 | CK-05 | Implement isolated database-v1 canonical storage | P2 | M2 | CK-04 | workstream:storage, type:quality, cutover:blocker | New root/database identity; selected schema; logical vectors/tiny oracle pass; no spike import/open/migration. |
 | CK-06 | Implement bounded Codex JSONL adapter and ingestion | P2 | M2 | CK-05 | workstream:adapter, type:performance, cutover:blocker | Source lifecycle/cursors/normalization/capabilities pass; selected history honest; deterministic parallel parse; no raw bodies. |
 | CK-07 | Implement lock-bounded publication and crash recovery | P2 | M2 | CK-06 | workstream:publication, type:performance, type:quality, cutover:blocker | No-change/ordinary-tail/large-artifact paths pass; reads available; crash matrix and duplicate-operation reuse pass. |
-| CK-08 | Implement fact-backed query and stable evidence | P3 | M2 | CK-07 | workstream:query, type:quality | Exact registry plans/evidence/cursors/labels/grades work from one snapshot; projection admission report measured. |
+| CK-07A | Reconcile fact-backed oracles and qualify packet seams | P2 | M2 | CK-07; CK-08 blocker evidence | workstream:contracts, workstream:fixtures, workstream:qualification, type:quality, cutover:blocker | All question cases derive independent truth from canonical scenarios; Foundation/Cutover cases replay through CK-06/CK-07/database-v1; CK-03–CK-07 evidence is requalified. |
+| CK-08 | Implement fact-backed query and stable evidence | P3 | M2 | CK-07A | workstream:query, type:quality | Exact registry plans/evidence/cursors/labels/grades work from one snapshot; projection admission report measured. |
 | CK-09 | Add measured current projections and named plans | P3 | M2 | CK-08 | workstream:query, workstream:publication, type:performance, parallel:eligible, cutover:blocker | Foundation/Cutover plans pass oracles/SQL/MCP/bytes; every projection has consumer, dirty keys, storage/fanout budget. |
 | CK-10 | Deliver agent-led setup, MCP, CLI, and skill | P3 | M3 | CK-09 | workstream:agent-experience, cutover:blocker | Recommended recent start, host wait/no polling, query-first warm path, closed bounded tools, version coherence. |
 | CK-11 | Automate exact installed Codex qualification | P4 | M3 | CK-10 | workstream:qualification, type:quality | Exact wheel/plugin/skill installs in isolation; fresh CLI/Desktop/default/lower-model scorecards generated deterministically. |
@@ -130,8 +131,9 @@ Use this body when creating each issue:
    it from that PR.
 3. Create CK-01 through CK-04. Keep CK-05 blocked until the decision artifact
    is accepted.
-4. Create CK-05 through CK-09 after M1. Use dependency links, not status text,
-   to enforce the critical path.
+4. Create CK-05 through CK-07 after M1. Admit CK-07A before CK-08 and make
+   CK-08 depend on its merged seam evidence; then create CK-08 and CK-09. Use
+   dependency links, not status text, to enforce the critical path.
 5. Create CK-10 through CK-12 after named-plan contracts stabilize.
 6. Do not put CK-13 in progress while any `cutover:blocker` is open.
 7. Create CK-14 only after the maintainer approves CK-13's deletion checkpoint.
@@ -144,6 +146,7 @@ Use this body when creating each issue:
 | CK-03 | Fixture generator; accounting/lifecycle/evidence oracle case sets | Shared manifest/oracle schemas frozen |
 | CK-04 | Candidate A; Candidate C; Candidate D | Shared harness complete, then decision integration |
 | CK-06/CK-07 | Adapter parser cases; crash/failure harness | CK-05 ports fixed; publication integrates |
+| CK-07A | Canonical scenario/reference evaluator; CK-04 proof replacement; CK-05–CK-07 replay | Shared scenario, expected-row, selector, and evidence schemas frozen |
 | CK-08/CK-11 | Query/evidence implementation; installed harness skeleton | Public schemas remain CK-10-owned |
 | CK-09 | Session/family; time/model; tool/resource; allowance projection families | Dirty-key/projection registry frozen |
 | CK-12 | Repeated performance; crash matrix; fresh CLI; fresh Desktop | Exact artifact and fixture digests frozen |

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -7,10 +7,10 @@ in the linked files under [`docs/roadmap/tasks/`](tasks/).
 
 ## Overall
 
-- Completed packets: **8 / 17**
-- In progress: **CK-08 blocked on a fact-backed oracle prerequisite**
-- Not started: **8**
-- Critical-path completion: **8 / 16**
+- Completed packets: **8 / 18**
+- In progress: **CK-07A admitted; CK-08 blocked until its seam evidence passes**
+- Not started: **9**
+- Critical-path completion: **8 / 17**
 - Optional packets: **CK-15**
 
 A packet may be checked only after its acceptance criteria and required checks
@@ -18,12 +18,18 @@ pass, measurements and residual risks are recorded, and any required review is
 resolved. Updating a checkbox also requires updating the packet's `Status`
 line and the milestone accounting below.
 
+Historical completion is preserved when a later consumer finds a semantic
+mismatch. The corrective packet becomes a new dependency and must publish
+linked requalification evidence for every affected prior packet. A digest,
+formula-consistent oracle, or prior completion status cannot replace the
+corrective packet's executable producer-to-consumer seam checks.
+
 ## Milestones
 
 - [x] **M0 — Authority Ready** · 1 / 1 · CK-00 complete
 - [x] **M1 — Architecture Selected** · 4 / 4 · CK-01–CK-04 complete
-- [ ] **M2 — Kernel Alpha** · 3 / 5 · CK-05–CK-07 complete; CK-08 blocked;
-  CK-09 not started
+- [ ] **M2 — Kernel Alpha** · 3 / 6 · CK-05–CK-07 complete; CK-07A admitted;
+  CK-08 blocked; CK-09 not started
 - [ ] **M3 — Codex MVP Qualified** · 0 / 3 · CK-10–CK-12 not started
 - [ ] **M4 — Clean Cutover** · 0 / 2 · CK-13–CK-14 not started
 - [ ] **M5 — Public Release** · 0 / 1 required · CK-16 not started
@@ -64,10 +70,14 @@ line and the milestone accounting below.
 - [x] **CK-07 — Implement publication, refresh, and recovery** · **Completed** ·
   depends on CK-06
   · [packet](tasks/ck-07-implement-publication-refresh-recovery.md)
+- [ ] **CK-07A — Reconcile fact-backed oracles and qualify packet seams** ·
+  **Admitted corrective prerequisite** · depends on CK-07 and the CK-08
+  blocker evidence
+  · [packet](tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md)
 - [ ] **CK-08 — Implement query and evidence** · **Blocked — the frozen CK-03
   question oracle rows are not derivable from database-v1 canonical facts;
   [evidence](../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)** ·
-  depends on CK-07
+  depends on CK-07A
   · [packet](tasks/ck-08-implement-query-and-evidence.md)
 - [ ] **CK-09 — Admit projections and named plans** · Not started ·
   depends on CK-08
@@ -108,8 +118,8 @@ line and the milestone accounting below.
 
 ## Critical path
 
-`CK-00 → CK-01 → CK-02 → CK-03 → CK-04 → CK-05 → CK-06 → CK-07 → CK-08
-→ CK-09 → CK-10 → CK-11 → CK-12 → CK-13 → CK-14 → CK-16`
+`CK-00 → CK-01 → CK-02 → CK-03 → CK-04 → CK-05 → CK-06 → CK-07 → CK-07A
+→ CK-08 → CK-09 → CK-10 → CK-11 → CK-12 → CK-13 → CK-14 → CK-16`
 
 CK-15 remains outside the critical path unless the maintainer explicitly
 promotes it into the release.

--- a/docs/roadmap/tasks/ck-03-build-synthetic-fixtures-and-oracles.md
+++ b/docs/roadmap/tasks/ck-03-build-synthetic-fixtures-and-oracles.md
@@ -119,3 +119,13 @@ patch candidates around an oracle error; fix and rerun all candidates.
 
 1. `test: add agent-kernel source fixture generator`
 2. `test: add accounting lifecycle and evidence oracles`
+
+## Corrective requalification
+
+CK-08 later proved that the question expected rows were generated independently
+from the canonical event stream for the same requests. Historical CK-03
+digests and execution evidence remain preserved, but the claim that question
+rows are canonical-fact truth is pending
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md).
+CK-07A owns the new fixture revision, independent reference evaluator, exact
+digest refresh, and linked requalification evidence.

--- a/docs/roadmap/tasks/ck-04-run-physical-architecture-bakeoff.md
+++ b/docs/roadmap/tasks/ck-04-run-physical-architecture-bakeoff.md
@@ -95,6 +95,14 @@ synthetic-prompt artifact identity/hash, token source, and authorization for
 billed calls were never frozen; CK-11 owns that installed-model operability
 record.
 
+CK-08 later established that Candidate A's “database-derived” query proof read
+`question_cases.observed_facts_json`, populated from `oracle_case` grading
+records. The physical measurements, recovery evidence, selected database-v1
+shape, and growth waiver remain historical evidence, but that query proof does
+not establish canonical-fact lineage. Corrective packet
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md) must
+replace and requalify it before CK-08 resumes.
+
 ## Cross-task execution handoff
 
 **Recorded:** 2026-07-29, America/New_York

--- a/docs/roadmap/tasks/ck-05-implement-canonical-storage-kernel.md
+++ b/docs/roadmap/tasks/ck-05-implement-canonical-storage-kernel.md
@@ -74,3 +74,11 @@ The CK-04 exception is unchanged: current-commit growth repetitions 3 and 4
 were waived and the strict v2 aggregate is not claimed. Growth build cost and
 SQLite I/O variance remain explicit risks. CK-06 owns bounded ingestion,
 streaming and batching beyond the repository seams, queue depth, and RSS.
+
+CK-05's schema and repository implementation are not implicated by the CK-03
+question-row mismatch: database-v1 contains no `question_cases` answer table.
+Its fixture digests, counts, and accounting evidence must nevertheless be
+reissued by
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md) after the
+corrected canonical scenario fixture is frozen. A code change is admitted only
+if that unchanged consumer replay exposes a concrete storage deficiency.

--- a/docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md
+++ b/docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md
@@ -71,3 +71,13 @@ limitation.
 
 1. `feat: add Codex source adapter`
 2. `perf: add bounded deterministic ingestion`
+
+## Corrective requalification
+
+CK-06 correctly exposed the canonical facts that revealed the CK-03 mismatch.
+Its implementation remains complete, while
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md) must replay
+the adapter against the corrected fixture, prove grading metadata cannot become
+canonical facts, and refresh fixture digests, counts, measurements, and
+evidence. A code change is admitted only if that unchanged replay exposes a
+concrete adapter deficiency.

--- a/docs/roadmap/tasks/ck-07-implement-publication-refresh-recovery.md
+++ b/docs/roadmap/tasks/ck-07-implement-publication-refresh-recovery.md
@@ -85,3 +85,11 @@ The CK-04 growth repetitions 3 and 4 remain explicitly waived. CK-07 makes no
 strict-v2 aggregate claim. CK-08 query/evidence, projections and named plans,
 public MCP/setup/CLI/skill surfaces, release, deployment, and optional CK-15
 remain outside this packet.
+
+CK-07's publication path correctly exposed the canonical result that disproved
+the frozen question row. Its implementation remains complete, while
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md) must replay
+no-change, tail, rebuild, replacement, late-event, and recovery behavior
+against the corrected fixture and refresh the linked evidence. A code change
+is admitted only if that unchanged replay exposes a concrete publication or
+recovery deficiency.

--- a/docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md
+++ b/docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md
@@ -1,0 +1,208 @@
+# CK-07A — Reconcile fact-backed oracles and qualify packet seams
+
+**Status:** Admitted corrective prerequisite
+**Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
+**Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
+
+**Goal:** Restore one executable truth chain from synthetic scenario through
+canonical database-v1 publication and independently calculated question
+answers, then requalify CK-03 through CK-07 before CK-08 resumes.
+
+**Why:** CK-08 proved that the frozen CK-03 question rows and the canonical
+facts emitted for the same requests describe different realities. CK-04's
+candidate-only `question_cases` query hid that mismatch instead of deriving
+answers from permitted facts.
+
+**Controls:** CK-01 through CK-07,
+`SUPPORTED_QUESTION_CONTRACTS.md`, `LOGICAL_KERNEL_CONTRACT.md`,
+`PHYSICAL_ARCHITECTURE_BAKEOFF.md`,
+`AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md`, `ADAPTER_CONTRACT.md`,
+`PUBLICATION_REFRESH_RECOVERY.md`,
+`QUERY_EVIDENCE_PROJECTION_CONTRACTS.md`, `QUALIFICATION_PLAN.md`, and the
+[CK-08 blocker evidence](../../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json).
+**Dependencies:** CK-07 merged and verified; CK-08 blocker evidence merged.
+
+## Frozen seam contracts
+
+The CK-07A implementation must use these exact starting authorities and real
+consumer paths. A replacement evidence artifact must record old and new
+identities; the old digests below identify the mismatch and are not expected
+outputs.
+
+| Seam | Starting producer identity | Required real consumer path | Independent evaluator | Executable replay and comparison | Requalification set |
+| --- | --- | --- | --- | --- | --- |
+| CK-03 scenario → question truth | `tests/agent_kernel/fixtures/tiny-v1/manifest.json`, revision `agent-kernel-structural-v1`, file SHA-256 `6cb0425f6a6fb755e87b5bbdf1144c7d9eca49c889577c8c9a0ec0961fe4e45e`; `oracle-bundle.json` SHA-256 `9f78b8f87c17ef5e98810be6a4a01f4a13bfc055ac8eb74c9f147a7087d8e41b`; catalog SHA-256 `51f9008297cf9cccd24dcc41b43f0e0285c71af1301090796951ba3367836824` | `tests.agent_kernel.fixtures.generator.generate.generate_fixture` → emitted structural JSONL → `tests.agent_kernel.fixtures.oracles.source_ledger.read_source_ledger` | new `tests.agent_kernel.fixtures.oracles.reference.evaluate_question_case` | `pytest tests/agent_kernel/test_fact_backed_question_oracles.py -q`; compare canonical request digest, complete expected row including NULLs, and selector logical IDs for all 80 variants | CK-03 packet, fixture README, manifest/oracle/tree digests |
+| CK-04 fixture → physical correctness | `docs/decisions/evidence/ck04/aggregate-evidence.json` SHA-256 `eba27ee24851fa4919c282e1edec5af7e096cec68fce5435d26866b82b96d3ce`; decision commit `95492032373beeaa700af90b542a0a07f4220c74`; growth repetitions 3 and 4 waived | corrected structural fixture → Candidate A permitted fact tables and plans; `candidate_a.queries.run_question` must no longer read `question_cases` or another expected-answer table | new `tests.agent_kernel.fixtures.oracles.database_replay.evaluate_published_question_case` over the candidate database | `pytest tests/experiments/physical-architecture/candidate_a/test_candidate_a_query_eligibility.py tests/agent_kernel/test_fact_backed_question_oracles.py -q`; compare all 80 rows/selectors, query sources/plans, response bytes, affected timings, selection score, and sensitivity result | CK-04 packet, decision query claim, affected aggregate/scoring evidence; growth waiver remains |
+| CK-05 canonical storage | `docs/decisions/evidence/ck05/canonical-storage-evidence.json` SHA-256 `b286907f73621283242af3099834732a2d26f62c6fdc05d36f59e0e5adbe33e1`; merged PR evidence at main before CK-07A | `codex_usage_tracker.agent_kernel.storage.database.initialize_analytical`, typed repositories, `codex_usage_tracker.agent_kernel.storage.database.open_read_only` | `tests.agent_kernel.fixtures.oracles.database_replay.evaluate_published_question_case` over database-v1 | `pytest tests/agent_kernel/storage tests/agent_kernel/test_fact_backed_question_oracles.py -q`; compare schema digest/inventory, identities, canonical counts, occurrence accounting, and all 80 replay rows | CK-05 packet/evidence and storage measurements |
+| CK-06 source → proposed changes | `docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json` SHA-256 `b45d88ceb799037090f06b79761168dbb7fba4554ba9e44a6582fc3fe94cb1cf`; merged CK-06 evidence | `codex_usage_tracker.agent_kernel.adapters.codex_jsonl.ingest.ingest` on the corrected emitted source files | scenario declarations plus `tests.agent_kernel.fixtures.oracles.reference.evaluate_question_case` | `pytest tests/agent_kernel/adapters tests/agent_kernel/test_fact_backed_question_oracles.py -q`; compare typed proposed facts, capabilities, cursors, privacy, strict counts, and prove grading metadata produces no proposed fact | CK-06 packet/evidence, ingestion counts/timings |
+| CK-07 proposed changes → publication | `docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json` SHA-256 `36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb`; merged CK-07 main `7ff3eaa268def98dfbff0693160211ffb0c2cedc` | `codex_usage_tracker.agent_kernel.publication.writer.prepare_write_set_from_changes` → `codex_usage_tracker.agent_kernel.publication.writer.PublicationWriter.publish` → `codex_usage_tracker.agent_kernel.storage.database.open_read_only` on the committed database-v1 publication | `tests.agent_kernel.fixtures.oracles.database_replay.evaluate_published_question_case` | `pytest tests/agent_kernel/publication tests/agent_kernel/test_fact_backed_question_oracles.py -q`; compare all 80 rows and occurrence selectors after initial build, rebuild, replacement, and late event, plus unchanged recovery/tail results | CK-07 packet/evidence, publication counts/timings, CK-08 unblock gate |
+
+Every command runs with `.venv/bin/python -m` from the exact worktree. The
+final evidence records the exact merged dependency SHA used for each row.
+
+## Frozen correction formats
+
+- The corrected fixture revision is `agent-kernel-structural-v2` under
+  `tests/agent_kernel/fixtures/tiny-v2/`. The historical `tiny-v1` artifacts
+  remain evidence only and are not runtime or qualification inputs after
+  CK-07A.
+- `question-scenarios.json` is outside `sources/` and has schema
+  `codex-usage-tracker.synthetic-question-scenarios.v1`. Its top level is
+  `schema`, `fixture_revision`, and ordered `cases`. Each case contains
+  `oracle_id`, `question_id`, `variant`, normalized typed `request`, ordered
+  canonical structural record declarations, required selector kinds, and the
+  question-contract digest. It contains no expected row.
+- Emitted source JSONL contains only adapter-ingestible structural events.
+  `oracle_case`, expected rows, answer grades, and grading metadata are absent.
+- `oracles.reference.evaluate_question_case` consumes the scenario declaration,
+  locked catalog/formulas, and serialized occurrence map. It produces the
+  expected row and selectors without SQLite or production code.
+- `oracles.database_replay.evaluate_published_question_case` consumes only a
+  read-only Candidate A or database-v1 connection plus the normalized request.
+  It cannot import the reference evaluator, oracle bundle, or scenario expected
+  output. It is test-only and cannot be imported by
+  `src/codex_usage_tracker/agent_kernel/`.
+- The regenerated oracle bundle uses
+  `codex-usage-tracker.synthetic-oracle-bundle.v2`. Its expected rows come only
+  from `oracles.reference.evaluate_question_case`.
+- CK-07A evidence uses
+  `codex-usage-tracker.ck07a-fact-backed-oracle-and-seam-qualification-evidence.v1`
+  and records every seam-table identity, command, result, comparison digest,
+  measurement, requalified evidence path, and residual risk.
+
+**Scope and expected files:**
+
+- freeze one scenario declaration, expected-row, selector, and seam-evidence
+  format before parallel implementation;
+- change the CK-03 generator/oracle modules so every question variant emits
+  canonical typed facts for its exact typed request;
+- calculate expected rows with an independent reference evaluator over those
+  scenario facts, never production SQL or copied grading output;
+- move `oracle_case` and equivalent grading metadata outside the runtime source
+  stream, or prove the adapter rejects it without creating canonical facts;
+- replace CK-04's `question_cases` answer proof with fact-backed qualification
+  over permitted tables, rerun affected correctness/planner/payload/timing and
+  aggregate score/sensitivity evidence, and preserve the recorded growth
+  waiver;
+- replay CK-05 storage, CK-06 adapter/ingestion, and CK-07
+  publication/recovery acceptance against the corrected fixture;
+- regenerate committed tiny fixture bytes, manifests, oracle bundle, exact
+  digests, strict counts, and affected measurements;
+- add
+  `docs/decisions/evidence/ck07a/fact-backed-oracle-and-seam-qualification-evidence.json`;
+- amend CK-03 through CK-07 packet/evidence records by linking the CK-07A
+  requalification result rather than deleting their historical evidence.
+
+**Schema/API changes:** Synthetic scenario/oracle formats may receive a new
+version. No production database-v1 table, public MCP/CLI/skill schema, or
+projection is admitted. A targeted CK-05–CK-07 implementation correction is
+allowed only when an executable replay proves a real deficiency in the
+existing owned boundary and the evidence names it exactly.
+
+**Non-goals:** CK-08 query/evidence implementation, CK-09 projections, public
+MCP/setup/CLI/skill, Console, generic SQL, narrative analysis, real Codex logs,
+frozen 0.28 imports, local tracker databases, release/tag/publish/deploy, or
+Linear mutation.
+
+**Invariants:**
+
+- keep all 40 catalog questions, 21 Foundation/Cutover named plans, 42
+  Foundation/Cutover variants, IDs, grades, formulas, limits, ordering, and
+  prohibited claims unless a separately recorded product-contract conflict
+  forces a stop;
+- correct the unified oracle generator for all 80 variants so one bundle
+  cannot retain mixed truth-lineage classes;
+- one scenario declaration emits canonical facts; an independent evaluator
+  derives expected rows; the actual downstream consumer derives the same rows;
+- reference and production paths may share locked formulas and typed contracts
+  but never computed answer rows;
+- every required selector resolves to an actual database-v1 entity and source
+  occurrence coordinate;
+- mutating grading metadata cannot change a consumer result; mutating canonical
+  facts changes the consumer result and breaks oracle equivalence;
+- no `question_cases`, `oracle_case` runtime read, answer cache, projection,
+  generic SQL surface, refresh/write query path, or spike dependency;
+- synthetic structural fixtures only; no raw bodies, secrets, private paths,
+  or local databases.
+
+**Required tests/checks:**
+
+- fail-first reproduction of the frozen `Q-ACC-01` mismatch;
+- all 80 question variants reconcile scenario facts to independent expected
+  rows and replay through CK-06, CK-07, and database-v1;
+- exact request windows, missingness, four token columns, valuation/rate-card,
+  allowance compatibility, hierarchy, lifecycle, ties, and selector
+  coordinates;
+- grading-metadata and canonical-fact mutation tests;
+- CK-04 all-variant correctness, query-plan/table allowlist, response payload,
+  affected timing, score, and sensitivity rerun proving no expected-answer
+  table; a CK-04 lane may be carried forward only when the evidence proves its
+  input digest and execution path are unchanged by CK-07A;
+- unchanged CK-05 repository/identity/accounting checks;
+- unchanged CK-06 discovery/cursor/normalization/privacy checks;
+- unchanged CK-07 no-change/tail/rebuild/replacement/late-event/crash checks;
+- deterministic fixture generation across supported Python versions;
+- focused tests first, then `just v`; run `just vc` because committed fixture
+  assets and build membership/digests change;
+- before each commit, GitNexus check plus exact staged `detect_changes` against
+  `origin/main`.
+
+**Measurements:** Record exact old/new fixture bytes and digests, catalog and
+variant counts, canonical row counts, per-variant reconciliation results,
+selector-coordinate counts, fixture generation time, CK-05 storage and CK-06
+ingestion counts, CK-07 publication/tail measurements, SQL sources/plans for
+the fact-backed proof, response payloads where applicable, privacy scan,
+review findings, reviewer token status, and the unchanged CK-04 growth waiver.
+Byte ratchets allow at most 25% headroom; exact counts remain strict.
+
+**Acceptance:**
+
+1. All 80 expected rows are independently derived from canonical scenario
+   facts and replay exactly through the real CK-06/CK-07/database-v1 path.
+2. The fact-backed proof contains no candidate-only or runtime expected-answer
+   table and no oracle/grading input in the consumer path.
+3. Every required selector resolves to a real canonical entity and occurrence
+   coordinate and remains stable across rebuild, replacement, and late event.
+4. CK-04 affected correctness and scoring evidence is recomputed against the
+   corrected fixture; any carried lane proves byte-identical inputs and an
+   unchanged execution path. CK-05–CK-07 acceptance passes unchanged, or any
+   narrowly necessary correction is explicitly evidenced, owned, and
+   requalified.
+5. CK-03–CK-07 historical evidence remains preserved and links one canonical
+   CK-07A requalification artifact with exact hashes and results.
+6. One final comprehensive read-only reviewer has no unresolved accepted
+   finding; required CI passes; the PR is merged and exact `main` is verified.
+7. Only after all prior items pass may CK-08 change from blocked to ready.
+
+**Failure/rollback:** If a locked product/logical contract cannot be
+materialized as canonical facts, record the exact conflicting question,
+formula, or missing physical prerequisite and stop. Do not change expected
+rows to match incidental fixture output, add an answer table, weaken grades or
+limits, admit a projection, or begin CK-08. Before merge, rollback is the
+packet branch; after merge, revert the corrective packet as one unit and keep
+CK-08 blocked.
+
+**Cleanup/docs:** Update the qualification claim class, fixture README,
+affected packet/evidence links, roadmap ledger, and current-boundary index.
+Retain the CK-08 blocker artifact as historical reproduction evidence. Record
+the merged SHA and create a separate CK-08 task only after exact-main
+verification.
+
+**Parallelism:** The primary integrator first freezes the shared scenario,
+expected-row, selector, and seam-evidence schemas. Then these lanes may proceed
+in disjoint files:
+
+- scenario/canonical-fact generator and independent reference evaluator;
+- CK-04 fact-backed proof replacement;
+- CK-05–CK-07 replay harness and evidence refresh.
+
+No lane independently changes shared schemas, the question catalog, the
+ledger, or the canonical CK-07A evidence format.
+
+**Suggested commits:**
+
+1. `test: freeze fact-backed question seam contracts`
+2. `fix: derive question oracles from canonical scenarios`
+3. `test: replace candidate answer-table qualification`
+4. `test: requalify canonical ingestion and publication seams`
+5. `docs: record CK-07A seam qualification evidence`

--- a/docs/roadmap/tasks/ck-08-implement-query-and-evidence.md
+++ b/docs/roadmap/tasks/ck-08-implement-query-and-evidence.md
@@ -9,8 +9,9 @@ resolve stable bounded evidence before adding projections.
 
 **Why:** Fact-backed truth is the oracle for every later optimization.
 
-**Controls:** `QUERY_EVIDENCE_PROJECTION_CONTRACTS.md`, CK-01, CK-05–CK-07.
-**Dependencies:** CK-07.
+**Controls:** `QUERY_EVIDENCE_PROJECTION_CONTRACTS.md`, CK-01, CK-05–CK-07,
+and CK-07A.
+**Dependencies:** CK-07A merged with exact-main seam evidence.
 
 **Scope and expected files:**
 
@@ -62,7 +63,9 @@ canonical facts.
 
 The exact inputs, hashes, SQL result, and contract references are recorded in
 [`fact-backed-oracle-prerequisite-gap.json`](../../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json).
-Before CK-08 can resume, the authority set must freeze Foundation/Cutover
+Corrective packet
+[CK-07A](ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md) owns this
+prerequisite. Before CK-08 can resume, the authority set must freeze Foundation/Cutover
 question cases whose expected rows are independently calculated from the
 canonical facts emitted for the same typed requests. The replacement must keep
 all 21 named plans, 42 variants, grades, formulas, selectors, and limits, and

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -245,6 +245,7 @@ CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS = frozenset(
         "docs/roadmap/tasks/ck-05-implement-canonical-storage-kernel.md",
         "docs/roadmap/tasks/ck-06-implement-codex-adapter-and-ingestion.md",
         "docs/roadmap/tasks/ck-07-implement-publication-refresh-recovery.md",
+        "docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md",
         "docs/roadmap/tasks/ck-08-implement-query-and-evidence.md",
         "docs/roadmap/tasks/ck-09-admit-projections-and-named-plans.md",
         "docs/roadmap/tasks/ck-10-deliver-setup-mcp-cli-skill.md",

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -27,6 +27,10 @@ _ARCHIVE_PATHS = (
     "docs/archive/spike/ALLOWANCE_EFFICIENCY_FINDINGS.md",
     "docs/archive/spike/OVERLAY_ADAPTER_CONTRACT_0_28.md",
 )
+_PACKET_IDS = {
+    *(f"CK-{number:02d}" for number in range(17)),
+    "CK-07A",
+}
 
 
 def _read(path: str) -> str:
@@ -60,16 +64,20 @@ def test_authority_set_exists_and_has_one_roadmap() -> None:
 def test_master_ledger_links_exactly_one_file_per_packet() -> None:
     ledger_path = _DOCS / "roadmap" / "TASK_PACKETS.md"
     ledger = ledger_path.read_text(encoding="utf-8")
-    packet_ids = re.findall(r"^- \[[ xX]\] \*\*(CK-\d{2})\b", ledger, re.MULTILINE)
+    packet_ids = re.findall(
+        r"^- \[[ xX]\] \*\*(CK-\d{2}A?)\b",
+        ledger,
+        re.MULTILINE,
+    )
     packet_links = re.findall(
-        r"\[packet\]\((tasks/ck-\d{2}-[^)]+\.md)\)",
+        r"\[packet\]\((tasks/ck-\d{2}a?-.*\.md)\)",
         ledger,
     )
 
-    assert len(packet_ids) == 17
-    assert set(packet_ids) == {f"CK-{number:02d}" for number in range(17)}
-    assert len(packet_links) == 17
-    assert len(set(packet_links)) == 17
+    assert len(packet_ids) == len(_PACKET_IDS)
+    assert set(packet_ids) == _PACKET_IDS
+    assert len(packet_links) == len(_PACKET_IDS)
+    assert len(set(packet_links)) == len(_PACKET_IDS)
     assert all((ledger_path.parent / link).is_file() for link in packet_links)
 
     task_files = sorted((_DOCS / "roadmap" / "tasks").glob("ck-*.md"))
@@ -98,6 +106,54 @@ def test_master_ledger_links_exactly_one_file_per_packet() -> None:
             "**Required tests/checks:**" in body
             or "**Tests/benchmarks:**" in body
         )
+
+
+def test_corrective_seam_packet_is_critical_path_authority() -> None:
+    agents = _read("AGENTS.md")
+    index = _read("docs/INDEX.md")
+    roadmap = _read("docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md")
+    ledger = _read("docs/roadmap/TASK_PACKETS.md")
+    backlog = _read("docs/roadmap/LINEAR_BACKLOG.md")
+    qualification = _read("docs/quality/QUALIFICATION_PLAN.md")
+    query_contract = _read(
+        "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md"
+    )
+    physical_decision = _read(
+        "docs/decisions/PHYSICAL_ARCHITECTURE_DECISION.md"
+    )
+    ck07a = _read(
+        "docs/roadmap/tasks/"
+        "ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md"
+    )
+    ck08 = _read("docs/roadmap/tasks/ck-08-implement-query-and-evidence.md")
+
+    assert "## Cross-packet semantic continuity" in agents
+    assert "producer artifact and exact identity" in agents
+    assert "independent truth source or reference evaluator" in agents
+    assert "CK-07A" in index
+    assert "CK-07 -> CK-07A -> CK-08" in roadmap
+    assert "CK-07 → CK-07A\n→ CK-08" in ledger
+    assert "| CK-07A |" in backlog
+    assert "### Evidence claim classes" in qualification
+    assert "### Fact-backed plan admission" in query_contract
+    assert "**Dependencies:** CK-07 merged and verified" in ck07a
+    assert "## Frozen seam contracts" in ck07a
+    assert "## Frozen correction formats" in ck07a
+    assert "agent-kernel-structural-v2" in ck07a
+    assert all(
+        evidence_path in ck07a
+        for evidence_path in (
+            "docs/decisions/evidence/ck04/aggregate-evidence.json",
+            "docs/decisions/evidence/ck05/canonical-storage-evidence.json",
+            "docs/decisions/evidence/ck06/codex-adapter-ingestion-evidence.json",
+            "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+        )
+    )
+    assert "all 80 variants" in ck07a
+    assert "all 80 question variants" in ck07a
+    assert "aggregate score/sensitivity evidence" in ck07a
+    assert "query correctness is not accepted" in physical_decision
+    assert "**Dependencies:** CK-07A merged with exact-main seam evidence." in ck08
 
 
 def test_question_catalog_and_diagram_inventory_are_complete() -> None:

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -235,8 +235,8 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         for path in CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS
         if path.startswith("docs/roadmap/tasks/")
     }
-    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 40
-    assert len(task_packets) == 17
+    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 41
+    assert len(task_packets) == 18
     assert {
         "docs/INDEX.md",
         "docs/architecture/AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md",


### PR DESCRIPTION
## Summary

- add executable cross-packet semantic-continuity requirements to repository governance and qualification authority
- admit corrective packet CK-07A between CK-07 and CK-08, with frozen producer identities, consumer symbols, independent evaluators, replay commands, formats, and requalification sets
- require all 80 question variants to reconcile through the real CK-06, CK-07, and database-v1 path
- mark CK-04 query correctness and affected scoring as pending CK-07A while preserving historical measurements and the growth waiver
- preserve CK-05 through CK-07 completion while requiring fixture/evidence replay and allowing code amendments only for deficiencies proven by unchanged replay
- enforce the new packet, critical path, and authority surfaces in repository tests and scope checks

## Root cause

CK-03 generated expected question rows independently from the canonical event stream. CK-04 persisted those grading rows in candidate-only `question_cases` and treated the SQLite round trip as database-derived query proof. CK-05 through CK-07 correctly implemented the canonical path, which exposed the mismatch when CK-08 compared the same request against published database-v1 facts.

The prior packet process connected work through identifiers, hashes, and completion status but did not require executable producer-to-consumer semantic replay.

## Validation

- `.venv/bin/python -m pytest tests/kernel/test_documentation_authority.py tests/kernel/test_kernel_scope.py -q` — 24 passed
- `.venv/bin/python scripts/check_kernel_scope.py`
- `.venv/bin/python scripts/check_release.py`
- `just vp`
- `git diff --check`
- GitNexus staged compare against `origin/main` — low risk, 0 affected processes
- relative-link audit across all modified authority documents — 0 broken links

## Review

One final read-only reviewer reported three findings; all three were accepted:

- freeze an exact CK-03 through CK-07 seam table and correction formats
- require all 80 variants through the real consumer path
- reopen CK-04 query correctness and affected scoring evidence under CK-07A

Reviewer token attribution remains pending because the installed tracker has no historical `strict` command. The measurement was not retried.

## Scope

This PR changes roadmap governance, documentation authority, and enforcement only. It does not implement CK-07A, CK-08, CK-09, a projection, or a public runtime surface. It reads no real Codex logs or local tracker databases.
