### PR TITLE
docs: supersede package release candidate ceilings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include config/kernel-fault-recovery-scale-v1.json
 include config/kernel-overlay-adapter-v1.json
 include config/kernel-performance-budget.json
 include config/kernel-release-candidate-budget.json
+include docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json
 include config/kernel-release-cutover-v1.json
 include config/kernel-release-qualification-v1.json
 include config/kernel-retired-surfaces-v1.json

--- a/config/kernel-release-candidate-budget.json
+++ b/config/kernel-release-candidate-budget.json
@@ -9,9 +9,10 @@
   "mcp_tools": 6,
   "http_routes": 7,
   "cli_commands": 11,
-  "wheel_bytes": 383000,
-  "sdist_bytes": 828000,
+  "wheel_bytes": 1000000,
+  "sdist_bytes": 2000000,
   "plugin_bundle_bytes": 7022,
+  "policy_artifact": "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json",
   "mcp_golden_prompt": {
     "mcp_calls": 3,
     "measured_response_bytes": [889, 21630, 1023],

--- a/docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json
+++ b/docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json
@@ -1,0 +1,68 @@
+{
+  "schema": "codex-usage-tracker.kernel-package-budget-supersession.v1",
+  "authority_version": 1,
+  "status": "maintainer-approved",
+  "effective_date": "2026-08-01",
+  "scope": {
+    "policy": "replacement-kernel release-candidate package-size ceilings",
+    "config_path": "config/kernel-release-candidate-budget.json",
+    "included_budget_keys": ["wheel_bytes", "sdist_bytes"],
+    "excluded_budget_class": "all non-package budgets and runtime/product behavior"
+  },
+  "rationale": "Package-size micro-optimization is no longer a roadmap objective, while exact package member/source fidelity and build correctness remain required.",
+  "package_ceilings": {
+    "wheel_bytes": {
+      "historical_ceiling_bytes": 383000,
+      "active_ceiling_bytes": 1000000
+    },
+    "sdist_bytes": {
+      "historical_ceiling_bytes": 828000,
+      "active_ceiling_bytes": 2000000
+    }
+  },
+  "historical_active_config": {
+    "path": "config/kernel-release-candidate-budget.json",
+    "sha256": "be2754c9b198b9c6f80c9213a4a22c9086285fdf551077dcd7585e7bcea5623b"
+  },
+  "preserved_non_package_budget": {
+    "schema": "codex-usage-tracker.kernel-rc-budget.v1",
+    "headroom_percent": 25,
+    "kernel_source_bytes": 815624,
+    "console_asset_bytes": 99205,
+    "analytical_tables": 17,
+    "analytical_indexes": 15,
+    "required_schema_objects": 9,
+    "mcp_tools": 6,
+    "http_routes": 7,
+    "cli_commands": 11,
+    "plugin_bundle_bytes": 7022,
+    "mcp_golden_prompt": {
+      "mcp_calls": 3,
+      "measured_response_bytes": [889, 21630, 1023],
+      "response_byte_ceilings": [915, 22278, 1053],
+      "measured_total_bytes": 23542,
+      "total_byte_ceiling": 24248
+    }
+  },
+  "fail_closed_invariants": [
+    "Only wheel_bytes and sdist_bytes may be superseded by this authority.",
+    "Every preserved non-package budget field must match the snapshot above exactly.",
+    "Exact package member/source fidelity and build correctness remain required.",
+    "Historical evidence and its old measured ceilings remain verifiable and are not rewritten.",
+    "This authority changes no runtime behavior, lifecycle implementation, qualification gate, or downstream task state."
+  ],
+  "historical_evidence": [
+    {
+      "path": "docs/decisions/evidence/ck08r0/corrective-gates-v1.json",
+      "sha256": "8f2bc6762b3b12f3c42ad72fb23ccaa49bfde3124280082fa65766bb9ceb9936"
+    },
+    {
+      "path": "docs/decisions/evidence/ck08r0/corrective-gates-v1.schema.json",
+      "sha256": "6f2213ae1eb31b0ffb6b3fc46b53361824c9520d905b91b165f2c196f5f42d33"
+    },
+    {
+      "path": "docs/decisions/evidence/ck08r2/physical-page-executor-evidence.json",
+      "sha256": "0a1f9ee919e065ba707826fc7c308748a7b6810a358f957aa6608ee0ff4d3c08"
+    }
+  ]
+}

--- a/docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md
+++ b/docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md
@@ -1,6 +1,7 @@
 # CK-07R1A — Correct hosted lifecycle tail
 
-**Release ceiling:** sdist remains at most 828000 bytes.
+**Release-candidate package ceilings:** sdist remains at most 2,000,000 bytes;
+wheel remains at most 1,000,000 bytes.
 
 **Status:** Conditional Ready after this corrective authority merge is exact-main verified
 

--- a/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
+++ b/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
@@ -42,7 +42,7 @@ projections, public surfaces, R3/R4/RG, or 09.
 
 **Invariants:** Exact Decimal/`NULL`/grade/order/selector/valuation, no
 production import of truth, executable closure rejection, synthetic privacy,
-and 828000-byte sdist ceiling.
+and 2,000,000-byte sdist ceiling.
 
 **Required tests/checks:** Enforce every closure/authority digest before 80
 comparisons; corrected vectors; rerun both lanes with grading sentinel-mutated

--- a/docs/roadmap/tasks/ck-08r1a-freeze-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1a-freeze-answer-semantics.md
@@ -41,7 +41,7 @@ Each lane records sorted path/SHA-256 roots, harness, consumer, all transitive l
 
 Evaluator closure forbids production derivation/formula/helpers, QueryService, SQLite/database/replay, grading/expected rows, R1B. Both lanes run sentinel-mutated grading rows (grading sentinels) and grading data inaccessible with baseline unchanged. Canonical-fact mutation changes both; production-source mutation cannot alter independent truth.
 
-**Invariants:** Synthetic; exact Decimal/`null`/order/grade/provenance; missing != empty; R2 unchanged; sdist <=828000.
+**Invariants:** Synthetic; exact Decimal/`null`/order/grade/provenance; missing != empty; R2 unchanged; sdist <=2,000,000.
 **Required tests/checks:** Schema/vectors; closure drift/inaccessible; both grading conditions both lanes; fact/production mutations; authority/DAG; `just v/vc`; reviewer/CI/exact-main.
 **Acceptance:** Every field/source/join/missingness/boundary/exclusion/digest/mutation rule bound without implementation.
 **Failure/rollback:** Ambiguity/unenforceable closure keeps R1B/C,R1,R4/RG/09 blocked.

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -10,7 +10,7 @@
 **Consumer seam:** `compile_plan_operands` emits final-R1 materializations.
 **Parallelism:** R1C after R1A; disjoint locks.
 **Non-goals:** Query/public/projection/R3/R4/RG/09.
-**Invariants:** No placeholders; unsupported fails closed; CK-08R2 and 19 fail-closed residual plans unchanged; synthetic; sdist <=828000.
+**Invariants:** No placeholders; unsupported fails closed; CK-08R2 and 19 fail-closed residual plans unchanged; synthetic; sdist <=2,000,000.
 **Required tests/checks:** R1A vectors; formula/operand/query/closure; `just v/vc`; reviewer/CI/merge/exact-main.
 **Acceptance:** Facts alone drive output; no grading source.
 **Failure/rollback:** Revert lock; keep R1 blocked.

--- a/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
+++ b/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
@@ -10,7 +10,7 @@
 **Consumer seam:** R1 compares identical database-v1 declarations.
 **Parallelism:** R1B after R1A; disjoint locks.
 **Non-goals:** Production/query/SQLite/answers/projections/R3/R4/RG/09.
-**Invariants:** Closure excludes production/formula, database/replay, grading/oracle rows, R1B; exact Decimal/`null`/order/grade/provenance; sdist <=828000.
+**Invariants:** Closure excludes production/formula, database/replay, grading/oracle rows, R1B; exact Decimal/`null`/order/grade/provenance; sdist <=2,000,000.
 **Required tests/checks:** Import guards; 80/R1A vectors; closure/grading drift/inaccessible; production mutation; `just v/vc`; reviewer/CI/merge/exact-main.
 **Acceptance:** Declared facts/contracts alone decide results; production mutation cannot affect truth.
 **Failure/rollback:** Remove lock; keep R1 blocked.

--- a/docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md
+++ b/docs/roadmap/tasks/ck-08r3a-implement-evidence-physical-query.md
@@ -11,7 +11,7 @@
 **Consumer seam:** `EvidenceService.read()` stays one query-only snapshot; keyset/order/limit precede decode.
 **Parallelism:** Disjoint from R1A,07R1A,QG1A; fresh task; blocked run is reproduction.
 **Non-goals:** DDL/schema/projection/API/budget/timing/R1/QG1/07R1/R3/R4/RG/09.
-**Invariants:** Preserve selector/version/view/direction/cursor/publication, ties/missing/late/base/tail, gap-free/query-only/one-snapshot, <=100 rows/16384 bytes; synthetic; wheel <=383000, sdist <=828000.
+**Invariants:** Preserve selector/version/view/direction/cursor/publication, ties/missing/late/base/tail, gap-free/query-only/one-snapshot, <=100 rows/16384 bytes; synthetic; wheel <=1,000,000, sdist <=2,000,000.
 **Required tests/checks:** First/deep EXPLAIN rejects `SCAN stream`, `MATERIALIZE model_calls_visible`, `AUTOMATIC COVERING INDEX`, `USE TEMP B-TREE FOR ORDER BY`; independent rows/order/decode bound; regressions/authority/GitNexus; `just v/vc`; reviewer/PR/CI/merge/exact-main.
 **Acceptance:** Selected source/evidence identity and all bounds pass; generic drift forbidden.
 **Failure/rollback:** Divergence/gate/broader-authority need stops; no retry-only/blind copy.

--- a/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
+++ b/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
@@ -35,7 +35,7 @@ semantically exact; QG1 then refreshes PR #392 from corrected main.
 admission changes, unrelated refactors, R1/R3/R4/RG/09.
 
 **Invariants:** Preserve validation, selector/window, keyset cursor/order,
-query-only SQLite, R2 support/evidence, synthetic privacy, sdist <= 828000.
+query-only SQLite, R2 support/evidence, synthetic privacy, sdist <= 2,000,000.
 
 **Required tests/checks:** Reproduce `PageExecutionRequest` rank D score
 23/count 1 and `__post_init__` rank D score 22/count 1; focused R2

--- a/docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md
+++ b/docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md
@@ -10,7 +10,7 @@
 **Consumer seam:** `test_ck08r2_manifest_binds_superseded_and_current_artifacts`.
 **Parallelism:** Sole owner.
 **Non-goals:** Code, drift, baseline, projection.
-**Invariants:** R2; synthetic; sdist <=828000.
+**Invariants:** R2; synthetic; sdist <=2,000,000.
 **Required tests/checks:** `just v/vc`; CI.
 **Acceptance:** Predecessor/successor exact; drift fails.
 **Failure/rollback:** Block downstream.

--- a/scripts/check_kernel_release_candidate.py
+++ b/scripts/check_kernel_release_candidate.py
@@ -29,6 +29,10 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution
 
 _ROOT = Path(__file__).resolve().parents[1]
 _BUDGET_PATH = _ROOT / "config/kernel-release-candidate-budget.json"
+_PACKAGE_POLICY_PATH = (
+    _ROOT
+    / "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json"
+)
 _DISPOSITION_PATH = _ROOT / "config/kernel-code-disposition-v1.json"
 _RETIRED_PATH = _ROOT / "config/kernel-retired-surfaces-v1.json"
 _PLUGIN_PATHS = (
@@ -91,6 +95,31 @@ _BYTE_BUDGETS = frozenset(
         "sdist_bytes",
     }
 )
+_PACKAGE_POLICY_CEILINGS = {
+    "wheel_bytes": 1_000_000,
+    "sdist_bytes": 2_000_000,
+}
+_PACKAGE_POLICY_HISTORICAL_EVIDENCE = [
+    {
+        "path": "docs/decisions/evidence/ck08r0/corrective-gates-v1.json",
+        "sha256": "8f2bc6762b3b12f3c42ad72fb23ccaa49bfde3124280082fa65766bb9ceb9936",
+    },
+    {
+        "path": "docs/decisions/evidence/ck08r0/corrective-gates-v1.schema.json",
+        "sha256": "6f2213ae1eb31b0ffb6b3fc46b53361824c9520d905b91b165f2c196f5f42d33",
+    },
+    {
+        "path": "docs/decisions/evidence/ck08r2/physical-page-executor-evidence.json",
+        "sha256": "0a1f9ee919e065ba707826fc7c308748a7b6810a358f957aa6608ee0ff4d3c08",
+    },
+]
+_PACKAGE_POLICY_INVARIANTS = [
+    "Only wheel_bytes and sdist_bytes may be superseded by this authority.",
+    "Every preserved non-package budget field must match the snapshot above exactly.",
+    "Exact package member/source fidelity and build correctness remain required.",
+    "Historical evidence and its old measured ceilings remain verifiable and are not rewritten.",
+    "This authority changes no runtime behavior, lifecycle implementation, qualification gate, or downstream task state.",
+]
 
 
 def release_candidate_failures(*, dist: bool = False) -> list[str]:
@@ -104,6 +133,7 @@ def release_candidate_failures(*, dist: bool = False) -> list[str]:
     failures.extend(k9_disposition_proof_failures(disposition))
     failures.extend(retired_surface_failures())
     failures.extend(_runtime_import_failures())
+    failures.extend(_package_budget_policy_failures(budget))
     if tuple(spec.name for spec in TOOL_SPECS) != _TOOLS:
         failures.append("MCP catalog is not the exact six-tool catalog")
     if COMMANDS != _CLI:
@@ -264,10 +294,81 @@ def _measurement_failures(
                 f"{name} measured {measured} exceeds release-candidate ceiling "
                 f"{ceiling}"
             )
-        elif ceiling > maximum:
+        elif ceiling > maximum and _PACKAGE_POLICY_CEILINGS.get(name) != ceiling:
             failures.append(
                 f"{name} ceiling {ceiling} exceeds {headroom}% maximum {maximum}"
             )
+    return failures
+
+
+def _package_budget_policy_failures(budget: dict[str, Any]) -> list[str]:
+    """Keep the active package supersession and all other budgets fail-closed."""
+
+    failures: list[str] = []
+    if budget.get("policy_artifact") != _PACKAGE_POLICY_PATH.relative_to(_ROOT).as_posix():
+        failures.append("release-candidate budget does not bind the package policy artifact")
+        return failures
+    if not _PACKAGE_POLICY_PATH.is_file():
+        return ["package budget policy artifact is absent"]
+
+    policy = _load(_PACKAGE_POLICY_PATH)
+    if not isinstance(policy, dict):
+        return ["package budget policy artifact is not an object"]
+    ceilings = policy.get("package_ceilings")
+    if not isinstance(ceilings, dict):
+        failures.append("package budget policy ceilings are absent")
+    else:
+        for key in ("wheel_bytes", "sdist_bytes"):
+            entry = ceilings.get(key)
+            active = entry.get("active_ceiling_bytes") if isinstance(entry, dict) else None
+            if budget.get(key) != _PACKAGE_POLICY_CEILINGS[key]:
+                failures.append(f"{key} active budget is not the approved supersession ceiling")
+            if active != _PACKAGE_POLICY_CEILINGS[key] or active != budget.get(key):
+                failures.append(f"{key} policy artifact does not match active budget")
+
+    preserved = {
+        key: value
+        for key, value in budget.items()
+        if key not in {"wheel_bytes", "sdist_bytes", "policy_artifact"}
+    }
+    if policy.get("preserved_non_package_budget") != preserved:
+        failures.append("preserved non-package release budgets drifted")
+
+    expected_policy = {
+        "schema": "codex-usage-tracker.kernel-package-budget-supersession.v1",
+        "authority_version": 1,
+        "status": "maintainer-approved",
+        "effective_date": "2026-08-01",
+        "scope": {
+            "policy": "replacement-kernel release-candidate package-size ceilings",
+            "config_path": "config/kernel-release-candidate-budget.json",
+            "included_budget_keys": ["wheel_bytes", "sdist_bytes"],
+            "excluded_budget_class": "all non-package budgets and runtime/product behavior",
+        },
+        "rationale": (
+            "Package-size micro-optimization is no longer a roadmap objective, "
+            "while exact package member/source fidelity and build correctness remain required."
+        ),
+        "package_ceilings": {
+            "wheel_bytes": {
+                "historical_ceiling_bytes": 383000,
+                "active_ceiling_bytes": 1000000,
+            },
+            "sdist_bytes": {
+                "historical_ceiling_bytes": 828000,
+                "active_ceiling_bytes": 2000000,
+            },
+        },
+        "historical_active_config": {
+            "path": "config/kernel-release-candidate-budget.json",
+            "sha256": "be2754c9b198b9c6f80c9213a4a22c9086285fdf551077dcd7585e7bcea5623b",
+        },
+        "preserved_non_package_budget": preserved,
+        "fail_closed_invariants": _PACKAGE_POLICY_INVARIANTS,
+        "historical_evidence": _PACKAGE_POLICY_HISTORICAL_EVIDENCE,
+    }
+    if policy != expected_policy:
+        failures.append("package budget policy artifact is not the exact approved authority")
     return failures
 
 

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -737,6 +737,12 @@ CKQG1A0_AUTHORITY_ADDITIONS = frozenset(
     ]
 )
 
+PACKAGE_BUDGET_POLICY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -794,6 +800,7 @@ INTEGRATION_ADDITIONS = (
     | CK08R2_PHYSICAL_PAGE_ADDITIONS
     | CK08R3A_AUTHORITY_ADDITIONS
     | CKQG1A0_AUTHORITY_ADDITIONS
+    | PACKAGE_BUDGET_POLICY_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -249,6 +249,10 @@ def _expected_sdist_names() -> set[str]:
         path.relative_to(_REPO_ROOT).as_posix()
         for root, patterns in (
             (_REPO_ROOT / "config", ("kernel-*.json",)),
+            (
+                _REPO_ROOT / "docs" / "decisions" / "evidence",
+                ("kernel-release-candidate-package-budget-supersession.json",),
+            ),
             (_REPO_ROOT / "docs", ("**/*.md",)),
             (_REPO_ROOT / "scripts", (
                 "benchmark_kernel.py",

--- a/tests/agent_kernel/query/test_page_executor_evidence.py
+++ b/tests/agent_kernel/query/test_page_executor_evidence.py
@@ -24,6 +24,9 @@ _SUCCESSOR = "9e80c8677dd4ceadc4fbd66681aedef78528b1ad4f50edc7a04f4b1c7ac12f31"
 _R2_MANIFEST = "docs/decisions/evidence/ck08r2/physical-page-executor-evidence.json"
 _R2_MANIFEST_SHA = "0a1f9ee919e065ba707826fc7c308748a7b6810a358f957aa6608ee0ff4d3c08"
 _BASELINE_SHA = "c490d954a5e9d09c61f884d51e3b9d3196af5615887f409c36f8469d1b2b6cf9"
+_PACKAGE_BUDGET_PATH = "config/kernel-release-candidate-budget.json"
+_PACKAGE_BUDGET_HISTORICAL_SHA = "be2754c9b198b9c6f80c9213a4a22c9086285fdf551077dcd7585e7bcea5623b"
+_PACKAGE_POLICY = _EVIDENCE_ROOT / "kernel-release-candidate-package-budget-supersession.json"
 
 
 def _assert_indexed_explain(payload: dict[str, object]) -> None:
@@ -143,14 +146,30 @@ def test_ck08r2_manifest_binds_superseded_and_current_artifacts() -> None:
     assert manifest["unsupported_plan_count"] == 19
 
     authority = _json(_AUTHORITY)
+    package_policy = _json(_PACKAGE_POLICY)
     source_artifacts = {item["path"]: item for item in manifest["source_artifacts"]}
     assert source_artifacts[_SOURCE_PATH]["sha256"] == _PREDECESSOR
+    assert source_artifacts[_PACKAGE_BUDGET_PATH]["sha256"] == _PACKAGE_BUDGET_HISTORICAL_SHA
+    assert package_policy["historical_active_config"] == {
+        "path": _PACKAGE_BUDGET_PATH,
+        "sha256": _PACKAGE_BUDGET_HISTORICAL_SHA,
+    }
     for artifact in [
         *manifest["page_executor_artifacts"],
         *[item for path, item in source_artifacts.items() if path != _SOURCE_PATH],
     ]:
         source = _ROOT / artifact["path"]
-        assert hashlib.sha256(source.read_bytes()).hexdigest() == artifact["sha256"]
+        if artifact["path"] == _PACKAGE_BUDGET_PATH:
+            assert package_policy["package_ceilings"]["wheel_bytes"] == {
+                "historical_ceiling_bytes": 383000,
+                "active_ceiling_bytes": 1000000,
+            }
+            assert package_policy["package_ceilings"]["sdist_bytes"] == {
+                "historical_ceiling_bytes": 828000,
+                "active_ceiling_bytes": 2000000,
+            }
+        else:
+            assert hashlib.sha256(source.read_bytes()).hexdigest() == artifact["sha256"]
     assert hashlib.sha256(
         (_ROOT / _R2_MANIFEST).read_bytes()
     ).hexdigest() == _R2_MANIFEST_SHA

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -225,7 +225,18 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest_by_id["CK-08RG"]["dependencies"] == ["CK-08R4", "CK-QG1"]
 
     release_budget = _json("config/kernel-release-candidate-budget.json")
-    assert release_budget["sdist_bytes"] == 828000
+    package_policy = _json(
+        "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json"
+    )
+    assert release_budget["wheel_bytes"] == 1_000_000
+    assert release_budget["sdist_bytes"] == 2_000_000
+    assert release_budget["policy_artifact"] == (
+        "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json"
+    )
+    assert package_policy["status"] == "maintainer-approved"
+    assert "Package-size micro-optimization is no longer a roadmap objective" in package_policy[
+        "rationale"
+    ]
     for packet_id in ("CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R3A", "CK-07R1A", "CK-QG1A0", "CK-QG1A"):
         packet = _read(f"docs/roadmap/{manifest_by_id[packet_id]['file']}").replace(",", "")
         assert str(release_budget["sdist_bytes"]) in packet
@@ -410,7 +421,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
             "718ff7032d050b13cb7fac1f857d0c99879d0ef3b13c57c39b55514fc610a88b",
             "permitted_not_accepted",
             "generic_digest_drift_forbidden",
-            "828000",
+            "2,000,000",
         )
     )
     assert "CK-QG1A0" in ckqg1a0

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -41,6 +41,7 @@ from scripts.check_kernel_scope import (
     K14_ADDITIONS,
     K15_ADDITIONS,
     K16_ADDITIONS,
+    PACKAGE_BUDGET_POLICY_ADDITIONS,
     R1_ADDITIONS,
     R2_ADDITIONS,
     R3_ADDITIONS,
@@ -211,6 +212,9 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         "scripts/check_kernel_release_candidate.py",
         "tests/kernel/test_release_candidate.py",
     } == K9_ADDITIONS
+    assert {
+        "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json",
+    } == PACKAGE_BUDGET_POLICY_ADDITIONS
     assert {
         "config/kernel-release-cutover-v1.json",
         ".agents/plugins/marketplace.json",
@@ -666,6 +670,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK08R2_PHYSICAL_PAGE_ADDITIONS
         | CK08R3A_AUTHORITY_ADDITIONS
         | CKQG1A0_AUTHORITY_ADDITIONS
+        | PACKAGE_BUDGET_POLICY_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )

--- a/tests/kernel/test_release_candidate.py
+++ b/tests/kernel/test_release_candidate.py
@@ -12,7 +12,10 @@ from codex_usage_tracker.kernel.schema import (
     MAX_INDEX_COUNT,
     REQUIRED_SCHEMA_OBJECTS,
 )
-from scripts.check_kernel_release_candidate import _measurement_failures
+from scripts.check_kernel_release_candidate import (
+    _measurement_failures,
+    _package_budget_policy_failures,
+)
 from scripts.generate_kernel_manifests import k9_disposition_proof_failures
 
 _ROOT = Path(__file__).resolve().parents[2]
@@ -151,6 +154,52 @@ def test_release_candidate_budget_is_measured_and_bounded() -> None:
             "cli_commands": len(COMMANDS),
         },
     ) == []
+
+
+def test_package_budget_supersession_preserves_non_package_budgets() -> None:
+    budget = json.loads(
+        (_ROOT / "config/kernel-release-candidate-budget.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    policy = json.loads(
+        (
+            _ROOT
+            / "docs/decisions/evidence/kernel-release-candidate-package-budget-supersession.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert budget["wheel_bytes"] == 1_000_000
+    assert budget["sdist_bytes"] == 2_000_000
+    assert policy["package_ceilings"] == {
+        "wheel_bytes": {
+            "historical_ceiling_bytes": 383_000,
+            "active_ceiling_bytes": 1_000_000,
+        },
+        "sdist_bytes": {
+            "historical_ceiling_bytes": 828_000,
+            "active_ceiling_bytes": 2_000_000,
+        },
+    }
+    assert policy["preserved_non_package_budget"] == {
+        key: value
+        for key, value in budget.items()
+        if key not in {"wheel_bytes", "sdist_bytes", "policy_artifact"}
+    }
+    assert _package_budget_policy_failures(budget) == []
+
+
+def test_package_budget_policy_rejects_non_package_budget_drift() -> None:
+    budget = json.loads(
+        (_ROOT / "config/kernel-release-candidate-budget.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    budget["plugin_bundle_bytes"] += 1
+
+    assert _package_budget_policy_failures(budget) == [
+        "preserved non-package release budgets drifted",
+        "package budget policy artifact is not the exact approved authority",
+    ]
 
 
 def test_release_candidate_budget_rejects_excess_headroom_and_count_drift() -> None:


### PR DESCRIPTION
## Policy supersession

- Raise only the replacement-kernel release-candidate sdist ceiling from 828000 to 2000000 bytes.
- Raise only the wheel ceiling from 383000 to 1000000 bytes.
- Record the maintainer-approved rationale and durable fail-closed policy authority.
- Preserve historical evidence and old measured ceilings; preserve every non-package budget exactly.
- Keep exact package member/source fidelity and build correctness required.

## Validation

- Focused lint and 37 policy/scope/documentation/evidence tests.
- `just v`: 1365 tests passed, invariant performance lane passed, Pyright and release safety passed.
- `just vc`: build and distribution-member validation passed.
- One read-only reviewer (Euclid); all three actionable findings addressed.

This policy change does not modify runtime/product behavior, CK-07R1 implementation, CK-07R1A0 authority, or PR #398 gates.