### PR TITLE
docs: gate evidence scale on physical query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,12 @@ evidence. A downstream architecture audit found that the expected-answer lane
 shares production evaluation, runtime keyset pagination follows complete
 Python materialization, projection classification combines execution stages,
 and publication/evidence scale plus replacement maintainability need
-corrective proof. CK-08R0 has frozen `corrective-gates-v1`; CK-09 remains
-blocked. CK-08R1, CK-08R2, CK-08R3, CK-07R1, and CK-QG1 become Ready only
-after the CK-08R0 merge is exact-main verified.
+corrective proof. CK-08R0 has frozen `corrective-gates-v1`; CK-08R2 is complete
+on merge, and CK-09 remains blocked. CK-08R1, CK-07R1, and CK-QG1 become Ready
+only after the CK-08R0 merge is exact-main verified. Retained CK-08R3 pre-scale evidence
+proved the EvidenceService outer query physically unbounded, so CK-08R3A now
+owns the isolated production fix and CK-08R3 remains blocked on its accepted,
+merged, exact-main-verified result.
 
 Advance only child tasks marked Ready in
 `docs/roadmap/REMAINING_EXECUTION_PLAN.md`. Parent CK-09 through CK-16 packets

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,39 +6,23 @@ and none of the archived documents may override them.
 
 ## Current packet boundary
 
-CK-07A is complete after consuming the merged CK-07B formula/provenance,
-CK-07C plan/direct-fact, CK-07D effective-dated valuation, and CK-07E
-independent-adapter prerequisites. Its
-[canonical evidence](decisions/evidence/ck07a/fact-backed-oracle-and-seam-qualification-evidence.json)
-records 80 / 80 fact-backed comparisons through structural-v2 source JSONL,
-CK-06 ingestion, CK-07 publication/recovery, query-only database-v1, Candidate
-A's permitted fact-table/planner path, and two fact-adapter consumers of the
-same production answer evaluator. All 185
-answer-field bindings, 14 selector kinds, six provenance kinds, exact ordered
-references, response bytes, timings, SQL sources/plans, lifecycle modes, and
-CK-03 through CK-07 requalifications are recorded.
+CK-07A's [evidence](decisions/evidence/ck07a/fact-backed-oracle-and-seam-qualification-evidence.json)
+records 80 / 80 variants after CK-07B/C/D/E and CK-03–07 replay. The
+[CK-08 gap](decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)
+is preserved/superseded; CK-04 runs 3/4 remain waived and five-run success
+unclaimed. Historical CK-08 covers 21 plans/42 variants, but shared truth,
+post-materialization paging, mixed timing and unproved scale cannot admit
+projections; [`corrective-gates-v1`](decisions/evidence/ck08r0/corrective-gates-v1.json)
+keeps CK-09 blocked.
 
-The historical
-[CK-08 prerequisite gap](decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json)
-remains preserved as the reproduction that caused the stop, but it is no
-longer the current boundary blocker. CK-04's invalid `question_cases`
-correctness proof is replaced; its current-commit growth repetitions 3 and 4
-remain explicitly waived and no strict five-repetition aggregate is claimed.
-CK-08 is historically complete on merge: all 21 plans and 42 fact-backed
-variants reconcile through the shared evaluator, every plan received a
-provisional physical classification, and no projection or public surface was
-added. Its single final reviewer findings were all accepted and corrected.
-
-A downstream architecture audit reproduced four corrective gaps. CK-08R2 is
-complete on merge and replaces full-result Python slicing with bounded
-physical keyset SQL for the two supported direct plans; 19 plans retain exact
-physical/index gaps without projection. Independent expected-answer truth,
-projection reclassification, publication/evidence scale, and replacement
-maintainability remain open.
-[`corrective-gates-v1`](decisions/evidence/ck08r0/corrective-gates-v1.json)
-preserves history and keeps CK-09 blocked.
-[REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md) is the
-central execution authority.
+CK-08R2 is complete on merge: two supported direct plans now use bounded
+physical keyset SQL; 19 plans retain explicit gaps without projection.
+Retained CK-08R3 `a28e9cdbff8e48d334712a449fdcee111c725673` then stopped
+before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
+fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
+truth, reclassification, publication/evidence scale and maintainability remain
+open. The central authority is
+[REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
 ## Authority set
 

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -150,10 +150,12 @@ consumer replay before admission.
 the exact inputs, page-execution request/result/stage contract, scale profiles,
 budgets, output evidence schemas, lane locks, failure rules, and
 requalification frontier in
-`docs/decisions/evidence/ck08r0/corrective-gates-v1.json`. CK-08R2 must apply
+`docs/decisions/evidence/ck08r0/corrective-gates-v1.json`. Completed CK-08R2 applies
 complete order, keyset predicates, and `LIMIT page_size + 1` in SQL before
 Python row materialization and may not call complete-result `evaluate_plan`.
-CK-08R3 must qualify evidence first/deep pages at both scales. CK-07R1 must
+CK-08R3A must first replace the physically unbounded EvidenceService outer
+query while preserving selector, cursor, order, and budget semantics; CK-08R3
+must then qualify evidence first/deep pages at both scales. CK-07R1 must
 qualify publication-valid lifecycle preparation. CK-08R4 alone may classify a
 plan as direct-page, evidence-page, or projection-required. CK-09 may admit
 only the resulting measured residual list after CK-08RG.

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -24,152 +24,83 @@ No lower level substitutes for a required higher level.
 
 ### Evidence claim classes
 
-Evidence must state the exact class proved; these claims are not
-interchangeable:
+Claims are not interchangeable:
 
 | Claim | Required proof |
 | --- | --- |
-| Structural validity | Schema, identity, ordering, and digest checks pass. |
-| Formula consistency | Values inside one oracle record satisfy its declared formulas. |
-| Canonical-fact lineage | The exact typed request selects canonical typed facts emitted by its scenario, and an independent evaluator derives the expected result from those facts. |
-| Consumer replay | The actual downstream adapter, storage, publication, or query path produces the same result from only its permitted inputs. |
+| Structural validity | Schema, identity, order and digests pass. |
+| Formula consistency | One oracle record satisfies its formulas. |
+| Canonical-fact lineage | A typed request selects scenario facts; independent truth derives the result. |
+| Consumer replay | The real downstream path matches from permitted inputs only. |
 
-A packet may claim only the classes it executed. A prior packet's completion,
-matching hashes, or internal oracle reconciliation cannot substitute for
-canonical-fact lineage or consumer replay.
+A packet claims only executed classes; completion, hashes or internal
+reconciliation never substitute for lineage/replay.
 
 Every dependency edge used as truth records a seam contract with:
 
 ```text
-producer artifact path, schema, revision, and digest
-consumer packet and executable path
-independent truth source or reference evaluator
-executable seam check
-exact request/result comparison
-affected evidence and packets to requalify after change
+producer path/schema/revision/digest
+consumer packet/executable
+independent truth
+executable exact request/result seam check
+affected requalification
 ```
 
-If consumer replay disproves an upstream claim, the dependent packet stops.
-The roadmap admits a corrective packet, preserves the historical record, and
-requires current requalification evidence before the dependency may be
-consumed again.
+Failed replay stops dependents; a corrective packet preserves history and
+requires current requalification before reuse.
 
-CK-07C adds an L0 prerequisite for CK-07A: the versioned plan-operand artifact
-must schema-validate and reconcile exactly 40 plans, 61 formula uses, 112
-direct bindings, 73 formula-output bindings, and all 185 answer fields. Its
-pure compiler/evaluator vectors cover request and fact typing, gates, grouping,
-total order, `NULL` and empty behavior, exact decimal serialization, missing
-operands, output extraction, and internal-only formula consumption. These
-contract vectors prove executability only; they do not substitute for
-CK-07A's 80-case canonical-fact lineage and database consumer replay.
+Prior L0 remains exact: CK-07C validates 40 plans, 61 formula uses, 112
+direct/73 formula bindings and 185 fields but not lineage; CK-07D selects the
+greatest publication-captured `effective_at_us <= call.event_at_us` revision
+and replays boundary/late/subset/future/missing/invalid/ambiguous and unpriced
+cases through pure/database-v1 truth, with CK-05/07/07C requalification;
+CK-07E independently matches structural/query-only `CanonicalFact`,
+`PlanRequest` and ordered evidence across every family, 14 selectors,
+provenance, ordering, valuation, privacy and lifecycle, while recording 0 / 80
+answers and changing no prior evidence. CK-07D's twelve proofs are
+`docs/decisions/evidence/ck07d/effective-dated-valuation-implementation-evidence.json`;
+local evidence alone did not unblock CK-07A/08.
 
-CK-07D adds the remaining L0 valuation prerequisite. Synthetic calls before,
-at, and after an explicit pricing boundary must select the greatest matching
-publication-captured revision effective at each call's `event_at_us`.
-Late-ingested historical calls, model-subset changes, future revisions, missing
-times, invalid lineages, and ambiguous equal-effective matches must replay
-identically through the pure reference boundary and database-v1 publication
-path. Typed unpriced valuation rows must remain unpriced in coverage. CK-05,
-CK-07, and CK-07C valuation seams require linked requalification before CK-07A
-may resume.
-
-CK-07D's local implementation results, artifact identities, twelve acceptance
-proofs, validation measurements, review state, and residual merge gates are
-recorded in
-`docs/decisions/evidence/ck07d/effective-dated-valuation-implementation-evidence.json`.
-That local evidence does not unblock CK-07A or CK-08 before merge and
-exact-main verification.
-
-CK-07E is the final L0 adapter prerequisite before CK-07A. A structural
-reference adapter and a separately implemented query-only database-v1 adapter
-must independently emit equivalent normalized `CanonicalFact` rows,
-`PlanRequest`, and exact ordered owner-specific evidence. Qualification covers
-every plan relation/fact family, all 14 selector owners, typed non-placeholder
-provenance, NULL/empty/ties/order/no-window behavior, effective-dated
-valuation and unpriced coverage, import/source independence, privacy, and
-clean rebuild/replacement/late-event stability. These comparisons stop at the
-fact/request/evidence boundary: CK-07E must record 0 / 80 CK-07A answer
-comparisons and cannot update CK-04 scoring or CK-03 through CK-07 seam
-evidence.
-
-Historical CK-07A evidence records 80 / 80 fact-adapter comparisons through
-structural-v2 source JSONL, CK-06 ingestion, CK-07 publication/recovery,
-query-only database-v1, Candidate A's permitted fact-table/planner lane, and
-two fact-adapter consumers that share production `evaluate_plan`. Its durable
-evidence records all 185 answer-field
-bindings, 14 selector kinds, six provenance kinds, ordered references, SQL
-sources/plans, response bytes, timings, lifecycle replay, privacy, and CK-03
-through CK-07 requalification. CK-04's current-commit growth repetitions 3 and
-4 remain waived; the strict five-repetition aggregate remains unclaimed.
-
-Historical CK-08 evidence adds L2 mechanism qualification and provisional L3
-scale classification.
-Its durable evidence executes 21 Foundation/Cutover plans across 42 fact-backed
-variants through the real internal query service, compares complete typed rows,
-grades, order, request/comparison digests, and evidence references, and records
-all SQL sources and exact `EXPLAIN` structures. It separately proves signed
-keyset pagination, exact-count opt-in, response-byte accounting, query-only
-write denial, and rebuild/replacement/late-event behavior.
-
-The standard query-only database-v1 fixture contains 100,000 synthetic calls;
-the production fixture contains 1,316,864. Repeated standard and production
-measurements classify three plans as fact-table-sufficient. Eighteen plans stop
-after a retained required-gate breach and carry provisional
-projection-candidate evidence that cannot authorize CK-09. That classification
-was a historical CK-08 outcome; it is not current admission, and CK-08
-implements no projection. The separate full
-publication-path attempt is retained as a bounded predecessor-path failure and
-is not mislabeled as a publication-valid scale result.
+Historical CK-07A records 80 / 80 structural-v2→CK-06/07→database-v1→Candidate
+A comparisons, 185 bindings, 14 selectors, six provenance kinds, SQL/plans,
+bytes/timings, lifecycle/privacy and CK-03–07 replay, but both truth consumers
+share `evaluate_plan`; CK-04 runs 3/4 remain waived and five-run success is
+unclaimed. Historical CK-08 records L2/provisional L3 for 21 plans/42 variants,
+signed keysets, exact count, bytes, write denial and lifecycle. Its
+100,000/1,316,864-call fixtures provisionally label three fact-table plans; 18
+stopped and cannot authorize CK-09. It added no projection, and its retained
+publication-path failure is not publication-valid scale.
 
 ### Corrective interpretation and immutable parallel qualification
 
-CK-07A/CK-08 remain historical fact-adapter and mechanism evidence. They do
-not currently prove independent answer semantics because both expected-answer
-consumers import production `evaluate_plan`. They also do not prove physical
-deep-page work is bounded before Python materialization. CK-08's
-`sql_p95_ms` combines compiler/Python evaluation and materialization, so its
-three-direct/eighteen-projection labels are provisional rather than CK-09
-admission. CK-08R0's `corrective-gates-v1` controls CK-08R1/R2/R3, CK-07R1,
-CK-QG1, CK-08R4, and CK-08RG; stale evidence fails closed and CK-09 stays
-blocked.
+CK-07A/08 remain historical: shared `evaluate_plan`, post-materialization
+paging and mixed `sql_p95_ms` leave truth, bounds and labels unproved. CK-08R0
+controls R1/R2/R3A/R3, 07R1, QG1 and R4/RG. Retained R3 EXPLAIN requires
+merged/exact-main R3A before scale; stale evidence blocks CK-09.
 
-The remaining execution plan decomposes CK-12 into one candidate freeze, four
-read-only lanes, and one integration decision. Every lane consumes
-byte-identical artifacts, fixtures, catalogs, registry, and budgets. A lane
-does not repair the candidate it measures. A failure is retained and routed by
-the integrator to a new narrowly owned corrective task; semantic repair creates
-a new candidate identity and reruns every affected lane.
+CK-12 freezes one candidate, runs four read-only lanes on byte-identical
+inputs/budgets, then integrates. Lanes never repair candidates; retained
+failure creates a narrow correction, new identity and affected-lane replay.
 
 ## Synthetic fixture strategy
 
-Fixtures contain no real local usage records or raw content. A deterministic
-generator emits:
-
-- Codex-shaped JSONL structural records;
-- source layouts, copies, archives, truncations, replacements, malformed lines,
-  uncertain dates, and moving tails;
-- sessions, turns, calls, tools, resources, activities, compactions, observed
-  mutations, hierarchy, allowance observations, and rate cards;
-- exact four token classes and deliberate missing fields;
-- expected canonical identities, counts, totals, lifecycle states, coverage,
-  selectors, occurrence coordinates, and question answers.
+Fixtures contain no real usage/raw content. Deterministic generation covers
+Codex-shaped structural JSONL; layouts/copies/archives/truncation/replacement/
+malformation/uncertain dates/tails; sessions through rate cards; four token
+classes/missing fields; and expected identities, counts, totals, lifecycle,
+coverage, selectors, occurrences and answers.
 
 Every fixture has a manifest:
 
 ```text
-schema and generator version
-seed and manifest digest
-history range and timezone
-source/file/byte counts
-event-kind and missingness distributions
-duplicate/replacement/late-event cases
-capabilities and rate-card revision
-expected canonical/projection counts
-question oracle IDs
+schema/generator/seed/digest
+history/timezone and source/file/byte counts
+event/missingness/duplicate/replacement/late distributions
+capabilities/rate-card revision
+expected canonical/projection counts and oracle IDs
 ```
 
-Tiny fixtures are hand-auditable. Scale fixtures are generated from the same
-semantic case library, not a separate simplified benchmark model.
+Tiny fixtures are auditable; scale uses the same semantic cases.
 
 CK-03 freezes the source revision as `agent-kernel-structural-v1`. Source
 records are compact canonical JSON Lines; manifests and oracle bundles use

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -59,49 +59,32 @@ spike and Console before the new public release.
 
 ```text
 CK-00 -> CK-01 -> CK-02 -> CK-03 -> CK-04 -> CK-05 -> CK-06
-      -> CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07E -> CK-07A -> CK-08
-      -> CK-08R0 -> {CK-08R1, CK-08R2, CK-08R3, CK-07R1, CK-QG1}
-      -> CK-08R4 -> CK-08RG -> CK-09 -> CK-10 -> CK-11 -> CK-12
-      -> CK-13 -> CK-14 -> CK-16
+-> CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07E -> CK-07A -> CK-08
+-> CK-08R0 -> {CK-08R1, CK-08R2, CK-08R3A, CK-07R1, CK-QG1}
+CK-08R3A -> CK-08R3
+{CK-08R1, CK-08R2, CK-08R3, CK-07R1} -> CK-08R4
+{CK-08R4, CK-QG1} -> CK-08RG -> CK-09 -> CK-10 -> CK-11 -> CK-12
+-> CK-13 -> CK-14 -> CK-16
+```
+
+```mermaid
+flowchart LR
+    R0[CK-08R0] --> R1[CK-08R1]
+    R0 --> R2[CK-08R2]
+    R0 --> R3A[CK-08R3A]
+    R0 --> R7[CK-07R1]
+    R0 --> QG[CK-QG1]
+    R3A --> R3[CK-08R3]
+    R1 --> R4[CK-08R4]
+    R2 --> R4
+    R3 --> R4
+    R7 --> R4
+    R4 --> RG[CK-08RG]
+    QG --> RG
 ```
 
 CK-15 is post-MVP enhancement and does not block CK-16 unless the maintainer
 explicitly includes it in the release scope.
-
-```mermaid
-flowchart LR
-    C0[CK-00 Authority cleanup] --> C1[CK-01 Question registry]
-    C1 --> C2[CK-02 Logical vectors]
-    C2 --> C3[CK-03 Fixtures and oracles]
-    C3 --> A[CK-04A Candidate A]
-    C3 --> C[CK-04C Candidate C]
-    C3 --> D[CK-04D Candidate D]
-    A --> DEC[CK-04 Decision]
-    C --> DEC
-    D --> DEC
-    DEC --> K[CK-05 Selected kernel]
-    K --> AD[CK-06 Codex adapter and ingest]
-    AD --> P[CK-07 Publication and recovery]
-    P --> CONTRACT[CK-07B Formula and provenance contract]
-    CONTRACT --> OPERANDS[CK-07C Plan operands and missing facts]
-    OPERANDS --> RATES[CK-07D Effective-dated valuation]
-    RATES --> ADAPTERS[CK-07E Independent fact adapters]
-    ADAPTERS --> SEAM[CK-07A Fact-lineage seam repair]
-    SEAM --> Q[CK-08 Query and evidence]
-    Q --> CF[CK-08R0 Corrective freeze]
-    CF --> CT[CK-08R1/R2/R3 and CK-07R1/CK-QG1]
-    CT --> CR[CK-08R4 Reclassification]
-    CR --> RG[CK-08RG Resume gate]
-    RG --> PR[CK-09 Projections and named plans]
-    PR --> UX[CK-10 Setup, MCP, skill]
-    UX --> IH[CK-11 Installed harness]
-    IH --> QUAL[CK-12 Qualification]
-    QUAL --> CUT[CK-13 Cutover]
-    CUT --> DEL[CK-14 Delete spike]
-    DEL --> REL[CK-16 Public docs and release]
-    DEL --> ENH[CK-15 Optional presentation]
-    ENH -. optional .-> REL
-```
 
 ## Parallel opportunities
 
@@ -117,7 +100,7 @@ Parallel work is optional and never changes dependency order.
 | CK-07E after CK-07D | Structural-reference adapter; query-only database-v1 adapter; parity/provenance/lifecycle qualification | One integrator freezes adapter interfaces, structural declarations, exact evidence schema, and disjoint file ownership before implementation lanes begin. |
 | CK-07A after CK-07E | Expected-row generation; CK-04 proof replacement; CK-05–CK-07 replay | One integrator consumes the qualified CK-07E adapters and owns expected-row and seam-evidence schemas before disjoint lanes begin. |
 | After CK-07A | Fact-backed query compiler; evidence cursor service; installed harness skeleton | Public request/result schemas and registry have one owner. |
-| Corrective Wave 2 | Independent truth; physical query; evidence scale; lifecycle scale; maintainability | CK-08R0 froze `corrective-gates-v1`; its five successor lanes have disjoint locks/evidence schemas; CK-08R4 alone integrates measurements. |
+| Corrective Wave 2 | Independent truth; query paging; EvidenceService physical query then evidence scale; lifecycle scale; maintainability | CK-08R0 froze `corrective-gates-v1`; five parallel lanes have disjoint locks, CK-08R3 is serialized after CK-08R3A, and CK-08R4 alone integrates measurements. |
 | CK-09 | Admitted disjoint projection families after CK-09-01 freezes the registry | Projection registry, DDL, publication call site, and query bindings each have one integrator. |
 | CK-10 | Application implementation and skill draft after CK-10-01 | Public schemas and manifests remain integrator-owned. |
 | CK-11 | Artifact/CLI trials and Desktop/lower-model trials | Harness schema and scorecard aggregation remain integrator-owned. |
@@ -185,126 +168,73 @@ Rollback: candidate database path is independent; spike remains untouched.
 
 ### Gate G4: answer kernel
 
-CK-08 historically completed a fact-backed mechanism lane, but it did not
-complete this gate. Its two fact adapters share production answer evaluation,
-runtime keyset slicing follows complete Python materialization, its SQL timing
-mixes compiler/evaluator work, and evidence/publication scale plus replacement
-maintainability remain corrective prerequisites. The three direct and 18
-projection-required labels are provisional. CK-09 stays blocked until
-CK-08R0 froze `corrective-gates-v1`; CK-08R1 through CK-08RG must consume it,
-merge, and reclassify every plan from corrected evidence.
-
-- CK-07D effective-dated valuation and affected seam requalification evidence
-  is complete;
-- CK-07E independent fact-adapter parity, provenance, independence, and
-  lifecycle evidence is complete;
-- CK-07A fact-adapter parity remains historical evidence; CK-08R1 must add
-  semantically independent expected-answer truth;
-- CK-08R2 physical keyset execution before materialization is complete on
-  merge for `data_health` and `latest_publication_delta`; 19 residual plans
-  retain exact physical/index gaps without projection;
-- CK-08R3 and CK-07R1 must prove evidence and publication-valid scale;
-- CK-QG1 must enforce replacement-kernel maintainability;
-- CK-08R4 must issue measured projection-admission v2 and CK-08RG must authorize
-  exact-main resumption;
-- Foundation and Cutover named plans pass exact oracles;
-- admitted projections name consumers and bounded dirty updates;
-- evidence selectors/cursors survive rebuild/replacement/late events;
-- complete-result sorting, exact counts, labels, four token columns,
-  cost/credits, and allowance coverage behave as contracted;
-- SQL/MCP/byte gates pass at both scales.
+CK-08's shared evaluator, post-materialization keyset, mixed SQL timing and
+unproved scale/maintainability leave its three/18 labels provisional. CK-08R0
+`corrective-gates-v1` keeps CK-09 blocked through CK-08RG: R1 supplies
+independent truth; completed R2 bounds `data_health` and
+`latest_publication_delta` keyset work while 19 plans retain exact gaps; R3A
+removes the unbounded EvidenceService shape without semantic/budget change; R3/07R1 prove
+evidence/publication scale; QG1 enforces maintainability; R4 emits measured
+admission v2; RG authorizes exact-main resumption. Foundation/Cutover plans,
+projection consumers/dirty bounds, lifecycle-stable evidence cursors, sorting,
+counts, labels, four token columns, cost/credits, allowance and SQL/MCP/byte
+gates must all pass their exact oracles at both scales.
 
 Rollback: remove failing projection/plan or fall back to a fact-backed plan only
 if it meets the named contract.
 
 ### Gate G5: installed Codex MVP
 
-- exact wheel/plugin/skill bundle installed cleanly;
-- fresh CLI and Desktop tool exposure coherent;
-- recommended setup and warm reopen pass;
-- every Foundation/Cutover prompt has 100% oracle accuracy;
-- call/poll/refresh, latency, response, and model-token budgets pass;
-- less-capable model passes;
-- no source-checkout or side-channel fallback.
-
-Rollback: keep the new runtime disabled and continue using public 0.28.
+Exact wheel/plugin/skill clean install, coherent fresh CLI/Desktop exposure,
+recommended setup/reopen, 100% Foundation/Cutover oracle accuracy,
+call/poll/refresh/latency/response/token budgets, and the less-capable lane must
+pass without checkout/side channel. Rollback: disable it and use public 0.28.
 
 ### Gate G6: clean cutover
 
-- side-by-side candidate drill passes;
-- rollback by reinstalling/selecting the prior public release is documented and
-  tested before deletion;
-- replacement becomes the only packaged/runtime path;
-- spike, Console, old schemas/tools/routes/tests/assets/Node dependencies, and
-  compatibility code are absent;
-- package and CI ratchets decrease.
-
-Rollback before merge: restore from the clean cutover base. Rollback after
-release: install the previous public version and its independent database; no
-legacy runtime is bundled.
+The side-by-side drill and tested prior-release rollback precede deletion; only
+the replacement remains packaged/runnable, with spike/Console/old schemas,
+tools, routes, tests, assets, Node dependencies and compatibility code absent,
+and package/CI ratchets lower. Before merge restore the cutover base; after
+release install the prior version and independent database—never bundle legacy.
 
 ### Gate G7: public release
 
-- public-facing name transition retains searchable Codex Usage Tracker
-  references;
-- setup examples, supported questions, grades, limitations, and Data Analytics
-  handoff are accurate;
-- one build-once artifact set passes exact hashes, clean/public install, fresh
-  task smoke, and release checks;
-- release evidence is recorded.
+The name transition retains searchable Codex Usage Tracker references; setup,
+questions, grades, limits and Data Analytics handoff stay accurate; one
+build-once artifact set passes hashes, clean/public install, fresh-task smoke
+and release checks; evidence is recorded.
 
 ## Performance objectives
 
-Hard budgets live in the bake-off and qualification documents. Program targets:
-
-- 30-day first useful publication p95 `<=5 s`, stretch `<=2 s`;
-- 90-day `<=15 s`;
-- one-year `<=45 s`;
-- 1.3-million-call all-time `<=120 s`, stretch `<=60 s`;
-- no-change `<=100 ms`;
-- one-call and one-tool complete-history tails `<=500 ms`;
-- named P1/P2 local MCP `<=500 ms`;
-- normal Tier 1 answer one tracker call and `<=16 KB`;
-- fresh installed answer p95 `<=15 s`, with tracker and host/model portions
-  reported separately.
+Hard budgets remain in bake-off/qualification: 30-day publication p95 `<=5 s`
+(stretch `<=2 s`); 90-day `<=15 s`; one-year `<=45 s`; 1.3-million-call
+all-time `<=120 s` (stretch `<=60 s`); no-change `<=100 ms`; one-call/tool
+tails and named P1/P2 local MCP `<=500 ms`; normal Tier 1 one tracker call and
+`<=16 KB`; fresh installed answer p95 `<=15 s`, split tracker/host-model.
 
 These are gates, not estimates to be weakened after implementation.
 
 ## Cutover criteria
 
-The maintainer may approve CK-13 only when:
-
-- every locked logical contract is implemented;
-- every Foundation/Cutover question passes;
-- all crash and source-lifecycle cases pass;
-- selected history and expansion are honest and monotonic;
-- public data is separate from the spike path;
-- exact installed artifacts pass both Codex hosts and lower-capability lane;
-- package/DB/WAL/response/model-token ratchets pass;
-- one final reviewer has no unresolved accepted finding;
-- the previous public release can be reinstalled without touching the new
-  database.
+CK-13 requires every locked contract and Foundation/Cutover question; all
+crash/lifecycle cases; honest monotonic history/expansion; public/spike data
+separation; exact artifacts on both Codex hosts and the lower-capability lane;
+package/DB/WAL/response/token ratchets; no unresolved accepted review finding;
+and reinstall of the prior public release without touching the new database.
 
 ## Runtime-retirement gate
 
-CK-14 may delete the spike runtime only after all of these active conditions
-are true:
-
-1. The A/C/D bake-off has a recorded winner and complete decision artifact.
-2. The replacement passes every Foundation and Cutover question oracle at
-   100,000-call and production-shaped scale.
-3. Cold setup, ordinary tail, no-change, query, evidence, payload, and
-   installed-agent budgets pass on the exact wheel/plugin/skill candidate.
-4. Crash, recovery, late-event, source-replacement, recanonicalization,
-   valuation-only, and cross-publication lifecycle tests pass.
-5. A side-by-side cutover drill proves the spike remains untouched and rollback
-   can reinstall/select public 0.28 without database conversion.
-6. Fresh Codex CLI and Desktop tasks meet accuracy, usefulness, call-count,
-   latency, and token budgets, including the less-capable-model lane.
-7. The exact locally built candidate artifacts are byte-identified and pass
-   clean-install smoke without source-checkout fallback.
-8. The maintainer approves the final deletion checkpoint and no accepted review
-   finding remains unresolved.
+CK-14 deletion requires: (1) recorded A/C/D winner/decision; (2) every
+Foundation/Cutover oracle at 100,000 and production scale; (3) exact
+wheel/plugin/skill cold/tail/no-change/query/evidence/payload/installed-agent
+budgets; (4) crash/recovery/late/replacement/recanonicalization/valuation/
+cross-publication lifecycle; (5) side-by-side drill with untouched spike and
+public-0.28 rollback without conversion; (6) fresh CLI/Desktop accuracy,
+usefulness, calls, latency and tokens including the less-capable lane; (7)
+exact locally built candidate artifacts byte-identified and passing clean
+install without checkout; and (8) maintainer deletion approval with no
+unresolved accepted finding.
 
 Public-index download/install verification is a CK-16 post-publication check,
 not a prerequisite for CK-14. CK-14 must leave the tree capable of producing
@@ -313,34 +243,19 @@ build and release.
 
 ## Definition of done
 
-The clean-cutover program is complete when:
-
-- the new agent kernel is the only packaged implementation;
-- the old runtime and Console are deleted;
-- the product answers the supported catalog within correctness/evidence/
-  performance/call/token budgets;
-- setup and reopen feel immediate for recommended history;
-- ordinary tails are incremental and lock-bounded;
-- fresh installed Codex tasks are the release gate;
-- public artifacts are verified and released;
-- the roadmap ledger and Linear backlog mark all blocking packets complete;
-- every dependency used as truth has producer identity, consumer replay,
-  independent truth, and current requalification evidence;
-- optional future seams add no current runtime burden.
+Done means: only the new kernel is packaged; old runtime/Console are deleted;
+the catalog meets correctness/evidence/performance/call/token budgets; setup/
+reopen is immediate and tails incremental/lock-bounded; fresh installed Codex
+tasks gate verified public artifacts; ledger/backlog blocking work is complete;
+every truth edge has producer identity, consumer replay, independent truth and
+current requalification; future seams add no runtime burden.
 
 ## Explicit future items
 
-Design seams exist, but MVP does not implement:
-
-- Claude Code and other agent adapters;
-- Evidence Viewer and Live Watch;
-- MCP Apps/native Codex widgets;
-- Claude Artifacts;
-- bring-your-own question packs;
-- cross-agent/team/hosted comparisons;
-- automated recommendations;
-- live overlay/DOM integration;
-- shareable reports and historical rate cards.
+MVP excludes Claude Code/other adapters, Evidence Viewer/Live Watch, MCP Apps/
+native widgets, Claude Artifacts, bring-your-own packs, cross-agent/team/hosted
+comparisons, automated recommendations, live overlay/DOM, shareable reports
+and historical rate cards.
 
 Admission requires a new question/experience contract, measured consumer value,
 and no regression to the Codex-first core.

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -12,6 +12,11 @@ CK-09 remains blocked until CK-08R independently proves semantics, physical
 paging, measurements, and scale. CK-08R0 freezes the exact contracts and
 requalification frontier in `docs/decisions/evidence/ck08r0/corrective-gates-v1.json`.
 Preserve CK-03–CK-08 history and supersede only its four named claims.
+Retained CK-08R3 pre-scale evidence at commit
+`a28e9cdbff8e48d334712a449fdcee111c725673` proves the EvidenceService outer
+query physically unbounded independent of scale profile. CK-08R3A owns that
+production fix. CK-08R3 must not become Ready or be redelegated until CK-08R3A
+is accepted, merged, and exact-main verified.
 
 ## Delegation law
 
@@ -37,6 +42,7 @@ Only one integrator may own a lock at a time:
 | --- | --- |
 | Authority | `AGENTS.md`, `docs/INDEX.md`, roadmap, this plan, ledger, qualification plan, parent packets |
 | Query physical | request/result contracts, query registry/compiler bindings, cursor version |
+| Evidence physical | `EvidenceService` fixed page SQL, scope-to-branch selection, bound parameters, focused physical tests |
 | Publication physical | analytical DDL, projection registry, writer/preparation integration ports |
 | Installed surface | application envelope, MCP catalog, plugin manifest, `.mcp.json`, entry points |
 | Qualification | candidate hashes, fixture identity, scorecard/evidence schemas, final aggregates |
@@ -46,7 +52,8 @@ Only one integrator may own a lock at a time:
 
 The machine DAG below controls readiness and dependencies; each child packet controls its owner and scope. Only these fan-outs are allowed:
 
-- CK-08R0 -> CK-08R1, CK-08R2, CK-08R3, CK-07R1, CK-QG1; join at CK-08R4/CK-08RG.
+- CK-08R0 -> CK-08R1, CK-08R2, CK-08R3A, CK-07R1, CK-QG1;
+  CK-08R3A -> CK-08R3; join at CK-08R4/CK-08RG.
 - CK-09-01 -> CK-09-02/03/04; join at CK-09-05.
 - CK-10-01 -> CK-10-02 and CK-10-04; CK-10-03 follows 10-02; join at 10-05.
 - CK-11-01 -> CK-11-02/03; join at CK-11-04.
@@ -74,16 +81,17 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
   "completed": ["CK-08R0", "CK-08R2"],
-  "ready": [],
+  "ready": ["CK-08R3A"],
   "conditional_ready": [{
     "condition": "CK-08R0 merged and exact-main verified",
-    "tasks": ["CK-08R1", "CK-08R3", "CK-07R1", "CK-QG1"]
+    "tasks": ["CK-08R1", "CK-07R1", "CK-QG1"]
   }],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},
     {"id": "CK-08R1", "file": "tasks/ck-08r1-build-independent-answer-truth.md", "dependencies": ["CK-08R0"]},
     {"id": "CK-08R2", "file": "tasks/ck-08r2-implement-physical-keyset-execution.md", "dependencies": ["CK-08R0"]},
-    {"id": "CK-08R3", "file": "tasks/ck-08r3-qualify-evidence-scale.md", "dependencies": ["CK-08R0"]},
+    {"id": "CK-08R3A", "file": "tasks/ck-08r3a-implement-evidence-physical-query.md", "dependencies": ["CK-08R0"]},
+    {"id": "CK-08R3", "file": "tasks/ck-08r3-qualify-evidence-scale.md", "dependencies": ["CK-08R3A"]},
     {"id": "CK-07R1", "file": "tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "dependencies": ["CK-08R0"]},
     {"id": "CK-QG1", "file": "tasks/ck-qg1-enforce-agent-kernel-maintainability.md", "dependencies": ["CK-08R0"]},
     {"id": "CK-08R4", "file": "tasks/ck-08r4-reclassify-physical-plans.md", "dependencies": ["CK-08R1", "CK-08R2", "CK-08R3", "CK-07R1"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -18,10 +18,10 @@ directly.
 - Critical-path completion: **13 / 21**
 - Optional packets: **CK-15**
 - Completed corrective child tasks: **2 — CK-08R0, CK-08R2**
-- Remaining delegable child tasks: **40**
-- Ready child tasks: **0**
-- Conditional-ready child tasks: **4 — CK-08R1, CK-08R3, CK-07R1, CK-QG1 after CK-08R0 exact-main verification**
-- Blocked child tasks: **36**
+- Remaining delegable child tasks: **41**
+- Ready child tasks: **1 — CK-08R3A**
+- Conditional-ready child tasks: **3 — CK-08R1, CK-07R1, CK-QG1 after CK-08R0 exact-main verification**
+- Blocked child tasks: **37**
 
 A packet may be checked only after its acceptance criteria and required checks
 pass, measurements and residual risks are recorded, and any required review is
@@ -157,16 +157,19 @@ corrective packet's executable producer-to-consumer seam checks.
 
 Readiness and parallelism are controlled by
 [REMAINING_EXECUTION_PLAN.md](REMAINING_EXECUTION_PLAN.md). CK-08R0 is
-complete on merge. Its five disjoint Wave-2 successors are Conditional Ready after
-exact-main verification; every join and later child remains blocked on its
-stated dependencies.
+complete on merge; CK-08R2 is also complete. Three Wave-2 successors remain
+Conditional Ready after exact-main verification. CK-08R3A is the separately owned Ready
+implementation dependency discovered by the retained CK-08R3 pre-scale
+blocker; every join and later child remains blocked on its stated
+dependencies.
 
 ### Corrective gates
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [ ] **CK-08R1 — Build independent expected-answer truth** · Conditional Ready after CK-08R0 exact-main verification · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
-- [ ] **CK-08R3 — Qualify evidence service scale** · Conditional Ready after CK-08R0 exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
+- [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Ready; depends on accepted CK-08R0 · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
+- [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after CK-08R0 exact-main verification · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Conditional Ready after CK-08R0 exact-main verification · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md
+++ b/docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md
@@ -1,10 +1,10 @@
 # CK-08R3 — Qualify evidence service scale
 
-**Status:** Conditional Ready after CK-08R0 merge and exact-main verification
+**Status:** Blocked on CK-08R3A acceptance, merge, and exact-main verification
 
 **Parent:** Corrective prerequisite for CK-09
 
-**Recommended owner:** `test_engineer evidence-scale`; Luna-class
+**Recommended owner:** `test_engineer evidence-scale`; Luna
 
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
 
@@ -12,49 +12,39 @@
 
 **Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 
-**Goal:** Prove bounded first/deep evidence pages at standard and
-production-shaped scale.
+**Goal:** Prove bounded first/deep pages at both frozen scales.
 
-**Why:** Current response bounds do not prove the outer UNION query remains
-bounded physically.
+**Dependencies:** CK-08R3A accepted, merged, and exact-main verified. CK-08R3A
+itself depends on accepted CK-08R0.
 
-**Controls:** Evidence selector/cursor, logical ordering, payload, index, and
-query-only contracts.
+**Owned files/interfaces:** Evidence tests/workload/artifact; never production.
 
-**Dependencies:** CK-08R0 merged and exact-main verified.
+**Produces:** Evidence-scale v1: SQL, EXPLAIN, rows/bytes/RSS, five p95 samples.
 
-**Owned files/interfaces:** Focused evidence tests, read-only benchmark
-workloads, and the dedicated evidence artifact. Production evidence helpers and
-service files are forbidden in this qualification task.
+**Independent truth source:** Typed selector/seven-part-order synthetic oracle.
 
-**Produces:** Evidence-scale qualification v1 with SQL, EXPLAIN, rows, bytes,
-RSS, and p95 samples.
+**Consumer seam:** Actual EvidenceService, one query-only snapshot; consume
+CK-08R3A's exact blocker identity, which ran no scale/admission.
 
-**Independent truth source:** Typed selector/order oracle over synthetic facts.
+**Parallelism:** Read-only after CK-08R3A; disjoint from Wave 2.
 
-**Consumer seam:** Actual `EvidenceService` in one query-only snapshot.
+**Non-goals:** Production fix, projection/backbone/API, index, or new budget.
 
-**Parallelism:** May run with other Wave-2 lanes; owns only evidence reads.
+**Invariants:** Typed provenance, stable late/replacement events, no
+gaps/duplicates, <=100 rows, <=16,384 bytes, exact count off.
 
-**Non-goals:** Evidence projection, event backbone, public evidence API, new
-indexes without a physical-contract amendment.
+**Required tests/checks:** Every view/scope/direction, ties/late/replacement/
+byte truncation, 100,000 and 1,316,864-call fixtures, first/deep plans and
+budgets at both scales, `just v/vc`.
 
-**Invariants:** Seven-part cursor order, typed non-placeholder provenance,
-stable replacement/late-event behavior, at most 100 rows and 16 KB.
+**Acceptance:** All preceding invariants/tests pass at both scales.
 
-**Required tests/checks:** Every view/scope/direction, ties, late insertion,
-replacement, byte truncation, 100k and 1,316,864-call fixtures, `just v/vc`.
+**Failure/rollback:** Retain first failure; stop scale/admission and route
+physical defects separately. Never weaken gates, create R4, or invent
+`evidence_timeline_current`.
 
-**Acceptance:** No gaps/duplicates; first/deep pages and SQL plans meet frozen
-budgets at both scales.
+**Handoff:** Evidence digest and classification input.
 
-**Failure/rollback:** Preserve the first failure. Create a separate
-implementation child with its own file and owner, merge it, then rerun this
-qualification task. Request a narrow physical amendment when needed; do not
-invent `evidence_timeline_current`.
-
-**Handoff:** Evidence digest and direct-versus-projection classification input.
-
-**Cleanup/docs:** Link measurements from CK-08R4 and qualification authority.
+**Cleanup/docs:** CK-08R4 links the result.
 
 **Suggested commit:** `test: qualify evidence service scale`

--- a/docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md
+++ b/docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md
@@ -1,0 +1,86 @@
+# CK-08R3A — Implement bounded EvidenceService physical queries
+
+**Status:** Ready; CK-08R0 accepted/merged/exact-main verified at `306cef37eea2ae017aca824d898cc435f7e1bea0`
+
+**Parent:** CK-08R3 implementation prerequisite
+
+**Recommended owner:** `worker evidence-physical-query`; Sol
+
+**Authority:** [TASK_PACKETS.md](../TASK_PACKETS.md),
+[REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md),
+[AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
+
+**Goal:** Apply scope/order/keyset and `LIMIT request.limit + 1` in SQLite
+before decode, without semantic/budget changes.
+
+**Blocker:** Retained commit `a28e9cdbff8e48d334712a449fdcee111c725673`
+artifact `docs/decisions/evidence/ck08r3/evidence-scale-qualification.json`,
+SHA-256 `ae9107eda155a21b9bd9ef5a77971007d00864b772c3a23bc521652b5b17d471`,
+stopped first/deep session `pre_scale_explain`: `SCAN stream`,
+`MATERIALIZE model_calls_visible`, `AUTOMATIC COVERING INDEX`, and outer
+`USE TEMP B-TREE FOR ORDER BY` preceded `LIMIT`. No scale/admission or
+production edit ran.
+
+**Dependencies:** Accepted CK-08R0. Consume `corrective-gates-v1` and current
+request/page, selector/provenance, cursor/publication contracts from exact main;
+never cherry-pick CK-08R3.
+
+**Owned files/interfaces:** Evidence physical lock only:
+`src/codex_usage_tracker/agent_kernel/evidence/service.py`, focused
+`tests/agent_kernel/evidence/test_service.py` plus optional sibling; page SQL/
+branches/parameters/decode. Forbid QueryService, registry/compiler/
+contracts, cursor codec/version, selectors, DDL/index/publication, R3 evidence,
+schema/projection and public/package APIs.
+
+**Produces:** Physical fix plus structural/EXPLAIN tests; no scale/admission.
+
+**Independent truth source:** Test-only relation evaluator uses no production
+query/helper; it forms typed events, applies selector/view/cursor,
+orders by `(time_missing, COALESCE(event_at_us,0), source_rank, source_order,
+event_kind_order, logical_id, transition_rank)`, slices `limit + 1`, and
+compares rows/order.
+
+**Consumer seam:** `EvidenceService.read()` keeps one query-only snapshot;
+`_page_rows()` applies scope/view/order/publication-bound keyset and final
+`LIMIT ?` before decoding `limit + 1`. Byte shrink/CursorCodec stay.
+
+**Parallelism:** R1/R2/07R1/QG1 stay independent; R3/R4/RG/09 stay blocked.
+
+**Non-goals:** R3 scale, R2 paging, DDL/index/schema/backbone,
+`evidence_timeline_current`, projections/counts/APIs/budgets, R4 and CK-09.
+
+**Invariants:** Preserve 14 selectors, six provenance kinds, boundary pairs,
+seven views/directions and that order. Cursor binds version, plan/version,
+publication, request digest, last order and expiry; tamper/replacement/stale
+fail closed. Tie/missing/late/replacement/base/tail cases stay gap-free.
+No-refresh/query-only/one-snapshot/exact-count-off, 100 rows, 16,384 bytes,
+catalog counts and 820,000-byte sdist remain fixed.
+
+**EXPLAIN acceptance:** First/deep session pages both directions plus other
+representative scopes omit all four blocker details. High-cardinality branches
+use existing named PK/scope-order indexes; singleton lookups may use PKs.
+Assert keyset, final `LIMIT ?`, bound/decode `limit + 1`, normalized failure
+and no permissive version wildcard.
+
+**Required tests/checks:** CK-07A builders plus synthetic tie/missing/base-tail/
+lifecycle/late/replacement/selector/direction cases; no scale/real data.
+Bootstrap/GitNexus; focused service/structural/EXPLAIN/semantic/cursor/byte/
+authority; diff/release; `just v/vc`; staged `detect_changes`; one reviewer/PR;
+hosted CI; squash merge; attached exact-main.
+
+**Acceptance:** Truth/production rows/order match; reversible gap-free pages
+are bounded; query-only/cursor/byte/release gates and lock hold.
+Authorizes only R3, never scale/projections.
+
+**Failure/rollback:** On forbidden plan/mismatch or lock/budget need, retain
+SQL/parameters/plan/fixture digest, stop/create no R3; revert service/tests
+without migration.
+
+**Handoff:** After accepted merge/CI/exact-main, create exactly one user-owned
+`test_engineer evidence-scale` task from new main with merge SHA, blocker
+artifact/digest, lock, fixtures/budgets, truth/seam, EXPLAIN/order/cursor,
+checks/risks/stops. It may create R4 only after R1/R2/R3/07R1 complete.
+
+**Cleanup/docs:** Link merge/exact-main from R3; keep blocker historical.
+
+**Suggested commit:** `fix: bound evidence physical queries`

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -257,6 +257,7 @@ CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS = frozenset(
         "docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md",
         "docs/roadmap/tasks/ck-08r2-implement-physical-keyset-execution.md",
         "docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md",
+        "docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md",
         "docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md",
         "docs/roadmap/tasks/ck-08rg-authorize-ck09-resumption.md",
         "docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md",

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -44,6 +44,7 @@ _PACKET_IDS = {
     "CK-08R0",
     "CK-08R1",
     "CK-08R2",
+    "CK-08R3A",
     "CK-08R3",
     "CK-08R4",
     "CK-08RG",
@@ -179,22 +180,31 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["orchestration"]["spawn"] == "all_newly_ready_successors"
     conditional_ready = {
         "CK-08R1",
-        "CK-08R3",
         "CK-07R1",
         "CK-QG1",
     }
     assert manifest["completed"] == ["CK-08R0", "CK-08R2"]
-    assert manifest["ready"] == []
+    ready = {"CK-08R3A"}
+    assert manifest["ready"] == ["CK-08R3A"]
     assert manifest["conditional_ready"] == [{
         "condition": "CK-08R0 merged and exact-main verified",
-        "tasks": ["CK-08R1", "CK-08R3", "CK-07R1", "CK-QG1"],
+        "tasks": ["CK-08R1", "CK-07R1", "CK-QG1"],
     }]
 
     tasks = manifest["tasks"]
-    assert len(tasks) == 42
+    assert len(tasks) == 43
     manifest_by_id = {task["id"]: task for task in tasks}
-    assert len(manifest_by_id) == 42
+    assert len(manifest_by_id) == 43
     assert set(manifest_by_id) == _DELEGATED_PACKET_IDS
+    assert manifest_by_id["CK-08R3A"]["dependencies"] == ["CK-08R0"]
+    assert manifest_by_id["CK-08R3"]["dependencies"] == ["CK-08R3A"]
+    assert manifest_by_id["CK-08R4"]["dependencies"] == [
+        "CK-08R1",
+        "CK-08R2",
+        "CK-08R3",
+        "CK-07R1",
+    ]
+    assert manifest_by_id["CK-08RG"]["dependencies"] == ["CK-08R4", "CK-QG1"]
 
     ledger_rows = re.findall(
         r"^- \[[ xX]\] \*\*(CK-[A-Z0-9]+(?:-[A-Z0-9]+)*)\b.*?"
@@ -227,6 +237,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         }
         if packet_id in conditional_ready:
             assert "**Status:** Conditional Ready after CK-08R0 merge" in body
+        elif packet_id in ready:
+            assert "**Status:** Ready" in body
         elif packet_id in {"CK-08R0", "CK-08R2"}:
             assert "**Status:** Completed on merge" in body
         else:
@@ -315,6 +327,10 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
         "docs/roadmap/tasks/ck-07e-implement-independent-fact-adapters.md"
     )
     ck08 = _read("docs/roadmap/tasks/ck-08-implement-query-and-evidence.md")
+    ck08r3a = _read(
+        "docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md"
+    )
+    ck08r3 = _read("docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md")
 
     assert "## Cross-packet semantic continuity" in agents
     assert "producer artifact and exact identity" in agents
@@ -362,6 +378,18 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     assert "explicit growth-evidence exception" in physical_decision
     assert "two current repetitions were waived" in physical_decision
     assert "**Dependencies:** CK-07A merged with exact-main seam evidence." in ck08
+    assert "a28e9cdbff8e48d334712a449fdcee111c725673" in ck08r3a
+    assert "ae9107eda155a21b9bd9ef5a77971007d00864b772c3a23bc521652b5b17d471" in ck08r3a
+    assert all(
+        plan_shape in ck08r3a
+        for plan_shape in (
+            "SCAN stream",
+            "MATERIALIZE model_calls_visible",
+            "AUTOMATIC COVERING INDEX",
+            "USE TEMP B-TREE FOR ORDER BY",
+        )
+    )
+    assert "**Dependencies:** CK-08R3A accepted, merged, and exact-main verified." in ck08r3
 
 
 def test_question_catalog_and_diagram_inventory_are_complete() -> None:

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -242,8 +242,8 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         for path in CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS
         if path.startswith("docs/roadmap/tasks/")
     }
-    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 88
-    assert len(task_packets) == 61
+    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 89
+    assert len(task_packets) == 62
     assert {
         "docs/INDEX.md",
         "docs/architecture/AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md",


### PR DESCRIPTION
## Summary
- add decision-complete CK-08R3A EvidenceService physical-query implementation packet
- gate CK-08R3 on accepted merge and exact-main verification of CK-08R3A
- preserve completed CK-08R2 and unchanged R4/RG joins while retaining the R3 blocker as historical reproduction
- update central DAG, ledger, qualification authority, and fail-closed documentation tests

## Scope
Authority only. No EvidenceService production helper, CK-08R1 packet, CK-QG1 packet, projection, schema, public contract, or CK-09 implementation is changed.

## Validation
- focused authority/scope/release: 58 passed
- just vc on current main plus this commit: 1,361 passed; 13 invariant performance tests; zero breaches
- release checks passed; combined sdist 826,723 bytes under current-main accepted 828,000-byte ceiling
- original required base build was 819,655 bytes under its 820,000-byte ceiling; this change does not modify the budget file
- GitNexus: low risk, zero affected execution processes
- exactly one read-only reviewer; one packaging finding accepted and resolved by retaining the full docs archive