### PR TITLE
docs: authorize PageExecutor source supersession

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,9 +21,8 @@ Retained CK-08R3 `a28e9cdbff8e48d334712a449fdcee111c725673` then stopped
 before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
 fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
 truth is now serialized as R1A contract freeze, disjoint R1B/R1C consumers,
-and final R1 requalification. QG1A separately corrects only the two R2
-page-executor C/B/B findings before PR #392 may refresh its unchanged frozen
-baseline. CK-07R1A separately corrects PR #394's exact hosted lifecycle-tail
+and final R1 requalification. CK-QG1A0 gates the selected R2 PageExecutor
+successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrects PR #394's exact hosted lifecycle-tail
 failure without a budget waiver. Reclassification and maintainability
 remain open. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -161,11 +161,9 @@ qualify publication-valid lifecycle preparation. CK-08R4 alone may classify a
 plan as direct-page, evidence-page, or projection-required. CK-09 may admit
 only the resulting measured residual list after CK-08RG.
 
-CK-QG1A is a separate behavior-preserving R2 source lock: it may reduce only
-the two page-executor rank-D findings and may not alter request validation,
-query-only access, cursor/order semantics, support, evidence, C/B/B threshold,
-or frozen baseline. Existing QG1 PR #392 resumes from QG1A exact main; no
-exemption or baseline broadening is admissible.
+CK-QG1A0 gates the selected PageExecutor successor. Exact-main QG1A then fixes
+R2 rank-D findings; R2 semantics, evidence, thresholds, baseline, and generic-drift
+prohibition remain binding.
 
 CK-07R1A is a separate lifecycle-performance lock: preserve the first hosted
 Python 3.14 `ordinary.2000_call_tail` failure, frozen five budgets, fold and

--- a/docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json
+++ b/docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json
@@ -1,0 +1,66 @@
+{
+  "schema": "codex-usage-tracker.page-executor-source-supersession-authority.v1",
+  "authority_version": 1,
+  "owner": "CK-QG1A0",
+  "authority_base_sha": "e26d7d5bfa32bf74c0855ed87266aca83a7ebce1",
+  "source_path": "src/codex_usage_tracker/agent_kernel/query/page_executor.py",
+  "predecessor": {
+    "sha256": "2a48a63e0fbb18173b8e0abe09d65309f76bf59b4796e35d6b2f97dea95df305",
+    "accepted_merge_sha": "53ab22cb54b9a6f30009caeb6bb22a3a57033261",
+    "manifest": {
+      "path": "docs/decisions/evidence/ck08r2/physical-page-executor-evidence.json",
+      "sha256": "0a1f9ee919e065ba707826fc7c308748a7b6810a358f957aa6608ee0ff4d3c08"
+    }
+  },
+  "selected_successor": {
+    "sha256": "9e80c8677dd4ceadc4fbd66681aedef78528b1ad4f50edc7a04f4b1c7ac12f31",
+    "status": "permitted_not_accepted",
+    "blocked_task": "019fbe2b-cce0-7ed2-87c5-71f5aff5594a",
+    "retained_branch": "fix/ck-qg1a-page-executor-complexity"
+  },
+  "r2_artifacts": [
+    {
+      "path": "docs/decisions/evidence/ck08r2/data-health-page-executor-benchmark-v2.json",
+      "sha256": "8ca52e40ad03d8bb8056ec2ca0d8a3ac7f58d3a4f1adf8daad7d8df6d87a0a3f"
+    },
+    {
+      "path": "docs/decisions/evidence/ck08r2/latest-publication-delta-page-executor-benchmark-v2.json",
+      "sha256": "6f897a9ca6f7c52f39c31d56e7943a621758feac3df22d0f0b6dbdc50f0d5604"
+    }
+  ],
+  "maintainability_baseline": {
+    "pr": 392,
+    "head_sha": "29f18ae178a4d048e9d4bd1ae49a4307dd8472dd",
+    "path": "config/agent-kernel/maintainability-baseline-v1.json",
+    "sha256": "c490d954a5e9d09c61f884d51e3b9d3196af5615887f409c36f8469d1b2b6cf9",
+    "schema": "codex-usage-tracker.agent-kernel-maintainability-baseline.v1",
+    "tool_identity": "xenon==0.9.3;radon==6.0.1",
+    "normalization_version": "xenon-threshold-findings-v1",
+    "thresholds": {"block": "C", "module": "B", "average": "B"}
+  },
+  "consumer_test_seam": {
+    "path": "tests/agent_kernel/query/test_page_executor_evidence.py",
+    "test": "test_ck08r2_manifest_binds_superseded_and_current_artifacts"
+  },
+  "preserved_semantics": [
+    "request_validation",
+    "optional_entity_kind_and_limit",
+    "typed_request_digest_binding",
+    "keyset_cursor_and_total_order",
+    "query_only_sqlite",
+    "limit_page_size_plus_one",
+    "exact_count_default_false_opt_in",
+    "indexed_explain_gates",
+    "two_supported_direct_plans",
+    "nineteen_other_plans_fail_closed",
+    "no_projection"
+  ],
+  "constraints": [
+    "predecessor_remains_historically_verifiable",
+    "selected_successor_only",
+    "third_digest_fails",
+    "missing_predecessor_fails",
+    "mismatched_manifest_or_baseline_fails",
+    "generic_source_drift_forbidden"
+  ]
+}

--- a/docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.schema.json
+++ b/docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://douglasmonsky.github.io/codex-usage-tracker/schemas/page-executor-source-supersession-authority.v1.schema.json",
+  "title": "CK-QG1A0 PageExecutor source supersession authority",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "authority_version", "owner", "authority_base_sha", "source_path",
+    "predecessor", "selected_successor", "r2_artifacts", "maintainability_baseline",
+    "consumer_test_seam", "preserved_semantics", "constraints"
+  ],
+  "properties": {
+    "schema": {"const": "codex-usage-tracker.page-executor-source-supersession-authority.v1"},
+    "authority_version": {"const": 1},
+    "owner": {"const": "CK-QG1A0"},
+    "authority_base_sha": {"$ref": "#/$defs/gitSha"},
+    "source_path": {"$ref": "#/$defs/nonEmpty"},
+    "predecessor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "accepted_merge_sha", "manifest"],
+      "properties": {
+        "sha256": {"$ref": "#/$defs/sha"},
+        "accepted_merge_sha": {"$ref": "#/$defs/gitSha"},
+        "manifest": {"$ref": "#/$defs/artifact"}
+      }
+    },
+    "selected_successor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "status", "blocked_task", "retained_branch"],
+      "properties": {
+        "sha256": {"$ref": "#/$defs/sha"},
+        "status": {"const": "permitted_not_accepted"},
+        "blocked_task": {"$ref": "#/$defs/nonEmpty"},
+        "retained_branch": {"$ref": "#/$defs/nonEmpty"}
+      }
+    },
+    "r2_artifacts": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {"$ref": "#/$defs/artifact"}
+    },
+    "maintainability_baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pr", "head_sha", "path", "sha256", "schema", "tool_identity",
+        "normalization_version", "thresholds"
+      ],
+      "properties": {
+        "pr": {"const": 392},
+        "head_sha": {"$ref": "#/$defs/gitSha"},
+        "path": {"$ref": "#/$defs/nonEmpty"},
+        "sha256": {"$ref": "#/$defs/sha"},
+        "schema": {"$ref": "#/$defs/nonEmpty"},
+        "tool_identity": {"$ref": "#/$defs/nonEmpty"},
+        "normalization_version": {"$ref": "#/$defs/nonEmpty"},
+        "thresholds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["block", "module", "average"],
+          "properties": {
+            "block": {"const": "C"},
+            "module": {"const": "B"},
+            "average": {"const": "B"}
+          }
+        }
+      }
+    },
+    "consumer_test_seam": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "test"],
+      "properties": {
+        "path": {"$ref": "#/$defs/nonEmpty"},
+        "test": {"$ref": "#/$defs/nonEmpty"}
+      }
+    },
+    "preserved_semantics": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/nonEmpty"}
+    },
+    "constraints": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/nonEmpty"}
+    }
+  },
+  "$defs": {
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "gitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "nonEmpty": {"type": "string", "minLength": 1},
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"$ref": "#/$defs/nonEmpty"},
+        "sha256": {"$ref": "#/$defs/sha"}
+      }
+    }
+  }
+}

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -47,8 +47,7 @@ paging, so they admit neither projections nor CK-09.
 
 R1A freezes Q-REV-03/Q-WF-02 and executable transitive closure before parallel
 R1B/C and final two-lane R1 replay. R3 scale awaits merged/exact-main R3A.
-QG1 PR #392 awaits QG1A removal of R2's two rank-D page-executor findings
-against its unchanged baseline. CK-07R1A preserves the first hosted Python
+QG1 PR #392 awaits CK-QG1A0 exact-main, then QG1A fixes only R2's two rank-D findings against its unchanged baseline. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and
 `5000/120000/100/500/500` budgets; only a controlled material correction can
 resume PR #394. Stale, grading-dependent, retried-only, or waived evidence

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -49,7 +49,7 @@ CK-00 -> CK-01 -> CK-02 -> CK-03 -> CK-04 -> CK-05 -> CK-06
 -> CK-07 -> CK-07B -> CK-07C -> CK-07D -> CK-07E -> CK-07A -> CK-08
 -> CK-08R0 -> {CK-08R1A, CK-08R2, CK-08R3A, CK-07R1A}
 CK-08R1A -> {CK-08R1B, CK-08R1C} -> CK-08R1
-CK-08R2 -> CK-QG1A -> CK-QG1
+CK-08R2 -> CK-QG1A0 -> CK-QG1A -> CK-QG1
 CK-08R3A -> CK-08R3
 CK-07R1A -> CK-07R1
 {CK-08R1, CK-08R2, CK-08R3, CK-07R1} -> CK-08R4
@@ -65,7 +65,8 @@ flowchart LR
  R1B --> R1[CK-08R1]
  R1C --> R1
  R0 --> R2[CK-08R2]
- R2 --> QGA[CK-QG1A]
+ R2 --> QGA0[CK-QG1A0]
+ QGA0 --> QGA[CK-QG1A]
  QGA --> QG[CK-QG1]
  R0 --> R3A[CK-08R3A]
  R3A --> R3[CK-08R3]
@@ -89,7 +90,7 @@ CK-15 is optional and blocks CK-16 only if selected.
 | CK-04 | A/C/D experiment dirs; integrator owns harness/contracts/score |
 | CK-07B–E | Formula/provenance → operands/valuation → two fact adapters; one contract/evidence owner |
 | CK-07A/08 | Oracle replay and query/evidence implementations; public schemas single-owned |
-| Corrective wave | R1A→R1B/C→R1; R2→QG1A→QG1; R3A→R3; 07R1A→07R1; R4 joins |
+| Corrective wave | R1A→R1B/C→R1; R2→QG1A0→QG1A→QG1; R3A→R3; 07R1A→07R1; R4 joins |
 | CK-09 | Admitted projection families after registry freeze |
 | CK-10/11/12 | App/skill, installed trial lanes, then immutable qualification lanes |
 | CK-14 | Runtime and frontend deletion; package/CI joins |
@@ -129,7 +130,8 @@ consumer replay reconciles published database-v1 facts to independent truth.
 CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1B/C
 implement separately; R1 requalifies. R2 bounds two direct plans while 19 fail
 closed. R3A removes unbounded EvidenceService shape; R3 measures it. 07R1A
-materially corrects the exact hosted tail before PR #394 resumes. QG1A removes
+materially corrects the exact hosted tail before PR #394 resumes. QG1A0 authorizes
+only the exact R2 PageExecutor successor; QG1A then removes
 only R2's C/B/B findings before QG1 refreshes its baseline. R4 joins accepted
 R1/R2/R3/07R1; RG plus QG1 alone may unblock CK-09. Exact oracles, selectors,
 four tokens, cost/credits, allowance, SQL/MCP/byte/scale gates remain binding.

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -61,7 +61,8 @@ Only one integrator may own a lock at a time:
 The machine DAG below controls readiness and dependencies; each child packet controls its owner and scope. Only these fan-outs are allowed:
 
 - CK-08R0 -> CK-08R2/CK-08R3A; CK-08R1A -> CK-08R1B/R1C
-  -> CK-08R1; CK-08R2 -> CK-QG1A -> CK-QG1; CK-08R3A -> CK-08R3;
+  -> CK-08R1; CK-08R2 -> CK-QG1A0 -> CK-QG1A -> CK-QG1;
+  CK-08R3A -> CK-08R3;
   CK-07R1A -> CK-07R1;
   join at CK-08R4/CK-08RG.
 - CK-09-01 -> CK-09-02/03/04; join at CK-09-05.
@@ -90,11 +91,14 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "duplicate_policy": "one_active_task_per_packet_and_dependency_frontier",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R2"],
+  "completed": ["CK-08R0", "CK-08R2", "CK-QG1A0"],
   "ready": [],
   "conditional_ready": [{
     "condition": "This serialized corrective authority correction accepted, merged, and exact-main verified",
-    "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A", "CK-QG1A"]
+    "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A"]
+  }, {
+    "condition": "CK-QG1A0 merged and exact-main verified",
+    "tasks": ["CK-QG1A"]
   }],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},
@@ -107,7 +111,8 @@ conditions in the table and child files; they are not unconditional DAG edges.
     {"id": "CK-08R3", "file": "tasks/ck-08r3-qualify-evidence-scale.md", "dependencies": ["CK-08R3A"]},
     {"id": "CK-07R1A", "file": "tasks/ck-07r1a-correct-hosted-lifecycle-tail.md", "dependencies": ["CK-08R0"]},
     {"id": "CK-07R1", "file": "tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "dependencies": ["CK-07R1A"]},
-    {"id": "CK-QG1A", "file": "tasks/ck-qg1a-correct-page-executor-complexity.md", "dependencies": ["CK-08R2"]},
+    {"id": "CK-QG1A0", "file": "tasks/ck-qg1a0-authorize-page-executor-source-supersession.md", "dependencies": ["CK-08R2"]},
+    {"id": "CK-QG1A", "file": "tasks/ck-qg1a-correct-page-executor-complexity.md", "dependencies": ["CK-QG1A0"]},
     {"id": "CK-QG1", "file": "tasks/ck-qg1-enforce-agent-kernel-maintainability.md", "dependencies": ["CK-QG1A"]},
     {"id": "CK-08R4", "file": "tasks/ck-08r4-reclassify-physical-plans.md", "dependencies": ["CK-08R1", "CK-08R2", "CK-08R3", "CK-07R1"]},
     {"id": "CK-08RG", "file": "tasks/ck-08rg-authorize-ck09-resumption.md", "dependencies": ["CK-08R4", "CK-QG1"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,13 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **2 — CK-08R0, CK-08R2**
+- Completed corrective child tasks: **3 — CK-08R0, CK-08R2, CK-QG1A0**
 - Remaining delegable child tasks: **46**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **4 — CK-08R1A, CK-08R3A, CK-07R1A, CK-QG1A after this corrective authority exact-main verification**
+- Conditional-ready child tasks: **4 — CK-08R1A, CK-08R3A, CK-07R1A; CK-QG1A after CK-QG1A0 exact-main**
 - Blocked child tasks: **42**
-
-Acceptance requires checks, measurements, risks, and review.
 
 ## Parent packets
 
@@ -48,8 +46,8 @@ Acceptance requires checks, measurements, risks, and review.
 ## Remaining delegated child tasks
 
 Readiness is controlled by
-[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1A, R3A, 07R1A, and QG1A
-are conditional on this authority exact-main.
+[the machine DAG](REMAINING_EXECUTION_PLAN.md). QG1A follows CK-QG1A0 exact-main;
+other corrective locks are unchanged.
 
 ### Corrective gates
 
@@ -59,11 +57,12 @@ are conditional on this authority exact-main.
 - [ ] **CK-08R1C — Build independent semantic evaluator** · Blocked on CK-08R1A · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B and CK-08R1C · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
+- [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
 - [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [ ] **CK-07R1A — Correct hosted lifecycle tail** · Conditional Ready after this corrective authority exact-main verification · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked on CK-07R1A and refresh of existing PR #394 on corrected main · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
-- [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after this corrective authority exact-main verification · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
+- [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
 - [ ] **CK-08RG — Authorize CK-09 resumption** · Blocked on CK-08R4 and CK-QG1 · [packet](tasks/ck-08rg-authorize-ck09-resumption.md)

--- a/docs/roadmap/tasks/DELEGATED_TASK_TEMPLATE.md
+++ b/docs/roadmap/tasks/DELEGATED_TASK_TEMPLATE.md
@@ -1,56 +1,21 @@
 # Delegated Task Template
-
-Copy this template for every new delegable unit. Add the file to
-[TASK_PACKETS.md](../TASK_PACKETS.md) and
-[REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md) before marking it
-Ready.
-
+Copy for each unit; add it to [TASK_PACKETS.md](../TASK_PACKETS.md) and the central plan before Ready.
 **Status:** Not started
-
 **Parent:** CK-XX umbrella
-
-**Recommended owner:** `<role> <short-scope>`; use write-capable `default` on
-Sol for decision/integration, or the named Luna role for bounded
-implementation/qualification. `architect` is read-only advisory support.
-
+**Recommended owner:** `<role> <short-scope>`; follow `AGENTS.md`.
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
-
-**Central plan:** [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md)
-
-**Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
-
-**Goal:** One outcome.
-
-**Why:** The consumer value or gate this produces.
-
-**Controls:** Exact contracts and predecessor evidence.
-
-**Dependencies:** Exact merged packets and artifacts.
-
-**Owned files/interfaces:** A disjoint write set; identify shared locks.
-
-**Produces:** A versioned artifact or interface with identity/digest.
-
-**Independent truth source:** A source that does not share the implementation
-under test.
-
-**Consumer seam:** The real downstream path that must consume the output.
-
-**Parallelism:** What may overlap and what is forbidden.
-
-**Non-goals:** Explicit scope exclusions.
-
-**Invariants:** Semantics, privacy, failure, compatibility, and lifecycle rules.
-
-**Required tests/checks:** Focused then complete checks and measured gates.
-
+**Goal:** Outcome.
+**Dependencies:** Exact packets/artifacts.
+**Owned files/interfaces:** Disjoint files/locks.
+**Produces:** Versioned artifact/interface with identity.
+**Independent truth source:** Independent eval.
+**Consumer seam:** Real downstream path.
+**Parallelism:** Allowed/forbidden.
+**Non-goals:** Exclusions.
+**Invariants:** Semantics/privacy/failure/compatibility.
+**Required tests/checks:** Focused checks.
 **Acceptance:** Observable pass conditions.
-
-**Failure/rollback:** Fail-closed stop rule and recoverable state.
-
-**Handoff:** Exact base/head, PR/CI, evidence digests, residuals, orchestrator
-task ID, newly Ready tasks, and the `AGENTS.md` orchestration protocol.
-
-**Cleanup/docs:** Authorities and evidence that must be reconciled.
-
+**Failure/rollback:** Fail-closed.
+**Handoff:** Base/head, CI, evidence.
+**Cleanup/docs:** Reconcile docs/evidence.
 **Suggested commit:** `type: concise outcome`

--- a/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
+++ b/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
@@ -1,6 +1,6 @@
 # CK-QG1A — Correct page-executor complexity
 
-**Status:** Conditional Ready after this corrective authority merge is exact-main verified
+**Status:** Conditional Ready after CK-QG1A0 merge is exact-main verified
 
 **Parent:** Corrective prerequisite for CK-QG1
 
@@ -14,7 +14,7 @@
 
 **Goal:** Remove only R2's two Xenon C/B/B violations, preserving behavior.
 
-**Dependencies:** CK-08R2 and this authority correction accepted, merged, exact-main verified.
+**Dependencies:** CK-08R2 plus CK-QG1A0 accepted, merged, and exact-main verified.
 
 **Owned files/interfaces:** Only `agent_kernel/query/page_executor.py` and its
 focused tests; no baseline/checker, registry/compiler, cursor version, R1/R3,

--- a/docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md
+++ b/docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md
@@ -1,0 +1,19 @@
+# CK-QG1A0 — Authorize PageExecutor source supersession
+**Status:** Completed on merge
+**Recommended owner:** `default page-evidence-gate`;
+**Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md) [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md) [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
+**Goal:** Authority.
+**Dependencies:** CK-08R2.
+**Owned files/interfaces:** docs/tests.
+**Produces:** [Authority v1](../../decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json); strict schema.
+**Independent truth source:** R2/hashes.
+**Consumer seam:** `test_ck08r2_manifest_binds_superseded_and_current_artifacts`.
+**Parallelism:** Sole owner.
+**Non-goals:** Code, drift, baseline, projection.
+**Invariants:** R2; synthetic; sdist <=828000.
+**Required tests/checks:** `just v/vc`; CI.
+**Acceptance:** Predecessor/successor exact; drift fails.
+**Failure/rollback:** Block downstream.
+**Handoff:** Report; QG1A gated.
+**Cleanup/docs:** PR #392 unchanged.
+**Suggested commit:** `docs: authorize page executor source supersession`

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+_GENERATED_TOOL_PATHS = frozenset({"tools/gitnexus/node_modules"})
 K1A_ADDITIONS = frozenset(
     {
         "scripts/check_kernel_scope.py",
@@ -265,6 +266,7 @@ CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS = frozenset(
         "docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md",
         "docs/roadmap/tasks/ck-08rg-authorize-ck09-resumption.md",
         "docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md",
+        "docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md",
         "docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md",
         "docs/roadmap/tasks/ck-09-admit-projections-and-named-plans.md",
         "docs/roadmap/tasks/ck-09-01-freeze-residual-projection-registry.md",
@@ -728,6 +730,13 @@ CK08R3A_AUTHORITY_ADDITIONS = frozenset(
     }
 )
 
+CKQG1A0_AUTHORITY_ADDITIONS = frozenset(
+    [
+        "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json",
+        "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.schema.json",
+    ]
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -784,6 +793,7 @@ INTEGRATION_ADDITIONS = (
     | CK08_QUERY_EVIDENCE_ADDITIONS
     | CK08R2_PHYSICAL_PAGE_ADDITIONS
     | CK08R3A_AUTHORITY_ADDITIONS
+    | CKQG1A0_AUTHORITY_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )
@@ -813,7 +823,7 @@ def active_paths(repo_root: Path) -> set[str]:
         capture_output=True,
         text=True,
     )
-    paths = {line for line in result.stdout.splitlines() if line}
+    paths = {line for line in result.stdout.splitlines() if line} - _GENERATED_TOOL_PATHS
     return {
         path for path in paths if (repo_root / path).exists() or (repo_root / path).is_symlink()
     }

--- a/tests/agent_kernel/query/test_page_executor_evidence.py
+++ b/tests/agent_kernel/query/test_page_executor_evidence.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+from copy import deepcopy
 from pathlib import Path
 
-from jsonschema import Draft202012Validator
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
 
 _ROOT = Path(__file__).resolve().parents[3]
 _EVIDENCE_ROOT = _ROOT / "docs" / "decisions" / "evidence"
@@ -14,6 +16,14 @@ _ARTIFACTS = (
     / "ck08r2"
     / "latest-publication-delta-page-executor-benchmark-v2.json",
 )
+_AUTHORITY = _EVIDENCE_ROOT / "ckqg1a0" / "page-executor-source-supersession-authority.json"
+_AUTHORITY_SCHEMA = _EVIDENCE_ROOT / "ckqg1a0" / "page-executor-source-supersession-authority.schema.json"
+_SOURCE_PATH = "src/codex_usage_tracker/agent_kernel/query/page_executor.py"
+_PREDECESSOR = "2a48a63e0fbb18173b8e0abe09d65309f76bf59b4796e35d6b2f97dea95df305"
+_SUCCESSOR = "9e80c8677dd4ceadc4fbd66681aedef78528b1ad4f50edc7a04f4b1c7ac12f31"
+_R2_MANIFEST = "docs/decisions/evidence/ck08r2/physical-page-executor-evidence.json"
+_R2_MANIFEST_SHA = "0a1f9ee919e065ba707826fc7c308748a7b6810a358f957aa6608ee0ff4d3c08"
+_BASELINE_SHA = "c490d954a5e9d09c61f884d51e3b9d3196af5615887f409c36f8469d1b2b6cf9"
 
 
 def _assert_indexed_explain(payload: dict[str, object]) -> None:
@@ -43,6 +53,49 @@ def _assert_indexed_explain(payload: dict[str, object]) -> None:
 
 def _json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert_supersession_bindings(authority: dict[str, object], current_source_sha: str) -> None:
+    predecessor = authority["predecessor"]
+    successor = authority["selected_successor"]
+    baseline = authority["maintainability_baseline"]
+    assert authority["authority_base_sha"] == "e26d7d5bfa32bf74c0855ed87266aca83a7ebce1"
+    assert authority["source_path"] == _SOURCE_PATH
+    assert predecessor["sha256"] == _PREDECESSOR
+    assert predecessor["accepted_merge_sha"] == "53ab22cb54b9a6f30009caeb6bb22a3a57033261"
+    assert predecessor["manifest"] == {"path": _R2_MANIFEST, "sha256": _R2_MANIFEST_SHA}
+    assert successor["sha256"] == _SUCCESSOR
+    assert successor["status"] == "permitted_not_accepted"
+    assert successor["blocked_task"] == "019fbe2b-cce0-7ed2-87c5-71f5aff5594a"
+    assert successor["retained_branch"] == "fix/ck-qg1a-page-executor-complexity"
+    assert authority["consumer_test_seam"] == {
+        "path": "tests/agent_kernel/query/test_page_executor_evidence.py",
+        "test": "test_ck08r2_manifest_binds_superseded_and_current_artifacts",
+    }
+    assert baseline == {
+        "pr": 392,
+        "head_sha": "29f18ae178a4d048e9d4bd1ae49a4307dd8472dd",
+        "path": "config/agent-kernel/maintainability-baseline-v1.json",
+        "sha256": _BASELINE_SHA,
+        "schema": "codex-usage-tracker.agent-kernel-maintainability-baseline.v1",
+        "tool_identity": "xenon==0.9.3;radon==6.0.1",
+        "normalization_version": "xenon-threshold-findings-v1",
+        "thresholds": {"block": "C", "module": "B", "average": "B"},
+    }
+    baseline_path = _ROOT / baseline["path"]
+    if baseline_path.exists():
+        assert hashlib.sha256(baseline_path.read_bytes()).hexdigest() == _BASELINE_SHA
+    assert set(authority["preserved_semantics"]) == {
+        "request_validation", "optional_entity_kind_and_limit", "typed_request_digest_binding",
+        "keyset_cursor_and_total_order", "query_only_sqlite", "limit_page_size_plus_one",
+        "exact_count_default_false_opt_in", "indexed_explain_gates", "two_supported_direct_plans",
+        "nineteen_other_plans_fail_closed", "no_projection",
+    }
+    assert set(authority["constraints"]) == {
+        "predecessor_remains_historically_verifiable", "selected_successor_only", "third_digest_fails",
+        "missing_predecessor_fails", "mismatched_manifest_or_baseline_fails", "generic_source_drift_forbidden",
+    }
+    assert current_source_sha in {_PREDECESSOR, _SUCCESSOR}
 
 
 def test_ck08r2_page_executor_artifacts_match_frozen_lane_schema() -> None:
@@ -89,10 +142,49 @@ def test_ck08r2_manifest_binds_superseded_and_current_artifacts() -> None:
     assert manifest["projection_added"] is False
     assert manifest["unsupported_plan_count"] == 19
 
-    artifacts = [
-        *manifest["source_artifacts"],
+    authority = _json(_AUTHORITY)
+    source_artifacts = {item["path"]: item for item in manifest["source_artifacts"]}
+    assert source_artifacts[_SOURCE_PATH]["sha256"] == _PREDECESSOR
+    for artifact in [
         *manifest["page_executor_artifacts"],
-    ]
-    for artifact in artifacts:
+        *[item for path, item in source_artifacts.items() if path != _SOURCE_PATH],
+    ]:
         source = _ROOT / artifact["path"]
         assert hashlib.sha256(source.read_bytes()).hexdigest() == artifact["sha256"]
+    assert hashlib.sha256(
+        (_ROOT / _R2_MANIFEST).read_bytes()
+    ).hexdigest() == _R2_MANIFEST_SHA
+    _assert_supersession_bindings(
+        authority,
+        hashlib.sha256((_ROOT / _SOURCE_PATH).read_bytes()).hexdigest(),
+    )
+    schema = _json(_AUTHORITY_SCHEMA)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(authority)
+    expected_r2 = {
+        path.relative_to(_ROOT).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in _ARTIFACTS
+    }
+    assert {item["path"]: item["sha256"] for item in authority["r2_artifacts"]} == expected_r2
+    changed = deepcopy(authority)
+    changed["r2_artifacts"][0]["path"] = "changed.json"
+    with pytest.raises(AssertionError):
+        assert {item["path"]: item["sha256"] for item in changed["r2_artifacts"]} == expected_r2
+    missing_predecessor = deepcopy(authority)
+    del missing_predecessor["predecessor"]
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(missing_predecessor)
+    for target, field in (("predecessor", "sha256"), ("selected_successor", "sha256"), ("maintainability_baseline", "sha256")):
+        changed = deepcopy(authority)
+        changed[target][field] = "f" * 64
+        with pytest.raises(AssertionError):
+            _assert_supersession_bindings(changed, _PREDECESSOR)
+    for field in ("blocked_task", "retained_branch"):
+        changed = deepcopy(authority)
+        changed["selected_successor"][field] = "changed"
+        with pytest.raises(AssertionError):
+            _assert_supersession_bindings(changed, _PREDECESSOR)
+    changed = deepcopy(authority)
+    changed["predecessor"]["manifest"]["sha256"] = "f" * 64
+    with pytest.raises(AssertionError):
+        _assert_supersession_bindings(changed, _PREDECESSOR)

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -52,6 +52,7 @@ _PACKET_IDS = {
     "CK-08R3",
     "CK-08R4",
     "CK-08RG",
+    "CK-QG1A0",
     "CK-QG1A",
     "CK-QG1",
     *(f"CK-09-{number:02d}" for number in range(1, 7)),
@@ -175,7 +176,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["schema"] == "codex-usage-tracker.remaining-delegation-dag.v1"
     assert manifest["orchestration"]["spawn"] == "all_newly_ready_successors"
     conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-07R1A", "CK-QG1A"}
-    assert manifest["completed"] == ["CK-08R0", "CK-08R2"]
+    assert manifest["completed"] == ["CK-08R0", "CK-08R2", "CK-QG1A0"]
     ready: set[str] = set()
     assert manifest["ready"] == []
     assert manifest["conditional_ready"] == [
@@ -183,8 +184,12 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             "condition": (
                 "This serialized corrective authority correction accepted, merged, and exact-main verified"
             ),
-            "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A", "CK-QG1A"],
-        }
+            "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A"],
+        },
+        {
+            "condition": "CK-QG1A0 merged and exact-main verified",
+            "tasks": ["CK-QG1A"],
+        },
     ]
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
@@ -196,9 +201,9 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     )
 
     tasks = manifest["tasks"]
-    assert len(tasks) == 48
+    assert len(tasks) == 49
     manifest_by_id = {task["id"]: task for task in tasks}
-    assert len(manifest_by_id) == 48
+    assert len(manifest_by_id) == 49
     assert set(manifest_by_id) == _DELEGATED_PACKET_IDS
     assert manifest_by_id["CK-08R3A"]["dependencies"] == ["CK-08R0"]
     assert manifest_by_id["CK-08R3"]["dependencies"] == ["CK-08R3A"]
@@ -206,7 +211,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest_by_id["CK-08R1B"]["dependencies"] == ["CK-08R1A"]
     assert manifest_by_id["CK-08R1C"]["dependencies"] == ["CK-08R1A"]
     assert manifest_by_id["CK-08R1"]["dependencies"] == ["CK-08R1B", "CK-08R1C"]
-    assert manifest_by_id["CK-QG1A"]["dependencies"] == ["CK-08R2"]
+    assert manifest_by_id["CK-QG1A0"]["dependencies"] == ["CK-08R2"]
+    assert manifest_by_id["CK-QG1A"]["dependencies"] == ["CK-QG1A0"]
     assert manifest_by_id["CK-QG1"]["dependencies"] == ["CK-QG1A"]
     assert manifest_by_id["CK-07R1A"]["dependencies"] == ["CK-08R0"]
     assert manifest_by_id["CK-07R1"]["dependencies"] == ["CK-07R1A"]
@@ -220,7 +226,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
 
     release_budget = _json("config/kernel-release-candidate-budget.json")
     assert release_budget["sdist_bytes"] == 828000
-    for packet_id in ("CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R3A", "CK-07R1A", "CK-QG1A"):
+    for packet_id in ("CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R3A", "CK-07R1A", "CK-QG1A0", "CK-QG1A"):
         packet = _read(f"docs/roadmap/{manifest_by_id[packet_id]['file']}").replace(",", "")
         assert str(release_budget["sdist_bytes"]) in packet
 
@@ -257,7 +263,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Conditional Ready after" in body
         elif packet_id in ready:
             assert "**Status:** Ready" in body
-        elif packet_id in {"CK-08R0", "CK-08R2"}:
+        elif packet_id in {"CK-08R0", "CK-08R2", "CK-QG1A0"}:
             assert "**Status:** Completed on merge" in body
         else:
             assert "**Status:** Blocked" in body
@@ -358,6 +364,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     ck08r1c = _read("docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md")
     ck08r1 = _read("docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md")
     ckqg1a = _read("docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md")
+    ckqg1a0 = _read("docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md")
     ckqg1 = _read("docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md")
     ck07r1a = _read("docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md")
     ck07r1 = _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
@@ -406,6 +413,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
             "828000",
         )
     )
+    assert "CK-QG1A0" in ckqg1a0
     assert "explicit growth-evidence exception" in physical_decision
     assert "two current repetitions were waived" in physical_decision
     assert "**Dependencies:** CK-07A merged with exact-main seam evidence." in ck08

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -22,6 +22,7 @@ from scripts.check_kernel_scope import (
     CK08_QUERY_EVIDENCE_ADDITIONS,
     CK08R2_PHYSICAL_PAGE_ADDITIONS,
     CK08R3A_AUTHORITY_ADDITIONS,
+    CKQG1A0_AUTHORITY_ADDITIONS,
     CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS,
     DEV_ENVIRONMENT_BOOTSTRAP_ADDITIONS,
     INTEGRATION_ADDITIONS,
@@ -243,8 +244,8 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         for path in CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS
         if path.startswith("docs/roadmap/tasks/")
     }
-    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 94
-    assert len(task_packets) == 67
+    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 95
+    assert len(task_packets) == 68
     assert {
         "docs/INDEX.md",
         "docs/architecture/AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md",
@@ -664,6 +665,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK08_QUERY_EVIDENCE_ADDITIONS
         | CK08R2_PHYSICAL_PAGE_ADDITIONS
         | CK08R3A_AUTHORITY_ADDITIONS
+        | CKQG1A0_AUTHORITY_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )


### PR DESCRIPTION
## Summary
- Add CK-QG1A0 authority and strict schema for the frozen CK-08R2 PageExecutor predecessor and one selected successor.
- Bind exact R2 evidence paths/digests, baseline identity, consumer seam, preserved semantics, and fail-closed drift tests.
- Update the roadmap DAG to CK-08R2 -> CK-QG1A0 -> CK-QG1A -> CK-QG1 without implementing CK-QG1A.

## Scope
- Documentation, evidence authority/schema, scope allowlist, and authority tests only.
- No PageExecutor implementation or candidate worktree changes.

## Validation
- Focused authority/scope suite: 28 passed.
- `just v` and `just vc`: passed.
- Full suite: 1362 passed, 1 warning.
- Invariants lane: 13 passed.
- Pyright, GitNexus compare audit, diff check, and release safety passed.
- sdist: 827976 bytes, below the fixed 828000-byte ceiling.

## Review
- One final comprehensive read-only reviewer completed; the exact R2 artifact path-to-SHA binding gap was fixed and independently confirmed closed.