### PR TITLE
CK-07E: qualify independent fact adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,11 @@ evidence, not authority.
 
 CK-07C additionally owns
 `docs/architecture/PLAN_OPERAND_AND_FACT_CONTRACT.md` and the versioned
-`config/agent-kernel/plan-operand-contract-v1.json`. CK-07D is the admitted
-corrective packet for effective-dated rate-card valuation. CK-07A remains
-blocked until CK-07D is implemented, merged, exact-main verified, and its
-affected CK-05/CK-07/CK-07C seams are requalified; neither corrective packet
+`config/agent-kernel/plan-operand-contract-v1.json`. CK-07D merged the
+effective-dated rate-card valuation correction at `e49531b`. CK-07E is the
+admitted test-only prerequisite for independent structural and query-only
+database-v1 fact adapters. CK-07A remains blocked and 0 / 80 requalified until
+CK-07E is merged and exact-main verified; neither prerequisite packet
 qualifies CK-07A's 80 structural-v2 variants.
 
 Advance CK packets in dependency order. Do not begin a dependent packet before

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,14 +30,18 @@ Review of its valuation seam then found that the pure compiler applies one
 selected revision to every call without using call event time. Corrective
 packet
 [CK-07D](roadmap/tasks/ck-07d-implement-effective-dated-rate-card-valuation.md)
-is implemented locally with the exact
+is merged through PR #385 at `e49531b` with the exact
 [gap evidence](decisions/evidence/ck07d/effective-dated-valuation-gap.json).
 Its
 [implementation evidence](decisions/evidence/ck07d/effective-dated-valuation-implementation-evidence.json)
 records the effective-time compiler, immutable publication frontier, schema and
 plan-contract identities, focused requalification, validation, review, and
-remaining merge gates. CK-07A remains blocked and is not requalified or
-complete until CK-07D is merged and exact-main verified.
+historical pre-merge gates. Corrective prerequisite
+[CK-07E](roadmap/tasks/ck-07e-implement-independent-fact-adapters.md) now
+qualifies the two independent normalization paths from structural declarations
+and one query-only database-v1 snapshot into plan facts and ordered evidence.
+CK-07A remains blocked and is 0 / 80 requalified until CK-07E is merged and
+exact-main verified.
 It must still repair CK-03 oracle lineage,
 replace CK-04's candidate-only answer proof, and requalify the unchanged
 CK-05–CK-07 consumer seams before CK-08 may resume. CK-08 remains blocked and

--- a/docs/architecture/PLAN_OPERAND_AND_FACT_CONTRACT.md
+++ b/docs/architecture/PLAN_OPERAND_AND_FACT_CONTRACT.md
@@ -241,9 +241,9 @@ source/capability coverage, entity counts, the latest accepted delta and
 bounded delta samples, active rate-card identity, and all selected facts.
 Writer-internal prior-state objects are not query/replay publication facts.
 
-## Evaluator independence and CK-07A handoff
+## Evaluator independence and CK-07E/CK-07A handoff
 
-CK-07A's reference evaluator converts one structural-v2 scenario declaration
+CK-07E's structural reference adapter converts one structural-v2 scenario declaration
 into `CanonicalFact` rows. Its database-v1 evaluator independently selects
 permitted rows from one query-only SQLite snapshot and normalizes those rows.
 
@@ -263,7 +263,9 @@ They may not share:
 - answer, oracle, grading, or comparison output; or
 - emitted expected rows.
 
-CK-07A compares normalized request digest; every answer value including
+CK-07E stops after proving normalized request, fact, owner, provenance, and
+lifecycle parity and claims 0 / 80 answer comparisons. CK-07A compares the
+normalized request digest; every answer value including
 `NULL`; grades; deterministic order; all 185 field bindings; and the exact
 ordered role-kind-selector-provenance sequence. This packet makes that replay
 executable but does not claim that any of the 80 variants has passed.

--- a/docs/decisions/evidence/ck07e/independent-fact-adapters-evidence.json
+++ b/docs/decisions/evidence/ck07e/independent-fact-adapters-evidence.json
@@ -1,0 +1,171 @@
+{
+  "schema": "codex-usage-tracker.ck07e-independent-fact-adapters-evidence.v1",
+  "packet": "CK-07E",
+  "status": "complete_on_merge_exact_main_pending",
+  "base": {
+    "ref": "feature/ck07e-independent-fact-adapters",
+    "sha": "e49531b0775c5c7f1043497042c25a200b447bb7",
+    "authority_pr": "https://github.com/douglasmonsky/codex-usage-tracker/pull/385"
+  },
+  "authority": {
+    "database_v1_schema_contract_digest": "1a2dcffe778633457bbeb60dd3a41c233a78c15af2a3393bf9cacc1d9e645bb5",
+    "logical_contract_sha256": "27981ec9bac8c245306e02784b8730e8ff9216b33a81da9efb8409403431fe3d",
+    "logical_vector_bundle_digest": "87b9d08a8d1186ab1e3eb794f58d17fd28b991e210fc0144713f1299ab224b2c",
+    "plan_operand_contract_sha256": "19b9c69f50f67b01321e1f269cee2f70370ca64c0c666ff4dac2cc52efa314b4",
+    "plan_operand_schema_sha256": "619b4f4e546def5a44bfd97d7ab9778fea204aca6cfc32cec3f7a92d54a037e8",
+    "plan_operand_vectors_sha256": "cc4d944354356136c45c6a22aa0a289849fe6c4804e4a5d5bd5574cac1ab72c2",
+    "selector_contract_sha256": "1a5ad492d7684b8050a71606af918d0e5964fffd32826c5ae0479d829131b41b",
+    "selector_schema_sha256": "c1ece7b92795a138a288b011139d1d238f8cdebb59368d45a76a4c1a3cb8b4af",
+    "ck07d_gap_evidence_sha256": "4e47170e4ffaa37bb85f6d0fdb79b6ab2d7a9e2a7c0c5c2e9d33fd6e82c5cd16",
+    "ck07d_implementation_evidence_sha256": "92947b3e956244370ce6b8b6250e365aca695802c8b57bdd9cf918714ce01872",
+    "analytical_sql_sha256": "4341ce05b119c44c83865b434751cd8569bad5445de26be2e8ceaa9345ada820"
+  },
+  "adapters": {
+    "reference": {
+      "path": "tests/agent_kernel/fact_adapters/reference.py",
+      "sha256": "03dbf06b3a3a6cc4590e7521bcb1a1bd7764ad989b45dcdf8591ef1b10fff19d",
+      "symbols": [
+        "StructuralReferenceFactAdapter",
+        "AdapterMaterialization",
+        "EvidenceReference",
+        "StructuralReferenceAdapterError"
+      ],
+      "sqlite_access": false,
+      "production_query_access": false
+    },
+    "database_v1": {
+      "path": "tests/agent_kernel/fact_adapters/database.py",
+      "sha256": "7005b1a06fdc1d866b5aa7d100eb5349f43fbb017aae6b876d60f1dd275f6e00",
+      "symbols": [
+        "DatabaseV1FactAdapter",
+        "DatabaseV1FactMaterialization",
+        "EvidenceReferenceV1",
+        "DatabaseAdapterContractError"
+      ],
+      "query_only_required": true,
+      "single_read_snapshot": true,
+      "persisted_relation_allowlist_count": 15,
+      "derived_relations": [
+        "valuation_match"
+      ],
+      "persisted_relation_allowlist": [
+        "allowance_observation",
+        "canonical_call",
+        "compaction_boundary",
+        "context_component",
+        "model_profile",
+        "project",
+        "publication",
+        "publication_delta",
+        "resource",
+        "session",
+        "source_manifestation",
+        "source_occurrence",
+        "state_change",
+        "tool_invocation",
+        "turn"
+      ]
+    },
+    "shared_computed_output": false,
+    "production_code_changed": false,
+    "database_v1_ddl_changed": false,
+    "synthetic_support": {
+      "path": "tests/agent_kernel/fact_adapters/support.py",
+      "sha256": "7ff92efd20ef7fe1226d1b04746b0d5b1efa40cb8cb98ad4c9f6b22441713e1d"
+    },
+    "contract_tests": {
+      "path": "tests/agent_kernel/fact_adapters/test_contracts.py",
+      "sha256": "43336e5bc22577dae47a7aaa3494e9443431d0c94e51ddda1a9bb1779a4de12c"
+    }
+  },
+  "qualification": {
+    "plan_contracts_compared": 40,
+    "normalized_plan_parity_failures": 0,
+    "fact_relations_covered": 16,
+    "fact_relations": [
+      "allowance_observation",
+      "canonical_call",
+      "compaction_boundary",
+      "context_component",
+      "model_profile",
+      "project",
+      "publication",
+      "publication_delta",
+      "resource",
+      "session",
+      "source_manifestation",
+      "source_occurrence",
+      "state_change",
+      "tool_invocation",
+      "turn",
+      "valuation_match"
+    ],
+    "selector_kinds": 14,
+    "provenance_kinds": 6,
+    "ordered_evidence_references_compared": 559,
+    "ordered_evidence_reference_failures": 0,
+    "lifecycle_variants": [
+      "initial",
+      "rebuild",
+      "replacement",
+      "late_event"
+    ],
+    "lifecycle_parity_failures": 0,
+    "ck07a_answer_comparisons": 0,
+    "ck04_scoring_or_timing_updated": false,
+    "ck03_through_ck07_evidence_refreshed": false
+  },
+  "valuation_reconciliation": {
+    "selection": "greatest matching captured revision with effective_at_us <= call.event_at_us",
+    "precedence": "effective-time recency first; exact profile before alias only at equal effective time",
+    "fetched_at_role": "provenance_only",
+    "selected_revision_digest_in_identity": true,
+    "typed_missing_measurement_proved": true,
+    "configured_estimate_excludes_unpriced": true,
+    "bounded_backdated_dirty_interval_proved": true,
+    "persisted_call_price_assignment": false,
+    "answer_cache": false,
+    "time_blind_singular_card_seam": false
+  },
+  "synthetic_privacy": {
+    "schema": "codex-usage-tracker.synthetic-structural-v2.v1",
+    "initial_declaration_rows": 52,
+    "initial_source_occurrences": 25,
+    "initial_jsonl_bytes": 24378,
+    "late_event_declaration_rows": 55,
+    "late_event_source_occurrences": 27,
+    "late_event_jsonl_bytes": 25898,
+    "real_codex_content_used": false,
+    "body_fields_used": false,
+    "expected_or_oracle_rows_emitted": false,
+    "grading_or_comparison_output_emitted": false,
+    "secrets_or_private_paths_emitted": false
+  },
+  "validation": {
+    "focused_ck07e": "31 passed in 1.19s after accepted review and follow-up corrections",
+    "coupled_kernel_storage_publication": "317 passed in 15.30s after accepted review and follow-up corrections",
+    "just_v": "passed final post-review state: 1241 tests in 111.31s, 13 performance invariants with zero breaches, lint, type, maintainability, frontend, and release-safety checks",
+    "just_vc": "passed final post-review state: 1241 tests in 102s, 13 performance invariants with zero breaches, then complete sdist and wheel checks",
+    "transient_nonblocking_breaches": [
+      "just vc repeated invariant sample observed allowance_read_p95_ms 627.07078 > 550.0; preceding just v measured 491.310506"
+    ],
+    "git_diff_check": "passed within both broad gates",
+    "gitnexus_bootstrap_check": "passed with repository-private GitNexus 1.6.9",
+    "gitnexus_detect_changes": "passed on the exact staged diff against origin/main: 19 files, 37 symbols, 0 affected processes, low risk",
+    "final_review": "eight findings accepted and corrected; four focused follow-up gaps corrected; final reviewer reports no actionable findings and safe to commit",
+    "review_measurement": "aggregate reviewer token attribution unavailable because installed usage tracker has no strict command; reviewer_calls and token totals unavailable without retry",
+    "required_ci": "pending",
+    "exact_main": "pending"
+  },
+  "completion": {
+    "pull_request": null,
+    "merged_sha": null,
+    "ck07a_resume_ready": "after merge and exact-main verification",
+    "ck08_status": "blocked"
+  },
+  "residual_risks": [
+    "Qualification is synthetic and test-only; CK-07A still owns all 80 complete answer comparisons.",
+    "Candidate A scoring and timing and CK-03 through CK-07 evidence remain intentionally unchanged.",
+    "CK-04 growth repetitions 3 and 4 remain waived; strict v2 aggregate success is not claimed."
+  ]
+}

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -80,6 +80,18 @@ recorded in
 That local evidence does not unblock CK-07A or CK-08 before merge and
 exact-main verification.
 
+CK-07E is the final L0 adapter prerequisite before CK-07A. A structural
+reference adapter and a separately implemented query-only database-v1 adapter
+must independently emit equivalent normalized `CanonicalFact` rows,
+`PlanRequest`, and exact ordered owner-specific evidence. Qualification covers
+every plan relation/fact family, all 14 selector owners, typed non-placeholder
+provenance, NULL/empty/ties/order/no-window behavior, effective-dated
+valuation and unpriced coverage, import/source independence, privacy, and
+clean rebuild/replacement/late-event stability. These comparisons stop at the
+fact/request/evidence boundary: CK-07E must record 0 / 80 CK-07A answer
+comparisons and cannot update CK-04 scoring or CK-03 through CK-07 seam
+evidence.
+
 ## Synthetic fixture strategy
 
 Fixtures contain no real local usage records or raw content. A deterministic

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -44,7 +44,7 @@ spike and Console before the new public release.
 | 0. Authority cleanup and spike freeze | CK-00 | 0.28 main and accepted direction | One docs index/roadmap, disposition, frozen oracle ref | No active contradictory docs or obsolete workflow artifacts |
 | 1. Question and logical contracts | CK-01–CK-03 | Authority docs and catalog | Executable question registry, logical vectors, shared fixtures/oracles | Every supported question maps to facts, plans, evidence, budgets |
 | 2. Physical decision | CK-04 | Shared contracts/harness | A/C/D results and architecture decision | One candidate passes hard gates and selection rule |
-| 3. Canonical kernel | CK-05–CK-07, CK-07B/CK-07C/CK-07D contract corrections, CK-07A seam correction | Selected design and executable seam contracts | Storage, identity, Codex adapter, ingestion, publication/recovery, executable formula/provenance/operand authority, effective-dated valuation, fact-lineage requalification | Exact facts and bounded tails survive lifecycle/crash matrix; pricing boundaries and published facts independently reconcile to question truth |
+| 3. Canonical kernel | CK-05–CK-07, CK-07B/CK-07C/CK-07D contract corrections, CK-07E fact adapters, CK-07A seam correction | Selected design and executable seam contracts | Storage, identity, Codex adapter, ingestion, publication/recovery, executable formula/provenance/operand authority, effective-dated valuation, independent fact adapters, fact-lineage requalification | Exact facts and bounded tails survive lifecycle/crash matrix; pricing boundaries and published facts independently reconcile to question truth |
 | 4. Answers and evidence | CK-08–CK-09 | Published canonical kernel | Query/evidence grammar, projections, Foundation/Cutover named plans | Question oracles and performance gates pass |
 | 5. Installed agent experience | CK-10–CK-12 | Queryable kernel | Setup, MCP/skill/CLI, exact installed harness, full qualification | Fresh CLI/Desktop tasks pass accuracy/call/token/latency gates |
 | 6. Clean cutover and retirement | CK-13–CK-14 | Fully qualified candidate | Cutover decision, clean package, spike/Console deletion | Replacement selected; prior public release remains reinstall rollback |
@@ -54,7 +54,7 @@ spike and Console before the new public release.
 
 ```text
 CK-00 -> CK-01 -> CK-02 -> CK-03 -> CK-04 -> CK-05 -> CK-06
-      -> CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07A -> CK-08 -> CK-09 -> CK-10 -> CK-11 -> CK-12
+      -> CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07E -> CK-07A -> CK-08 -> CK-09 -> CK-10 -> CK-11 -> CK-12
       -> CK-13 -> CK-14 -> CK-16
 ```
 
@@ -78,7 +78,8 @@ flowchart LR
     P --> CONTRACT[CK-07B Formula and provenance contract]
     CONTRACT --> OPERANDS[CK-07C Plan operands and missing facts]
     OPERANDS --> RATES[CK-07D Effective-dated valuation]
-    RATES --> SEAM[CK-07A Fact-lineage seam repair]
+    RATES --> ADAPTERS[CK-07E Independent fact adapters]
+    ADAPTERS --> SEAM[CK-07A Fact-lineage seam repair]
     SEAM --> Q[CK-08 Query and evidence]
     Q --> PR[CK-09 Projections and named plans]
     PR --> UX[CK-10 Setup, MCP, skill]
@@ -102,7 +103,8 @@ Parallel work is optional and never changes dependency order.
 | After CK-05 | Codex adapter parser cases; storage failure-injection harness | Identity/domain/schema interfaces have one owner. |
 | CK-07C after CK-07B | Plan/direct-fact binding artifact and pure compiler; deterministic valuation relation; missing canonical-fact representation | One integrator owns the binding schema, pure interface, database amendment, and CK-07A resume contract. |
 | CK-07D after CK-07C | Effective-time boundary evaluator; rate-card frontier/compiler; database/publication integration and affected seam requalification | One integrator owns revision selection semantics, schema/publication amendments, valuation compiler, and CK-07A resume evidence. |
-| CK-07A after CK-07D | Scenario/canonical-fact generation; independent reference evaluator; CK-04 proof replacement; CK-05–CK-07 replay | One integrator consumes the CK-07B/CK-07C/CK-07D formula, selector, operand, fact, and valuation authority and owns scenario, expected-row, selector, and seam-evidence schemas before disjoint lanes begin. |
+| CK-07E after CK-07D | Structural-reference adapter; query-only database-v1 adapter; parity/provenance/lifecycle qualification | One integrator freezes adapter interfaces, structural declarations, exact evidence schema, and disjoint file ownership before implementation lanes begin. |
+| CK-07A after CK-07E | Expected-row generation; CK-04 proof replacement; CK-05–CK-07 replay | One integrator consumes the qualified CK-07E adapters and owns expected-row and seam-evidence schemas before disjoint lanes begin. |
 | After CK-07A | Fact-backed query compiler; evidence cursor service; installed harness skeleton | Public request/result schemas and registry have one owner. |
 | CK-09 | Disjoint projection families after dirty-key registry is frozen | Projection registry and publication call site have one owner. |
 | CK-12 | CLI and Desktop fresh-task runs; performance repetitions; crash matrix | Candidate artifacts, fixture digest, and scorecard schema are immutable. |
@@ -171,6 +173,8 @@ Rollback: candidate database path is independent; spike remains untouched.
 
 - CK-07D effective-dated valuation and affected seam requalification evidence
   is complete;
+- CK-07E independent fact-adapter parity, provenance, independence, and
+  lifecycle evidence is complete;
 - CK-07A fact-lineage and downstream seam requalification evidence is complete;
 - Foundation and Cutover named plans pass exact oracles;
 - admitted projections name consumers and bounded dirty updates;

--- a/docs/roadmap/LINEAR_BACKLOG.md
+++ b/docs/roadmap/LINEAR_BACKLOG.md
@@ -78,7 +78,8 @@ complete contract and `TASK_PACKETS.md` as the completion ledger.
 | CK-07B | Freeze formula and selector-provenance authority | P2 | M2 | CK-07; CK-07A blocker evidence | workstream:contracts, type:quality, cutover:blocker | All 45 formulas and 185 fields are executable; all 14 selector kinds resolve through authoritative owners with exact provenance and lifecycle gates. |
 | CK-07C | Freeze plan operands and missing canonical facts | P2 | M2 | CK-07B; retained CK-07A blocker evidence | workstream:contracts, workstream:storage, type:quality, cutover:blocker | All 61 formula uses and 185 answer fields have executable plan bindings; valuation, context, allowance, hierarchy, order, and publication inputs are materially representable without expected-answer data. |
 | CK-07D | Implement effective-dated rate-card valuation | P2 | M2 | CK-07C; retained CK-07A/CK-08 blocker evidence | workstream:contracts, workstream:storage, workstream:publication, type:quality, cutover:blocker | Each call selects the greatest matching publication-captured revision effective at its event time; invalid or ambiguous lineages fail closed; CK-05/CK-07/CK-07C seams are requalified. |
-| CK-07A | Reconcile fact-backed oracles and qualify packet seams | P2 | M2 | CK-07D; CK-08 blocker evidence | workstream:contracts, workstream:fixtures, workstream:qualification, type:quality, cutover:blocker | All question cases derive independent truth from canonical scenarios; Foundation/Cutover cases replay through CK-06/CK-07/database-v1; CK-03–CK-07 evidence is requalified. |
+| CK-07E | Implement independent fact adapters | P2 | M2 | CK-07D; retained CK-07A/CK-08 blocker evidence | workstream:contracts, workstream:fixtures, workstream:storage, type:quality, cutover:blocker | Structural declarations and one query-only database-v1 snapshot independently normalize equivalent plan facts, requests, and exact owner-specific evidence across all fact families, selectors, pricing, and lifecycle replays. |
+| CK-07A | Reconcile fact-backed oracles and qualify packet seams | P2 | M2 | CK-07E; CK-08 blocker evidence | workstream:contracts, workstream:fixtures, workstream:qualification, type:quality, cutover:blocker | All question cases derive independent truth from canonical scenarios; Foundation/Cutover cases replay through CK-06/CK-07/database-v1; CK-03–CK-07 evidence is requalified. |
 | CK-08 | Implement fact-backed query and stable evidence | P3 | M2 | CK-07A | workstream:query, type:quality | Exact registry plans/evidence/cursors/labels/grades work from one snapshot; projection admission report measured. |
 | CK-09 | Add measured current projections and named plans | P3 | M2 | CK-08 | workstream:query, workstream:publication, type:performance, parallel:eligible, cutover:blocker | Foundation/Cutover plans pass oracles/SQL/MCP/bytes; every projection has consumer, dirty keys, storage/fanout budget. |
 | CK-10 | Deliver agent-led setup, MCP, CLI, and skill | P3 | M3 | CK-09 | workstream:agent-experience, cutover:blocker | Recommended recent start, host wait/no polling, query-first warm path, closed bounded tools, version coherence. |
@@ -135,7 +136,7 @@ Use this body when creating each issue:
 3. Create CK-01 through CK-04. Keep CK-05 blocked until the decision artifact
    is accepted.
 4. Create CK-05 through CK-07 after M1. Close CK-07B and CK-07C, implement
-   CK-07D, then resume CK-07A before CK-08. Make CK-08 depend on merged seam
+   CK-07D and CK-07E, then resume CK-07A before CK-08. Make CK-08 depend on merged seam
    evidence; then create CK-08 and CK-09. Use dependency links, not status
    text, to enforce the critical path.
 5. Create CK-10 through CK-12 after named-plan contracts stabilize.
@@ -151,7 +152,8 @@ Use this body when creating each issue:
 | CK-04 | Candidate A; Candidate C; Candidate D | Shared harness complete, then decision integration |
 | CK-06/CK-07 | Adapter parser cases; crash/failure harness | CK-05 ports fixed; publication integrates |
 | CK-07D after CK-07C | Boundary evaluator; revision-frontier/compiler; database/publication integration | Effective-time, lineage, publication, and requalification contracts frozen |
-| CK-07A after CK-07D | Canonical scenario/reference evaluator; CK-04 proof replacement; CK-05–CK-07 replay | Shared formula, scenario, expected-row, selector, and evidence schemas frozen |
+| CK-07E after CK-07D | Structural-reference adapter; query-only database-v1 adapter; contract parity/lifecycle qualification | Adapter interfaces, structural declarations, evidence schema, and disjoint ownership frozen |
+| CK-07A after CK-07E | Expected-row evaluator; CK-04 proof replacement; CK-05–CK-07 replay | Shared expected-row, selector, and seam-evidence schemas frozen |
 | CK-08/CK-11 | Query/evidence implementation; installed harness skeleton | Public schemas remain CK-10-owned |
 | CK-09 | Session/family; time/model; tool/resource; allowance projection families | Dirty-key/projection registry frozen |
 | CK-12 | Repeated performance; crash matrix; fresh CLI; fresh Desktop | Exact artifact and fixture digests frozen |

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -7,10 +7,10 @@ in the linked files under [`docs/roadmap/tasks/`](tasks/).
 
 ## Overall
 
-- Completed packets: **10 / 21**
-- In progress: **CK-07D implemented, validated, and reviewed locally; commit/merge acceptance pending**
+- Completed packets: **12 / 22**
+- In progress: **None**
 - Not started: **10**
-- Critical-path completion: **10 / 20**
+- Critical-path completion: **12 / 21**
 - Optional packets: **CK-15**
 
 A packet may be checked only after its acceptance criteria and required checks
@@ -28,8 +28,8 @@ corrective packet's executable producer-to-consumer seam checks.
 
 - [x] **M0 — Authority Ready** · 1 / 1 · CK-00 complete
 - [x] **M1 — Architecture Selected** · 4 / 4 · CK-01–CK-04 complete
-- [ ] **M2 — Kernel Alpha** · 5 / 9 · CK-05–CK-07, CK-07B, and CK-07C
-  complete; CK-07D implemented locally with acceptance pending; CK-07A and
+- [ ] **M2 — Kernel Alpha** · 7 / 10 · CK-05–CK-07 and CK-07B–CK-07E
+  complete; CK-07A remains 0 / 80 requalified and
   CK-08 blocked; CK-09 not started
 - [ ] **M3 — Codex MVP Qualified** · 0 / 3 · CK-10–CK-12 not started
 - [ ] **M4 — Clean Cutover** · 0 / 2 · CK-13–CK-14 not started
@@ -82,17 +82,22 @@ corrective packet's executable producer-to-consumer seam checks.
   the completion handoff** · corrective dependency discovered by CK-07A after CK-07B;
   depends on CK-07B and retained CK-07A blocker evidence
   · [packet](tasks/ck-07c-freeze-plan-operands-and-missing-facts.md)
-- [ ] **CK-07D — Implement effective-dated rate-card valuation** ·
-  **Implemented, validated, and reviewed locally; commit, CI, merge, and exact-main
-  acceptance pending** · corrective dependency discovered
+- [x] **CK-07D — Implement effective-dated rate-card valuation** ·
+  **Completed on merge via PR #385; exact-main verified at `e49531b`** · corrective dependency discovered
   after CK-07C; depends on merged CK-07C and retained CK-07A/CK-08 blocker
   evidence
   · [packet](tasks/ck-07d-implement-effective-dated-rate-card-valuation.md)
   · [gap evidence](../decisions/evidence/ck07d/effective-dated-valuation-gap.json)
   · [implementation evidence](../decisions/evidence/ck07d/effective-dated-valuation-implementation-evidence.json)
+- [x] **CK-07E — Implement independent fact adapters** ·
+  **Completed on merge; exact-main verification is recorded in the completion
+  handoff; CK-07A remains 0 / 80 requalified** · prerequisite packet
+  discovered after merged CK-07D; depends on CK-07B, CK-07C, CK-07D, and
+  retained CK-07A/CK-08 blocker evidence
+  · [packet](tasks/ck-07e-implement-independent-fact-adapters.md)
 - [ ] **CK-07A — Reconcile fact-backed oracles and qualify packet seams** ·
-  **Blocked pending CK-07D; not requalified** · depends on CK-07, the CK-08
-  blocker evidence, CK-07B, CK-07C, and CK-07D
+  **Blocked pending CK-07E; 0 / 80 requalified** · depends on CK-07, the CK-08
+  blocker evidence, CK-07B, CK-07C, CK-07D, and CK-07E
   · [packet](tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md)
 - [ ] **CK-08 — Implement query and evidence** · **Blocked — the frozen CK-03
   question oracle rows are not derivable from database-v1 canonical facts;
@@ -139,7 +144,7 @@ corrective packet's executable producer-to-consumer seam checks.
 ## Critical path
 
 `CK-00 → CK-01 → CK-02 → CK-03 → CK-04 → CK-05 → CK-06 → CK-07 → CK-07B
-→ CK-07C → CK-07D → CK-07A → CK-08 → CK-09 → CK-10 → CK-11 → CK-12 → CK-13 →
+→ CK-07C → CK-07D → CK-07E → CK-07A → CK-08 → CK-09 → CK-10 → CK-11 → CK-12 → CK-13 →
 CK-14 → CK-16`
 
 CK-15 remains outside the critical path unless the maintainer explicitly

--- a/docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md
+++ b/docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md
@@ -1,6 +1,6 @@
 # CK-07A — Reconcile fact-backed oracles and qualify packet seams
 
-**Status:** Blocked pending CK-07D; not requalified
+**Status:** Blocked pending CK-07E; 0 / 80 requalified
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
@@ -21,8 +21,19 @@ answers from permitted facts.
 `FORMULA_AND_SELECTOR_CONTRACT.md`,
 `QUERY_EVIDENCE_PROJECTION_CONTRACTS.md`, `QUALIFICATION_PLAN.md`, and the
 [CK-08 blocker evidence](../../decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json).
-**Dependencies:** CK-07, CK-07B, CK-07C, and CK-07D merged and verified;
+**Dependencies:** CK-07, CK-07B, CK-07C, CK-07D, and CK-07E merged and verified;
 CK-08 blocker evidence merged.
+
+## CK-07E resume authority
+
+Consume only CK-07E's merged `StructuralReferenceFactAdapter` and
+`DatabaseV1FactAdapter`, their frozen structural declaration/evidence
+interfaces, and their durable parity/provenance/lifecycle evidence. CK-07A
+must invoke each adapter through its own input lane and may compare normalized
+facts, requests, and references, but neither lane may consume computed output
+from the other. CK-07E proves adapter prerequisites only and contributes
+0 / 80 complete answer comparisons; CK-07A still owns all expected rows,
+Candidate A scoring/timing, and CK-03 through CK-07 evidence refresh.
 
 ## CK-07D resume authority
 

--- a/docs/roadmap/tasks/ck-07d-implement-effective-dated-rate-card-valuation.md
+++ b/docs/roadmap/tasks/ck-07d-implement-effective-dated-rate-card-valuation.md
@@ -1,6 +1,6 @@
 # CK-07D — Implement effective-dated rate-card valuation
 
-**Status:** Implemented, validated, and reviewed locally; commit, CI, merge, and exact-main verification pending
+**Status:** Completed on merge via PR #385; exact-main verified at `e49531b0775c5c7f1043497042c25a200b447bb7`
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
@@ -154,7 +154,7 @@ post-merge verification.
     affected match rules, dirties that historical interval, and preserves
     selected digests and values outside it through publication/recovery.
 
-## Local implementation record
+## Implementation and merge record
 
 The implementation and its coupled evidence are recorded in
 [effective-dated-valuation-implementation-evidence.json](../../decisions/evidence/ck07d/effective-dated-valuation-implementation-evidence.json).
@@ -164,9 +164,12 @@ validation, bounded valuation dirty intervals, corrected pricing coverage, and
 the CK-05/CK-07/CK-07C focused requalification lane. Historical CK-07C evidence
 remains unchanged.
 
-This local state does not satisfy the packet's PR, CI, merge, or exact-main
-acceptance gates. CK-07A remains zero of 80 variants requalified and CK-08
-remains blocked until those gates pass.
+PR #385 passed required CI, merged as
+`e49531b0775c5c7f1043497042c25a200b447bb7`, and was verified as exact
+`origin/main`. The implementation evidence remains the immutable pre-merge
+record; this packet and CK-07E accounting record the merge acceptance. CK-07A
+remains zero of 80 variants requalified and CK-08 remains blocked pending the
+independent fact-adapter prerequisite.
 
 ## Requalification and acceptance
 

--- a/docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md
+++ b/docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md
@@ -1,0 +1,156 @@
+# CK-07E — Implement independent fact adapters
+
+**Status:** Completed on merge; exact-main verification is recorded in the completion handoff; CK-07A remains 0 / 80 requalified
+**Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
+**Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
+
+**Goal:** Supply the two independently implemented, test-only normalization
+paths that CK-07A needs to compare structural-v2 question truth with one
+database-v1 publication.
+
+**Why:** Merged CK-07C freezes the pure plan/direct-fact compiler, and merged
+CK-07D freezes effective-dated valuation. CK-07A still lacks qualified adapters
+that independently turn structural declarations and a query-only database
+snapshot into exact `CanonicalFact`, `PlanRequest`, and ordered evidence
+inputs. Coupling those truth lanes inside CK-07A would invalidate the required
+independence proof.
+
+**Dependencies:** CK-07B, CK-07C, and CK-07D merged; immutable CK-07D authority
+`e49531b0775c5c7f1043497042c25a200b447bb7`; retained CK-07A and CK-08
+blocker evidence.
+
+**Controls:** `LOGICAL_KERNEL_CONTRACT.md`,
+`FORMULA_AND_SELECTOR_CONTRACT.md`, `PLAN_OPERAND_AND_FACT_CONTRACT.md`,
+`AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md`, `ADAPTER_CONTRACT.md`,
+`PUBLICATION_REFRESH_RECOVERY.md`, `QUERY_EVIDENCE_PROJECTION_CONTRACTS.md`,
+`TARGET_ARCHITECTURE.md`, `QUALIFICATION_PLAN.md`, and the CK-07A through
+CK-07D packets.
+
+## Frozen interfaces and independence
+
+- `StructuralReferenceFactAdapter` consumes only body-free structural-v2
+  declarations, emitted structural facts and source occurrences, a typed
+  `PlanRequest`, and merged pure contracts. It cannot access SQLite,
+  production query code, scenario outputs, expected answers, grades,
+  comparisons, or the database adapter.
+- `DatabaseV1FactAdapter` consumes only a caller-owned query-only SQLite
+  connection, a typed `PlanRequest`, and merged pure contracts. In one read
+  snapshot it selects only explicitly allowlisted database-v1 relations. It
+  cannot import the reference adapter, scenario generator or output, oracle
+  bundle, Candidate A paths, grading/comparison output, or refresh/write code.
+- Both adapters may share only merged schemas/contracts and pure CK-07C/CK-07D
+  symbols. Each independently emits `CanonicalFact` rows, the normalized
+  `PlanRequest`, and ordered owner-specific evidence references. Required and
+  materialized `(role, selector_kind, selector)` triples must match exactly.
+
+## Fact and provenance coverage
+
+Qualification spans calls/tokens/model profiles, sessions/hierarchy/cohorts,
+tools/resources/retry stages, state changes, context components, allowance
+observations/cycles/intervals, CK-07D valuation/frontiers/unpriced reasons,
+publication/head/coverage/delta snapshots, source manifestations/occurrences,
+transient structural investigation inputs, and the seven-part total order.
+The four CK-07B no-window cases retain owner-specific scope; neither adapter
+may fabricate a time window.
+
+All 14 CK-07B selector kinds remain admitted:
+
+```text
+allowance_interval allowance_observation call model_profile project
+publication rate_card resource session source_manifestation state_change
+tool turn window
+```
+
+Every reference resolves through its authoritative owner and carries one of
+the six typed, non-placeholder provenance kinds. Required/materialized order,
+entity existence, and semantic selector identity must remain stable through
+clean rebuild, source replacement, and late-event replay. Occurrence
+coordinates may change or multiply without changing semantic identity.
+
+## Effective-dated valuation
+
+Both adapters independently materialize the publication-captured immutable
+rate-card frontier and derive `valuation_match` through merged CK-07D pure
+symbols. Each call selects the greatest matching captured revision whose
+`effective_at_us <= call.event_at_us`; effective-time recency wins before
+same-time exact-profile versus alias precedence. `fetched_at_us` is
+provenance-only, and the selected revision digest participates in valuation
+identity. Invalid or missing inputs produce typed unpriced rows, and
+configured-estimate coverage excludes them. No call-to-price assignment,
+answer cache, or time-blind singular card is persisted or admitted.
+
+## Artifacts
+
+- `tests/agent_kernel/fact_adapters/reference.py`
+- `tests/agent_kernel/fact_adapters/database.py`
+- `tests/agent_kernel/fact_adapters/support.py`
+- `tests/agent_kernel/fact_adapters/test_contracts.py`
+- `docs/decisions/evidence/ck07e/independent-fact-adapters-evidence.json`
+
+No production package or database-v1 DDL change is admitted.
+
+**Invariants:** Test-only adapters remain independent and body-free; database
+reads remain query-only and snapshot-bound; all selector owners and evidence
+references remain typed and ordered; CK-07D effective-time semantics remain
+unchanged; CK-07A remains 0 / 80 requalified and CK-08 remains blocked.
+
+**Required tests/checks:**
+
+- Structural and database materialization parity for every permitted
+  plan-operand relation and fact family, including `NULL`, empty, ties,
+  deterministic order, and owner-specific no-window scope.
+- All 14 selector kinds with exact ordered required/materialized triples,
+  authoritative entity existence, complete typed provenance, and clean
+  rebuild/replacement/late-event stability.
+- Effective-time before/exact/after selection, newer-alias versus older-exact
+  precedence, same-time exact precedence, missing measurement, immutable
+  frontier validation, selected-digest identity, configured-estimate coverage,
+  and bounded backdated dirty intervals.
+- Import/source allowlists proving evaluator independence and rejection of
+  expected/oracle/grading/comparison/body inputs.
+- Focused adapter, plan, formula, selector, valuation, schema, storage, and
+  publication checks, followed by `just v` and `just vc`.
+- Repository-private GitNexus bootstrap and exact compare-based
+  `detect_changes` before each commit; one comprehensive read-only final review
+  after the diff stabilizes; required CI; merge; exact-main verification.
+
+**Acceptance:**
+
+1. Both adapters independently emit equivalent normalized facts, request, and
+   ordered evidence for every required fact family without importing or
+   consuming output from the other.
+2. Every current plan relation and all 14 selector owners are materially
+   represented with exact missingness, deterministic order, real entity
+   ownership, and typed non-placeholder provenance.
+3. CK-07D valuation selection, frontier, identity, unpriced, coverage, and
+   dirty-interval semantics reconcile between structural truth and the
+   query-only database snapshot.
+4. Clean rebuild, replacement, and late-event replay preserve semantic selector
+   identity and normalized parity.
+5. Emitted structural JSONL and adapter sources contain no expected/oracle
+   rows, grades, grading, comparison results, answer caches, secrets, private
+   paths, real Codex content, production query imports, or refresh/write paths.
+6. Focused and full local profiles, independent final review, required CI,
+   merge, and exact-main post-merge verification pass.
+7. CK-07A becomes ready to resume only when durable CK-07E evidence has no
+   residual fact-family, selector-owner, provenance, independence, or
+   effective-valuation gap. CK-07E claims **0 / 80** CK-07A answer
+   comparisons; CK-08 remains blocked.
+
+**Non-goals:** CK-07A expected-row generation or 80-answer comparison,
+Candidate A scoring/timing, CK-03 through CK-07 evidence refresh, production
+query/evidence code, generic SQL, MCP/setup/CLI/skill, release/tag/publishing,
+deployment, Linear mutation, CK-08, CK-09, or CK-15.
+
+**Failure/rollback:** If any fact family, selector owner, independence rule, or
+CK-07D valuation contract cannot be implemented inside this test-only
+boundary, record the exact blocker, keep CK-07A and CK-08 blocked, and stop.
+Before merge, discard the branch. After merge, revert CK-07E as one
+prerequisite packet; no database migration is required.
+
+**Cleanup/docs:** Retain the dedicated CK-07E worktree and exact-main
+verification worktree. Update the documentation authority, roadmap, packet
+ledger, CK-07A resume boundary, qualification plan, scope classifier, and
+durable CK-07E evidence in this change.
+
+**Suggested commit:** `test(agent-kernel): qualify independent fact adapters`

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -591,6 +591,18 @@ CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS = frozenset(
     }
 )
 
+CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck07e/independent-fact-adapters-evidence.json",
+        "docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md",
+        "tests/agent_kernel/fact_adapters/__init__.py",
+        "tests/agent_kernel/fact_adapters/database.py",
+        "tests/agent_kernel/fact_adapters/reference.py",
+        "tests/agent_kernel/fact_adapters/support.py",
+        "tests/agent_kernel/fact_adapters/test_contracts.py",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -642,6 +654,7 @@ INTEGRATION_ADDITIONS = (
     | CK07B_FORMULA_PROVENANCE_ADDITIONS
     | CK07C_PLAN_OPERAND_FACT_ADDITIONS
     | CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS
+    | CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )

--- a/tests/agent_kernel/fact_adapters/__init__.py
+++ b/tests/agent_kernel/fact_adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Test-only CK-07E independent fact-adapter qualification package."""

--- a/tests/agent_kernel/fact_adapters/database.py
+++ b/tests/agent_kernel/fact_adapters/database.py
@@ -1,0 +1,1852 @@
+"""Independent database-v1 fact selection for the CK-07E test seam.
+
+This module is deliberately self-contained.  It is a test-only read adapter:
+the only non-stdlib imports are the frozen, pure agent-kernel value/domain
+types.  It does not share relation selection, evidence resolution, or output
+objects with the scenario adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
+from typing import Any
+
+from codex_usage_tracker.agent_kernel.domain.identity import semantic_id
+from codex_usage_tracker.agent_kernel.domain.plan_operands import (
+    CanonicalFact,
+    FactCoordinates,
+    PlanRequest,
+)
+from codex_usage_tracker.agent_kernel.domain.valuation import (
+    RateCardFrontier,
+    RateCardRevision,
+    compile_current_valuation_matches,
+)
+
+
+class DatabaseAdapterContractError(ValueError):
+    """The database snapshot or supplied seam contract is not admissible."""
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _canonical_request_digest(request: PlanRequest) -> str:
+    def normalize(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            if not value.is_finite():
+                raise DatabaseAdapterContractError("request contains a non-finite decimal")
+            return str(value)
+        if isinstance(value, Mapping):
+            return {str(key): normalize(item) for key, item in sorted(value.items())}
+        if isinstance(value, (list, tuple)):
+            return [normalize(item) for item in value]
+        if isinstance(value, float) and not math.isfinite(value):
+            raise DatabaseAdapterContractError("request contains a non-finite number")
+        return value
+
+    payload = json.dumps(
+        normalize(
+            {
+                "gates": request.gates,
+                "parameters": request.parameters,
+                "plan_id": request.plan_id,
+            }
+        ),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterRequest:
+    """The typed request and exact ordered evidence-selection mapping."""
+
+    plan_request: PlanRequest
+    required_role_kinds: tuple[tuple[str, str], ...]
+    selector_ids: Mapping[str, str] = field(default_factory=dict)
+    publication_id: str = ""
+    request_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan_request, PlanRequest):
+            raise DatabaseAdapterContractError("plan_request must be a PlanRequest")
+        if not self.required_role_kinds:
+            raise DatabaseAdapterContractError("required evidence roles must not be empty")
+        roles: set[str] = set()
+        normalized: list[tuple[str, str]] = []
+        for item in self.required_role_kinds:
+            if (
+                not isinstance(item, (tuple, list))
+                or len(item) != 2
+                or not isinstance(item[0], str)
+                or not item[0]
+                or not isinstance(item[1], str)
+                or not item[1]
+            ):
+                raise DatabaseAdapterContractError("evidence role/kind entries are malformed")
+            if item[0] in roles:
+                raise DatabaseAdapterContractError("evidence roles must be unique")
+            roles.add(item[0])
+            normalized.append((item[0], item[1]))
+        object.__setattr__(self, "required_role_kinds", tuple(normalized))
+        if not isinstance(self.selector_ids, Mapping):
+            raise DatabaseAdapterContractError("selector_ids must be a mapping")
+        if any(
+            not isinstance(key, str) or not isinstance(value, str) or not value
+            for key, value in self.selector_ids.items()
+        ):
+            raise DatabaseAdapterContractError("selector IDs must be nonempty strings")
+        object.__setattr__(self, "selector_ids", MappingProxyType(dict(self.selector_ids)))
+        digest = self.request_digest or _canonical_request_digest(self.plan_request)
+        if not isinstance(digest, str) or not digest:
+            raise DatabaseAdapterContractError("request digest must be a nonempty string")
+        object.__setattr__(self, "request_digest", digest)
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReferenceV1:
+    """One owner-dispatched selector with typed provenance."""
+
+    role: str
+    selector_kind: str
+    selector: str
+    logical_id: str
+    provenance_kind: str
+    provenance: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(value, str) and value
+            for value in (
+                self.role,
+                self.selector_kind,
+                self.selector,
+                self.logical_id,
+                self.provenance_kind,
+            )
+        ):
+            raise DatabaseAdapterContractError("evidence reference identity is malformed")
+        if not isinstance(self.provenance, Mapping):
+            raise DatabaseAdapterContractError("evidence provenance must be a mapping")
+        object.__setattr__(self, "provenance", _freeze(dict(self.provenance)))
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseV1FactMaterialization:
+    """Frozen normalized facts, request, evidence, and read-snapshot token."""
+
+    request: PlanRequest
+    facts: tuple[CanonicalFact, ...]
+    evidence_references: tuple[EvidenceReferenceV1, ...]
+    snapshot_token: str
+    source: str = "database_v1"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, PlanRequest):
+            raise DatabaseAdapterContractError("materialization request is malformed")
+        object.__setattr__(self, "facts", tuple(self.facts))
+        object.__setattr__(self, "evidence_references", tuple(self.evidence_references))
+        if not self.snapshot_token:
+            raise DatabaseAdapterContractError("materialization has no snapshot token")
+
+    @property
+    def evidence(self) -> tuple[EvidenceReferenceV1, ...]:
+        return self.evidence_references
+
+
+# Compatibility names are local aliases, not imports from another adapter.
+EvidenceReference = EvidenceReferenceV1
+AdapterMaterialization = DatabaseV1FactMaterialization
+
+
+_RELATION_QUERIES: Mapping[str, str] = MappingProxyType(
+    {
+        "canonical_call": """
+            SELECT mc.call_id, mc.session_id, mc.turn_id, mc.model_profile_id,
+                   s.project_id, NULL AS tool_id, mc.lifecycle_state AS lifecycle,
+                   mc.context_window_tokens, mc.uncached_input_tokens,
+                   mc.cached_input_tokens, mc.reasoning_tokens, mc.output_tokens,
+                   mc.event_at_us, mc.source_rank, mc.source_order,
+                   mc.event_kind_order, mc.transition_rank
+              FROM model_calls_visible AS mc
+              JOIN sessions AS s ON s.session_id = mc.session_id
+             ORDER BY mc.call_id
+        """,
+        "project": """
+            SELECT p.project_id, NULL AS parent_project_id,
+                   NULL AS event_at_us, COALESCE(sm.source_rank, 0) AS source_rank,
+                   COALESCE(o.record_ordinal, 0) AS source_order,
+                   CASE WHEN o.occurrence_id IS NULL THEN 0 ELSE 10 END AS event_kind_order,
+                   0 AS transition_rank
+              FROM projects AS p
+              LEFT JOIN source_occurrences AS o
+                ON o.occurrence_id = (
+                    SELECT so.occurrence_id
+                      FROM source_occurrences AS so
+                     WHERE so.semantic_logical_id = p.project_id
+                     ORDER BY so.record_ordinal, so.occurrence_id
+                     LIMIT 1
+                )
+              LEFT JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY project_id
+        """,
+        "session": """
+            SELECT session_id, project_id, root_session_id, parent_session_id,
+                   delegation_depth, lifecycle_state, start_at_us, end_at_us,
+                   completion_basis, start_at_us AS event_at_us,
+                   COALESCE(sm.source_rank, 0) AS source_rank,
+                   COALESCE(o.record_ordinal, 0) AS source_order,
+                   CASE WHEN o.occurrence_id IS NULL THEN 0 ELSE 10 END AS event_kind_order,
+                   0 AS transition_rank
+              FROM sessions AS s
+              LEFT JOIN source_occurrences AS o
+                ON o.occurrence_id = s.primary_occurrence_id
+              LEFT JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY session_id
+        """,
+        "turn": """
+            SELECT t.turn_id, t.session_id, t.ordinal,
+                   t.lifecycle_state AS lifecycle, t.lifecycle_state,
+                   t.start_at_us, t.end_at_us, t.completion_basis,
+                   json_object(
+                       'event_at_us', t.start_at_us,
+                       'source_rank', sm.source_rank,
+                       'source_order', o.record_ordinal
+                   ) AS first_boundary_coordinates,
+                   t.start_at_us AS event_at_us,
+                   COALESCE(sm.source_rank, 0) AS source_rank,
+                   COALESCE(o.record_ordinal, 0) AS source_order,
+                   CASE WHEN o.occurrence_id IS NULL THEN 0 ELSE 10 END AS event_kind_order,
+                   0 AS transition_rank
+              FROM turns AS t
+              LEFT JOIN source_occurrences AS o
+                ON o.occurrence_id = t.primary_occurrence_id
+              LEFT JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY t.turn_id
+        """,
+        "model_profile": """
+            SELECT p.model_profile_id, p.model,
+                   reasoning_effort AS effort, service_tier AS tier,
+                   NULL AS event_at_us, COALESCE(sm.source_rank, 0) AS source_rank,
+                   COALESCE(o.record_ordinal, 0) AS source_order,
+                   CASE WHEN o.occurrence_id IS NULL THEN 0 ELSE 10 END AS event_kind_order,
+                   0 AS transition_rank
+              FROM model_profiles AS p
+              LEFT JOIN source_occurrences AS o
+                ON o.occurrence_id = (
+                    SELECT so.occurrence_id
+                      FROM source_occurrences AS so
+                     WHERE so.semantic_logical_id = p.model_profile_id
+                     ORDER BY so.record_ordinal, so.occurrence_id
+                     LIMIT 1
+                )
+              LEFT JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY model_profile_id
+        """,
+        "tool_invocation": """
+            SELECT t.tool_id, t.session_id, t.turn_id, t.transport_name,
+                   t.semantic_operation, t.tool_family,
+                   t.primary_resource_id AS resource_id,
+                   (
+                       SELECT json_group_array(resource_id)
+                         FROM (
+                             SELECT resource_id, MIN(primary_order) AS primary_order
+                               FROM (
+                                   SELECT t.primary_resource_id AS resource_id,
+                                          0 AS primary_order
+                                    WHERE t.primary_resource_id IS NOT NULL
+                                   UNION ALL
+                                   SELECT tr.resource_id, 1 AS primary_order
+                                     FROM tool_resources AS tr
+                                    WHERE tr.tool_id = t.tool_id
+                               )
+                              WHERE resource_id IS NOT NULL
+                              GROUP BY resource_id
+                              ORDER BY primary_order, resource_id
+                         )
+                   ) AS resource_links,
+                   r.resource_kind, t.write_intent,
+                   t.lifecycle_state AS lifecycle,
+                   t.observed_duration_us AS duration_us, t.output_bytes,
+                   t.error_category, t.start_at_us AS event_at_us,
+                   t.start_source_rank AS source_rank,
+                   t.start_source_order AS source_order,
+                   t.start_event_kind_order AS event_kind_order,
+                   t.start_transition_rank AS transition_rank
+              FROM tool_invocations AS t
+              LEFT JOIN resources AS r ON r.resource_id = t.primary_resource_id
+             ORDER BY t.tool_id
+        """,
+        "resource": """
+            SELECT r.resource_id, r.resource_kind,
+                   NULL AS event_at_us, COALESCE(sm.source_rank, 0) AS source_rank,
+                   COALESCE(o.record_ordinal, 0) AS source_order,
+                   CASE WHEN o.occurrence_id IS NULL THEN 0 ELSE 10 END AS event_kind_order,
+                   0 AS transition_rank
+              FROM resources AS r
+              LEFT JOIN source_occurrences AS o
+                ON o.occurrence_id = (
+                    SELECT so.occurrence_id
+                      FROM source_occurrences AS so
+                     WHERE so.semantic_logical_id = r.resource_id
+                     ORDER BY so.record_ordinal, so.occurrence_id
+                     LIMIT 1
+                )
+              LEFT JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY resource_id
+        """,
+        "state_change": """
+            SELECT change_id AS state_change_id, session_id, turn_id,
+                   resource_id, change_kind AS mutation_kind,
+                   event_at_us, source_rank, source_order,
+                   event_kind_order, transition_rank
+              FROM state_changes
+             ORDER BY change_id
+        """,
+        "compaction_boundary": """
+            SELECT compaction_id, session_id,
+                   event_at_us, source_rank, source_order,
+                   event_kind_order, transition_rank
+              FROM compaction_boundaries
+             ORDER BY compaction_id
+        """,
+        "context_component": """
+            SELECT component_id, session_id, turn_id, call_id, category,
+                   observed_utf8_bytes, observed_event_count, estimated_tokens,
+                   total_context_utf8_bytes, event_at_us, source_rank,
+                   source_order, event_kind_order, transition_rank
+              FROM context_components
+             ORDER BY component_id
+        """,
+        "allowance_observation": """
+            SELECT o.observation_id, o.limit_id, l.provider,
+                   o.plan_identity AS plan, o.window_kind, o.reset_identity,
+                   o.observed_at_us, o.used_percent, o.remaining_percent,
+                   'same_cycle_adjacent' AS compatibility_basis,
+                   c.completion_status, o.source_rank, o.source_order,
+                   o.event_kind_order, o.transition_rank
+              FROM allowance_observations AS o
+              JOIN allowance_limits AS l ON l.limit_id = o.limit_id
+              JOIN allowance_cycles AS c ON c.cycle_id = o.cycle_id
+             ORDER BY o.observation_id
+        """,
+        "publication": """
+            SELECT p.publication_id,
+                   (
+                       SELECT json_group_object(
+                           c.capability_id,
+                           json(CASE WHEN c.observed_entity_count > 0
+                                     THEN 'true' ELSE 'false' END)
+                       )
+                         FROM publication_capability_coverage AS c
+                        WHERE c.publication_id = p.publication_id
+                   ) AS capabilities,
+                   (
+                       SELECT json_group_object(e.entity_kind, e.entity_count)
+                         FROM publication_entity_counts AS e
+                        WHERE e.publication_id = p.publication_id
+                   ) AS measurements,
+                   p.indexed_from_us,
+                   p.guaranteed_complete_from_us,
+                   json_object(
+                       'basis', (
+                           SELECT c.grade
+                             FROM publication_capability_coverage AS c
+                            WHERE c.publication_id = p.publication_id
+                              AND c.capability_id = 'valuation'
+                       ),
+                       'priced_calls', (
+                           SELECT c.eligible_entity_count - c.unavailable_entity_count
+                             FROM publication_capability_coverage AS c
+                            WHERE c.publication_id = p.publication_id
+                              AND c.capability_id = 'valuation'
+                       )
+                   ) AS valuation_coverage,
+                   p.observed_through_us,
+                   p.indexed_through_us AS _indexed_through_us,
+                   p.operation_id, p.artifact_manifest_sha256,
+                   p.committed_at_us, p.committed_at_us AS event_at_us,
+                   0 AS source_rank, 0 AS source_order,
+                   0 AS event_kind_order, 0 AS transition_rank
+              FROM publication_head AS h
+              JOIN publications AS p ON p.publication_id = h.publication_id
+             WHERE h.singleton = 1 AND p.status = 'committed'
+             ORDER BY p.committed_at_us DESC
+             LIMIT 1
+        """,
+        "publication_delta": """
+            SELECT d.inserted_count, d.removed_count, d.corrected_count,
+                   d.recanonicalized_count, d.terminalized_count,
+                   COALESCE(d.uncached_input_token_delta, 0)
+                   + COALESCE(d.cached_input_token_delta, 0)
+                   + COALESCE(d.reasoning_token_delta, 0)
+                   + COALESCE(d.output_token_delta, 0) AS token_delta,
+                   'publication-delta:' || substr(
+                       d.publication_id, length('publication:') + 1
+                   ) AS publication_id,
+                   NULL AS event_at_us,
+                   0 AS source_rank, 0 AS source_order,
+                   0 AS event_kind_order, 0 AS transition_rank
+              FROM publication_head AS h
+              JOIN publication_deltas AS d ON d.publication_id = h.publication_id
+             WHERE h.singleton = 1
+             ORDER BY d.publication_id DESC
+             LIMIT 1
+        """,
+        "source_manifestation": """
+            SELECT manifestation_id AS source_manifestation_id,
+                   state AS lifecycle_state,
+                   'source_inventory' AS canonical_basis,
+                   NULL AS event_at_us, source_rank AS source_rank,
+                   source_rank AS source_order, 10 AS event_kind_order,
+                   0 AS transition_rank
+              FROM source_manifestations
+             ORDER BY manifestation_id
+        """,
+        "source_occurrence": """
+            SELECT o.occurrence_id, o.semantic_logical_id,
+                   sm.manifestation_id AS source_manifestation_id,
+                   o.source_revision, o.record_ordinal, o.byte_start,
+                   o.byte_end, o.adapter_version,
+                   NULL AS event_at_us,
+                   json_object(
+                       'adapter_version', o.adapter_version,
+                       'byte_end', o.byte_end,
+                       'byte_start', o.byte_start,
+                       'record_ordinal', o.record_ordinal,
+                       'source_revision', o.source_revision
+                   ) AS occurrence_coordinates,
+                   sm.source_rank AS source_rank, o.record_ordinal AS source_order,
+                   10 AS event_kind_order, 0 AS transition_rank
+              FROM source_occurrences AS o
+              JOIN source_manifestations AS sm
+                ON sm.manifestation_key = o.manifestation_key
+             ORDER BY o.occurrence_id
+        """,
+    }
+)
+
+_RELATION_ID_FIELDS: Mapping[str, str] = MappingProxyType(
+    {
+        "canonical_call": "call_id",
+        "project": "project_id",
+        "session": "session_id",
+        "turn": "turn_id",
+        "model_profile": "model_profile_id",
+        "tool_invocation": "tool_id",
+        "resource": "resource_id",
+        "state_change": "state_change_id",
+        "compaction_boundary": "compaction_id",
+        "context_component": "component_id",
+        "allowance_observation": "observation_id",
+        "publication": "publication_id",
+        "publication_delta": "publication_id",
+        "source_manifestation": "source_manifestation_id",
+        "source_occurrence": "occurrence_id",
+    }
+)
+
+_RELATION_FIELDS: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "canonical_call": frozenset(
+            {
+                "call_id",
+                "session_id",
+                "turn_id",
+                "model_profile_id",
+                "project_id",
+                "tool_id",
+                "context_window_tokens",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens",
+                "lifecycle",
+            }
+        ),
+        "project": frozenset({"project_id", "parent_project_id"}),
+        "session": frozenset(
+            {
+                "session_id",
+                "project_id",
+                "root_session_id",
+                "parent_session_id",
+                "delegation_depth",
+                "start_at_us",
+                "end_at_us",
+                "lifecycle_state",
+                "completion_basis",
+            }
+        ),
+        "turn": frozenset(
+            {
+                "turn_id",
+                "session_id",
+                "ordinal",
+                "lifecycle",
+                "lifecycle_state",
+                "start_at_us",
+                "end_at_us",
+                "completion_basis",
+                "first_boundary_coordinates",
+            }
+        ),
+        "model_profile": frozenset({"model_profile_id", "model", "effort", "tier"}),
+        "tool_invocation": frozenset(
+            {
+                "tool_id",
+                "session_id",
+                "turn_id",
+                "transport_name",
+                "semantic_operation",
+                "tool_family",
+                "resource_links",
+                "resource_id",
+                "resource_kind",
+                "write_intent",
+                "lifecycle",
+                "output_bytes",
+                "duration_us",
+                "error_category",
+            }
+        ),
+        "resource": frozenset({"resource_id", "resource_kind"}),
+        "state_change": frozenset(
+            {"state_change_id", "session_id", "turn_id", "resource_id", "mutation_kind"}
+        ),
+        "compaction_boundary": frozenset({"compaction_id", "session_id"}),
+        "context_component": frozenset(
+            {
+                "component_id",
+                "session_id",
+                "turn_id",
+                "call_id",
+                "category",
+                "observed_utf8_bytes",
+                "observed_event_count",
+                "estimated_tokens",
+                "total_context_utf8_bytes",
+            }
+        ),
+        "allowance_observation": frozenset(
+            {
+                "observation_id",
+                "provider",
+                "limit_id",
+                "plan",
+                "window_kind",
+                "reset_identity",
+                "observed_at_us",
+                "allowance_percent",
+                "completion_status",
+                "compatibility_basis",
+            }
+        ),
+        "publication": frozenset(
+            {
+                "publication_id",
+                "capabilities",
+                "measurements",
+                "indexed_from_us",
+                "guaranteed_complete_from_us",
+                "valuation_coverage",
+                "observed_through_us",
+            }
+        ),
+        "publication_delta": frozenset(
+            {
+                "inserted_count",
+                "removed_count",
+                "corrected_count",
+                "recanonicalized_count",
+                "terminalized_count",
+                "token_delta",
+            }
+        ),
+        "source_manifestation": frozenset(
+            {"source_manifestation_id", "lifecycle_state", "canonical_basis"}
+        ),
+        "source_occurrence": frozenset(
+            {
+                "occurrence_id",
+                "semantic_logical_id",
+                "source_manifestation_id",
+                "occurrence_coordinates",
+            }
+        ),
+        "valuation_match": frozenset(
+            {
+                "call_id",
+                "rate_card_digest",
+                "match_basis",
+                "configured_cost_usd",
+                "estimated_credits",
+                "coverage_basis",
+                "cost_grade",
+                "cost_unpriced_reason",
+                "unpriced_reason",
+            }
+        ),
+    }
+)
+
+_SELECTOR_KINDS = frozenset(
+    {
+        "allowance_interval",
+        "allowance_observation",
+        "call",
+        "model_profile",
+        "project",
+        "publication",
+        "rate_card",
+        "resource",
+        "session",
+        "source_manifestation",
+        "state_change",
+        "tool",
+        "turn",
+        "window",
+    }
+)
+
+_SOURCE_OWNER_ENTITY_QUERIES: Mapping[str, str] = MappingProxyType(
+    {
+        "allowance_observation": "SELECT 1 FROM allowance_observations WHERE observation_id = ? LIMIT 1",
+        "call": "SELECT 1 FROM model_calls_visible WHERE call_id = ? LIMIT 1",
+        "model_profile": "SELECT 1 FROM model_profiles WHERE model_profile_id = ? LIMIT 1",
+        "project": "SELECT 1 FROM projects WHERE project_id = ? LIMIT 1",
+        "resource": "SELECT 1 FROM resources WHERE resource_id = ? LIMIT 1",
+        "session": "SELECT 1 FROM sessions WHERE session_id = ? LIMIT 1",
+        "state_change": "SELECT 1 FROM state_changes WHERE change_id = ? LIMIT 1",
+        "tool": "SELECT 1 FROM tool_invocations WHERE tool_id = ? LIMIT 1",
+        "turn": "SELECT 1 FROM turns WHERE turn_id = ? LIMIT 1",
+    }
+)
+
+_SOURCE_OCCURRENCES_SQL = """
+    SELECT o.occurrence_id, o.semantic_logical_id, sm.manifestation_id,
+           o.source_revision, o.record_ordinal, o.byte_start, o.byte_end,
+           o.adapter_version
+      FROM source_occurrences AS o
+     JOIN source_manifestations AS sm ON sm.manifestation_key = o.manifestation_key
+     WHERE o.semantic_logical_id = ?
+     ORDER BY o.record_ordinal, o.occurrence_id
+"""
+
+
+def _row_dict(row: Any, description: Sequence[Any] | None = None) -> dict[str, Any]:
+    if isinstance(row, sqlite3.Row):
+        return {key: row[key] for key in row.keys()}  # noqa: SIM118
+    if isinstance(row, Mapping):
+        return dict(row)
+    if description is None:
+        raise DatabaseAdapterContractError("database row has no column description")
+    return {column[0]: value for column, value in zip(description, row, strict=True)}
+
+
+def _typed_value(field: str, value: Any) -> Any:
+    json_fields = {
+        "capabilities",
+        "measurements",
+        "valuation_coverage",
+        "occurrence_coordinates",
+        "first_boundary_coordinates",
+        "resource_links",
+    }
+    decimal_fields = {"allowance_percent", "used_percent", "remaining_percent"}
+    if field in json_fields and isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise DatabaseAdapterContractError(
+                f"malformed JSON in database field {field}"
+            ) from error
+    if field in decimal_fields and value is not None:
+        if field == "allowance_percent" and isinstance(value, Decimal):
+            if not value.is_finite():
+                raise DatabaseAdapterContractError("database field allowance_percent is not finite")
+            return value
+        if not isinstance(value, str):
+            raise DatabaseAdapterContractError(
+                f"database field {field} must be a canonical decimal string"
+            )
+        try:
+            decimal = Decimal(value)
+        except (InvalidOperation, ValueError) as error:
+            raise DatabaseAdapterContractError(
+                f"malformed decimal in database field {field}"
+            ) from error
+        if not decimal.is_finite():
+            raise DatabaseAdapterContractError(f"non-finite decimal in database field {field}")
+        canonical = "0" if decimal == 0 else format(decimal.normalize(), "f")
+        if "." in canonical:
+            canonical = canonical.rstrip("0").rstrip(".")
+        if value != canonical:
+            raise DatabaseAdapterContractError(
+                f"database field {field} is not a canonical decimal string"
+            )
+        return decimal
+    return value
+
+
+def _allowance_remaining_percent(values: Mapping[str, Any]) -> Decimal | None:
+    used = _typed_value("used_percent", values.get("used_percent"))
+    remaining = _typed_value("remaining_percent", values.get("remaining_percent"))
+    lower = Decimal("0")
+    upper = Decimal("100")
+    for name, value in (("used_percent", used), ("remaining_percent", remaining)):
+        if value is not None and (value < lower or value > upper):
+            raise DatabaseAdapterContractError(f"{name} is outside the canonical percentage range")
+    if used is None and remaining is None:
+        return None
+    if used is not None and remaining is not None and used + remaining != upper:
+        raise DatabaseAdapterContractError("allowance used_percent and remaining_percent disagree")
+    if remaining is not None:
+        return remaining
+    assert used is not None
+    return upper - used
+
+
+def _coordinates(values: Mapping[str, Any]) -> FactCoordinates:
+    event_at = values.get("event_at_us")
+    if event_at is None:
+        event_at = values.get("observed_at_us")
+    return FactCoordinates(
+        event_at_us=event_at,
+        source_rank=int(values.get("source_rank", 0) or 0),
+        source_order=int(values.get("source_order", 0) or 0),
+        event_kind_order=int(values.get("event_kind_order", 0) or 0),
+        transition_rank=int(values.get("transition_rank", 0) or 0),
+    )
+
+
+def _selector_prefix(kind: str) -> str:
+    return kind.replace("_", "-")
+
+
+class DatabaseV1FactAdapter:
+    """Select only permitted logical facts from one query-only snapshot."""
+
+    source_name = "database_v1"
+
+    def __init__(
+        self,
+        contract: Mapping[str, Any] | None = None,
+        selector_contract: Mapping[str, Any] | None = None,
+        evidence_selection: Any = None,
+    ) -> None:
+        self._contract = contract
+        self._selector_contract = selector_contract
+        self._evidence_selection = evidence_selection
+
+    def materialize(
+        self,
+        connection: sqlite3.Connection,
+        request: PlanRequest | AdapterRequest | Any,
+        required_role_kinds: Any = None,
+        selector_ids: Mapping[str, str] | None = None,
+    ) -> DatabaseV1FactMaterialization:
+        self._assert_query_only(connection)
+        plan_request, required, selected_ids, request_digest, publication_id = self._request_parts(
+            request, required_role_kinds, selector_ids
+        )
+        plan = self._plan(plan_request.plan_id)
+        permitted = self._permitted_sources(plan)
+        owner_rules = self._owner_rules()
+
+        connection.execute("BEGIN")
+        try:
+            facts: list[CanonicalFact] = []
+            for relation in permitted:
+                if relation == "valuation_match":
+                    facts.extend(self._valuation_facts(connection, permitted[relation]))
+                    continue
+                cursor = connection.execute(_RELATION_QUERIES[relation])
+                description = cursor.description
+                for row in cursor:
+                    raw = _row_dict(row, description)
+                    if relation == "allowance_observation":
+                        raw["allowance_percent"] = _allowance_remaining_percent(raw)
+                    elif relation == "publication":
+                        self._validate_publication_authority(connection, raw)
+                    logical_id_field = _RELATION_ID_FIELDS[relation]
+                    logical_id = raw.get(logical_id_field)
+                    if not isinstance(logical_id, str) or not logical_id:
+                        raise DatabaseAdapterContractError(
+                            f"{relation} row has no logical identity"
+                        )
+                    values = {
+                        key: _typed_value(key, value)
+                        for key, value in raw.items()
+                        if key in permitted[relation]
+                    }
+                    facts.append(
+                        CanonicalFact(
+                            relation,
+                            logical_id,
+                            values,
+                            _coordinates(raw),
+                        )
+                    )
+            if not facts:
+                raise DatabaseAdapterContractError(
+                    f"database snapshot produced no facts for {plan_request.plan_id}"
+                )
+            evidence = self._evidence(
+                connection,
+                plan_request,
+                required,
+                selected_ids,
+                request_digest,
+                owner_rules,
+            )
+            self._validate_evidence(required, evidence, owner_rules)
+            snapshot_token = self._snapshot_token(connection, publication_id)
+        except DatabaseAdapterContractError:
+            raise
+        except (sqlite3.DatabaseError, TypeError, ValueError) as error:
+            raise DatabaseAdapterContractError("database snapshot is malformed") from error
+        finally:
+            if connection.in_transaction:
+                connection.execute("ROLLBACK")
+
+        ordered = sorted(
+            facts,
+            key=lambda fact: (
+                fact.coordinates.key(fact.logical_id)  # type: ignore[union-attr]
+                if fact.coordinates is not None
+                else (True, 0, 0, 0, 0, fact.logical_id, 0)
+            ),
+        )
+        keys = [fact.coordinates.key(fact.logical_id) for fact in ordered if fact.coordinates]
+        if len(keys) != len(set(keys)):
+            raise DatabaseAdapterContractError("fact coordinates do not form a total order")
+        return DatabaseV1FactMaterialization(
+            request=plan_request,
+            facts=tuple(ordered),
+            evidence_references=tuple(evidence),
+            snapshot_token=snapshot_token,
+        )
+
+    @staticmethod
+    def _assert_query_only(connection: sqlite3.Connection) -> None:
+        if not isinstance(connection, sqlite3.Connection):
+            raise DatabaseAdapterContractError("connection must be sqlite3.Connection")
+        try:
+            query_only = connection.execute("PRAGMA query_only").fetchone()[0]
+        except sqlite3.DatabaseError as error:
+            raise DatabaseAdapterContractError(
+                "connection is not a SQLite query surface"
+            ) from error
+        if int(query_only) != 1:
+            raise DatabaseAdapterContractError("database-v1 adapter requires PRAGMA query_only=1")
+        if connection.in_transaction:
+            raise DatabaseAdapterContractError("adapter owns the read transaction")
+
+    def _request_parts(
+        self,
+        request: PlanRequest | AdapterRequest | Any,
+        required_role_kinds: Any,
+        selector_ids: Mapping[str, str] | None,
+    ) -> tuple[PlanRequest, tuple[Mapping[str, Any], ...], Mapping[str, str], str, str]:
+        wrapper = request if hasattr(request, "plan_request") else None
+        plan_request = request.plan_request if wrapper is not None else request
+        if not isinstance(plan_request, PlanRequest):
+            raise DatabaseAdapterContractError("request must contain a PlanRequest")
+        supplied_required = (
+            required_role_kinds
+            if required_role_kinds is not None
+            else getattr(wrapper, "required_role_kinds", None)
+        )
+        if supplied_required is None:
+            supplied_required = self._evidence_selection
+        required = self._normalize_required(supplied_required)
+        selected = (
+            selector_ids if selector_ids is not None else getattr(wrapper, "selector_ids", {})
+        )
+        if not isinstance(selected, Mapping):
+            raise DatabaseAdapterContractError("selector IDs must be a mapping")
+        selected_values: dict[str, str] = dict(selected)
+        for entry in required:
+            role = entry["role"]
+            kind = entry["selector_kind"]
+            explicit_selector = entry.get("selector")
+            explicit_logical_id = entry.get("logical_id")
+            if kind == "window":
+                if isinstance(explicit_logical_id, str) and explicit_logical_id:
+                    selected_values.setdefault(role, explicit_logical_id)
+                elif isinstance(explicit_selector, str):
+                    _prefix, suffix = self._selector_parts(explicit_selector, kind)
+                    selected_values.setdefault(role, suffix)
+                continue
+            if isinstance(explicit_logical_id, str) and explicit_logical_id:
+                selected_values.setdefault(role, explicit_logical_id)
+            elif isinstance(explicit_selector, str):
+                _prefix, suffix = self._selector_parts(explicit_selector, kind)
+                selected_values.setdefault(role, suffix)
+            elif role not in selected_values and kind in selected_values:
+                selected_values[role] = selected_values[kind]
+        digest = _canonical_request_digest(plan_request)
+        supplied_digest = getattr(wrapper, "request_digest", None)
+        if supplied_digest is not None and supplied_digest != digest:
+            raise DatabaseAdapterContractError("request digest does not match the typed request")
+        publication_id = getattr(wrapper, "publication_id", "") or ""
+        return plan_request, required, MappingProxyType(selected_values), digest, publication_id
+
+    @staticmethod
+    def _normalize_required(value: Any) -> tuple[Mapping[str, Any], ...]:
+        if isinstance(value, Mapping):
+            for key in ("selections", "required", "evidence"):
+                if key in value:
+                    return DatabaseV1FactAdapter._normalize_required(value[key])
+            if "required_role_kinds" in value:
+                role_kinds = value["required_role_kinds"]
+                selector_values = value.get("selector_ids", {})
+                if not isinstance(selector_values, Mapping):
+                    raise DatabaseAdapterContractError("selector_ids are malformed")
+                entries = []
+                for pair in role_kinds:
+                    if (
+                        not isinstance(pair, Sequence)
+                        or isinstance(pair, (str, bytes))
+                        or len(pair) != 2
+                    ):
+                        raise DatabaseAdapterContractError("required role/kind entry is malformed")
+                    role, kind = pair
+                    entry: dict[str, Any] = {"role": role, "selector_kind": kind}
+                    if kind != "window":
+                        selected = selector_values.get(role, selector_values.get(kind))
+                        if not isinstance(selected, str):
+                            raise DatabaseAdapterContractError(
+                                f"{role} has no exact selector mapping"
+                            )
+                        entry["selector"] = selected
+                    elif role in selector_values:
+                        selected = selector_values[role]
+                        if not isinstance(selected, str) or not selected:
+                            raise DatabaseAdapterContractError(
+                                f"{role} has a malformed exact window identity"
+                            )
+                        entry["logical_id"] = selected
+                    entries.append(entry)
+                value = entries
+            else:
+                entries = []
+                for role, selected in value.items():
+                    if isinstance(selected, Mapping):
+                        entry = dict(selected)
+                        entry.setdefault("role", role)
+                    elif isinstance(selected, str):
+                        entry = {"role": role, "selector": selected}
+                    else:
+                        raise DatabaseAdapterContractError("evidence selection is malformed")
+                    entries.append(entry)
+                value = entries
+        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+            raise DatabaseAdapterContractError("exact required evidence mapping is missing")
+        if value and all(
+            isinstance(item, Sequence)
+            and not isinstance(item, (str, bytes))
+            and len(item) == 2
+            and all(isinstance(part, str) and part for part in item)
+            for item in value
+        ):
+            value = tuple(
+                {"role": item[0], "selector_kind": item[1]}  # type: ignore[index]
+                for item in value
+            )
+        result: list[Mapping[str, Any]] = []
+        roles: set[str] = set()
+        for item in value:
+            if isinstance(item, Mapping):
+                entry = dict(item)
+                role, kind = entry.get("role"), entry.get("selector_kind", entry.get("kind"))
+            else:
+                raise DatabaseAdapterContractError("required evidence mapping is malformed")
+            if (
+                not isinstance(role, str)
+                or not role
+                or role in roles
+                or not isinstance(kind, str)
+                or not kind
+            ):
+                raise DatabaseAdapterContractError("required evidence mapping has empty identity")
+            entry["role"] = role
+            entry["selector_kind"] = kind
+            selector = entry.get("selector")
+            if selector is not None and (not isinstance(selector, str) or not selector):
+                raise DatabaseAdapterContractError("evidence selector is malformed")
+            result.append(entry)
+            roles.add(role)
+        if not result:
+            raise DatabaseAdapterContractError("required evidence mapping must not be empty")
+        return tuple(result)
+
+    @staticmethod
+    def _selector_parts(selector: str, kind: str) -> tuple[str, str]:
+        prefix, separator, suffix = selector.partition(":")
+        if not separator or prefix != _selector_prefix(kind) or not suffix:
+            raise DatabaseAdapterContractError(
+                f"selector prefix does not match {kind}: {selector!r}"
+            )
+        return prefix, suffix
+
+    def _plan(self, plan_id: str) -> Mapping[str, Any]:
+        if not isinstance(self._contract, Mapping):
+            raise DatabaseAdapterContractError("plan-operand contract data is missing")
+        matches = [
+            item for item in self._contract.get("plans", ()) if item.get("plan_id") == plan_id
+        ]
+        if len(matches) != 1:
+            raise DatabaseAdapterContractError(f"plan must resolve exactly once: {plan_id}")
+        return matches[0]
+
+    @staticmethod
+    def _permitted_sources(plan: Mapping[str, Any]) -> dict[str, frozenset[str]]:
+        sources = plan.get("permitted_sources")
+        if isinstance(sources, (str, bytes)) or not isinstance(sources, Sequence):
+            raise DatabaseAdapterContractError("plan permitted_sources is malformed")
+        permitted: dict[str, frozenset[str]] = {}
+        for source in sources:
+            if not isinstance(source, Mapping):
+                raise DatabaseAdapterContractError("plan source declaration is malformed")
+            relation = source.get("relation")
+            fields = source.get("fields")
+            if (
+                relation in permitted
+                or not isinstance(relation, str)
+                or relation not in _RELATION_QUERIES
+                and relation != "valuation_match"
+            ):
+                raise DatabaseAdapterContractError(
+                    f"relation is not in the database-v1 allowlist: {relation!r}"
+                )
+            if isinstance(fields, (str, bytes)) or not isinstance(fields, Sequence):
+                raise DatabaseAdapterContractError(f"fields are malformed for {relation}")
+            selected = frozenset(fields)
+            if not selected or not all(isinstance(field, str) for field in selected):
+                raise DatabaseAdapterContractError(f"fields are malformed for {relation}")
+            allowed = _RELATION_FIELDS.get(relation, frozenset())
+            if not selected.issubset(allowed):
+                raise DatabaseAdapterContractError(f"fields are not allowed for {relation}")
+            permitted[relation] = selected
+        if not permitted:
+            raise DatabaseAdapterContractError("plan has no permitted sources")
+        return permitted
+
+    @staticmethod
+    def _validate_publication_authority(
+        connection: sqlite3.Connection,
+        publication: Mapping[str, Any],
+    ) -> None:
+        """Validate the committed publication's independent coverage rows."""
+
+        publication_id = publication.get("publication_id")
+        if not isinstance(publication_id, str) or not publication_id:
+            raise DatabaseAdapterContractError("publication authority has no logical identity")
+
+        def integer(value: Any, label: str, *, nullable: bool = False) -> int | None:
+            if value is None and nullable:
+                return None
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise DatabaseAdapterContractError(f"{label} is not an integer")
+            return value
+
+        def nonnegative(value: Any, label: str) -> int:
+            typed = integer(value, label)
+            assert typed is not None
+            if typed < 0:
+                raise DatabaseAdapterContractError(f"{label} is negative")
+            return typed
+
+        for bound_field in (
+            "indexed_from_us",
+            "guaranteed_complete_from_us",
+            "observed_through_us",
+            "_indexed_through_us",
+        ):
+            integer(
+                publication.get(bound_field),
+                f"publication.{bound_field}",
+                nullable=True,
+            )
+
+        source_cursor = connection.execute(
+            """
+                SELECT source_id,
+                       selected_manifestation_count, selected_manifestation_bytes,
+                       deferred_manifestation_count, deferred_manifestation_bytes,
+                       malformed_manifestation_count, malformed_manifestation_bytes,
+                       missing_manifestation_count, missing_manifestation_bytes,
+                       uncertain_manifestation_count, uncertain_manifestation_bytes,
+                       malformed_range_count, malformed_range_bytes,
+                       selected_complete_record_count,
+                       tail_pending,
+                       indexed_from_us, indexed_through_us,
+                       guaranteed_complete_from_us, guaranteed_complete_through_us,
+                       clock_quality, clock_uncertainty_us,
+                       inventory_started_at_us, inventory_completed_at_us
+                  FROM publication_source_coverage
+                 WHERE publication_id = ?
+                 ORDER BY source_id
+            """,
+            (publication_id,),
+        )
+        source_rows = [_row_dict(row, source_cursor.description) for row in source_cursor]
+        if not source_rows:
+            raise DatabaseAdapterContractError(
+                "publication source coverage is missing for the current publication"
+            )
+        source_ids: set[str] = set()
+        source_count_fields = (
+            "selected_manifestation_count",
+            "selected_manifestation_bytes",
+            "deferred_manifestation_count",
+            "deferred_manifestation_bytes",
+            "malformed_manifestation_count",
+            "malformed_manifestation_bytes",
+            "missing_manifestation_count",
+            "missing_manifestation_bytes",
+            "uncertain_manifestation_count",
+            "uncertain_manifestation_bytes",
+            "malformed_range_count",
+            "malformed_range_bytes",
+            "selected_complete_record_count",
+        )
+        for row in source_rows:
+            source_id = row.get("source_id")
+            if not isinstance(source_id, str) or not source_id or source_id in source_ids:
+                raise DatabaseAdapterContractError("publication source coverage is malformed")
+            source_ids.add(source_id)
+            for count_field in source_count_fields:
+                nonnegative(row.get(count_field), f"source coverage {count_field}")
+            tail_pending = integer(row.get("tail_pending"), "source coverage tail pending")
+            if tail_pending not in {0, 1}:
+                raise DatabaseAdapterContractError("source coverage tail pending is malformed")
+            for bound_field in (
+                "indexed_from_us",
+                "indexed_through_us",
+                "guaranteed_complete_from_us",
+                "guaranteed_complete_through_us",
+            ):
+                integer(
+                    row.get(bound_field),
+                    f"source coverage {bound_field}",
+                    nullable=True,
+                )
+            indexed_from = row.get("indexed_from_us")
+            indexed_through = row.get("indexed_through_us")
+            guaranteed_from = row.get("guaranteed_complete_from_us")
+            guaranteed_through = row.get("guaranteed_complete_through_us")
+            if (indexed_from is None) != (indexed_through is None):
+                raise DatabaseAdapterContractError("source coverage indexed bounds are malformed")
+            if indexed_from is not None and indexed_from > indexed_through:
+                raise DatabaseAdapterContractError("source coverage indexed bounds are reversed")
+            if (guaranteed_from is None) != (guaranteed_through is None):
+                raise DatabaseAdapterContractError(
+                    "source coverage completeness bounds are malformed"
+                )
+            if guaranteed_from is not None and guaranteed_from > guaranteed_through:
+                raise DatabaseAdapterContractError(
+                    "source coverage completeness bounds are reversed"
+                )
+            if (
+                indexed_from != publication.get("indexed_from_us")
+                or indexed_through != publication.get("_indexed_through_us")
+                or guaranteed_from != publication.get("guaranteed_complete_from_us")
+                or guaranteed_through
+                != (
+                    publication.get("_indexed_through_us")
+                    if publication.get("guaranteed_complete_from_us") is not None
+                    else None
+                )
+            ):
+                raise DatabaseAdapterContractError(
+                    "publication source coverage bounds do not match the committed publication"
+                )
+            clock_quality = row.get("clock_quality")
+            if clock_quality not in {"unknown", "unsynchronized", "bounded"}:
+                raise DatabaseAdapterContractError("source coverage clock quality is malformed")
+            uncertainty = integer(
+                row.get("clock_uncertainty_us"),
+                "source coverage clock uncertainty",
+                nullable=True,
+            )
+            if clock_quality == "bounded" and uncertainty is None:
+                raise DatabaseAdapterContractError(
+                    "bounded source coverage has no clock uncertainty"
+                )
+            if uncertainty is not None and uncertainty < 0:
+                raise DatabaseAdapterContractError("source coverage clock uncertainty is negative")
+            if clock_quality != "bounded" and uncertainty is not None:
+                raise DatabaseAdapterContractError(
+                    "non-bounded source coverage has clock uncertainty"
+                )
+            started = integer(row.get("inventory_started_at_us"), "source inventory start")
+            completed = integer(row.get("inventory_completed_at_us"), "source inventory end")
+            assert started is not None and completed is not None
+            if started > completed:
+                raise DatabaseAdapterContractError("source inventory bounds are reversed")
+
+        inventory_cursor = connection.execute(
+            """
+                SELECT DISTINCT source_id
+                  FROM source_manifestations
+                 ORDER BY source_id
+            """
+        )
+        inventory_ids = {row[0] for row in inventory_cursor}
+        if inventory_ids and inventory_ids != source_ids:
+            raise DatabaseAdapterContractError(
+                "publication source coverage does not match the source inventory"
+            )
+
+        capability_cursor = connection.execute(
+            """
+                SELECT capability_id, eligible_entity_count, observed_entity_count,
+                       unavailable_entity_count, measurement_mask, grade, basis
+                  FROM publication_capability_coverage
+                 WHERE publication_id = ?
+                 ORDER BY capability_id
+            """,
+            (publication_id,),
+        )
+        capability_rows = [
+            _row_dict(row, capability_cursor.description) for row in capability_cursor
+        ]
+        if not capability_rows:
+            raise DatabaseAdapterContractError(
+                "publication capability coverage is missing for the current publication"
+            )
+        capabilities: dict[str, bool] = {}
+        valuation_rows: list[Mapping[str, Any]] = []
+        for row in capability_rows:
+            capability_id = row.get("capability_id")
+            if (
+                not isinstance(capability_id, str)
+                or not capability_id
+                or capability_id in capabilities
+            ):
+                raise DatabaseAdapterContractError("publication capability coverage is malformed")
+            eligible = nonnegative(row.get("eligible_entity_count"), "capability eligible count")
+            observed = nonnegative(row.get("observed_entity_count"), "capability observed count")
+            unavailable = nonnegative(
+                row.get("unavailable_entity_count"), "capability unavailable count"
+            )
+            nonnegative(row.get("measurement_mask"), "capability measurement mask")
+            if observed > eligible or unavailable > eligible or observed + unavailable > eligible:
+                raise DatabaseAdapterContractError("publication capability counts are inconsistent")
+            grade = row.get("grade")
+            basis = row.get("basis")
+            if grade not in {"exact", "deterministic", "configured_estimate"}:
+                raise DatabaseAdapterContractError("publication capability grade is malformed")
+            if not isinstance(basis, str) or not basis:
+                raise DatabaseAdapterContractError("publication capability basis is malformed")
+            capabilities[capability_id] = observed > 0
+            if capability_id == "valuation":
+                valuation_rows.append(row)
+
+        if len(valuation_rows) != 1:
+            raise DatabaseAdapterContractError(
+                "publication valuation coverage is missing or ambiguous"
+            )
+        valuation = valuation_rows[0]
+        if valuation.get("grade") != "configured_estimate":
+            raise DatabaseAdapterContractError(
+                "publication valuation coverage is not a configured estimate"
+            )
+        priced_calls = int(valuation["eligible_entity_count"]) - int(
+            valuation["unavailable_entity_count"]
+        )
+        expected_valuation = {
+            "basis": "configured_estimate",
+            "priced_calls": priced_calls,
+        }
+
+        entity_cursor = connection.execute(
+            """
+                SELECT entity_kind, entity_count
+                  FROM publication_entity_counts
+                 WHERE publication_id = ?
+                 ORDER BY entity_kind
+            """,
+            (publication_id,),
+        )
+        entity_rows = [_row_dict(row, entity_cursor.description) for row in entity_cursor]
+        if not entity_rows:
+            raise DatabaseAdapterContractError(
+                "publication entity counts are missing for the current publication"
+            )
+        measurements: dict[str, int] = {}
+        for row in entity_rows:
+            entity_kind = row.get("entity_kind")
+            if not isinstance(entity_kind, str) or not entity_kind or entity_kind in measurements:
+                raise DatabaseAdapterContractError("publication entity counts are malformed")
+            measurements[entity_kind] = nonnegative(
+                row.get("entity_count"), "publication entity count"
+            )
+
+        capabilities_value = _typed_value("capabilities", publication.get("capabilities"))
+        measurements_value = _typed_value("measurements", publication.get("measurements"))
+        valuation_value = _typed_value("valuation_coverage", publication.get("valuation_coverage"))
+        if capabilities_value != capabilities:
+            raise DatabaseAdapterContractError(
+                "publication capabilities do not match authoritative coverage"
+            )
+        if measurements_value != measurements:
+            raise DatabaseAdapterContractError(
+                "publication measurements do not match authoritative entity counts"
+            )
+        if valuation_value != expected_valuation:
+            raise DatabaseAdapterContractError(
+                "publication valuation coverage does not match authoritative coverage"
+            )
+
+    def _owner_rules(self) -> Mapping[str, Mapping[str, Any]]:
+        if not isinstance(self._selector_contract, Mapping):
+            raise DatabaseAdapterContractError("selector-provenance contract data is missing")
+        ownership = self._selector_contract.get("ownership")
+        if isinstance(ownership, (str, bytes)) or not isinstance(ownership, Sequence):
+            raise DatabaseAdapterContractError("selector ownership contract is malformed")
+        rules = {
+            item.get("kind"): item
+            for item in ownership
+            if isinstance(item, Mapping) and isinstance(item.get("kind"), str)
+        }
+        if set(rules) != _SELECTOR_KINDS:
+            raise DatabaseAdapterContractError(
+                "selector ownership contract does not cover all 14 kinds"
+            )
+        return rules
+
+    def _valuation_facts(
+        self,
+        connection: sqlite3.Connection,
+        permitted_fields: frozenset[str],
+    ) -> list[CanonicalFact]:
+        calls_cursor = connection.execute(
+            """
+                SELECT call_id, model_profile_id, uncached_input_tokens,
+                       cached_input_tokens, reasoning_tokens, output_tokens,
+                       event_at_us, source_rank, source_order,
+                       event_kind_order, transition_rank
+                  FROM model_calls_visible
+                 ORDER BY call_id
+            """
+        )
+        calls = [_row_dict(row, calls_cursor.description) for row in calls_cursor]
+        profiles_cursor = connection.execute(
+            """
+                SELECT model_profile_id, model, reasoning_effort, service_tier
+                  FROM model_profiles
+                 ORDER BY model_profile_id
+            """
+        )
+        profiles = [_row_dict(row, profiles_cursor.description) for row in profiles_cursor]
+        frontier, publication_digest = self._frontier(connection)
+        matches = compile_current_valuation_matches(
+            calls,
+            profiles,
+            frontier,
+            publication_rate_card_digest=publication_digest,
+        )
+        coordinates = {row["call_id"]: _coordinates(row) for row in calls}
+        facts: list[CanonicalFact] = []
+        for match in matches:
+            cost_reason = getattr(match.cost_unpriced_reason, "value", match.cost_unpriced_reason)
+            credit_reason = getattr(
+                match.credit_unpriced_reason, "value", match.credit_unpriced_reason
+            )
+            values = {
+                "call_id": match.call_id,
+                "configured_cost_usd": match.configured_cost_usd,
+                "coverage_basis": {
+                    "cost": match.cost_coverage,
+                    "credit": match.credit_coverage,
+                    "rate_card_digest": match.rate_card_digest,
+                },
+                "estimated_credits": match.estimated_credits,
+                "match_basis": match.match_basis,
+                "rate_card_digest": match.rate_card_digest,
+                "cost_grade": match.cost_grade,
+                "cost_unpriced_reason": cost_reason,
+                "unpriced_reason": cost_reason or credit_reason,
+            }
+            values = {key: value for key, value in values.items() if key in permitted_fields}
+            logical_id = match.valuation_id or semantic_id(
+                "valuation", [match.call_id, match.rate_card_digest]
+            )
+            facts.append(
+                CanonicalFact(
+                    "valuation_match",
+                    logical_id,
+                    values,
+                    coordinates.get(match.call_id),
+                )
+            )
+        return facts
+
+    @staticmethod
+    def _frontier(
+        connection: sqlite3.Connection,
+    ) -> tuple[RateCardFrontier | None, str | None]:
+        head = connection.execute(
+            """
+                SELECT p.publication_id, p.rate_card_digest, a.rate_card_id,
+                       a.publication_id AS active_publication_id
+                  FROM publication_head AS h
+                  JOIN publications AS p ON p.publication_id = h.publication_id
+                  LEFT JOIN active_rate_card AS a ON a.singleton = 1
+                 WHERE h.singleton = 1 AND p.status = 'committed'
+            """
+        ).fetchone()
+        if head is None:
+            return None, None
+        publication_digest = head[1]
+        if head[3] != head[0]:
+            return RateCardFrontier(str(publication_digest or ""), ()), publication_digest
+        rows_cursor = connection.execute(
+            """
+                SELECT rate_card_id, digest, predecessor_rate_card_id,
+                       source_name, source_url, effective_at_us, fetched_at_us,
+                       currency, model_match_rules_json, four_class_rates_json,
+                       credit_rates_json, reasoning_in_output, confidence,
+                       validation_status
+                  FROM rate_card_revisions
+                 ORDER BY digest
+            """
+        )
+        rows = [_row_dict(row, rows_cursor.description) for row in rows_cursor]
+        by_id = {row.get("rate_card_id"): row for row in rows}
+        head_id = head[2]
+        if not isinstance(head_id, str) or head_id not in by_id:
+            return RateCardFrontier(str(publication_digest or ""), ()), publication_digest
+        chain: list[RateCardRevision] = []
+        current_id: str | None = head_id
+        seen: set[str] = set()
+        while current_id is not None and current_id not in seen:
+            seen.add(current_id)
+            row = by_id[current_id]
+            rules = _json_or_invalid(row.get("model_match_rules_json"), [])
+            rates = _json_or_invalid(row.get("four_class_rates_json"), None)
+            credits = _json_or_invalid(row.get("credit_rates_json"), None)
+            predecessor_id = row.get("predecessor_rate_card_id")
+            predecessor_digest = (
+                by_id[predecessor_id].get("digest")
+                if predecessor_id in by_id
+                else ("0" * 64 if predecessor_id else None)
+            )
+            chain.append(
+                RateCardRevision(
+                    rate_card_id=str(row.get("rate_card_id") or ""),
+                    digest=str(row.get("digest") or ""),
+                    predecessor_digest=predecessor_digest,
+                    effective_at_us=row.get("effective_at_us"),
+                    fetched_at_us=row.get("fetched_at_us"),
+                    source_name=str(row.get("source_name") or ""),
+                    source_url=row.get("source_url"),
+                    currency=str(row.get("currency") or ""),
+                    model_match_rules=tuple(rules)
+                    if isinstance(rules, Sequence) and not isinstance(rules, (str, bytes))
+                    else rules,
+                    four_class_rates=rates,
+                    credit_rates=credits,
+                    reasoning_in_output=bool(row.get("reasoning_in_output")),
+                    confidence=str(row.get("confidence") or ""),
+                    validation_status=str(row.get("validation_status") or ""),
+                )
+            )
+            current_id = predecessor_id
+        if current_id in seen:
+            # The already-built predecessor links retain the cycle for the
+            # pure compiler's typed fail-closed result.
+            pass
+        return RateCardFrontier(str(publication_digest or ""), tuple(chain)), publication_digest
+
+    @staticmethod
+    def _snapshot_token(connection: sqlite3.Connection, fallback: str) -> str:
+        row = connection.execute(
+            """
+                SELECT p.publication_id
+                  FROM publication_head AS h
+                  JOIN publications AS p ON p.publication_id = h.publication_id
+                 WHERE h.singleton = 1 AND p.status = 'committed'
+            """
+        ).fetchone()
+        if row is None or not row[0]:
+            if fallback:
+                return fallback
+            raise DatabaseAdapterContractError("read snapshot has no committed publication head")
+        return str(row[0])
+
+    def _evidence(
+        self,
+        connection: sqlite3.Connection,
+        plan_request: PlanRequest,
+        required: tuple[Mapping[str, Any], ...],
+        selected_ids: Mapping[str, str],
+        request_digest: str,
+        owner_rules: Mapping[str, Mapping[str, Any]],
+    ) -> tuple[EvidenceReferenceV1, ...]:
+        references: list[EvidenceReferenceV1] = []
+        for entry in required:
+            role = entry["role"]
+            kind = entry["selector_kind"]
+            if kind not in _SELECTOR_KINDS:
+                raise DatabaseAdapterContractError(f"unsupported selector kind: {kind}")
+            rule = owner_rules.get(kind)
+            if rule is None:
+                raise DatabaseAdapterContractError(f"selector owner is missing for {kind}")
+            if kind == "window":
+                window = self._window_value(plan_request.parameters, role)
+                if not isinstance(window, Mapping):
+                    raise DatabaseAdapterContractError(f"{role} has no typed window")
+                start, end, timezone = (
+                    window.get("start_us"),
+                    window.get("end_us"),
+                    window.get("timezone", "UTC"),
+                )
+                if (
+                    isinstance(start, bool)
+                    or not isinstance(start, int)
+                    or isinstance(end, bool)
+                    or not isinstance(end, int)
+                    or start > end
+                    or not isinstance(timezone, str)
+                    or not timezone
+                ):
+                    raise DatabaseAdapterContractError(f"{role} has malformed window bounds")
+                logical_id = semantic_id("window", [request_digest, role, start, end, timezone])
+                selector = entry.get("selector")
+                if selector is None:
+                    selector = f"window:{logical_id}"
+                _prefix, suffix = self._selector_parts(selector, kind)
+                if suffix != logical_id:
+                    raise DatabaseAdapterContractError(
+                        f"{role} window selector does not match its request parameter"
+                    )
+                supplied_logical_ids: list[Any] = []
+                if role in selected_ids:
+                    supplied_logical_ids.append(selected_ids[role])
+                if "logical_id" in entry:
+                    supplied_logical_ids.append(entry["logical_id"])
+                if any(
+                    not isinstance(value, str) or not value or value != logical_id
+                    for value in supplied_logical_ids
+                ):
+                    raise DatabaseAdapterContractError(
+                        f"{role} window logical ID does not match its request parameter"
+                    )
+                selected_logical_id = logical_id
+                provenance = {
+                    "end_us": end,
+                    "parameter_role": role,
+                    "request_digest": request_digest,
+                    "start_us": start,
+                    "timezone": timezone,
+                }
+                references.append(
+                    EvidenceReferenceV1(
+                        role, kind, selector, selected_logical_id, "request_derivation", provenance
+                    )
+                )
+                continue
+            requested_logical_id = selected_ids.get(role)
+            entry_logical_id = entry.get("logical_id")
+            if entry_logical_id is not None and (
+                not isinstance(entry_logical_id, str) or not entry_logical_id
+            ):
+                raise DatabaseAdapterContractError(f"{role} has no logical selector")
+            if (
+                requested_logical_id is not None
+                and entry_logical_id is not None
+                and requested_logical_id != entry_logical_id
+            ):
+                raise DatabaseAdapterContractError(f"{role} has conflicting selected logical IDs")
+            logical_id = entry_logical_id or requested_logical_id
+            if not isinstance(logical_id, str) or not logical_id:
+                raise DatabaseAdapterContractError(f"{role} has no selected selector")
+            selector = entry.get("selector")
+            if selector is None:
+                selector = f"{_selector_prefix(kind)}:{logical_id}"
+            _prefix, suffix = self._selector_parts(selector, kind)
+            provenance_kind = rule.get("provenance_kind")
+            if not isinstance(provenance_kind, str):
+                raise DatabaseAdapterContractError(f"{kind} owner provenance is malformed")
+            provenance = self._owner_provenance(connection, kind, logical_id, provenance_kind)
+            if kind == "rate_card":
+                resolved_digest = provenance.get("digest")
+                if not isinstance(resolved_digest, str) or not resolved_digest:
+                    raise DatabaseAdapterContractError("rate-card provenance has no digest")
+                if suffix != resolved_digest or any(
+                    value is not None and value != resolved_digest
+                    for value in (requested_logical_id, entry_logical_id)
+                ):
+                    raise DatabaseAdapterContractError(
+                        f"{role} rate-card selector does not identify its revision digest"
+                    )
+                logical_id = resolved_digest
+            elif logical_id != suffix:
+                raise DatabaseAdapterContractError(
+                    f"{role} selector does not identify its selected entity"
+                )
+            references.append(
+                EvidenceReferenceV1(
+                    role,
+                    kind,
+                    selector,
+                    logical_id,
+                    provenance_kind,
+                    provenance,
+                )
+            )
+        return tuple(references)
+
+    @staticmethod
+    def _window_value(parameters: Mapping[str, Any], role: str) -> Any:
+        return parameters.get(role)
+
+    def _owner_provenance(
+        self,
+        connection: sqlite3.Connection,
+        kind: str,
+        logical_id: str,
+        provenance_kind: str,
+    ) -> Mapping[str, Any]:
+        if provenance_kind == "source_occurrence":
+            query = _SOURCE_OWNER_ENTITY_QUERIES.get(kind)
+            if query is None:
+                raise DatabaseAdapterContractError(f"{kind} has no source owner")
+            if connection.execute(query, (logical_id,)).fetchone() is None:
+                raise DatabaseAdapterContractError(f"{kind} selector does not resolve")
+            if kind == "model_profile":
+                profile = connection.execute(
+                    "SELECT model, reasoning_effort, service_tier FROM model_profiles WHERE model_profile_id = ?",
+                    (logical_id,),
+                ).fetchone()
+                call_cursor = connection.execute(
+                    "SELECT call_id FROM model_calls_visible WHERE model_profile_id = ? ORDER BY call_id",
+                    (logical_id,),
+                )
+                call_ids = [row[0] for row in call_cursor]
+                call_occurrences: list[Mapping[str, Any]] = []
+                for call_id in call_ids:
+                    occurrences = self._occurrence_mappings(connection, call_id)
+                    if not occurrences:
+                        raise DatabaseAdapterContractError(
+                            f"{kind} representative call has no source occurrence"
+                        )
+                    call_occurrences.extend(occurrences)
+                if profile is None or any(value in (None, "") for value in profile) or not call_ids:
+                    raise DatabaseAdapterContractError(
+                        f"{kind} selector has no representative call"
+                    )
+                call_occurrences.sort(
+                    key=lambda item: (
+                        item["record_ordinal"],
+                        item["occurrence_id"],
+                    )
+                )
+                return {
+                    "profile_tuple": {
+                        "model": profile[0],
+                        "reasoning_effort": profile[1],
+                        "service_tier": profile[2],
+                    },
+                    "representative_call_occurrences": call_occurrences,
+                    "representative_call_selectors": [f"call:{call_id}" for call_id in call_ids],
+                }
+            occurrences = self._occurrence_mappings(connection, logical_id)
+            if not occurrences:
+                raise DatabaseAdapterContractError(f"{kind} selector has no source occurrence")
+            return {"occurrences": occurrences}
+        if provenance_kind == "configured_artifact":
+            row = connection.execute(
+                """
+                    SELECT r.digest, r.source_name, r.fetched_at_us, r.validation_status
+                      FROM rate_card_revisions AS r
+                      JOIN publication_head AS h ON h.singleton = 1
+                      JOIN publications AS p ON p.publication_id = h.publication_id
+                     WHERE (r.rate_card_id = ? OR r.digest = ?)
+                       AND p.rate_card_digest IS NOT NULL
+                """,
+                (logical_id, logical_id),
+            ).fetchone()
+            if row is None:
+                raise DatabaseAdapterContractError("rate-card selector does not resolve")
+            frontier, _digest = self._frontier(connection)
+            if frontier is None or not any(
+                revision.rate_card_id == logical_id or revision.digest == logical_id
+                for revision in frontier.revisions
+            ):
+                raise DatabaseAdapterContractError(
+                    "rate-card selector is outside the captured frontier"
+                )
+            return {
+                "digest": row[0],
+                "source_name": row[1],
+                "fetched_at_us": row[2],
+                "validation_status": row[3],
+            }
+        if provenance_kind == "publication_commit":
+            row = connection.execute(
+                """
+                    SELECT p.operation_id, p.artifact_manifest_sha256, p.committed_at_us
+                      FROM publication_head AS h
+                      JOIN publications AS p ON p.publication_id = h.publication_id
+                     WHERE h.singleton = 1 AND p.publication_id = ? AND p.status = 'committed'
+                """,
+                (logical_id,),
+            ).fetchone()
+            if row is None:
+                raise DatabaseAdapterContractError(
+                    "publication selector does not resolve to the committed head"
+                )
+            return {
+                "operation_id": row[0],
+                "artifact_manifest_sha256": row[1],
+                "committed_at_us": row[2],
+            }
+        if provenance_kind == "source_inventory":
+            row = connection.execute(
+                """
+                    SELECT sm.source_id, sm.content_revision, sm.state,
+                           h.publication_id AS selected_publication_id
+                      FROM source_manifestations AS sm
+                      JOIN publication_head AS h ON h.singleton = 1
+                     WHERE sm.manifestation_id = ?
+                """,
+                (logical_id,),
+            ).fetchone()
+            if row is None:
+                raise DatabaseAdapterContractError("source manifestation selector does not resolve")
+            return {
+                "source_id": row[0],
+                "content_revision": row[1],
+                "state": row[2],
+                "selected_publication_id": row[3],
+            }
+        if provenance_kind == "derived_boundary_pair":
+            row = connection.execute(
+                """
+                    SELECT start_observation_id, end_observation_id,
+                           compatibility_basis
+                      FROM allowance_intervals
+                     WHERE interval_id = ?
+                """,
+                (logical_id,),
+            ).fetchone()
+            if row is None:
+                raise DatabaseAdapterContractError("allowance interval selector does not resolve")
+            start_id, end_id, compatibility = row
+            start_occurrences = self._occurrence_mappings(connection, start_id)
+            end_occurrences = self._occurrence_mappings(connection, end_id)
+            if not compatibility or not start_occurrences or not end_occurrences:
+                raise DatabaseAdapterContractError(
+                    "allowance interval boundary provenance is incomplete"
+                )
+            return {
+                "compatibility_version": "allowance-compatibility-v1",
+                "end_observation_selector": f"allowance-observation:{end_id}",
+                "end_occurrences": end_occurrences,
+                "start_observation_selector": f"allowance-observation:{start_id}",
+                "start_occurrences": start_occurrences,
+            }
+        raise DatabaseAdapterContractError(f"unsupported owner provenance: {provenance_kind}")
+
+    @staticmethod
+    def _occurrence_mappings(
+        connection: sqlite3.Connection, logical_id: str
+    ) -> list[Mapping[str, Any]]:
+        cursor = connection.execute(_SOURCE_OCCURRENCES_SQL, (logical_id,))
+        result = []
+        for row in cursor:
+            values = _row_dict(row, cursor.description)
+            result.append(
+                {
+                    "adapter_version": values["adapter_version"],
+                    "byte_end": values["byte_end"],
+                    "byte_start": values["byte_start"],
+                    "occurrence_id": values["occurrence_id"],
+                    "record_ordinal": values["record_ordinal"],
+                    "semantic_logical_id": values["semantic_logical_id"],
+                    "source_manifestation_id": values["manifestation_id"],
+                    "source_revision": values["source_revision"],
+                }
+            )
+        return result
+
+    @staticmethod
+    def _validate_evidence(
+        required: tuple[Mapping[str, Any], ...],
+        materialized: Sequence[EvidenceReferenceV1],
+        owner_rules: Mapping[str, Mapping[str, Any]],
+    ) -> None:
+        expected = [
+            (entry.get("role"), entry.get("selector_kind"), entry.get("selector"))
+            for entry in required
+        ]
+        actual = [(item.role, item.selector_kind, item.selector) for item in materialized]
+        expected = [
+            (role, kind, selector if selector is not None else next_item.selector)
+            for (role, kind, selector), next_item in zip(expected, materialized, strict=True)
+        ]
+        if expected != actual:
+            raise DatabaseAdapterContractError(
+                "required and materialized evidence sequences differ"
+            )
+        for item in materialized:
+            rule = owner_rules.get(item.selector_kind)
+            if rule is None or item.provenance_kind != rule.get("provenance_kind"):
+                raise DatabaseAdapterContractError(f"{item.role} uses unsupported provenance")
+            fields = rule.get("required_provenance_fields")
+            if isinstance(fields, (str, bytes)) or not isinstance(fields, Sequence):
+                raise DatabaseAdapterContractError(f"{item.role} owner rule is malformed")
+            missing = [
+                field for field in fields if item.provenance.get(field) in (None, "", [], {})
+            ]
+            if missing:
+                raise DatabaseAdapterContractError(
+                    f"{item.role} provenance is incomplete: {missing}"
+                )
+
+
+def _json_or_invalid(value: Any, fallback: Any) -> Any:
+    if not isinstance(value, str):
+        return fallback
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return fallback
+
+
+__all__ = [
+    "AdapterMaterialization",
+    "AdapterRequest",
+    "DatabaseAdapterContractError",
+    "DatabaseV1FactAdapter",
+    "DatabaseV1FactMaterialization",
+    "EvidenceReference",
+    "EvidenceReferenceV1",
+]

--- a/tests/agent_kernel/fact_adapters/reference.py
+++ b/tests/agent_kernel/fact_adapters/reference.py
@@ -1,0 +1,1008 @@
+"""Independent structural-v2 to canonical-fact normalization for CK-07E.
+
+The adapter accepts only body-free structural declarations and pure contract
+inputs.  It owns its evidence and materialization values so the structural
+truth lane cannot accidentally share adapter state with the database lane.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from types import MappingProxyType
+from typing import Any
+
+from codex_usage_tracker.agent_kernel.domain.identity import semantic_id
+from codex_usage_tracker.agent_kernel.domain.plan_operands import (
+    CanonicalFact,
+    FactCoordinates,
+    PlanRequest,
+)
+from codex_usage_tracker.agent_kernel.domain.valuation import (
+    RateCardFrontier,
+    RateCardRevision,
+    compile_current_valuation_matches,
+)
+
+
+class StructuralReferenceAdapterError(ValueError):
+    """The structural declaration cannot satisfy the adapter contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReference:
+    """One owner-resolved selector and its typed provenance."""
+
+    role: str
+    selector_kind: str
+    selector: str
+    logical_id: str
+    provenance_kind: str
+    provenance: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(value, str) and value
+            for value in (
+                self.role,
+                self.selector_kind,
+                self.selector,
+                self.logical_id,
+                self.provenance_kind,
+            )
+        ):
+            raise StructuralReferenceAdapterError(
+                "evidence references require non-empty string identities"
+            )
+        if not isinstance(self.provenance, Mapping):
+            raise StructuralReferenceAdapterError("evidence provenance must be a mapping")
+        _assert_structural(self.provenance, path=f"evidence.{self.role}")
+        object.__setattr__(self, "provenance", MappingProxyType(dict(self.provenance)))
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterMaterialization:
+    """Frozen structural facts, request, and ordered evidence references."""
+
+    request: PlanRequest
+    facts: tuple[CanonicalFact, ...]
+    evidence_references: tuple[EvidenceReference, ...]
+    source: str
+    snapshot_token: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, PlanRequest):
+            raise StructuralReferenceAdapterError("materialization requires a PlanRequest")
+        if not isinstance(self.facts, tuple) or not isinstance(self.evidence_references, tuple):
+            raise StructuralReferenceAdapterError("materialization collections must be tuples")
+        if not isinstance(self.source, str) or not self.source:
+            raise StructuralReferenceAdapterError("materialization source is required")
+        if not isinstance(self.snapshot_token, str) or not self.snapshot_token:
+            raise StructuralReferenceAdapterError("materialization snapshot token is required")
+
+
+_STRUCTURAL_SCHEMAS = frozenset(
+    {
+        "codex-usage-tracker.agent-kernel.structural-v2.v1",
+        "codex-usage-tracker.synthetic-structural-v2.v1",
+    }
+)
+_SELECTOR_KINDS = frozenset(
+    {
+        "allowance_interval",
+        "allowance_observation",
+        "call",
+        "model_profile",
+        "project",
+        "publication",
+        "rate_card",
+        "resource",
+        "session",
+        "source_manifestation",
+        "state_change",
+        "tool",
+        "turn",
+        "window",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "answer",
+        "answers",
+        "comparison",
+        "comparisons",
+        "expected",
+        "grade",
+        "grades",
+        "grading",
+        "oracle",
+        "oracle_case",
+        "question_cases",
+        "scenario_answer",
+    }
+)
+_FORBIDDEN_BODY_KEYS = frozenset(
+    {
+        "body",
+        "command",
+        "content",
+        "diff",
+        "patch",
+        "prompt",
+        "reasoning",
+        "response",
+        "stderr",
+        "stdout",
+        "tool_output",
+    }
+)
+
+
+def _assert_structural(value: Any, *, path: str = "record") -> None:
+    """Reject answer caches, bodies, and binary floats recursively."""
+
+    if isinstance(value, float):
+        raise StructuralReferenceAdapterError(f"{path} contains a binary float")
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise StructuralReferenceAdapterError(f"{path} contains a non-string key")
+            lowered = key.lower()
+            if lowered in _FORBIDDEN_KEYS or lowered.startswith(
+                ("answer_", "oracle_", "grading_", "comparison_")
+            ):
+                raise StructuralReferenceAdapterError(
+                    f"{path} contains forbidden answer field: {key}"
+                )
+            if (
+                lowered in _FORBIDDEN_BODY_KEYS
+                or lowered.endswith("_body")
+                or lowered.startswith("raw_")
+            ):
+                raise StructuralReferenceAdapterError(
+                    f"{path} contains forbidden body field: {key}"
+                )
+            _assert_structural(item, path=f"{path}.{key}")
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for index, item in enumerate(value):
+            _assert_structural(item, path=f"{path}[{index}]")
+    elif isinstance(value, Decimal) and not value.is_finite():
+        raise StructuralReferenceAdapterError(f"{path} contains a non-finite decimal")
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+        raise StructuralReferenceAdapterError(f"{label} must be a string-keyed mapping")
+    return value
+
+
+def _integer(value: Any, label: str, *, nullable: bool = False) -> int | None:
+    if value is None and nullable:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise StructuralReferenceAdapterError(f"{label} must be an integer")
+    return value
+
+
+def _coordinates(raw: Mapping[str, Any], label: str) -> FactCoordinates:
+    source = raw.get("coordinates", raw)
+    if source is None:
+        source = {}
+    source = _mapping(source, f"{label}.coordinates")
+    return FactCoordinates(
+        event_at_us=_integer(source.get("event_at_us"), f"{label}.event_at_us", nullable=True),
+        source_rank=_integer(source.get("source_rank", 0), f"{label}.source_rank"),
+        source_order=_integer(source.get("source_order", 0), f"{label}.source_order"),
+        event_kind_order=_integer(source.get("event_kind_order", 0), f"{label}.event_kind_order"),
+        transition_rank=_integer(source.get("transition_rank", 0), f"{label}.transition_rank"),
+    )
+
+
+def _ordered_occurrences(
+    values: Sequence[Mapping[str, Any]],
+    label: str,
+) -> list[Mapping[str, Any]]:
+    def key(value: Mapping[str, Any]) -> tuple[int, str]:
+        ordinal = value.get("record_ordinal")
+        occurrence_id = value.get("occurrence_id")
+        if (
+            isinstance(ordinal, bool)
+            or not isinstance(ordinal, int)
+            or not isinstance(occurrence_id, str)
+            or not occurrence_id
+        ):
+            raise StructuralReferenceAdapterError(f"{label} has malformed occurrence ordering")
+        return ordinal, occurrence_id
+
+    return sorted(values, key=key)
+
+
+def _selected_fact_values(
+    relation: str,
+    values: Mapping[str, Any],
+    fields: frozenset[str],
+) -> dict[str, Any]:
+    selected = {key: value for key, value in values.items() if key in fields}
+    if relation != "tool_invocation":
+        return selected
+    links = selected.get("resource_links")
+    primary = selected.get("resource_id")
+    if (
+        not isinstance(links, Sequence)
+        or isinstance(links, (str, bytes))
+        or any(not isinstance(item, str) or not item for item in links)
+    ):
+        raise StructuralReferenceAdapterError("tool_invocation resource_links must be resource IDs")
+    unique = set(links)
+    if isinstance(primary, str) and primary:
+        unique.add(primary)
+        selected["resource_links"] = [
+            primary,
+            *sorted(item for item in unique if item != primary),
+        ]
+    else:
+        selected["resource_links"] = sorted(unique)
+    return selected
+
+
+def _request_digest(request: PlanRequest) -> str:
+    def normalize(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {key: normalize(item) for key, item in sorted(value.items())}
+        if isinstance(value, (list, tuple)):
+            return [normalize(item) for item in value]
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+
+    payload = json.dumps(
+        normalize(
+            {
+                "gates": request.gates,
+                "parameters": request.parameters,
+                "plan_id": request.plan_id,
+            }
+        ),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _selector_prefix(kind: str) -> str:
+    return kind.replace("_", "-")
+
+
+def _selector_parts(selector: str) -> tuple[str, str]:
+    if not isinstance(selector, str):
+        raise StructuralReferenceAdapterError("selector must be a string")
+    prefix, separator, logical_id = selector.partition(":")
+    if not separator or not prefix or not logical_id:
+        raise StructuralReferenceAdapterError(f"invalid selector: {selector!r}")
+    return prefix, logical_id
+
+
+def _required_entries(required: Any) -> tuple[Mapping[str, Any], ...]:
+    """Normalize ordered selection mappings without losing their order."""
+
+    if isinstance(required, Mapping):
+        for key in ("selections", "required", "evidence"):
+            if key in required:
+                return _required_entries(required[key])
+        if "required_role_kinds" in required:
+            role_kinds = required["required_role_kinds"]
+            selector_ids = required.get("selector_ids", {})
+            if not isinstance(role_kinds, Sequence) or not isinstance(selector_ids, Mapping):
+                raise StructuralReferenceAdapterError("required evidence mapping is malformed")
+            entries = []
+            for pair in role_kinds:
+                if (
+                    not isinstance(pair, Sequence)
+                    or len(pair) != 2
+                    or not all(isinstance(item, str) for item in pair)
+                ):
+                    raise StructuralReferenceAdapterError("required role/kind entry is malformed")
+                role, kind = pair
+                if kind == "window":
+                    entry = {"role": role, "selector_kind": kind}
+                    selector = selector_ids.get(role, selector_ids.get(kind))
+                    if selector is not None:
+                        if not isinstance(selector, str):
+                            raise StructuralReferenceAdapterError(
+                                f"{role} has an invalid exact selector mapping"
+                            )
+                        entry["selector"] = selector
+                    entries.append(entry)
+                else:
+                    selector = selector_ids.get(role, selector_ids.get(kind))
+                    if not isinstance(selector, str):
+                        raise StructuralReferenceAdapterError(
+                            f"{role} has no exact selector mapping"
+                        )
+                    entries.append({"role": role, "selector_kind": kind, "selector": selector})
+            return tuple(entries)
+        entries = []
+        for role, value in required.items():
+            if not isinstance(role, str):
+                raise StructuralReferenceAdapterError("evidence roles must be strings")
+            if isinstance(value, Mapping):
+                item = dict(value)
+                item.setdefault("role", role)
+                entries.append(item)
+            elif isinstance(value, str):
+                entries.append({"role": role, "selector": value})
+            else:
+                raise StructuralReferenceAdapterError("evidence selection must be a mapping")
+        return tuple(entries)
+    if isinstance(required, Sequence) and not isinstance(required, (str, bytes)):
+        if not all(isinstance(item, Mapping) for item in required):
+            raise StructuralReferenceAdapterError("evidence selections must be mappings")
+        return tuple(required)
+    raise StructuralReferenceAdapterError("required evidence selections are malformed")
+
+
+class StructuralReferenceFactAdapter:
+    """Build permitted canonical facts and evidence from structural mappings."""
+
+    source_name = "structural_reference"
+
+    def __init__(
+        self,
+        plan_contract: Mapping[str, Any],
+        selector_contract: Mapping[str, Any],
+    ) -> None:
+        self._plan_contract = _mapping(plan_contract, "plan contract")
+        selector_contract = _mapping(selector_contract, "selector contract")
+        ownership = selector_contract.get("ownership", ())
+        if not isinstance(ownership, Sequence):
+            raise StructuralReferenceAdapterError("selector ownership is malformed")
+        self._owner_rules = {
+            item["kind"]: item
+            for item in ownership
+            if isinstance(item, Mapping) and isinstance(item.get("kind"), str)
+        }
+
+    def materialize(
+        self,
+        declarations: Mapping[str, Any],
+        request: PlanRequest,
+        required_evidence: Any,
+    ) -> AdapterMaterialization:
+        declarations = self._validate_declarations(declarations)
+        if not isinstance(request, PlanRequest):
+            raise StructuralReferenceAdapterError("request must be a PlanRequest")
+        _assert_structural(request.parameters, path="request.parameters")
+        _assert_structural(required_evidence, path="required_evidence")
+        plan = self._plan(request.plan_id)
+        permitted = self._permitted_sources(plan)
+        raw_facts = self._facts(declarations["facts"])
+        facts = [
+            CanonicalFact(
+                relation,
+                logical_id,
+                _selected_fact_values(relation, values, permitted[relation]),
+                coordinates,
+            )
+            for relation, logical_id, values, coordinates in raw_facts
+            if relation in permitted
+        ]
+        if "valuation_match" in permitted:
+            facts = [fact for fact in facts if fact.relation != "valuation_match"]
+            facts.extend(
+                self._valuation_facts(declarations, raw_facts, permitted["valuation_match"])
+            )
+        if not facts:
+            raise StructuralReferenceAdapterError(
+                f"scenario has no permitted facts for {request.plan_id}"
+            )
+        references = self._evidence(declarations, request, required_evidence, raw_facts)
+        ordered = tuple(sorted(facts, key=lambda fact: fact.coordinates.key(fact.logical_id)))
+        return AdapterMaterialization(
+            request=request,
+            facts=ordered,
+            evidence_references=references,
+            source=self.source_name,
+            snapshot_token=declarations["scenario_id"],
+        )
+
+    def _validate_declarations(self, declarations: Mapping[str, Any]) -> Mapping[str, Any]:
+        _assert_structural(declarations)
+        declarations = _mapping(declarations, "structural declarations")
+        if declarations.get("schema") not in _STRUCTURAL_SCHEMAS:
+            raise StructuralReferenceAdapterError("unsupported structural-v2 schema")
+        scenario_id = declarations.get("scenario_id")
+        if not isinstance(scenario_id, str) or not scenario_id:
+            raise StructuralReferenceAdapterError("scenario_id must be non-empty")
+        for key in (
+            "facts",
+            "occurrences",
+            "selector_entities",
+            "source_manifestations",
+        ):
+            if key not in declarations or not isinstance(declarations[key], (Mapping, Sequence)):
+                raise StructuralReferenceAdapterError(f"{key} is missing or malformed")
+        return declarations
+
+    def _plan(self, plan_id: str) -> Mapping[str, Any]:
+        if self._plan_contract.get("schema") != "codex-usage-tracker.plan-operand-contract.v1":
+            raise StructuralReferenceAdapterError("unsupported plan operand contract")
+        plans = self._plan_contract.get("plans")
+        if not isinstance(plans, Sequence):
+            raise StructuralReferenceAdapterError("plan contract plans are malformed")
+        matches = [
+            item for item in plans if isinstance(item, Mapping) and item.get("plan_id") == plan_id
+        ]
+        if len(matches) != 1:
+            raise StructuralReferenceAdapterError(f"plan must resolve exactly once: {plan_id}")
+        return matches[0]
+
+    @staticmethod
+    def _permitted_sources(plan: Mapping[str, Any]) -> dict[str, frozenset[str]]:
+        sources = plan.get("permitted_sources")
+        if not isinstance(sources, Sequence):
+            raise StructuralReferenceAdapterError("permitted_sources are malformed")
+        permitted: dict[str, frozenset[str]] = {}
+        for source in sources:
+            if not isinstance(source, Mapping):
+                raise StructuralReferenceAdapterError("permitted source is malformed")
+            relation, fields = source.get("relation"), source.get("fields")
+            if not isinstance(relation, str) or not isinstance(fields, Sequence):
+                raise StructuralReferenceAdapterError("permitted source identity is malformed")
+            if any(not isinstance(field, str) for field in fields):
+                raise StructuralReferenceAdapterError("permitted source fields must be strings")
+            permitted[relation] = frozenset(fields)
+        return permitted
+
+    @staticmethod
+    def _facts(raw: Any) -> tuple[tuple[str, str, Mapping[str, Any], FactCoordinates], ...]:
+        if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+            raise StructuralReferenceAdapterError("facts must be an ordered sequence")
+        result = []
+        for index, item in enumerate(raw):
+            item = _mapping(item, f"facts[{index}]")
+            relation = item.get("relation")
+            logical_id = item.get("logical_id")
+            values = item.get("values", {})
+            if not isinstance(relation, str) or not relation:
+                raise StructuralReferenceAdapterError(f"facts[{index}] has no relation")
+            if not isinstance(logical_id, str) or not logical_id:
+                raise StructuralReferenceAdapterError(f"facts[{index}] has no logical_id")
+            values = _mapping(values, f"facts[{index}].values")
+            result.append((relation, logical_id, values, _coordinates(item, f"facts[{index}]")))
+        return tuple(result)
+
+    @staticmethod
+    def _frontier(raw: Any) -> RateCardFrontier | None:
+        if raw is None:
+            return None
+        if not isinstance(raw, Mapping):
+            raise StructuralReferenceAdapterError("rate_card_frontier must be a mapping or null")
+        revisions = raw.get("revisions")
+        if not isinstance(revisions, Sequence):
+            raise StructuralReferenceAdapterError("rate_card_frontier revisions are malformed")
+        typed: list[RateCardRevision] = []
+        required = (
+            "rate_card_id",
+            "digest",
+            "source_name",
+            "currency",
+            "model_match_rules",
+            "four_class_rates",
+            "credit_rates",
+            "reasoning_in_output",
+            "confidence",
+            "validation_status",
+        )
+        for index, value in enumerate(revisions):
+            value = _mapping(value, f"rate_card_frontier.revisions[{index}]")
+            missing = [field for field in required if field not in value]
+            if missing:
+                raise StructuralReferenceAdapterError(
+                    f"rate-card revision is missing fields: {missing}"
+                )
+            typed.append(
+                RateCardRevision(
+                    rate_card_id=value["rate_card_id"],
+                    digest=value["digest"],
+                    predecessor_digest=value.get("predecessor_digest"),
+                    effective_at_us=value.get("effective_at_us"),
+                    fetched_at_us=value.get("fetched_at_us"),
+                    source_name=value["source_name"],
+                    source_url=value.get("source_url"),
+                    currency=value["currency"],
+                    model_match_rules=tuple(value["model_match_rules"]),
+                    four_class_rates=value["four_class_rates"],
+                    credit_rates=value["credit_rates"],
+                    reasoning_in_output=value["reasoning_in_output"],
+                    confidence=value["confidence"],
+                    validation_status=value["validation_status"],
+                )
+            )
+        return RateCardFrontier(head_digest=raw.get("head_digest"), revisions=tuple(typed))
+
+    def _valuation_facts(
+        self,
+        declarations: Mapping[str, Any],
+        raw_facts: Sequence[tuple[str, str, Mapping[str, Any], FactCoordinates]],
+        permitted_fields: frozenset[str],
+    ) -> tuple[CanonicalFact, ...]:
+        calls = []
+        profiles = []
+        coordinates: dict[str, FactCoordinates] = {}
+        for relation, logical_id, values, fact_coordinates in raw_facts:
+            if relation == "canonical_call":
+                call_id = values.get("call_id", logical_id)
+                coordinates[logical_id] = fact_coordinates
+                if isinstance(call_id, str):
+                    coordinates[call_id] = fact_coordinates
+                calls.append(
+                    {
+                        "call_id": call_id,
+                        "model_profile_id": values.get("model_profile_id"),
+                        "uncached_input_tokens": values.get("uncached_input_tokens"),
+                        "cached_input_tokens": values.get("cached_input_tokens"),
+                        "reasoning_tokens": values.get("reasoning_tokens"),
+                        "output_tokens": values.get("output_tokens"),
+                        "event_at_us": fact_coordinates.event_at_us,
+                    }
+                )
+            elif relation == "model_profile":
+                profiles.append(
+                    {
+                        "model_profile_id": values.get("model_profile_id", logical_id),
+                        "model": values.get("model"),
+                        "reasoning_effort": values.get("effort", values.get("reasoning_effort")),
+                        "service_tier": values.get("tier", values.get("service_tier")),
+                    }
+                )
+        publication_digest = declarations.get("publication_rate_card_digest")
+        if publication_digest is not None and not isinstance(publication_digest, str):
+            raise StructuralReferenceAdapterError(
+                "publication_rate_card_digest must be a string or null"
+            )
+        try:
+            matches = compile_current_valuation_matches(
+                calls,
+                profiles,
+                self._frontier(declarations.get("rate_card_frontier")),
+                publication_rate_card_digest=publication_digest,
+            )
+        except (TypeError, ValueError) as error:
+            raise StructuralReferenceAdapterError(
+                f"valuation declarations are invalid: {error}"
+            ) from error
+        result = []
+        for match in matches:
+            values = {
+                "call_id": match.call_id,
+                "configured_cost_usd": match.configured_cost_usd,
+                "coverage_basis": {
+                    "cost": match.cost_coverage,
+                    "credit": match.credit_coverage,
+                    "rate_card_digest": match.rate_card_digest,
+                },
+                "cost_grade": match.cost_grade,
+                "estimated_credits": match.estimated_credits,
+                "match_basis": match.match_basis,
+                "rate_card_digest": match.rate_card_digest,
+                "unpriced_reason": match.cost_unpriced_reason or match.credit_unpriced_reason,
+                "cost_unpriced_reason": match.cost_unpriced_reason,
+            }
+            logical_id = match.valuation_id or semantic_id(
+                "valuation", [match.call_id, match.rate_card_digest or publication_digest]
+            )
+            result.append(
+                CanonicalFact(
+                    "valuation_match",
+                    logical_id,
+                    {key: value for key, value in values.items() if key in permitted_fields},
+                    coordinates.get(match.call_id),
+                )
+            )
+        return tuple(result)
+
+    def _evidence(
+        self,
+        declarations: Mapping[str, Any],
+        request: PlanRequest,
+        required: Any,
+        raw_facts: Sequence[tuple[str, str, Mapping[str, Any], FactCoordinates]],
+    ) -> tuple[EvidenceReference, ...]:
+        entries = _required_entries(required)
+        references: list[EvidenceReference] = []
+        for index, entry in enumerate(entries):
+            entry = _mapping(entry, f"required_evidence[{index}]")
+            role = entry.get("role")
+            kind = entry.get("selector_kind", entry.get("kind"))
+            selector = entry.get("selector")
+            if (
+                not isinstance(role, str)
+                or not role
+                or not isinstance(kind, str)
+                or kind not in _SELECTOR_KINDS
+            ):
+                raise StructuralReferenceAdapterError("evidence role or selector kind is invalid")
+            if kind == "window":
+                window = self._window(request, role)
+                request_digest = _request_digest(request)
+                derived_logical_id = semantic_id(
+                    "window",
+                    [
+                        request_digest,
+                        role,
+                        window["start_us"],
+                        window["end_us"],
+                        window["timezone"],
+                    ],
+                )
+                expected_selector = f"{_selector_prefix(kind)}:{derived_logical_id}"
+                if selector is not None and selector != expected_selector:
+                    raise StructuralReferenceAdapterError(
+                        f"{role} window selector does not match its request identity"
+                    )
+                supplied_logical_id = entry.get("logical_id")
+                if supplied_logical_id is not None and supplied_logical_id != derived_logical_id:
+                    raise StructuralReferenceAdapterError(
+                        f"{role} window logical ID does not match its request identity"
+                    )
+                selector = expected_selector
+                logical_id = derived_logical_id
+                provenance = {
+                    "end_us": window["end_us"],
+                    "parameter_role": role,
+                    "request_digest": request_digest,
+                    "start_us": window["start_us"],
+                    "timezone": window["timezone"],
+                }
+            else:
+                if not isinstance(selector, str):
+                    raise StructuralReferenceAdapterError(f"{role} has no exact selector")
+                prefix, selector_logical_id = _selector_parts(selector)
+                selected_logical_id = entry.get("logical_id", selector_logical_id)
+                if not isinstance(selected_logical_id, str) or not selected_logical_id:
+                    raise StructuralReferenceAdapterError(f"{role} has no logical selector")
+                if prefix != _selector_prefix(kind):
+                    raise StructuralReferenceAdapterError(
+                        f"{role} selector prefix does not match {kind}"
+                    )
+                if kind == "rate_card":
+                    selected_digest = self._selected_frontier_digest(declarations)
+                    if (
+                        selector_logical_id != selected_digest
+                        or selected_logical_id != selected_digest
+                    ):
+                        raise StructuralReferenceAdapterError(
+                            f"{role} rate-card selector and logical ID must equal "
+                            "the selected publication frontier digest"
+                        )
+                    logical_id = selected_digest
+                else:
+                    logical_id = selected_logical_id
+                if kind != "rate_card" and logical_id != selector_logical_id:
+                    raise StructuralReferenceAdapterError(
+                        f"{role} selector does not identify its selected entity"
+                    )
+                provenance_kind, provenance = self._provenance(
+                    declarations, kind, logical_id, raw_facts
+                )
+                if kind == "rate_card" and _selector_parts(selector)[1] != provenance.get("digest"):
+                    raise StructuralReferenceAdapterError(
+                        f"{role} rate-card selector does not identify its revision"
+                    )
+                references.append(
+                    EvidenceReference(role, kind, selector, logical_id, provenance_kind, provenance)
+                )
+                continue
+            references.append(
+                EvidenceReference(
+                    role, kind, selector, logical_id, "request_derivation", provenance
+                )
+            )
+        self._validate_evidence(entries, references, declarations)
+        return tuple(references)
+
+    @staticmethod
+    def _window(request: PlanRequest, role: str) -> Mapping[str, Any]:
+        if role not in request.parameters:
+            raise StructuralReferenceAdapterError(f"{role} has no typed request window")
+        value = request.parameters[role]
+        if not isinstance(value, Mapping):
+            raise StructuralReferenceAdapterError(f"{role} has no typed request window")
+        start = _integer(value.get("start_us"), f"{role}.start_us")
+        end = _integer(value.get("end_us"), f"{role}.end_us")
+        timezone = value.get("timezone", "UTC")
+        if not isinstance(timezone, str) or not timezone or end < start:
+            raise StructuralReferenceAdapterError(f"{role} has an invalid request window")
+        return {"start_us": start, "end_us": end, "timezone": timezone}
+
+    def _provenance(
+        self,
+        declarations: Mapping[str, Any],
+        kind: str,
+        logical_id: str,
+        raw_facts: Sequence[tuple[str, str, Mapping[str, Any], FactCoordinates]],
+    ) -> tuple[str, Mapping[str, Any]]:
+        self._require_owner(kind)
+        entities = declarations["selector_entities"]
+        if not isinstance(entities, Mapping) or logical_id not in entities.get(kind, ()):
+            raise StructuralReferenceAdapterError(
+                f"selector has no scenario-owned entity: {logical_id}"
+            )
+        rule = self._owner_rules[kind]
+        provenance_kind = rule.get("provenance_kind")
+        if not isinstance(provenance_kind, str):
+            raise StructuralReferenceAdapterError(f"owner rule is malformed for {kind}")
+        if provenance_kind == "source_occurrence":
+            provenance = self._source_occurrence_provenance(
+                declarations, kind, logical_id, raw_facts
+            )
+        elif provenance_kind == "configured_artifact":
+            provenance = self._rate_card_provenance(declarations, logical_id)
+        elif provenance_kind == "publication_commit":
+            provenance = self._publication_provenance(raw_facts, logical_id)
+        elif provenance_kind == "derived_boundary_pair":
+            provenance = self._boundary_provenance(declarations, logical_id)
+        elif provenance_kind == "source_inventory":
+            manifestations = _mapping(
+                declarations["source_manifestations"], "source_manifestations"
+            )
+            provenance = _mapping(
+                manifestations.get(logical_id), f"source_manifestations.{logical_id}"
+            )
+        else:
+            raise StructuralReferenceAdapterError(
+                f"unsupported owner provenance: {provenance_kind}"
+            )
+        required = rule.get("required_provenance_fields", ())
+        if not isinstance(required, Sequence) or any(
+            field not in provenance or provenance[field] in (None, "", [], {}) for field in required
+        ):
+            raise StructuralReferenceAdapterError(f"{kind} provenance is incomplete")
+        return provenance_kind, provenance
+
+    def _require_owner(self, kind: str) -> None:
+        if kind not in self._owner_rules:
+            raise StructuralReferenceAdapterError(f"selector owner is missing for {kind}")
+
+    @staticmethod
+    def _source_occurrence_provenance(
+        declarations: Mapping[str, Any],
+        kind: str,
+        logical_id: str,
+        raw_facts: Sequence[tuple[str, str, Mapping[str, Any], FactCoordinates]],
+    ) -> Mapping[str, Any]:
+        if kind == "model_profile":
+            calls = [
+                call_id
+                for relation, call_id, values, _coordinates_value in raw_facts
+                if relation == "canonical_call" and values.get("model_profile_id") == logical_id
+            ]
+            occurrences_by_id = _mapping(declarations["occurrences"], "occurrences")
+            representative: list[Mapping[str, Any]] = []
+            for call_id in sorted(calls):
+                call_occurrences = occurrences_by_id.get(call_id)
+                if (
+                    not isinstance(call_occurrences, Sequence)
+                    or isinstance(call_occurrences, (str, bytes))
+                    or not call_occurrences
+                    or any(not isinstance(item, Mapping) or not item for item in call_occurrences)
+                ):
+                    raise StructuralReferenceAdapterError(
+                        f"{logical_id} has no representative call occurrence"
+                    )
+                representative.extend(
+                    _ordered_occurrences(
+                        call_occurrences,
+                        f"{logical_id} representative call",
+                    )
+                )
+            profile = next(
+                (
+                    values
+                    for relation, fact_id, values, _coordinates_value in raw_facts
+                    if relation == "model_profile" and fact_id == logical_id
+                ),
+                None,
+            )
+            if not representative:
+                raise StructuralReferenceAdapterError(
+                    f"{logical_id} has no representative call occurrence"
+                )
+            profile_tuple = {
+                "model": profile.get("model") if profile else None,
+                "reasoning_effort": profile.get("effort", profile.get("reasoning_effort"))
+                if profile
+                else None,
+                "service_tier": profile.get("tier", profile.get("service_tier"))
+                if profile
+                else None,
+            }
+            if any(value in (None, "") for value in profile_tuple.values()):
+                raise StructuralReferenceAdapterError(
+                    f"{logical_id} has incomplete profile provenance"
+                )
+            return {
+                "profile_tuple": profile_tuple,
+                "representative_call_selectors": [f"call:{call_id}" for call_id in sorted(calls)],
+                "representative_call_occurrences": _ordered_occurrences(
+                    representative,
+                    f"{logical_id} representative calls",
+                ),
+            }
+        occurrences = _mapping(declarations["occurrences"], "occurrences").get(logical_id)
+        if (
+            not isinstance(occurrences, Sequence)
+            or isinstance(occurrences, (str, bytes))
+            or not occurrences
+        ):
+            raise StructuralReferenceAdapterError(f"{logical_id} has no source occurrence")
+        if any(not isinstance(item, Mapping) or not item for item in occurrences):
+            raise StructuralReferenceAdapterError(
+                f"{logical_id} has invalid source occurrence provenance"
+            )
+        return {
+            "occurrences": _ordered_occurrences(
+                occurrences,
+                logical_id,
+            )
+        }
+
+    @staticmethod
+    def _selected_frontier_digest(declarations: Mapping[str, Any]) -> str:
+        digest = declarations.get("publication_rate_card_digest")
+        frontier = declarations.get("rate_card_frontier")
+        if not isinstance(frontier, Mapping):
+            raise StructuralReferenceAdapterError("rate card evidence has no frontier")
+        if not isinstance(digest, str) or not digest:
+            raise StructuralReferenceAdapterError(
+                "rate card evidence has no selected publication digest"
+            )
+        if frontier.get("head_digest") != digest:
+            raise StructuralReferenceAdapterError(
+                "rate card evidence does not match the selected publication frontier"
+            )
+        return digest
+
+    @classmethod
+    def _rate_card_provenance(
+        cls, declarations: Mapping[str, Any], logical_id: str
+    ) -> Mapping[str, Any]:
+        selected_digest = cls._selected_frontier_digest(declarations)
+        if logical_id != selected_digest:
+            raise StructuralReferenceAdapterError(
+                "rate card logical ID must equal the selected publication frontier digest"
+            )
+        frontier = _mapping(declarations["rate_card_frontier"], "rate_card_frontier")
+        revisions = frontier.get("revisions")
+        if not isinstance(revisions, Sequence) or isinstance(revisions, (str, bytes)):
+            raise StructuralReferenceAdapterError("rate card frontier revisions are malformed")
+        matches = [
+            revision
+            for revision in revisions
+            if isinstance(revision, Mapping) and revision.get("digest") == selected_digest
+        ]
+        if len(matches) != 1:
+            raise StructuralReferenceAdapterError(
+                "selected publication rate-card digest is not uniquely captured in the frontier"
+            )
+        revision = matches[0]
+        return {
+            "digest": revision.get("digest"),
+            "fetched_at_us": revision.get("fetched_at_us"),
+            "source_name": revision.get("source_name"),
+            "validation_status": revision.get("validation_status"),
+        }
+
+    @staticmethod
+    def _publication_provenance(
+        raw_facts: Sequence[tuple[str, str, Mapping[str, Any], FactCoordinates]], logical_id: str
+    ) -> Mapping[str, Any]:
+        for relation, fact_id, values, _coordinates_value in raw_facts:
+            if relation == "publication" and fact_id == logical_id:
+                return {
+                    "artifact_manifest_sha256": values.get("artifact_manifest_sha256"),
+                    "committed_at_us": values.get("committed_at_us"),
+                    "operation_id": values.get("operation_id"),
+                }
+        raise StructuralReferenceAdapterError(
+            f"publication is not a scenario-owned fact: {logical_id}"
+        )
+
+    @staticmethod
+    def _boundary_provenance(declarations: Mapping[str, Any], logical_id: str) -> Mapping[str, Any]:
+        entities = _mapping(declarations["selector_entities"], "selector_entities")
+        observations = entities.get("allowance_observation")
+        if isinstance(observations, (str, bytes)) or not isinstance(observations, Sequence):
+            raise StructuralReferenceAdapterError("allowance observation entities are malformed")
+        intervals = declarations.get("allowance_intervals")
+        if not isinstance(intervals, Mapping):
+            raise StructuralReferenceAdapterError("allowance interval boundary mapping is missing")
+        interval = intervals.get(logical_id)
+        if not isinstance(interval, Mapping):
+            raise StructuralReferenceAdapterError(
+                f"allowance interval has no boundary mapping: {logical_id}"
+            )
+        start = interval.get("start_observation_id")
+        end = interval.get("end_observation_id")
+        if (
+            not isinstance(start, str)
+            or not start
+            or not isinstance(end, str)
+            or not end
+            or start == end
+            or start not in observations
+            or end not in observations
+        ):
+            raise StructuralReferenceAdapterError(
+                f"allowance interval has malformed or nonexistent boundaries: {logical_id}"
+            )
+        occurrences = _mapping(declarations["occurrences"], "occurrences")
+
+        def boundary_occurrences(observation_id: str) -> list[Mapping[str, Any]]:
+            values = occurrences.get(observation_id)
+            if (
+                not isinstance(values, Sequence)
+                or isinstance(values, (str, bytes))
+                or not values
+                or any(not isinstance(item, Mapping) or not item for item in values)
+            ):
+                raise StructuralReferenceAdapterError(
+                    f"allowance interval boundary has no real occurrences: {observation_id}"
+                )
+            return _ordered_occurrences(values, observation_id)
+
+        start_occurrences = boundary_occurrences(start)
+        end_occurrences = boundary_occurrences(end)
+        return {
+            "compatibility_version": "allowance-compatibility-v1",
+            "end_observation_selector": f"allowance-observation:{end}",
+            "end_occurrences": end_occurrences,
+            "start_observation_selector": f"allowance-observation:{start}",
+            "start_occurrences": start_occurrences,
+        }
+
+    def _validate_evidence(
+        self,
+        entries: Sequence[Mapping[str, Any]],
+        references: Sequence[EvidenceReference],
+        declarations: Mapping[str, Any],
+    ) -> None:
+        expected: list[tuple[str, str, str]] = []
+        for entry in entries:
+            role = entry.get("role")
+            kind = entry.get("selector_kind", entry.get("kind"))
+            selector = entry.get("selector")
+            if kind == "window" and selector is None:
+                selector = next(item.selector for item in references if item.role == role)
+            if (
+                not isinstance(role, str)
+                or not isinstance(kind, str)
+                or not isinstance(selector, str)
+            ):
+                raise StructuralReferenceAdapterError("required evidence triple is malformed")
+            expected.append((role, kind, selector))
+        actual = [(item.role, item.selector_kind, item.selector) for item in references]
+        if expected != actual:
+            raise StructuralReferenceAdapterError(
+                "required and materialized evidence selections differ"
+            )
+        for reference in references:
+            if reference.selector_kind != "window":
+                entities = _mapping(declarations["selector_entities"], "selector_entities")
+                if reference.logical_id not in entities.get(reference.selector_kind, ()):
+                    raise StructuralReferenceAdapterError(
+                        f"{reference.role} references no scenario-owned entity"
+                    )
+
+
+__all__ = [
+    "AdapterMaterialization",
+    "EvidenceReference",
+    "StructuralReferenceAdapterError",
+    "StructuralReferenceFactAdapter",
+]

--- a/tests/agent_kernel/fact_adapters/support.py
+++ b/tests/agent_kernel/fact_adapters/support.py
@@ -1,0 +1,1468 @@
+"""Synthetic, body-free CK-07E declarations and database-v1 snapshots.
+
+This module is test setup only.  Neither adapter imports it: the reference
+adapter receives the structural declaration value, while the database adapter
+receives only the sealed query-only connection produced here.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sqlite3
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from codex_usage_tracker.agent_kernel.domain.identity import semantic_id
+from codex_usage_tracker.agent_kernel.domain.plan_operands import PlanRequest
+from codex_usage_tracker.agent_kernel.storage.schema import schema_ddl
+
+ROOT = Path(__file__).resolve().parents[3]
+PLAN_CONTRACT_PATH = ROOT / "config/agent-kernel/plan-operand-contract-v1.json"
+SELECTOR_CONTRACT_PATH = ROOT / "config/agent-kernel/selector-provenance-v1.json"
+
+OLD_DIGEST = "1" * 64
+HEAD_DIGEST = "2" * 64
+PUBLICATION_ID = "publication:ck07e"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError(f"{path} must contain one object")
+    return value
+
+
+def plan_contract() -> dict[str, Any]:
+    return load_json(PLAN_CONTRACT_PATH)
+
+
+def selector_contract() -> dict[str, Any]:
+    return load_json(SELECTOR_CONTRACT_PATH)
+
+
+def _request_digest(request: PlanRequest) -> str:
+    def normalize(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, Mapping):
+            return {
+                str(key): normalize(item)
+                for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            }
+        if isinstance(value, (list, tuple)):
+            return [normalize(item) for item in value]
+        return value
+
+    payload = json.dumps(
+        normalize(
+            {
+                "gates": request.gates,
+                "parameters": request.parameters,
+                "plan_id": request.plan_id,
+            }
+        ),
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _coordinates(
+    event_at_us: int | None,
+    source_order: int,
+    event_kind_order: int = 10,
+    transition_rank: int = 0,
+) -> dict[str, int | None]:
+    return {
+        "event_at_us": event_at_us,
+        "source_rank": 1,
+        "source_order": source_order,
+        "event_kind_order": event_kind_order,
+        "transition_rank": transition_rank,
+    }
+
+
+def _fact(
+    relation: str,
+    logical_id: str,
+    values: Mapping[str, Any],
+    coordinates: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "relation": relation,
+        "logical_id": logical_id,
+        "values": dict(values),
+        "coordinates": None if coordinates is None else dict(coordinates),
+    }
+
+
+def _occurrence(logical_id: str, ordinal: int, *, revision: str) -> dict[str, Any]:
+    manifestation = (
+        "source-manifestation:replacement"
+        if revision == "replacement"
+        else "source-manifestation:active"
+    )
+    return {
+        "occurrence_id": f"occurrence:{revision}:{ordinal}",
+        "semantic_logical_id": logical_id,
+        "source_manifestation_id": manifestation,
+        "source_revision": f"{revision}-v1",
+        "record_ordinal": ordinal,
+        "byte_start": ordinal * 100,
+        "byte_end": ordinal * 100 + 80,
+        "adapter_version": "codex-jsonl.synthetic-v2",
+    }
+
+
+def build_structural_v2(
+    *,
+    lifecycle: str = "initial",
+    include_late_call: bool = False,
+    null_cached_tokens: bool = False,
+) -> dict[str, Any]:
+    """Return one rich structural-v2 declaration spanning all fact families."""
+
+    if lifecycle not in {"initial", "rebuild", "replacement", "late_event"}:
+        raise ValueError(f"unsupported lifecycle: {lifecycle}")
+    revision = "replacement" if lifecycle == "replacement" else "active"
+    facts: list[dict[str, Any]] = []
+    order = 1
+
+    def add(
+        relation: str,
+        logical_id: str,
+        values: Mapping[str, Any],
+        event_at_us: int | None = None,
+        *,
+        event_kind_order: int = 10,
+        transition_rank: int = 0,
+    ) -> None:
+        nonlocal order
+        facts.append(
+            _fact(
+                relation,
+                logical_id,
+                values,
+                _coordinates(event_at_us, order, event_kind_order, transition_rank),
+            )
+        )
+        order += 1
+
+    add("project", "project:alpha", {"project_id": "project:alpha", "parent_project_id": None})
+    add(
+        "session",
+        "session:root",
+        {
+            "session_id": "session:root",
+            "project_id": "project:alpha",
+            "root_session_id": "session:root",
+            "parent_session_id": None,
+            "delegation_depth": 0,
+            "start_at_us": 50,
+            "end_at_us": 500,
+            "lifecycle_state": "succeeded",
+            "completion_basis": "terminal_event",
+        },
+        50,
+    )
+    add(
+        "session",
+        "session:child",
+        {
+            "session_id": "session:child",
+            "project_id": "project:alpha",
+            "root_session_id": "session:root",
+            "parent_session_id": "session:root",
+            "delegation_depth": 1,
+            "start_at_us": 150,
+            "end_at_us": 450,
+            "lifecycle_state": "succeeded",
+            "completion_basis": "terminal_event",
+        },
+        150,
+    )
+    for ordinal, (turn_id, session_id, start, end) in enumerate(
+        (
+            ("turn:root", "session:root", 75, 240),
+            ("turn:child", "session:child", 175, 440),
+        ),
+        start=1,
+    ):
+        add(
+            "turn",
+            turn_id,
+            {
+                "turn_id": turn_id,
+                "session_id": session_id,
+                "ordinal": ordinal,
+                "lifecycle": "succeeded",
+                "lifecycle_state": "succeeded",
+                "start_at_us": start,
+                "end_at_us": end,
+                "completion_basis": "terminal_event",
+                "first_boundary_coordinates": {
+                    "event_at_us": start,
+                    "source_rank": 1,
+                    "source_order": order,
+                },
+            },
+            start,
+        )
+    add(
+        "model_profile",
+        "profile:alpha",
+        {
+            "model_profile_id": "profile:alpha",
+            "model": "synthetic-model",
+            "effort": "high",
+            "tier": "priority",
+        },
+    )
+    add(
+        "model_profile",
+        "profile:beta",
+        {
+            "model_profile_id": "profile:beta",
+            "model": "synthetic-other",
+            "effort": "medium",
+            "tier": "standard",
+        },
+    )
+    call_rows = [
+        ("call:before", "session:root", "turn:root", "profile:alpha", 100, 100, 20, 5, 10),
+        ("call:boundary", "session:child", "turn:child", "profile:alpha", 250, 200, 40, 10, 20),
+        ("call:other", "session:child", "turn:child", "profile:beta", 300, 300, 60, 15, 30),
+    ]
+    if include_late_call:
+        call_rows.append(
+            ("call:late", "session:root", "turn:root", "profile:alpha", 125, 80, 10, 2, 8)
+        )
+    priced_call_count = sum(
+        1 for row in call_rows if not (null_cached_tokens and row[0] == "call:before")
+    )
+    for (
+        call_id,
+        session_id,
+        turn_id,
+        profile_id,
+        at,
+        uncached,
+        cached,
+        reasoning,
+        output,
+    ) in call_rows:
+        add(
+            "canonical_call",
+            call_id,
+            {
+                "call_id": call_id,
+                "session_id": session_id,
+                "turn_id": turn_id,
+                "model_profile_id": profile_id,
+                "project_id": "project:alpha",
+                "tool_id": None,
+                "context_window_tokens": 128_000,
+                "uncached_input_tokens": uncached,
+                "cached_input_tokens": None
+                if null_cached_tokens and call_id == "call:before"
+                else cached,
+                "reasoning_tokens": reasoning,
+                "output_tokens": output,
+                "lifecycle": "succeeded",
+            },
+            at,
+        )
+    add("resource", "resource:file", {"resource_id": "resource:file", "resource_kind": "file"})
+    add(
+        "resource",
+        "resource:test",
+        {"resource_id": "resource:test", "resource_kind": "test_target"},
+    )
+    tool_rows = (
+        ("tool:inspect", "read", "read", "resource:file", False, "succeeded", 180),
+        ("tool:attempt", "execute", "write", "resource:file", True, "failed", 200),
+        ("tool:retry", "test", "test", "resource:test", True, "succeeded", 220),
+    )
+    for tool_id, operation, family, resource_id, write_intent, lifecycle_state, at in tool_rows:
+        resource_links = (
+            ["resource:file", "resource:test"] if tool_id == "tool:inspect" else [resource_id]
+        )
+        add(
+            "tool_invocation",
+            tool_id,
+            {
+                "tool_id": tool_id,
+                "session_id": "session:root",
+                "turn_id": "turn:root",
+                "transport_name": "synthetic",
+                "semantic_operation": operation,
+                "tool_family": family,
+                "resource_id": resource_id,
+                "resource_links": resource_links,
+                "resource_kind": "file" if resource_id == "resource:file" else "test_target",
+                "write_intent": write_intent,
+                "lifecycle": lifecycle_state,
+                "duration_us": 25,
+                "output_bytes": 64,
+                "error_category": "synthetic_failure" if lifecycle_state == "failed" else None,
+            },
+            at,
+        )
+    add(
+        "state_change",
+        "state-change:file",
+        {
+            "state_change_id": "state-change:file",
+            "session_id": "session:root",
+            "turn_id": "turn:root",
+            "resource_id": "resource:file",
+            "mutation_kind": "modified",
+        },
+        210,
+    )
+    add(
+        "compaction_boundary",
+        "compaction:one",
+        {"compaction_id": "compaction:one", "session_id": "session:root"},
+        230,
+    )
+    for index, category in enumerate(("tool_output", "workspace_context"), start=1):
+        add(
+            "context_component",
+            f"context-component:{index}",
+            {
+                "component_id": f"context-component:{index}",
+                "session_id": "session:root",
+                "turn_id": "turn:root",
+                "call_id": "call:boundary",
+                "category": category,
+                "observed_utf8_bytes": 1000 * index,
+                "estimated_tokens": 250 * index,
+                "total_context_utf8_bytes": 5000,
+            },
+            235 + index,
+        )
+    for index, (observed_at_us, allowance_percent) in enumerate(
+        (
+            (90, Decimal("90")),
+            (190, Decimal("80")),
+            (190, Decimal("80")),
+            (290, Decimal("70")),
+        ),
+        start=1,
+    ):
+        add(
+            "allowance_observation",
+            f"allowance-observation:{index}",
+            {
+                "observation_id": f"allowance-observation:{index}",
+                "limit_id": "allowance-limit:weekly",
+                "provider": "synthetic-provider",
+                "plan": "synthetic-plan",
+                "window_kind": "rolling_week",
+                "reset_identity": "reset:one",
+                "observed_at_us": observed_at_us,
+                "allowance_percent": allowance_percent,
+                "compatibility_basis": "same_cycle_adjacent",
+                "completion_status": "completed",
+            },
+            observed_at_us,
+            event_kind_order=30,
+            transition_rank=index,
+        )
+    add(
+        "publication",
+        PUBLICATION_ID,
+        {
+            "publication_id": PUBLICATION_ID,
+            "operation_id": "operation:ck07e",
+            "artifact_manifest_sha256": "b" * 64,
+            "committed_at_us": 600,
+            "observed_through_us": 500,
+            "indexed_from_us": 50,
+            "guaranteed_complete_from_us": 50,
+            "capabilities": {"context_components": True, "valuation": True},
+            "measurements": {"calls": len(call_rows), "sources": 2},
+            "valuation_coverage": {
+                "basis": "configured_estimate",
+                "priced_calls": priced_call_count,
+            },
+        },
+        None,
+    )
+    add(
+        "publication_delta",
+        "publication-delta:ck07e",
+        {
+            "inserted_count": len(facts),
+            "removed_count": 0,
+            "corrected_count": 1 if lifecycle == "replacement" else 0,
+            "recanonicalized_count": 0,
+            "terminalized_count": 1,
+            "token_delta": sum(
+                int(row[5]) + int(row[6]) + int(row[7]) + int(row[8]) for row in call_rows
+            ),
+            "publication_id": PUBLICATION_ID,
+        },
+        None,
+    )
+    for manifestation_id, state in (
+        ("source-manifestation:active", "active"),
+        ("source-manifestation:replacement", "replaced"),
+    ):
+        add(
+            "source_manifestation",
+            manifestation_id,
+            {
+                "source_manifestation_id": manifestation_id,
+                "lifecycle_state": state,
+                "canonical_basis": "source_inventory",
+            },
+            None,
+        )
+
+    for fact in facts:
+        relation = fact["relation"]
+        if relation == "model_profile":
+            fact["coordinates"] = {
+                "event_at_us": None,
+                "source_rank": 0,
+                "source_order": 0,
+                "event_kind_order": 0,
+                "transition_rank": 0,
+            }
+        elif relation == "publication":
+            fact["coordinates"] = {
+                "event_at_us": 600,
+                "source_rank": 0,
+                "source_order": 0,
+                "event_kind_order": 0,
+                "transition_rank": 0,
+            }
+        elif relation == "source_manifestation":
+            manifestation_order = 1 if fact["logical_id"] == "source-manifestation:active" else 2
+            fact["coordinates"] = {
+                "event_at_us": None,
+                "source_rank": manifestation_order,
+                "source_order": manifestation_order,
+                "event_kind_order": 10,
+                "transition_rank": 0,
+            }
+        elif relation == "publication_delta":
+            fact["coordinates"] = {
+                "event_at_us": None,
+                "source_rank": 0,
+                "source_order": 0,
+                "event_kind_order": 0,
+                "transition_rank": 0,
+            }
+        elif lifecycle == "replacement":
+            fact["coordinates"]["source_rank"] = 2
+
+    occurrences: dict[str, list[dict[str, Any]]] = {}
+    for ordinal, fact in enumerate(facts, start=1):
+        if fact["relation"] == "model_profile":
+            continue
+        occurrence = _occurrence(fact["logical_id"], ordinal, revision=revision)
+        occurrences.setdefault(fact["logical_id"], []).append(occurrence)
+        if lifecycle == "rebuild":
+            occurrences[fact["logical_id"]][0] = {
+                **occurrence,
+                "occurrence_id": f"occurrence:rebuild:{ordinal}",
+            }
+        if lifecycle == "late_event" and fact["logical_id"] == "call:before":
+            occurrences[fact["logical_id"]].append(
+                _occurrence(fact["logical_id"], ordinal + 10_000, revision=revision)
+            )
+    occurrence_facts: list[dict[str, Any]] = []
+    for logical_occurrences in occurrences.values():
+        for occurrence in logical_occurrences:
+            occurrence_facts.append(
+                _fact(
+                    "source_occurrence",
+                    occurrence["occurrence_id"],
+                    {
+                        "occurrence_id": occurrence["occurrence_id"],
+                        "semantic_logical_id": occurrence["semantic_logical_id"],
+                        "source_manifestation_id": occurrence["source_manifestation_id"],
+                        "occurrence_coordinates": {
+                            "source_revision": occurrence["source_revision"],
+                            "record_ordinal": occurrence["record_ordinal"],
+                            "byte_start": occurrence["byte_start"],
+                            "byte_end": occurrence["byte_end"],
+                            "adapter_version": occurrence["adapter_version"],
+                        },
+                    },
+                    {
+                        **_coordinates(None, occurrence["record_ordinal"]),
+                        "source_rank": (
+                            2
+                            if occurrence["source_manifestation_id"]
+                            == "source-manifestation:replacement"
+                            else 1
+                        ),
+                    },
+                )
+            )
+    facts.extend(occurrence_facts)
+
+    selector_entities = {
+        "allowance_interval": [
+            "allowance-interval:one",
+            "allowance-interval:two",
+        ],
+        "allowance_observation": [
+            "allowance-observation:1",
+            "allowance-observation:2",
+            "allowance-observation:3",
+            "allowance-observation:4",
+        ],
+        "call": [row[0] for row in call_rows],
+        "model_profile": ["profile:alpha", "profile:beta"],
+        "project": ["project:alpha"],
+        "publication": [PUBLICATION_ID],
+        "rate_card": [HEAD_DIGEST],
+        "resource": ["resource:file", "resource:test"],
+        "session": ["session:root", "session:child"],
+        "source_manifestation": [
+            "source-manifestation:active",
+            "source-manifestation:replacement",
+        ],
+        "state_change": ["state-change:file"],
+        "tool": ["tool:inspect", "tool:attempt", "tool:retry"],
+        "turn": ["turn:root", "turn:child"],
+    }
+    frontier = {
+        "head_digest": HEAD_DIGEST,
+        "revisions": [
+            {
+                "rate_card_id": "rate-card:old",
+                "digest": OLD_DIGEST,
+                "predecessor_digest": None,
+                "effective_at_us": 0,
+                "fetched_at_us": 900,
+                "source_name": "synthetic-old",
+                "source_url": None,
+                "currency": "USD",
+                "model_match_rules": [
+                    {
+                        "model_profile_id": "profile:alpha",
+                        "match_basis": "exact_model_profile",
+                    },
+                    {
+                        "model_profile_id": "profile:beta",
+                        "match_basis": "exact_model_profile",
+                    },
+                ],
+                "four_class_rates": {
+                    "uncached_input_tokens": "1",
+                    "cached_input_tokens": "1",
+                    "reasoning_tokens": "1",
+                    "output_tokens": "1",
+                },
+                "credit_rates": {
+                    "uncached_input_tokens": "1",
+                    "cached_input_tokens": "1",
+                    "reasoning_tokens": "1",
+                    "output_tokens": "1",
+                },
+                "reasoning_in_output": False,
+                "confidence": "synthetic",
+                "validation_status": "valid",
+            },
+            {
+                "rate_card_id": "rate-card:new",
+                "digest": HEAD_DIGEST,
+                "predecessor_digest": OLD_DIGEST,
+                "effective_at_us": 250,
+                "fetched_at_us": 100,
+                "source_name": "synthetic-new",
+                "source_url": None,
+                "currency": "USD",
+                "model_match_rules": [
+                    {
+                        "model_alias": "synthetic-model",
+                        "match_basis": "model_alias",
+                    }
+                ],
+                "four_class_rates": {
+                    "uncached_input_tokens": "2",
+                    "cached_input_tokens": "2",
+                    "reasoning_tokens": "2",
+                    "output_tokens": "2",
+                },
+                "credit_rates": {
+                    "uncached_input_tokens": "2",
+                    "cached_input_tokens": "2",
+                    "reasoning_tokens": "2",
+                    "output_tokens": "2",
+                },
+                "reasoning_in_output": False,
+                "confidence": "synthetic",
+                "validation_status": "valid",
+            },
+        ],
+    }
+    source_manifestations = {
+        "source-manifestation:active": {
+            "source_id": "source:active",
+            "content_revision": f"{revision}-v1",
+            "state": "active",
+            "selected_publication_id": PUBLICATION_ID,
+        },
+        "source-manifestation:replacement": {
+            "source_id": "source:replacement",
+            "content_revision": "replacement-v1",
+            "state": "replaced",
+            "selected_publication_id": PUBLICATION_ID,
+        },
+    }
+    declaration = {
+        "schema": "codex-usage-tracker.synthetic-structural-v2.v1",
+        "scenario_id": f"ck07e:{lifecycle}",
+        "facts": facts,
+        "occurrences": occurrences,
+        "selector_entities": selector_entities,
+        "allowance_intervals": {
+            "allowance-interval:one": {
+                "start_observation_id": "allowance-observation:1",
+                "end_observation_id": "allowance-observation:2",
+            },
+            "allowance-interval:two": {
+                "start_observation_id": "allowance-observation:3",
+                "end_observation_id": "allowance-observation:4",
+            },
+        },
+        "source_manifestations": source_manifestations,
+        "rate_card_frontier": frontier,
+        "publication_rate_card_digest": HEAD_DIGEST,
+    }
+    return copy.deepcopy(declaration)
+
+
+def required_references(
+    *,
+    request: PlanRequest | None = None,
+    include_window: bool = True,
+) -> tuple[dict[str, str], ...]:
+    """Return one exact ordered selection covering every admitted selector kind."""
+
+    rows = [
+        (
+            "interval",
+            "allowance_interval",
+            "allowance-interval:allowance-interval:one",
+            "allowance-interval:one",
+        ),
+        (
+            "observation",
+            "allowance_observation",
+            "allowance-observation:allowance-observation:1",
+            "allowance-observation:1",
+        ),
+        ("call", "call", "call:call:before", "call:before"),
+        ("profile", "model_profile", "model-profile:profile:alpha", "profile:alpha"),
+        ("project", "project", "project:project:alpha", "project:alpha"),
+        ("publication", "publication", f"publication:{PUBLICATION_ID}", PUBLICATION_ID),
+        ("rate_card", "rate_card", f"rate-card:{HEAD_DIGEST}", HEAD_DIGEST),
+        ("resource", "resource", "resource:resource:file", "resource:file"),
+        ("session", "session", "session:session:root", "session:root"),
+        (
+            "source",
+            "source_manifestation",
+            "source-manifestation:source-manifestation:active",
+            "source-manifestation:active",
+        ),
+        ("state", "state_change", "state-change:state-change:file", "state-change:file"),
+        ("tool", "tool", "tool:tool:inspect", "tool:inspect"),
+        ("turn", "turn", "turn:turn:root", "turn:root"),
+    ]
+    if include_window:
+        if request is None:
+            request = adapter_request()
+        request_digest = _request_digest(request)
+        for role, value in request.parameters.items():
+            if role != "window" and not role.endswith("_window"):
+                continue
+            if not isinstance(value, Mapping):
+                raise TypeError(f"{role} must be a typed request window")
+            start = value.get("start_us")
+            end = value.get("end_us")
+            timezone = value.get("timezone", "UTC")
+            if (
+                isinstance(start, bool)
+                or not isinstance(start, int)
+                or isinstance(end, bool)
+                or not isinstance(end, int)
+                or not isinstance(timezone, str)
+            ):
+                raise TypeError(f"{role} must contain typed window bounds")
+            logical_id = semantic_id(
+                "window",
+                [request_digest, role, start, end, timezone],
+            )
+            rows.append((role, "window", f"window:{logical_id}", logical_id))
+    return tuple(
+        {
+            "role": role,
+            "selector_kind": kind,
+            "selector": selector,
+            "logical_id": logical_id,
+        }
+        for role, kind, selector, logical_id in rows
+    )
+
+
+def adapter_request(plan_id: str = "current_usage", *, with_window: bool = True) -> PlanRequest:
+    parameters: dict[str, Any] = {}
+    plan = next(item for item in plan_contract()["plans"] if item["plan_id"] == plan_id)
+    declared_parameters = {
+        *plan["request_schema"]["required"],
+        *plan["request_schema"].get("optional", {}),
+    }
+    if with_window and "window" in declared_parameters:
+        parameters["window"] = {
+            "start_us": 0,
+            "end_us": 1_000,
+            "timezone": "UTC",
+        }
+    for name, declaration in plan["request_schema"]["required"].items():
+        if name in parameters:
+            continue
+        declared_type = declaration["type"]
+        if name in {"start_observation_id", "end_observation_id"}:
+            parameters[name] = (
+                "allowance-observation:1" if name.startswith("start") else "allowance-observation:2"
+            )
+        elif name == "as_of_us":
+            parameters[name] = 1_000
+        elif name == "cohorts":
+            parameters[name] = {
+                "left": ["session:root"],
+                "right": ["session:child"],
+            }
+        elif name == "family_mode":
+            parameters[name] = "root" if plan_id == "parent_subagent_usage" else "project"
+        elif declared_type == "integer":
+            parameters[name] = 10
+        elif declared_type == "array":
+            parameters[name] = ["session:root"]
+        elif declared_type == "object":
+            parameters[name] = {
+                "start_us": 0,
+                "end_us": 1_000,
+                "timezone": "UTC",
+            }
+        else:
+            parameters[name] = f"synthetic-{name}"
+    return PlanRequest(
+        plan_id=plan_id,
+        parameters=parameters,
+        gates={gate: True for gate in plan["gates"]},
+    )
+
+
+def emitted_structural_jsonl(declaration: Mapping[str, Any]) -> bytes:
+    def normalize(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, Mapping):
+            return {str(key): normalize(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [normalize(item) for item in value]
+        return value
+
+    return b"".join(
+        json.dumps(
+            normalize(
+                {
+                    "type": "structural_fact",
+                    "relation": fact["relation"],
+                    "logical_id": fact["logical_id"],
+                    "values": fact["values"],
+                    "coordinates": fact["coordinates"],
+                }
+            ),
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        + b"\n"
+        for fact in declaration["facts"]
+    )
+
+
+def _sql_value(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+    if isinstance(value, bool):
+        return int(value)
+    return value
+
+
+def build_query_only_database(declaration: Mapping[str, Any]) -> sqlite3.Connection:
+    """Populate one database-v1 analytical snapshot, then seal it query-only."""
+
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    connection.executescript(schema_ddl("analytical"))
+    connection.execute("PRAGMA foreign_keys = OFF")
+
+    def insert(table: str, values: Mapping[str, Any]) -> None:
+        columns = tuple(values)
+        connection.execute(
+            f"INSERT INTO {table} ({','.join(columns)}) VALUES ({','.join('?' for _ in columns)})",
+            tuple(_sql_value(values[column]) for column in columns),
+        )
+
+    facts = declaration["facts"]
+    by_relation: dict[str, list[Mapping[str, Any]]] = {}
+    for fact in facts:
+        by_relation.setdefault(fact["relation"], []).append(fact)
+    publication_fact = by_relation["publication"][0]
+    insert(
+        "publications",
+        {
+            "publication_id": PUBLICATION_ID,
+            "parent_publication_id": None,
+            "operation_id": "operation:ck07e",
+            "schema_contract_id": "codex-usage-tracker.agent-kernel.schema-contract.v1",
+            "schema_contract_sha256": "a" * 64,
+            "identity_version": "v1",
+            "adapter_id": "adapter:synthetic",
+            "adapter_version": "structural-v2",
+            "normalization_version": "v1",
+            "projection_registry_sha256": None,
+            "rate_card_digest": HEAD_DIGEST,
+            "history_preset": "all_time",
+            "requested_cutoff_us": None,
+            "committed_at_us": 600,
+            "observed_through_us": publication_fact["values"]["observed_through_us"],
+            "indexed_from_us": publication_fact["values"]["indexed_from_us"],
+            "indexed_through_us": 600,
+            "guaranteed_complete_from_us": publication_fact["values"][
+                "guaranteed_complete_from_us"
+            ],
+            "artifact_manifest_sha256": "b" * 64,
+            "status": "committed",
+        },
+    )
+    insert(
+        "publication_head",
+        {"singleton": 1, "publication_id": PUBLICATION_ID, "activated_at_us": 601},
+    )
+    for source_id in ("source:active", "source:replacement"):
+        insert(
+            "publication_source_coverage",
+            {
+                "publication_id": PUBLICATION_ID,
+                "source_id": source_id,
+                "selected_manifestation_count": 1,
+                "selected_manifestation_bytes": 10_000,
+                "deferred_manifestation_count": 0,
+                "deferred_manifestation_bytes": 0,
+                "malformed_manifestation_count": 0,
+                "malformed_manifestation_bytes": 0,
+                "missing_manifestation_count": 0,
+                "missing_manifestation_bytes": 0,
+                "uncertain_manifestation_count": 0,
+                "uncertain_manifestation_bytes": 0,
+                "malformed_range_count": 0,
+                "malformed_range_bytes": 0,
+                "selected_complete_record_count": 1,
+                "tail_pending": 0,
+                "indexed_from_us": publication_fact["values"]["indexed_from_us"],
+                "indexed_through_us": 600,
+                "guaranteed_complete_from_us": publication_fact["values"][
+                    "guaranteed_complete_from_us"
+                ],
+                "guaranteed_complete_through_us": 600,
+                "clock_quality": "bounded",
+                "clock_uncertainty_us": 0,
+                "inventory_started_at_us": 590,
+                "inventory_completed_at_us": 600,
+            },
+        )
+    for capability_id, eligible, observed, unavailable, grade in (
+        ("context_components", 2, 2, 0, "exact"),
+        (
+            "valuation",
+            publication_fact["values"]["measurements"]["calls"],
+            publication_fact["values"]["valuation_coverage"]["priced_calls"],
+            publication_fact["values"]["measurements"]["calls"]
+            - publication_fact["values"]["valuation_coverage"]["priced_calls"],
+            "configured_estimate",
+        ),
+    ):
+        insert(
+            "publication_capability_coverage",
+            {
+                "publication_id": PUBLICATION_ID,
+                "capability_id": capability_id,
+                "eligible_entity_count": eligible,
+                "observed_entity_count": observed,
+                "unavailable_entity_count": unavailable,
+                "measurement_mask": 0,
+                "grade": grade,
+                "basis": "structural-v2",
+            },
+        )
+    for entity_kind, entity_count in publication_fact["values"]["measurements"].items():
+        insert(
+            "publication_entity_counts",
+            {
+                "publication_id": PUBLICATION_ID,
+                "entity_kind": entity_kind,
+                "entity_count": entity_count,
+            },
+        )
+    manifestation_keys: dict[str, int] = {}
+    for index, (manifestation_id, manifest) in enumerate(
+        declaration["source_manifestations"].items(),
+        start=1,
+    ):
+        manifestation_keys[manifestation_id] = index
+        insert(
+            "source_manifestations",
+            {
+                "manifestation_id": manifestation_id,
+                "manifestation_key": index,
+                "source_id": manifest["source_id"],
+                "adapter_native_file_key": f"file-{index}",
+                "technical_path_key": f"synthetic/file-{index}.jsonl",
+                "display_label": f"synthetic-{index}",
+                "filesystem_identity_json": None,
+                "size_bytes": 10_000,
+                "modified_at_us": 500,
+                "prefix_sha256": "c" * 64,
+                "suffix_sha256": "d" * 64,
+                "content_revision": manifest["content_revision"],
+                "source_rank": index,
+                "state": manifest["state"],
+                "time_range_start_us": 0,
+                "time_range_end_us": 600,
+                "time_range_confidence": "trusted",
+                "selected": 1,
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+                "ended_publication_id": None,
+            },
+        )
+    for logical_occurrences in declaration["occurrences"].values():
+        for occurrence in logical_occurrences:
+            insert(
+                "source_occurrences",
+                {
+                    "occurrence_id": occurrence["occurrence_id"],
+                    "semantic_logical_id": occurrence["semantic_logical_id"],
+                    "manifestation_key": manifestation_keys[occurrence["source_manifestation_id"]],
+                    "source_revision": occurrence["source_revision"],
+                    "record_ordinal": occurrence["record_ordinal"],
+                    "byte_start": occurrence["byte_start"],
+                    "byte_end": occurrence["byte_end"],
+                    "adapter_version": occurrence["adapter_version"],
+                    "first_seen_publication_id": PUBLICATION_ID,
+                },
+            )
+    insert(
+        "projects",
+        {
+            "project_id": "project:alpha",
+            "workspace_key": "synthetic-workspace",
+            "first_event_at_us": 50,
+            "last_event_at_us": 500,
+            "provenance_json": "[]",
+            "first_seen_publication_id": PUBLICATION_ID,
+            "last_seen_publication_id": PUBLICATION_ID,
+        },
+    )
+
+    def occurrence_id(logical_id: str) -> str:
+        return declaration["occurrences"][logical_id][0]["occurrence_id"]
+
+    for fact in by_relation["model_profile"]:
+        values = fact["values"]
+        insert(
+            "model_profiles",
+            {
+                "model_profile_id": fact["logical_id"],
+                "model": values["model"],
+                "reasoning_effort": values.get("effort"),
+                "service_tier": values.get("tier"),
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["session"]:
+        values = fact["values"]
+        insert(
+            "sessions",
+            {
+                "session_id": fact["logical_id"],
+                "adapter_native_session_key": fact["logical_id"],
+                "identity_version": "v1",
+                "project_id": values["project_id"],
+                "root_session_id": values.get("root_session_id"),
+                "parent_session_id": values.get("parent_session_id"),
+                "relationship_basis": "structural",
+                "delegation_depth": values.get("delegation_depth"),
+                "lifecycle_state": values["lifecycle_state"],
+                "state_basis": "structural",
+                "transition_version": 1,
+                "start_at_us": values.get("start_at_us"),
+                "end_at_us": values.get("end_at_us"),
+                "observed_duration_us": 450,
+                "completion_basis": values.get("completion_basis"),
+                "label_candidates_json": "[]",
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["turn"]:
+        values = fact["values"]
+        insert(
+            "turns",
+            {
+                "turn_id": fact["logical_id"],
+                "session_id": values["session_id"],
+                "ordinal": values["ordinal"],
+                "lifecycle_state": values["lifecycle_state"],
+                "state_basis": "structural",
+                "transition_version": 1,
+                "start_at_us": values["start_at_us"],
+                "end_at_us": values["end_at_us"],
+                "start_source_order": 1,
+                "end_source_order": 2,
+                "completion_basis": values["completion_basis"],
+                "membership_json": "{}",
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["canonical_call"]:
+        values = fact["values"]
+        coordinates = fact["coordinates"]
+        insert(
+            "model_call_locations",
+            {"call_id": fact["logical_id"], "storage_class": "base"},
+        )
+        insert(
+            "model_calls",
+            {
+                "call_id": fact["logical_id"],
+                "storage_class": "base",
+                "adapter_native_call_key": fact["logical_id"],
+                "session_id": values["session_id"],
+                "turn_id": values["turn_id"],
+                "model_profile_id": values["model_profile_id"],
+                "lifecycle_state": values["lifecycle"],
+                "state_basis": "structural",
+                "transition_version": 1,
+                "event_at_us": coordinates["event_at_us"],
+                "source_rank": coordinates["source_rank"],
+                "source_order": coordinates["source_order"],
+                "event_kind_order": coordinates["event_kind_order"],
+                "transition_rank": coordinates["transition_rank"],
+                "context_window_tokens": values["context_window_tokens"],
+                "uncached_input_tokens": values["uncached_input_tokens"],
+                "cached_input_tokens": values["cached_input_tokens"],
+                "reasoning_tokens": values["reasoning_tokens"],
+                "output_tokens": values["output_tokens"],
+                "token_basis": "structural",
+                "finish_category": None,
+                "error_category": None,
+                "measurement_mask": 0,
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["resource"]:
+        values = fact["values"]
+        insert(
+            "resources",
+            {
+                "resource_id": fact["logical_id"],
+                "project_id": "project:alpha",
+                "resource_kind": values["resource_kind"],
+                "normalized_key": fact["logical_id"],
+                "normalization_version": "v1",
+                "display_label": fact["logical_id"],
+                "provenance_json": "[]",
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["tool_invocation"]:
+        values = fact["values"]
+        coordinates = fact["coordinates"]
+        insert(
+            "tool_invocations",
+            {
+                "tool_id": fact["logical_id"],
+                "adapter_native_invocation_key": fact["logical_id"],
+                "session_id": values["session_id"],
+                "turn_id": values["turn_id"],
+                "transport_name": values["transport_name"],
+                "semantic_operation": values["semantic_operation"],
+                "tool_family": values["tool_family"],
+                "primary_resource_id": values["resource_id"],
+                "write_intent": values["write_intent"],
+                "lifecycle_state": values["lifecycle"],
+                "state_basis": "structural",
+                "transition_version": 1,
+                "start_at_us": coordinates["event_at_us"],
+                "start_source_rank": coordinates["source_rank"],
+                "start_source_order": coordinates["source_order"],
+                "start_event_kind_order": coordinates["event_kind_order"],
+                "start_transition_rank": coordinates["transition_rank"],
+                "start_occurrence_id": occurrence_id(fact["logical_id"]),
+                "terminal_at_us": coordinates["event_at_us"] + values["duration_us"],
+                "terminal_source_rank": coordinates["source_rank"],
+                "terminal_source_order": coordinates["source_order"] + 1,
+                "terminal_event_kind_order": coordinates["event_kind_order"],
+                "terminal_transition_rank": 1,
+                "terminal_occurrence_id": occurrence_id(fact["logical_id"]),
+                "observed_duration_us": values["duration_us"],
+                "output_bytes": values["output_bytes"],
+                "error_category": values["error_category"],
+                "measurement_mask": 0,
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+        for resource_id in dict.fromkeys(values["resource_links"]):
+            insert(
+                "tool_resources",
+                {
+                    "tool_id": fact["logical_id"],
+                    "resource_id": resource_id,
+                    "relationship_role": (
+                        "tested"
+                        if values["semantic_operation"] == "test"
+                        else "read"
+                        if values["semantic_operation"] == "read"
+                        else "executed"
+                    ),
+                    "occurrence_id": occurrence_id(fact["logical_id"]),
+                },
+            )
+    for fact in by_relation["state_change"]:
+        values = fact["values"]
+        coordinates = fact["coordinates"]
+        insert(
+            "state_changes",
+            {
+                "change_id": fact["logical_id"],
+                "session_id": values["session_id"],
+                "turn_id": values["turn_id"],
+                "resource_id": values["resource_id"],
+                "change_kind": values["mutation_kind"],
+                "before_revision": None,
+                "after_revision": "revision:after",
+                "confidence": "synthetic",
+                "event_at_us": coordinates["event_at_us"],
+                "source_rank": coordinates["source_rank"],
+                "source_order": coordinates["source_order"],
+                "event_kind_order": coordinates["event_kind_order"],
+                "transition_rank": coordinates["transition_rank"],
+                "measurement_mask": 0,
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["compaction_boundary"]:
+        coordinates = fact["coordinates"]
+        insert(
+            "compaction_boundaries",
+            {
+                "compaction_id": fact["logical_id"],
+                "session_id": fact["values"]["session_id"],
+                "before_context_epoch": "epoch:before",
+                "after_context_epoch": "epoch:after",
+                "event_at_us": coordinates["event_at_us"],
+                "source_rank": coordinates["source_rank"],
+                "source_order": coordinates["source_order"],
+                "event_kind_order": coordinates["event_kind_order"],
+                "transition_rank": coordinates["transition_rank"],
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    for fact in by_relation["context_component"]:
+        values = fact["values"]
+        coordinates = fact["coordinates"]
+        insert(
+            "context_components",
+            {
+                "component_id": fact["logical_id"],
+                "session_id": values["session_id"],
+                "turn_id": values["turn_id"],
+                "call_id": values["call_id"],
+                "category": values["category"],
+                "observed_utf8_bytes": values["observed_utf8_bytes"],
+                "observed_event_count": 1,
+                "estimator": "synthetic",
+                "estimated_tokens": values["estimated_tokens"],
+                "total_context_utf8_bytes": values["total_context_utf8_bytes"],
+                "inclusion_basis": "observed_in_source",
+                "capability_basis": "structural",
+                "measurement_basis": "synthetic",
+                "event_at_us": coordinates["event_at_us"],
+                "source_rank": coordinates["source_rank"],
+                "source_order": coordinates["source_order"],
+                "event_kind_order": coordinates["event_kind_order"],
+                "transition_rank": coordinates["transition_rank"],
+                "measurement_mask": 0,
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+                "last_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    insert(
+        "allowance_limits",
+        {
+            "limit_id": "allowance-limit:weekly",
+            "provider": "synthetic-provider",
+            "account_local_identity": "synthetic-account",
+            "plan_identity": "synthetic-plan",
+            "window_kind": "rolling_week",
+            "configured_duration_us": 604_800_000_000,
+            "capability_basis": "structural",
+            "first_seen_publication_id": PUBLICATION_ID,
+            "last_seen_publication_id": PUBLICATION_ID,
+        },
+    )
+    insert(
+        "allowance_cycles",
+        {
+            "cycle_id": "allowance-cycle:one",
+            "limit_id": "allowance-limit:weekly",
+            "reset_identity": "reset:one",
+            "start_at_us": 0,
+            "end_at_us": 1_000,
+            "reset_basis": "structural",
+            "completion_status": "completed",
+            "first_seen_publication_id": PUBLICATION_ID,
+            "last_seen_publication_id": PUBLICATION_ID,
+        },
+    )
+    for index, fact in enumerate(by_relation["allowance_observation"], start=1):
+        values = fact["values"]
+        coordinates = fact["coordinates"]
+        insert(
+            "allowance_observations",
+            {
+                "observation_id": fact["logical_id"],
+                "limit_id": values["limit_id"],
+                "cycle_id": "allowance-cycle:one",
+                "plan_identity": values["plan"],
+                "window_kind": values["window_kind"],
+                "reset_identity": values["reset_identity"],
+                "observation_ordinal": index,
+                "used_percent": (
+                    Decimal("10")
+                    if index == 1
+                    else Decimal("20")
+                    if index == 3
+                    else Decimal("30")
+                    if index == 4
+                    else None
+                ),
+                "remaining_percent": (Decimal("80") if index in {2, 3} else None),
+                "absolute_fields_json": "{}",
+                "reset_time_us": None,
+                "observed_at_us": values["observed_at_us"],
+                "source_rank": coordinates["source_rank"],
+                "source_order": coordinates["source_order"],
+                "event_kind_order": coordinates["event_kind_order"],
+                "transition_rank": coordinates["transition_rank"],
+                "measurement_mask": 0,
+                "primary_occurrence_id": occurrence_id(fact["logical_id"]),
+                "first_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    allowance_facts = {fact["logical_id"]: fact for fact in by_relation["allowance_observation"]}
+    for interval_id, interval in declaration["allowance_intervals"].items():
+        start_fact = allowance_facts[interval["start_observation_id"]]
+        end_fact = allowance_facts[interval["end_observation_id"]]
+        start_percent = start_fact["values"]["allowance_percent"]
+        end_percent = end_fact["values"]["allowance_percent"]
+        insert(
+            "allowance_intervals",
+            {
+                "interval_id": interval_id,
+                "limit_id": "allowance-limit:weekly",
+                "cycle_id": "allowance-cycle:one",
+                "start_observation_id": start_fact["logical_id"],
+                "end_observation_id": end_fact["logical_id"],
+                "start_us": start_fact["values"]["observed_at_us"],
+                "end_us": end_fact["values"]["observed_at_us"],
+                "percent_delta": start_percent - end_percent,
+                "compatibility_basis": "allowance-compatibility-v1",
+                "ratio_eligible": int(start_percent > end_percent),
+                "coverage_json": "{}",
+                "first_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+    delta = by_relation["publication_delta"][0]["values"]
+    insert(
+        "publication_deltas",
+        {
+            "publication_id": PUBLICATION_ID,
+            "parent_publication_id": None,
+            "inserted_count": delta["inserted_count"],
+            "corrected_count": delta["corrected_count"],
+            "terminalized_count": delta["terminalized_count"],
+            "recanonicalized_count": delta["recanonicalized_count"],
+            "removed_count": delta["removed_count"],
+            "uncached_input_token_delta": delta["token_delta"],
+            "cached_input_token_delta": 0,
+            "reasoning_token_delta": 0,
+            "output_token_delta": 0,
+            "affected_session_count": 2,
+            "affected_turn_count": 2,
+            "affected_tool_count": 3,
+            "affected_resource_count": 2,
+            "affected_state_change_count": 1,
+            "affected_allowance_observation_count": 4,
+            "source_coverage_changed": 0,
+            "sample_truncated": 0,
+        },
+    )
+    revisions = declaration["rate_card_frontier"]["revisions"]
+    predecessor_id: str | None = None
+    for revision in revisions:
+        insert(
+            "rate_card_revisions",
+            {
+                "rate_card_id": revision["rate_card_id"],
+                "digest": revision["digest"],
+                "predecessor_rate_card_id": predecessor_id,
+                "source_name": revision["source_name"],
+                "source_url": revision["source_url"],
+                "effective_at_us": revision["effective_at_us"],
+                "fetched_at_us": revision["fetched_at_us"],
+                "currency": revision["currency"],
+                "model_match_rules_json": revision["model_match_rules"],
+                "four_class_rates_json": revision["four_class_rates"],
+                "credit_rates_json": revision["credit_rates"],
+                "reasoning_in_output": revision["reasoning_in_output"],
+                "confidence": revision["confidence"],
+                "validation_status": revision["validation_status"],
+                "first_seen_publication_id": PUBLICATION_ID,
+            },
+        )
+        predecessor_id = revision["rate_card_id"]
+    insert(
+        "active_rate_card",
+        {
+            "singleton": 1,
+            "rate_card_id": "rate-card:new",
+            "selected_at_us": 600,
+            "publication_id": PUBLICATION_ID,
+        },
+    )
+    connection.commit()
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def normalize_materialization(materialization: Any) -> tuple[Any, ...]:
+    """Cross-adapter comparison that depends on neither adapter's result type."""
+
+    def normalized(value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return ("decimal", str(value))
+        if isinstance(value, Mapping):
+            return tuple(
+                (str(key), normalized(item))
+                for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(normalized(item) for item in value)
+        if hasattr(value, "value") and isinstance(value.value, str):
+            return value.value
+        return value
+
+    def normalized_provenance(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            mapped = dict(value)
+            if "occurrence_id" in mapped:
+                if "source_manifestation_id" in mapped:
+                    mapped["manifestation_id"] = mapped.pop("source_manifestation_id")
+                if "source_revision" in mapped:
+                    mapped["revision"] = mapped.pop("source_revision")
+                mapped.pop("semantic_logical_id", None)
+            return tuple(
+                (str(key), normalized_provenance(item))
+                for key, item in sorted(mapped.items(), key=lambda pair: str(pair[0]))
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(normalized_provenance(item) for item in value)
+        return normalized(value)
+
+    facts = tuple(
+        sorted(
+            (
+                fact.relation,
+                fact.logical_id,
+                normalized(fact.values),
+                None
+                if fact.coordinates is None
+                else (
+                    fact.coordinates.event_at_us,
+                    fact.coordinates.source_rank,
+                    fact.coordinates.source_order,
+                    fact.coordinates.event_kind_order,
+                    fact.coordinates.transition_rank,
+                ),
+            )
+            for fact in materialization.facts
+        )
+    )
+    references = tuple(
+        (
+            reference.role,
+            reference.selector_kind,
+            reference.selector,
+            reference.logical_id,
+            reference.provenance_kind,
+            normalized_provenance(reference.provenance),
+        )
+        for reference in materialization.evidence_references
+    )
+    request = (
+        materialization.request.plan_id,
+        normalized(materialization.request.parameters),
+        normalized(materialization.request.gates),
+    )
+    return request, facts, references
+
+
+__all__ = [
+    "HEAD_DIGEST",
+    "OLD_DIGEST",
+    "PLAN_CONTRACT_PATH",
+    "PUBLICATION_ID",
+    "SELECTOR_CONTRACT_PATH",
+    "adapter_request",
+    "build_query_only_database",
+    "build_structural_v2",
+    "emitted_structural_jsonl",
+    "normalize_materialization",
+    "plan_contract",
+    "required_references",
+    "selector_contract",
+]

--- a/tests/agent_kernel/fact_adapters/test_contracts.py
+++ b/tests/agent_kernel/fact_adapters/test_contracts.py
@@ -1,0 +1,704 @@
+from __future__ import annotations
+
+import ast
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_usage_tracker.agent_kernel.domain.valuation import (
+    RateCardFrontier,
+    RateCardRevision,
+    derive_frontier_dirty_intervals,
+)
+from tests.agent_kernel.fact_adapters.database import (
+    DatabaseAdapterContractError,
+    DatabaseV1FactAdapter,
+)
+from tests.agent_kernel.fact_adapters.reference import (
+    StructuralReferenceAdapterError,
+    StructuralReferenceFactAdapter,
+)
+from tests.agent_kernel.fact_adapters.support import (
+    HEAD_DIGEST,
+    OLD_DIGEST,
+    adapter_request,
+    build_query_only_database,
+    build_structural_v2,
+    emitted_structural_jsonl,
+    normalize_materialization,
+    plan_contract,
+    required_references,
+    selector_contract,
+)
+
+PACKAGE = Path(__file__).resolve().parent
+PLAN_RELATIONS = {
+    source["relation"] for plan in plan_contract()["plans"] for source in plan["permitted_sources"]
+}
+SELECTOR_KINDS = {
+    "allowance_interval",
+    "allowance_observation",
+    "call",
+    "model_profile",
+    "project",
+    "publication",
+    "rate_card",
+    "resource",
+    "session",
+    "source_manifestation",
+    "state_change",
+    "tool",
+    "turn",
+    "window",
+}
+PROVENANCE_KINDS = {
+    "configured_artifact",
+    "derived_boundary_pair",
+    "publication_commit",
+    "request_derivation",
+    "source_inventory",
+    "source_occurrence",
+}
+
+
+def _references(request, *, window: bool) -> tuple[dict[str, str], ...]:
+    references = [
+        dict(item) for item in required_references(request=request, include_window=window)
+    ]
+    if window:
+        # The selector is a pure request derivation and is intentionally not
+        # declared as a scenario/database entity.
+        pass
+    return tuple(references)
+
+
+def _materialize_pair(
+    declaration,
+    *,
+    plan_id: str = "current_usage",
+    window: bool = True,
+):
+    contract = plan_contract()
+    selectors = selector_contract()
+    request = adapter_request(plan_id, with_window=window)
+    evidence = _references(request, window=window)
+    reference = StructuralReferenceFactAdapter(contract, selectors).materialize(
+        declaration,
+        request,
+        evidence,
+    )
+    connection = build_query_only_database(declaration)
+    database = DatabaseV1FactAdapter(contract, selectors, evidence).materialize(
+        connection,
+        request,
+        evidence,
+    )
+    return reference, database
+
+
+def test_current_usage_facts_request_and_evidence_are_equivalent() -> None:
+    reference, database = _materialize_pair(build_structural_v2())
+
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    assert len(reference.evidence_references) == len(SELECTOR_KINDS)
+    assert {item.selector_kind for item in reference.evidence_references} == SELECTOR_KINDS
+    assert {item.provenance_kind for item in reference.evidence_references} == PROVENANCE_KINDS
+
+
+def test_every_plan_relation_is_selected_independently() -> None:
+    declaration = build_structural_v2()
+    reference_relations: set[str] = set()
+    database_relations: set[str] = set()
+
+    for plan in plan_contract()["plans"]:
+        plan_id = plan["plan_id"]
+        reference, database = _materialize_pair(
+            declaration,
+            plan_id=plan_id,
+        )
+        reference_facts = {(fact.relation, fact.logical_id): fact for fact in reference.facts}
+        database_facts = {(fact.relation, fact.logical_id): fact for fact in database.facts}
+        assert set(reference_facts) == set(database_facts), plan_id
+        reference_relations.update(fact.relation for fact in reference.facts)
+        database_relations.update(fact.relation for fact in database.facts)
+
+    assert reference_relations == database_relations == PLAN_RELATIONS
+    assert len(PLAN_RELATIONS) == 16
+
+
+@pytest.mark.parametrize(
+    "plan_id",
+    ["allowance_interval_events", "latest_publication_delta"],
+)
+def test_owner_specific_no_window_plans_do_not_fabricate_windows(plan_id: str) -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(),
+        plan_id=plan_id,
+        window=False,
+    )
+
+    assert "window" not in reference.request.parameters
+    assert "window" not in database.request.parameters
+    assert all(item.selector_kind != "window" for item in reference.evidence_references)
+    assert all(item.selector_kind != "window" for item in database.evidence_references)
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "include_late_call"),
+    [
+        ("initial", False),
+        ("rebuild", False),
+        ("replacement", False),
+        ("late_event", True),
+    ],
+)
+def test_rebuild_replacement_and_late_event_preserve_parity(
+    lifecycle: str,
+    include_late_call: bool,
+) -> None:
+    declaration = build_structural_v2(
+        lifecycle=lifecycle,
+        include_late_call=include_late_call,
+    )
+    reference, database = _materialize_pair(
+        declaration,
+        plan_id="dedup_source_audit",
+    )
+
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    assert [
+        (item.role, item.selector_kind, item.selector) for item in reference.evidence_references
+    ] == [(item.role, item.selector_kind, item.selector) for item in database.evidence_references]
+
+
+def test_effective_dated_selection_and_typed_missingness_reconcile() -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(
+            include_late_call=True,
+            null_cached_tokens=True,
+        ),
+        plan_id="pricing_coverage",
+        window=False,
+    )
+    normalized_reference = normalize_materialization(reference)
+    normalized_database = normalize_materialization(database)
+    assert normalized_reference == normalized_database
+
+    matches = {
+        fact.values["call_id"]: fact
+        for fact in reference.facts
+        if fact.relation == "valuation_match"
+    }
+    assert matches["call:before"].values["rate_card_digest"] == OLD_DIGEST
+    assert matches["call:late"].values["rate_card_digest"] == OLD_DIGEST
+    assert matches["call:boundary"].values["rate_card_digest"] == HEAD_DIGEST
+    assert matches["call:boundary"].values["match_basis"] == "model_alias"
+    assert matches["call:other"].values["rate_card_digest"] == OLD_DIGEST
+    assert matches["call:before"].values["cost_unpriced_reason"] == "missing_measurement"
+
+
+def test_same_time_exact_profile_precedes_alias_in_both_adapters() -> None:
+    declaration = build_structural_v2()
+    declaration["rate_card_frontier"]["revisions"][-1]["model_match_rules"].insert(
+        0,
+        {
+            "model_profile_id": "profile:alpha",
+            "match_basis": "exact_model_profile",
+        },
+    )
+    reference, database = _materialize_pair(declaration)
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    boundary = next(
+        fact
+        for fact in reference.facts
+        if fact.relation == "valuation_match" and fact.values["call_id"] == "call:boundary"
+    )
+    assert boundary.values["match_basis"] == "exact_model_profile"
+
+
+def test_backdated_revision_has_one_bounded_dirty_interval() -> None:
+    declaration = build_structural_v2()
+
+    def revision(value) -> RateCardRevision:
+        return RateCardRevision(**value)
+
+    old = revision(declaration["rate_card_frontier"]["revisions"][0])
+    head = revision(declaration["rate_card_frontier"]["revisions"][1])
+    previous = RateCardFrontier(head_digest=old.digest, revisions=(old,))
+    current = RateCardFrontier(head_digest=head.digest, revisions=(old, head))
+
+    intervals = derive_frontier_dirty_intervals(previous, current)
+    assert [
+        (
+            item.revision_digest,
+            item.effective_at_us,
+            item.next_effective_at_us,
+        )
+        for item in intervals
+    ] == [(HEAD_DIGEST, 250, None)]
+
+
+def test_database_adapter_requires_a_query_only_caller_owned_snapshot() -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+    connection.execute("PRAGMA query_only = OFF")
+    adapter = DatabaseV1FactAdapter(
+        plan_contract(),
+        selector_contract(),
+        _references(adapter_request(), window=True),
+    )
+
+    with pytest.raises(DatabaseAdapterContractError, match="query_only"):
+        adapter.materialize(
+            connection,
+            adapter_request(),
+            _references(adapter_request(), window=True),
+        )
+
+
+def test_structural_adapter_rejects_expected_grading_body_and_float_inputs() -> None:
+    adapter = StructuralReferenceFactAdapter(plan_contract(), selector_contract())
+    request = adapter_request()
+    evidence = _references(request, window=True)
+    forbidden_values = [
+        {"oracle_case": "forbidden"},
+        {"expected": {"calls": 1}},
+        {"grading": {"status": "forbidden"}},
+        {"prompt": "private body"},
+        {"measurement": 0.5},
+    ]
+
+    for value in forbidden_values:
+        declaration = build_structural_v2()
+        declaration["facts"][0]["values"]["forbidden_probe"] = value
+        with pytest.raises(StructuralReferenceAdapterError):
+            adapter.materialize(declaration, request, evidence)
+
+
+def test_emitted_structural_jsonl_contains_only_body_free_fact_records() -> None:
+    payload = emitted_structural_jsonl(build_structural_v2())
+    lowered = payload.lower()
+    for token in (
+        b"oracle_case",
+        b"expected",
+        b'"grade"',
+        b"grading",
+        b"comparison",
+        b"answer_cache",
+        b'"prompt"',
+        b'"response"',
+        b'"reasoning"',
+        b'"command"',
+        b'"patch"',
+    ):
+        assert token not in lowered
+    assert payload.count(b"\n") > 0
+
+
+def test_adapter_imports_and_sources_enforce_independence() -> None:
+    allowed_domain_imports = {
+        "codex_usage_tracker.agent_kernel.domain.identity",
+        "codex_usage_tracker.agent_kernel.domain.plan_operands",
+        "codex_usage_tracker.agent_kernel.domain.valuation",
+    }
+    forbidden_import_roots = (
+        "codex_usage_tracker.agent_kernel.publication",
+        "codex_usage_tracker.agent_kernel.query",
+        "codex_usage_tracker.agent_kernel.storage",
+        "tests.agent_kernel.fact_adapters",
+        "tests.agent_kernel.fixtures",
+        "tests.experiments.physical_architecture.candidate_a",
+    )
+
+    for name in ("reference.py", "database.py"):
+        source = (PACKAGE / name).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported_modules: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+        agent_kernel_imports = {
+            module
+            for module in imported_modules
+            if module.startswith("codex_usage_tracker.agent_kernel")
+        }
+        assert agent_kernel_imports <= allowed_domain_imports
+        for module in imported_modules:
+            assert not module.startswith(forbidden_import_roots)
+
+
+def test_total_order_preserves_null_and_same_time_ties() -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(),
+        plan_id="allowance_interval_events",
+        window=False,
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    observations = [fact for fact in reference.facts if fact.relation == "allowance_observation"]
+    same_time = [
+        fact.logical_id
+        for fact in observations
+        if fact.coordinates and fact.coordinates.event_at_us == 190
+    ]
+    assert same_time == ["allowance-observation:2", "allowance-observation:3"]
+    assert all(fact.coordinates is not None for fact in reference.facts)
+
+
+def test_all_plans_use_exact_request_window_roles_and_559_references() -> None:
+    declaration = build_structural_v2()
+    total_references = 0
+    roles_by_plan: dict[str, set[str]] = {}
+    for plan in plan_contract()["plans"]:
+        plan_id = plan["plan_id"]
+        request = adapter_request(plan_id)
+        has_window = any(
+            role == "window" or role.endswith("_window") for role in request.parameters
+        )
+        references = _references(request, window=has_window)
+        reference, database = _materialize_pair(
+            declaration,
+            plan_id=plan_id,
+            window=has_window,
+        )
+        assert [
+            (item.role, item.selector_kind, item.selector) for item in reference.evidence_references
+        ] == [
+            (item.role, item.selector_kind, item.selector) for item in database.evidence_references
+        ]
+        total_references += len(references)
+        roles_by_plan[plan_id] = {
+            item["role"] for item in references if item["selector_kind"] == "window"
+        }
+
+    assert total_references == 559
+    assert roles_by_plan["period_drivers"] == {
+        "current_window",
+        "previous_window",
+    }
+    assert roles_by_plan["weekly_review"] == {
+        "current_window",
+        "previous_window",
+    }
+
+
+def test_wrong_window_and_rate_card_selectors_fail_closed() -> None:
+    declaration = build_structural_v2()
+    contract = plan_contract()
+    selectors = selector_contract()
+    request = adapter_request("period_drivers")
+    references = [dict(item) for item in _references(request, window=True)]
+    window_index = next(
+        index for index, item in enumerate(references) if item["selector_kind"] == "window"
+    )
+    references[window_index]["selector"] = "window:not-the-derived-window"
+    references[window_index]["logical_id"] = "window:not-the-derived-window"
+
+    with pytest.raises(StructuralReferenceAdapterError, match="window"):
+        StructuralReferenceFactAdapter(contract, selectors).materialize(
+            declaration,
+            request,
+            references,
+        )
+    connection = build_query_only_database(declaration)
+    with pytest.raises(DatabaseAdapterContractError, match="window"):
+        DatabaseV1FactAdapter(contract, selectors, references).materialize(
+            connection,
+            request,
+            references,
+        )
+
+    request = adapter_request()
+    references = [dict(item) for item in _references(request, window=True)]
+    rate_index = next(
+        index for index, item in enumerate(references) if item["selector_kind"] == "rate_card"
+    )
+    references[rate_index]["selector"] = f"rate-card:{'0' * 64}"
+    with pytest.raises(StructuralReferenceAdapterError, match="rate-card"):
+        StructuralReferenceFactAdapter(contract, selectors).materialize(
+            declaration,
+            request,
+            references,
+        )
+    connection = build_query_only_database(declaration)
+    with pytest.raises(DatabaseAdapterContractError, match="rate-card"):
+        DatabaseV1FactAdapter(contract, selectors, references).materialize(
+            connection,
+            request,
+            references,
+        )
+
+
+def test_model_profile_uses_representative_call_occurrences() -> None:
+    declaration = build_structural_v2()
+    assert "profile:alpha" not in declaration["occurrences"]
+    assert "profile:beta" not in declaration["occurrences"]
+    reference, database = _materialize_pair(declaration)
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    profile = next(
+        item for item in reference.evidence_references if item.selector_kind == "model_profile"
+    )
+    assert profile.provenance_kind == "source_occurrence"
+    assert (
+        profile.provenance["representative_call_occurrences"][0]["semantic_logical_id"]
+        == "call:before"
+    )
+
+
+def test_authoritative_publication_coverage_excludes_unpriced_calls() -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(null_cached_tokens=True),
+        plan_id="data_health",
+        window=False,
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    publication = next(fact for fact in reference.facts if fact.relation == "publication")
+    assert publication.values["valuation_coverage"] == {
+        "basis": "configured_estimate",
+        "priced_calls": 2,
+    }
+    assert publication.values["capabilities"] == {
+        "context_components": True,
+        "valuation": True,
+    }
+
+
+def test_tool_resource_links_include_every_normalized_relationship() -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(),
+        plan_id="repeated_resource_operations",
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    tool = next(
+        fact
+        for fact in reference.facts
+        if fact.relation == "tool_invocation" and fact.logical_id == "tool:inspect"
+    )
+    assert tuple(tool.values["resource_links"]) == (
+        "resource:file",
+        "resource:test",
+    )
+
+
+def test_allowance_forms_normalize_to_remaining_percent_basis() -> None:
+    reference, database = _materialize_pair(
+        build_structural_v2(),
+        plan_id="allowance_interval_events",
+        window=False,
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    values = {
+        fact.logical_id: fact.values["allowance_percent"]
+        for fact in reference.facts
+        if fact.relation == "allowance_observation"
+    }
+    assert values == {
+        "allowance-observation:1": 90,
+        "allowance-observation:2": 80,
+        "allowance-observation:3": 80,
+        "allowance-observation:4": 70,
+    }
+
+
+def test_each_allowance_interval_resolves_its_own_boundary_pair() -> None:
+    declaration = build_structural_v2()
+    request = adapter_request("allowance_interval_events", with_window=False)
+    references = [dict(item) for item in _references(request, window=False)]
+    interval = next(item for item in references if item["selector_kind"] == "allowance_interval")
+    interval.update(
+        {
+            "selector": "allowance-interval:allowance-interval:two",
+            "logical_id": "allowance-interval:two",
+        }
+    )
+    contract = plan_contract()
+    selectors = selector_contract()
+    reference = StructuralReferenceFactAdapter(contract, selectors).materialize(
+        declaration,
+        request,
+        references,
+    )
+    connection = build_query_only_database(declaration)
+    database = DatabaseV1FactAdapter(contract, selectors, references).materialize(
+        connection,
+        request,
+        references,
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    selected = next(
+        item for item in reference.evidence_references if item.selector_kind == "allowance_interval"
+    )
+    assert (
+        selected.provenance["start_observation_selector"]
+        == "allowance-observation:allowance-observation:3"
+    )
+    assert (
+        selected.provenance["end_observation_selector"]
+        == "allowance-observation:allowance-observation:4"
+    )
+
+
+def test_database_frontier_publication_mismatch_fails_closed() -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+    connection.execute("PRAGMA query_only = OFF")
+    connection.execute("UPDATE active_rate_card SET publication_id = 'publication:stale'")
+    connection.commit()
+    connection.execute("PRAGMA query_only = ON")
+    request = adapter_request("pricing_coverage", with_window=False)
+    references = _references(request, window=False)
+    with pytest.raises(DatabaseAdapterContractError, match="rate-card"):
+        DatabaseV1FactAdapter(
+            plan_contract(),
+            selector_contract(),
+            references,
+        ).materialize(connection, request, references)
+
+
+def test_database_publication_coverage_missing_state_fails_closed() -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+    connection.execute("PRAGMA query_only = OFF")
+    connection.execute(
+        """
+        DELETE FROM publication_capability_coverage
+        WHERE capability_id = 'valuation'
+        """
+    )
+    connection.commit()
+    connection.execute("PRAGMA query_only = ON")
+    request = adapter_request("data_health", with_window=False)
+    references = _references(request, window=False)
+    with pytest.raises(DatabaseAdapterContractError, match="coverage"):
+        DatabaseV1FactAdapter(
+            plan_contract(),
+            selector_contract(),
+            references,
+        ).materialize(connection, request, references)
+
+
+@pytest.mark.parametrize(
+    ("used_percent", "remaining_percent"),
+    [
+        ("20", "70"),
+        ("101", None),
+    ],
+)
+def test_database_allowance_inconsistent_or_out_of_range_fails_closed(
+    used_percent: str,
+    remaining_percent: str | None,
+) -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+    connection.execute("PRAGMA query_only = OFF")
+    connection.execute(
+        """
+        UPDATE allowance_observations
+        SET used_percent = ?, remaining_percent = ?
+        WHERE observation_id = 'allowance-observation:1'
+        """,
+        (used_percent, remaining_percent),
+    )
+    connection.commit()
+    connection.execute("PRAGMA query_only = ON")
+    request = adapter_request("allowance_interval_events", with_window=False)
+    references = _references(request, window=False)
+    with pytest.raises(DatabaseAdapterContractError, match="allowance|percent"):
+        DatabaseV1FactAdapter(
+            plan_contract(),
+            selector_contract(),
+            references,
+        ).materialize(connection, request, references)
+
+
+def test_occurrence_provenance_is_coordinate_ordered() -> None:
+    declaration = build_structural_v2(
+        lifecycle="late_event",
+        include_late_call=True,
+    )
+    declaration["occurrences"]["call:before"].reverse()
+    reference, database = _materialize_pair(declaration)
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    profile = next(
+        item for item in reference.evidence_references if item.selector_kind == "model_profile"
+    )
+    assert [
+        item["record_ordinal"]
+        for item in profile.provenance["representative_call_occurrences"]
+        if item["semantic_logical_id"] == "call:before"
+    ] == [8, 10_008]
+
+
+def test_tool_resource_links_are_primary_first_and_stably_deduplicated() -> None:
+    declaration = build_structural_v2()
+    tool = next(
+        fact
+        for fact in declaration["facts"]
+        if fact["relation"] == "tool_invocation" and fact["logical_id"] == "tool:inspect"
+    )
+    tool["values"]["resource_links"] = [
+        "resource:test",
+        "resource:file",
+        "resource:test",
+    ]
+    reference, database = _materialize_pair(
+        declaration,
+        plan_id="repeated_resource_operations",
+    )
+    assert normalize_materialization(reference) == normalize_materialization(database)
+    normalized = next(
+        fact
+        for fact in reference.facts
+        if fact.relation == "tool_invocation" and fact.logical_id == "tool:inspect"
+    )
+    assert normalized.values["resource_links"] == [
+        "resource:file",
+        "resource:test",
+    ]
+
+
+def test_database_noncanonical_allowance_decimal_fails_closed() -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+    connection.execute("PRAGMA query_only = OFF")
+    connection.execute(
+        """
+        UPDATE allowance_observations
+        SET used_percent = '2E1', remaining_percent = NULL
+        WHERE observation_id = 'allowance-observation:1'
+        """
+    )
+    connection.commit()
+    connection.execute("PRAGMA query_only = ON")
+    request = adapter_request("allowance_interval_events", with_window=False)
+    references = _references(request, window=False)
+    with pytest.raises(DatabaseAdapterContractError, match="canonical decimal"):
+        DatabaseV1FactAdapter(
+            plan_contract(),
+            selector_contract(),
+            references,
+        ).materialize(connection, request, references)
+
+
+def test_database_rolls_back_snapshot_for_unexpected_row_factory_error() -> None:
+    declaration = build_structural_v2()
+    connection = build_query_only_database(declaration)
+
+    def exploding_row_factory(cursor, row):
+        fields = {column[0] for column in cursor.description or ()}
+        if "call_id" in fields:
+            raise RuntimeError("synthetic row-factory failure")
+        return sqlite3.Row(cursor, row)
+
+    connection.row_factory = exploding_row_factory
+    request = adapter_request()
+    references = _references(request, window=True)
+    with pytest.raises(RuntimeError, match="row-factory"):
+        DatabaseV1FactAdapter(
+            plan_contract(),
+            selector_contract(),
+            references,
+        ).materialize(connection, request, references)
+    assert not connection.in_transaction

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -34,6 +34,7 @@ _PACKET_IDS = {
     "CK-07B",
     "CK-07C",
     "CK-07D",
+    "CK-07E",
 }
 
 
@@ -69,12 +70,12 @@ def test_master_ledger_links_exactly_one_file_per_packet() -> None:
     ledger_path = _DOCS / "roadmap" / "TASK_PACKETS.md"
     ledger = ledger_path.read_text(encoding="utf-8")
     packet_ids = re.findall(
-        r"^- \[[ xX]\] \*\*(CK-\d{2}[ABCD]?)\b",
+        r"^- \[[ xX]\] \*\*(CK-\d{2}[ABCDE]?)\b",
         ledger,
         re.MULTILINE,
     )
     packet_links = re.findall(
-        r"\[packet\]\((tasks/ck-\d{2}[abcd]?-.*\.md)\)",
+        r"\[packet\]\((tasks/ck-\d{2}[abcde]?-.*\.md)\)",
         ledger,
     )
 
@@ -133,22 +134,38 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
         "docs/roadmap/tasks/"
         "ck-07d-implement-effective-dated-rate-card-valuation.md"
     )
+    ck07e = _read(
+        "docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md"
+    )
     ck08 = _read("docs/roadmap/tasks/ck-08-implement-query-and-evidence.md")
 
     assert "## Cross-packet semantic continuity" in agents
     assert "producer artifact and exact identity" in agents
     assert "independent truth source or reference evaluator" in agents
     assert "CK-07A" in index
-    assert "CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07A -> CK-08" in roadmap
-    assert "CK-07 → CK-07B\n→ CK-07C → CK-07D → CK-07A → CK-08" in ledger
+    assert (
+        "CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07E -> CK-07A -> CK-08"
+        in roadmap
+    )
+    assert (
+        "CK-07 → CK-07B\n→ CK-07C → CK-07D → CK-07E → CK-07A → CK-08"
+        in ledger
+    )
     assert "| CK-07D |" in backlog
+    assert "| CK-07E |" in backlog
     assert "| CK-07A |" in backlog
     assert "### Evidence claim classes" in qualification
     assert "### Fact-backed plan admission" in query_contract
-    assert "**Dependencies:** CK-07, CK-07B, CK-07C, and CK-07D merged" in ck07a
+    assert (
+        "**Dependencies:** CK-07, CK-07B, CK-07C, CK-07D, and CK-07E merged"
+        in ck07a
+    )
     assert "greatest eligible" in ck07d
     assert "fetched_at_us" in ck07d
     assert "late-ingested" in ck07d
+    assert "StructuralReferenceFactAdapter" in ck07e
+    assert "DatabaseV1FactAdapter" in ck07e
+    assert "0 / 80" in ck07e
     assert "## Frozen seam contracts" in ck07a
     assert "## Frozen correction formats" in ck07a
     assert "agent-kernel-structural-v2" in ck07a

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -16,6 +16,7 @@ from scripts.check_kernel_scope import (
     CK07B_FORMULA_PROVENANCE_ADDITIONS,
     CK07C_PLAN_OPERAND_FACT_ADDITIONS,
     CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS,
+    CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS,
     CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS,
     DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS,
@@ -551,6 +552,15 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/publication/test_rate_cards.py",
     } == CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS
     assert {
+        "docs/decisions/evidence/ck07e/independent-fact-adapters-evidence.json",
+        "docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md",
+        "tests/agent_kernel/fact_adapters/__init__.py",
+        "tests/agent_kernel/fact_adapters/database.py",
+        "tests/agent_kernel/fact_adapters/reference.py",
+        "tests/agent_kernel/fact_adapters/support.py",
+        "tests/agent_kernel/fact_adapters/test_contracts.py",
+    } == CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS
+    assert {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
     } == CK08_PREREQUISITE_BLOCKER_ADDITIONS
     assert INTEGRATION_ADDITIONS == (
@@ -586,6 +596,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK07B_FORMULA_PROVENANCE_ADDITIONS
         | CK07C_PLAN_OPERAND_FACT_ADDITIONS
         | CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS
+        | CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )


### PR DESCRIPTION
## Summary

- add independent test-only structural and database-v1 fact adapters
- bind all current plan-operand fact families and all 14 selector kinds
- prove exact normalized fact, request, evidence, lifecycle, and effective-dated valuation parity
- admit CK-07E authority and preserve CK-07A at 0/80 requalified

## Why

CK-07A requires two independent normalization paths between merged CK-07C/CK-07D authority and its later 80-answer requalification. This packet supplies and qualifies those prerequisites without adding production query or write surfaces.

## Validation

- focused CK-07E: 31 passed
- coupled scope/documentation: 55 passed
- coupled kernel/storage/publication: 317 passed
- `just v`: 1241 passed; 13 performance invariants, zero breaches
- `just vc`: 1241 passed; distribution builds and checks passed
- final independent review: no actionable findings
- staged GitNexus: low risk, zero affected processes

## Boundaries

No CK-07A 80-answer comparison, CK-04 scoring/timing refresh, production schema/query API, or CK-08+ work is included.