### PR TITLE
Freeze CK-07R1 lifecycle planner/recovery path authority

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,8 +22,10 @@ before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
 fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
 truth is now serialized as R1A contract freeze, disjoint R1B/R1C consumers,
 and final R1 requalification. CK-QG1A0 gates the selected R2 PageExecutor
-successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrects PR #394's exact hosted lifecycle-tail
-failure without a budget waiver. Reclassification and maintainability
+successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrected
+PR #394's exact hosted lifecycle-tail failure without a budget waiver.
+CK-07R1A0 now freezes the reachable planner/recovery path because the retained
+all-profile receipt was writer-only; CK-07R1 remains blocked. Reclassification and maintainability
 remain open. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
@@ -20,7 +20,7 @@
       "recover_startup(pointer_path, selection=..., store=..., ...)"
     ],
     "planner": [
-      "plan_refresh(changes, intent, limits=..., dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
+      "plan_refresh(changes, intent, limits=approved_tail_limits, dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
     ],
     "small_publication": [
       "PublicationWriter.publish_with_pointer(plan, request, write_set, pointer_path=..., operational_store=..., pointer_request=..., validate_open=...)",
@@ -49,10 +49,25 @@
   "append_safe_small": {
     "operation_class": "append_safe_small",
     "selection_reason": "all_small_tail_bounds_proven",
+    "approved_tail_limits": {
+      "selected_bytes": 8388608,
+      "selected_records": 32,
+      "observations": 12000,
+      "occurrences": 12000,
+      "affected_sessions": 2000,
+      "affected_turns": 4000,
+      "affected_resources": 4000,
+      "affected_allowance_cycles": 512,
+      "dirty_keys": 16000,
+      "projection_rows": 16000,
+      "expected_wal_bytes": 16777216,
+      "planning_staleness_us": 5000000,
+      "model_call_tail_rows": 32000
+    },
     "selection_conditions": [
       "no_schema_adapter_identity_normalization_or_projection_compatibility_change",
       "no_no_change_history_expand_source_replace_or_valuation_only_classification_applies",
-      "estimate_change_set_has_no_limit_breaches_under_the_supplied_TailLimits",
+      "estimate_change_set_has_no_limit_breaches_under_approved_TailLimits",
       "the_selected_sources_and_refresh_intent are the inputs to plan_refresh"
     ],
     "breach_result": "any_limit_breach_selects_append_safe_large_and_small_writer_rejects_it",
@@ -86,7 +101,7 @@
       "a crash/retry is idempotent and does not duplicate or silently replace a publication",
       "owned artifacts and rollback protection remain intact until reconciliation completes"
     ],
-    "required_receipt_fields": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
+    "required_receipt_fields": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "planner_tail_limits", "planner_change_estimate", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
   },
   "run_authorization": {
     "status": "not_executed_by_this_packet",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
@@ -1,0 +1,206 @@
+{
+  "schema": "codex-usage-tracker.lifecycle-path-authority.v1",
+  "authority_version": 1,
+  "owner": "CK-07R1A0",
+  "authority_base_sha": "979f88eca2f23f6225c0c7a530b8f36f793c5748",
+  "upstream_acceptance": [
+    {"packet": "CK-QG1A0", "sha": "eb3ded92408d9549d4a4c15c69c045cc3845689c", "status": "accepted_merged_exact_main_verified"},
+    {"packet": "CK-07R1A", "sha": "4d8074952f679877f2b4fbb3e89c51015e96a197", "status": "accepted_merged_exact_main_verified"},
+    {"packet": "CK-08R0", "sha": "306cef37eea2ae017aca824d898cc435f7e1bea0", "status": "accepted_merged_exact_main_verified"}
+  ],
+  "blocked_requalification": {
+    "packet": "CK-07R1",
+    "status": "BLOCKED",
+    "reason": "planner_valid_lifecycle_receipt_and_this_authority",
+    "accepted_receipt_required": true
+  },
+  "reachable_path": {
+    "startup_recovery": [
+      "select_readable_artifact(pointer_path, validate_open=...)",
+      "recover_startup(pointer_path, selection=..., store=..., ...)"
+    ],
+    "planner": [
+      "plan_refresh(changes, intent, limits=..., dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
+    ],
+    "small_publication": [
+      "PublicationWriter.publish_with_pointer(plan, request, write_set, pointer_path=..., operational_store=..., pointer_request=..., validate_open=...)",
+      "publish_small_with_pointer(..., commit_analytical=...)",
+      "PublicationWriter.publish(plan, request, write_set)"
+    ],
+    "ordering": "recovery_read_first; planner_before_writer_lock; selected_plan_unchanged_through_writer",
+    "forbidden_shortcuts": [
+      "manually_constructed_PublicationPlan",
+      "manual_OperationClass_APPEND_SAFE_SMALL_override",
+      "direct_PublicationWriter_publish_without_plan_refresh",
+      "publication_receipt_without_reachable_recovery_path"
+    ],
+    "identity_binding": {
+      "same_publication_identity": [
+        "ReadSelection.head.publication_id == RefreshIntent.parent_publication_id",
+        "RefreshIntent.parent_publication_id == PublicationPlan.parent_publication_id",
+        "PublicationPlan.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+        "SmallPublicationRequest.expected_active_publication_id == pre_commit_pointer.active.publication_id",
+        "committed_AnalyticalHead.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+        "post_commit_pointer.active.publication_id == committed_AnalyticalHead.publication_id"
+      ],
+      "mismatch_result": "fail_closed_before_acceptance_no_stitched_artifacts_or_cross_run_identity_binding"
+    }
+  },
+  "append_safe_small": {
+    "operation_class": "append_safe_small",
+    "selection_reason": "all_small_tail_bounds_proven",
+    "selection_conditions": [
+      "no_schema_adapter_identity_normalization_or_projection_compatibility_change",
+      "no_no_change_history_expand_source_replace_or_valuation_only_classification_applies",
+      "estimate_change_set_has_no_limit_breaches_under_the_supplied_TailLimits",
+      "the_selected_sources_and_refresh_intent are the inputs to plan_refresh"
+    ],
+    "breach_result": "any_limit_breach_selects_append_safe_large_and_small_writer_rejects_it",
+    "writer_identity_rule": "the_plan_returned_by_plan_refresh_is passed unchanged to the pointer-coordinated writer"
+  },
+  "independent_truth": {
+    "oracle_path": "tests/agent_kernel/contracts/reference/lifecycle.py",
+    "oracle_symbol": "fold_lifecycle",
+    "derivation": "derive ordered transition vectors from synthetic observations plus prior transitions, then compare lifecycle identities, versions, folds, counts, and digests",
+    "forbidden_sources": [
+      "codex_usage_tracker.agent_kernel.publication.preparation",
+      "codex_usage_tracker.agent_kernel.publication.planner",
+      "codex_usage_tracker.agent_kernel.publication.writer",
+      "codex_usage_tracker.agent_kernel.publication.recovery",
+      "SQLite rows as expected answers"
+    ],
+    "comparisons": ["transition_identity_and_version", "fold_identity_and_digest", "publication_counts_and_chain"]
+  },
+  "postconditions": {
+    "publication": [
+      "publication_head is the final direct child and every parent_publication_id is the preceding head",
+      "source_occurrences equals inserted_occurrences with no duplicate occurrence identities",
+      "lifecycle transition/entity counts and fold digest equal independent truth",
+      "preparation transaction is closed before the writer begins and no analytical transaction remains open",
+      "artifact manifest, operation_id, publication_id, schema identity, and pointer head agree"
+    ],
+    "recovery": [
+      "select_readable_artifact validates the active artifact and falls back only to a validated rollback artifact",
+      "recover_startup runs only after readable selection and reconciles pending intents, stale leases, and dead jobs",
+      "pointer generation, active publication, analytical head, and recovery intent identities agree after reconciliation",
+      "a crash/retry is idempotent and does not duplicate or silently replace a publication",
+      "owned artifacts and rollback protection remain intact until reconciliation completes"
+    ],
+    "required_receipt_fields": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
+  },
+  "run_authorization": {
+    "status": "not_executed_by_this_packet",
+    "maximum_new_end_to_end_runs": 1,
+    "scope": "one fresh synthetic all-profile CK-07R1 publication/recovery run after implementation correction",
+    "permitted_only_if": [
+      "this authority is accepted merged and exact-main verified",
+      "the implementation successor starts from that exact main and touches only its authorized files",
+      "the harness proves the reachable_path and append_safe_small rules without manual plan construction",
+      "the independent oracle and all publication/recovery postconditions pass on the same run",
+      "all five frozen budgets and the first hosted failure remain unchanged and visible",
+      "no prior run identity or receipt is reused and no concurrent production run exists"
+    ],
+    "failure_action": "retain the first new result, perform no retry, and keep CK-07R1 blocked"
+  },
+  "prior_attempts": [
+    {
+      "run_id": "all-profile-initial-serializer",
+      "classification": "failed_preserved",
+      "profile": "all-profile",
+      "timestamp_status": "output observed at local minute precision",
+      "observed_at_local": "2026-08-01T15:59",
+      "completed_at_local": null,
+      "pid": null,
+      "parent_pid": null,
+      "usable_final_json": false,
+      "publication_state": "none",
+      "failure_or_result": "TypeError: cannot pickle mappingproxy object during receipt serialization",
+      "receipt_digest": null,
+      "fold_digest": null,
+      "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+    },
+    {
+      "run_id": "all-profile-corrected-serializer-tail-oracle",
+      "classification": "failed_preserved",
+      "profile": "all-profile",
+      "timestamp_status": "exact process timestamps are not recoverable from current task records",
+      "observed_at_local": null,
+      "completed_at_local": null,
+      "pid": null,
+      "parent_pid": null,
+      "usable_final_json": false,
+      "publication_state": "temporary database cleaned",
+      "failure_or_result": "independent lifecycle-fold truth omitted prior publication transitions",
+      "receipt_digest": null,
+      "fold_digest": null,
+      "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+    },
+    {
+      "run_id": "all-profile-pid-60367-recovery",
+      "classification": "writer_only_not_publication_valid",
+      "profile": "all-profile",
+      "timestamp_status": "exact completion timestamp retained",
+      "observed_at_local": null,
+      "completed_at_local": "2026-08-01T16:26:43-04:00",
+      "pid": 60367,
+      "parent_pid": 1124,
+      "usable_final_json": true,
+      "publication_state": "writer_only_not_reachable_planner_recovery",
+      "failure_or_result": "full JSON produced; reviewer rejected publication-valid acceptance because the harness manually forced APPEND_SAFE_SMALL and called PublicationWriter directly",
+      "receipt_digest": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
+      "fold_digest": "19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+      "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+    },
+    {
+      "run_id": "production-only-valid-profile",
+      "classification": "distinct_packet_required_profile",
+      "profile": "production-only",
+      "timestamp_status": "exact completion timestamp retained",
+      "observed_at_local": null,
+      "completed_at_local": "2026-08-01T15:56:26-04:00",
+      "pid": null,
+      "parent_pid": null,
+      "usable_final_json": true,
+      "publication_state": "valid_for_distinct_production_only_profile_not_all_profile",
+      "failure_or_result": "five unprofiled all-time samples [18563.027, 18916.769, 19198.25, 18765.469, 18732.573] ms; max 19198.25 ms; fold digest 19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+      "receipt_digest": null,
+      "fold_digest": "19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+      "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+    }
+  ],
+  "retained_evidence": {
+    "source_path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+    "sha256": "9dcebcbd72e2bfd0eca25783bad97d9367a568f28f171cfa466cdbf8689a00ba",
+    "dependency_sha": "4d8074952f679877f2b4fbb3e89c51015e96a197",
+    "branch": "feature/ck-07r1-lifecycle-preparation",
+    "status": "retained_uncommitted_read_only_evidence",
+    "writer_only_receipt_digest": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
+    "fixture_digest": "7d58cbdcda25fe98f42e8b896d0b3b064504cd564bc26c51f35cc1461666af9d",
+    "implementation_sha256": "ab6f5ccc1524b1471857d2bff3a3fd4403a726fe67f154b3986846ac4f31fc52",
+    "benchmark_sha256": "d619595aa96f6edd9b22605c573cc4607d04fe2702eecd300c8cb118e3c29e3a",
+    "test_sha256": "da6f9a4ed619a6753e28661065eee88ebea91de4e695e90f4954e435b5e02c8d"
+  },
+  "scope_additions": [
+    {"path": "scripts/benchmark_ck07r1_lifecycle_scale.py", "sha256": "d619595aa96f6edd9b22605c573cc4607d04fe2702eecd300c8cb118e3c29e3a", "source_of_proof": "retained CK-07R1 uncommitted diff at dependency_sha"},
+    {"path": "tests/agent_kernel/publication/test_lifecycle_scale.py", "sha256": "da6f9a4ed619a6753e28661065eee88ebea91de4e695e90f4954e435b5e02c8d", "source_of_proof": "retained CK-07R1 uncommitted diff at dependency_sha"}
+  ],
+  "dependencies": [
+    "CK-QG1A0@eb3ded92408d9549d4a4c15c69c045cc3845689c",
+    "CK-07R1A@4d8074952f679877f2b4fbb3e89c51015e96a197",
+    "CK-08R0 accepted",
+    "PR-394 retained read-only",
+    "no CK-08R4/CK-08RG/CK-09 successor"
+  ],
+  "fail_closed_rules": [
+    "do not run production qualification in CK-07R1A0",
+    "do not accept a manually forced operation class as planner evidence",
+    "do not accept a direct writer call that bypasses plan_refresh or recovery",
+    "do not reuse or overwrite prior publication, operation, run, PID, or receipt identities",
+    "do not infer missing timestamps; retain unrecoverable precision as stated",
+    "do not weaken budgets, ceilings, first-sample requirements, or synthetic-only data rules",
+    "stop if the two scope additions cannot be proven from the retained diff",
+    "stop if any authority identity, schema, DAG, ledger, review, hosted CI, merge, or exact-main gate fails",
+    "do not update PR-394, historical worktrees, or downstream corrective packets",
+    "do not dispatch CK-07R1 or any dependent successor from this packet"
+  ]
+}

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
@@ -26,21 +26,14 @@
     "schema": {"const": "codex-usage-tracker.lifecycle-path-authority.v1"},
     "authority_version": {"const": 1},
     "owner": {"const": "CK-07R1A0"},
-    "authority_base_sha": {"$ref": "#/$defs/gitSha"},
+    "authority_base_sha": {"const": "979f88eca2f23f6225c0c7a530b8f36f793c5748"},
     "upstream_acceptance": {
       "type": "array",
-      "minItems": 3,
-      "maxItems": 3,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["packet", "sha", "status"],
-        "properties": {
-          "packet": {"type": "string", "pattern": "^CK-[A-Z0-9]+(?:-[A-Z0-9]+)*$"},
-          "sha": {"$ref": "#/$defs/gitSha"},
-          "status": {"const": "accepted_merged_exact_main_verified"}
-        }
-      }
+      "const": [
+        {"packet": "CK-QG1A0", "sha": "eb3ded92408d9549d4a4c15c69c045cc3845689c", "status": "accepted_merged_exact_main_verified"},
+        {"packet": "CK-07R1A", "sha": "4d8074952f679877f2b4fbb3e89c51015e96a197", "status": "accepted_merged_exact_main_verified"},
+        {"packet": "CK-08R0", "sha": "306cef37eea2ae017aca824d898cc435f7e1bea0", "status": "accepted_merged_exact_main_verified"}
+      ]
     },
     "blocked_requalification": {
       "type": "object",
@@ -68,7 +61,7 @@
         "planner": {
           "type": "array",
           "const": [
-            "plan_refresh(changes, intent, limits=..., dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
+            "plan_refresh(changes, intent, limits=approved_tail_limits, dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
           ]
         },
         "small_publication": {
@@ -113,16 +106,33 @@
     "append_safe_small": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["operation_class", "selection_reason", "selection_conditions", "breach_result", "writer_identity_rule"],
+      "required": ["operation_class", "selection_reason", "approved_tail_limits", "selection_conditions", "breach_result", "writer_identity_rule"],
       "properties": {
         "operation_class": {"const": "append_safe_small"},
         "selection_reason": {"const": "all_small_tail_bounds_proven"},
+        "approved_tail_limits": {
+          "const": {
+            "selected_bytes": 8388608,
+            "selected_records": 32,
+            "observations": 12000,
+            "occurrences": 12000,
+            "affected_sessions": 2000,
+            "affected_turns": 4000,
+            "affected_resources": 4000,
+            "affected_allowance_cycles": 512,
+            "dirty_keys": 16000,
+            "projection_rows": 16000,
+            "expected_wal_bytes": 16777216,
+            "planning_staleness_us": 5000000,
+            "model_call_tail_rows": 32000
+          }
+        },
         "selection_conditions": {
           "type": "array",
           "const": [
             "no_schema_adapter_identity_normalization_or_projection_compatibility_change",
             "no_no_change_history_expand_source_replace_or_valuation_only_classification_applies",
-            "estimate_change_set_has_no_limit_breaches_under_the_supplied_TailLimits",
+            "estimate_change_set_has_no_limit_breaches_under_approved_TailLimits",
             "the_selected_sources_and_refresh_intent are the inputs to plan_refresh"
           ]
         },
@@ -181,7 +191,7 @@
         },
         "required_receipt_fields": {
           "type": "array",
-          "const": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
+          "const": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "planner_tail_limits", "planner_change_estimate", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
         }
       }
     },
@@ -285,15 +295,15 @@
       "required": ["source_path", "sha256", "dependency_sha", "branch", "status", "writer_only_receipt_digest", "fixture_digest", "implementation_sha256", "benchmark_sha256", "test_sha256"],
       "properties": {
         "source_path": {"const": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json"},
-        "sha256": {"$ref": "#/$defs/sha256"},
-        "dependency_sha": {"$ref": "#/$defs/gitSha"},
+        "sha256": {"const": "9dcebcbd72e2bfd0eca25783bad97d9367a568f28f171cfa466cdbf8689a00ba"},
+        "dependency_sha": {"const": "4d8074952f679877f2b4fbb3e89c51015e96a197"},
         "branch": {"const": "feature/ck-07r1-lifecycle-preparation"},
         "status": {"const": "retained_uncommitted_read_only_evidence"},
         "writer_only_receipt_digest": {"const": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d"},
-        "fixture_digest": {"$ref": "#/$defs/sha256"},
-        "implementation_sha256": {"$ref": "#/$defs/sha256"},
-        "benchmark_sha256": {"$ref": "#/$defs/sha256"},
-        "test_sha256": {"$ref": "#/$defs/sha256"}
+        "fixture_digest": {"const": "7d58cbdcda25fe98f42e8b896d0b3b064504cd564bc26c51f35cc1461666af9d"},
+        "implementation_sha256": {"const": "ab6f5ccc1524b1471857d2bff3a3fd4403a726fe67f154b3986846ac4f31fc52"},
+        "benchmark_sha256": {"const": "d619595aa96f6edd9b22605c573cc4607d04fe2702eecd300c8cb118e3c29e3a"},
+        "test_sha256": {"const": "da6f9a4ed619a6753e28661065eee88ebea91de4e695e90f4954e435b5e02c8d"}
       }
     },
     "scope_additions": {
@@ -320,8 +330,18 @@
     },
     "fail_closed_rules": {
       "type": "array",
-      "minItems": 8,
-      "items": {"type": "string"}
+      "const": [
+        "do not run production qualification in CK-07R1A0",
+        "do not accept a manually forced operation class as planner evidence",
+        "do not accept a direct writer call that bypasses plan_refresh or recovery",
+        "do not reuse or overwrite prior publication, operation, run, PID, or receipt identities",
+        "do not infer missing timestamps; retain unrecoverable precision as stated",
+        "do not weaken budgets, ceilings, first-sample requirements, or synthetic-only data rules",
+        "stop if the two scope additions cannot be proven from the retained diff",
+        "stop if any authority identity, schema, DAG, ledger, review, hosted CI, merge, or exact-main gate fails",
+        "do not update PR-394, historical worktrees, or downstream corrective packets",
+        "do not dispatch CK-07R1 or any dependent successor from this packet"
+      ]
     }
   },
   "$defs": {

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-path-authority-v1.schema.json",
+  "title": "CK-07R1A0 lifecycle path authority",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "authority_version",
+    "owner",
+    "authority_base_sha",
+    "upstream_acceptance",
+    "blocked_requalification",
+    "reachable_path",
+    "append_safe_small",
+    "independent_truth",
+    "postconditions",
+    "run_authorization",
+    "prior_attempts",
+    "retained_evidence",
+    "scope_additions",
+    "dependencies",
+    "fail_closed_rules"
+  ],
+  "properties": {
+    "schema": {"const": "codex-usage-tracker.lifecycle-path-authority.v1"},
+    "authority_version": {"const": 1},
+    "owner": {"const": "CK-07R1A0"},
+    "authority_base_sha": {"$ref": "#/$defs/gitSha"},
+    "upstream_acceptance": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["packet", "sha", "status"],
+        "properties": {
+          "packet": {"type": "string", "pattern": "^CK-[A-Z0-9]+(?:-[A-Z0-9]+)*$"},
+          "sha": {"$ref": "#/$defs/gitSha"},
+          "status": {"const": "accepted_merged_exact_main_verified"}
+        }
+      }
+    },
+    "blocked_requalification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["packet", "status", "reason", "accepted_receipt_required"],
+      "properties": {
+        "packet": {"const": "CK-07R1"},
+        "status": {"const": "BLOCKED"},
+        "reason": {"const": "planner_valid_lifecycle_receipt_and_this_authority"},
+        "accepted_receipt_required": {"const": true}
+      }
+    },
+    "reachable_path": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["startup_recovery", "planner", "small_publication", "ordering", "forbidden_shortcuts", "identity_binding"],
+      "properties": {
+        "startup_recovery": {
+          "type": "array",
+          "const": [
+            "select_readable_artifact(pointer_path, validate_open=...)",
+            "recover_startup(pointer_path, selection=..., store=..., ...)"
+          ]
+        },
+        "planner": {
+          "type": "array",
+          "const": [
+            "plan_refresh(changes, intent, limits=..., dirty_keys=..., projection_rows=..., expected_wal_bytes=...)"
+          ]
+        },
+        "small_publication": {
+          "type": "array",
+          "const": [
+            "PublicationWriter.publish_with_pointer(plan, request, write_set, pointer_path=..., operational_store=..., pointer_request=..., validate_open=...)",
+            "publish_small_with_pointer(..., commit_analytical=...)",
+            "PublicationWriter.publish(plan, request, write_set)"
+          ]
+        },
+        "ordering": {"const": "recovery_read_first; planner_before_writer_lock; selected_plan_unchanged_through_writer"},
+        "forbidden_shortcuts": {
+          "type": "array",
+          "const": [
+            "manually_constructed_PublicationPlan",
+            "manual_OperationClass_APPEND_SAFE_SMALL_override",
+            "direct_PublicationWriter_publish_without_plan_refresh",
+            "publication_receipt_without_reachable_recovery_path"
+          ]
+        },
+        "identity_binding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["same_publication_identity", "mismatch_result"],
+          "properties": {
+            "same_publication_identity": {
+              "type": "array",
+              "const": [
+                "ReadSelection.head.publication_id == RefreshIntent.parent_publication_id",
+                "RefreshIntent.parent_publication_id == PublicationPlan.parent_publication_id",
+                "PublicationPlan.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+                "SmallPublicationRequest.expected_active_publication_id == pre_commit_pointer.active.publication_id",
+                "committed_AnalyticalHead.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+                "post_commit_pointer.active.publication_id == committed_AnalyticalHead.publication_id"
+              ]
+            },
+            "mismatch_result": {"const": "fail_closed_before_acceptance_no_stitched_artifacts_or_cross_run_identity_binding"}
+          }
+        }
+      }
+    },
+    "append_safe_small": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation_class", "selection_reason", "selection_conditions", "breach_result", "writer_identity_rule"],
+      "properties": {
+        "operation_class": {"const": "append_safe_small"},
+        "selection_reason": {"const": "all_small_tail_bounds_proven"},
+        "selection_conditions": {
+          "type": "array",
+          "const": [
+            "no_schema_adapter_identity_normalization_or_projection_compatibility_change",
+            "no_no_change_history_expand_source_replace_or_valuation_only_classification_applies",
+            "estimate_change_set_has_no_limit_breaches_under_the_supplied_TailLimits",
+            "the_selected_sources_and_refresh_intent are the inputs to plan_refresh"
+          ]
+        },
+        "breach_result": {"const": "any_limit_breach_selects_append_safe_large_and_small_writer_rejects_it"},
+        "writer_identity_rule": {"const": "the_plan_returned_by_plan_refresh_is passed unchanged to the pointer-coordinated writer"}
+      }
+    },
+    "independent_truth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["oracle_path", "oracle_symbol", "derivation", "forbidden_sources", "comparisons"],
+      "properties": {
+        "oracle_path": {"const": "tests/agent_kernel/contracts/reference/lifecycle.py"},
+        "oracle_symbol": {"const": "fold_lifecycle"},
+        "derivation": {"const": "derive ordered transition vectors from synthetic observations plus prior transitions, then compare lifecycle identities, versions, folds, counts, and digests"},
+        "forbidden_sources": {
+          "type": "array",
+          "const": [
+            "codex_usage_tracker.agent_kernel.publication.preparation",
+            "codex_usage_tracker.agent_kernel.publication.planner",
+            "codex_usage_tracker.agent_kernel.publication.writer",
+            "codex_usage_tracker.agent_kernel.publication.recovery",
+            "SQLite rows as expected answers"
+          ]
+        },
+        "comparisons": {
+          "type": "array",
+          "const": ["transition_identity_and_version", "fold_identity_and_digest", "publication_counts_and_chain"]
+        }
+      }
+    },
+    "postconditions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["publication", "recovery", "required_receipt_fields"],
+      "properties": {
+        "publication": {
+          "type": "array",
+          "const": [
+            "publication_head is the final direct child and every parent_publication_id is the preceding head",
+            "source_occurrences equals inserted_occurrences with no duplicate occurrence identities",
+            "lifecycle transition/entity counts and fold digest equal independent truth",
+            "preparation transaction is closed before the writer begins and no analytical transaction remains open",
+            "artifact manifest, operation_id, publication_id, schema identity, and pointer head agree"
+          ]
+        },
+        "recovery": {
+          "type": "array",
+          "const": [
+            "select_readable_artifact validates the active artifact and falls back only to a validated rollback artifact",
+            "recover_startup runs only after readable selection and reconciles pending intents, stale leases, and dead jobs",
+            "pointer generation, active publication, analytical head, and recovery intent identities agree after reconciliation",
+            "a crash/retry is idempotent and does not duplicate or silently replace a publication",
+            "owned artifacts and rollback protection remain intact until reconciliation completes"
+          ]
+        },
+        "required_receipt_fields": {
+          "type": "array",
+          "const": ["run_id", "profile_identity", "planner_operation_class", "planner_reason", "publication_chain", "recovery_report", "independent_truth_digest", "postconditions"]
+        }
+      }
+    },
+    "run_authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "maximum_new_end_to_end_runs", "scope", "permitted_only_if", "failure_action"],
+      "properties": {
+        "status": {"const": "not_executed_by_this_packet"},
+        "maximum_new_end_to_end_runs": {"const": 1},
+        "scope": {"const": "one fresh synthetic all-profile CK-07R1 publication/recovery run after implementation correction"},
+        "permitted_only_if": {
+          "type": "array",
+          "const": [
+            "this authority is accepted merged and exact-main verified",
+            "the implementation successor starts from that exact main and touches only its authorized files",
+            "the harness proves the reachable_path and append_safe_small rules without manual plan construction",
+            "the independent oracle and all publication/recovery postconditions pass on the same run",
+            "all five frozen budgets and the first hosted failure remain unchanged and visible",
+            "no prior run identity or receipt is reused and no concurrent production run exists"
+          ]
+        },
+        "failure_action": {"const": "retain the first new result, perform no retry, and keep CK-07R1 blocked"}
+      }
+    },
+    "prior_attempts": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        {"const": {
+          "run_id": "all-profile-initial-serializer",
+          "classification": "failed_preserved",
+          "profile": "all-profile",
+          "timestamp_status": "output observed at local minute precision",
+          "observed_at_local": "2026-08-01T15:59",
+          "completed_at_local": null,
+          "pid": null,
+          "parent_pid": null,
+          "usable_final_json": false,
+          "publication_state": "none",
+          "failure_or_result": "TypeError: cannot pickle mappingproxy object during receipt serialization",
+          "receipt_digest": null,
+          "fold_digest": null,
+          "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+        }},
+        {"const": {
+          "run_id": "all-profile-corrected-serializer-tail-oracle",
+          "classification": "failed_preserved",
+          "profile": "all-profile",
+          "timestamp_status": "exact process timestamps are not recoverable from current task records",
+          "observed_at_local": null,
+          "completed_at_local": null,
+          "pid": null,
+          "parent_pid": null,
+          "usable_final_json": false,
+          "publication_state": "temporary database cleaned",
+          "failure_or_result": "independent lifecycle-fold truth omitted prior publication transitions",
+          "receipt_digest": null,
+          "fold_digest": null,
+          "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+        }},
+        {"const": {
+          "run_id": "all-profile-pid-60367-recovery",
+          "classification": "writer_only_not_publication_valid",
+          "profile": "all-profile",
+          "timestamp_status": "exact completion timestamp retained",
+          "observed_at_local": null,
+          "completed_at_local": "2026-08-01T16:26:43-04:00",
+          "pid": 60367,
+          "parent_pid": 1124,
+          "usable_final_json": true,
+          "publication_state": "writer_only_not_reachable_planner_recovery",
+          "failure_or_result": "full JSON produced; reviewer rejected publication-valid acceptance because the harness manually forced APPEND_SAFE_SMALL and called PublicationWriter directly",
+          "receipt_digest": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
+          "fold_digest": "19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+          "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+        }},
+        {"const": {
+          "run_id": "production-only-valid-profile",
+          "classification": "distinct_packet_required_profile",
+          "profile": "production-only",
+          "timestamp_status": "exact completion timestamp retained",
+          "observed_at_local": null,
+          "completed_at_local": "2026-08-01T15:56:26-04:00",
+          "pid": null,
+          "parent_pid": null,
+          "usable_final_json": true,
+          "publication_state": "valid_for_distinct_production_only_profile_not_all_profile",
+          "failure_or_result": "five unprofiled all-time samples [18563.027, 18916.769, 19198.25, 18765.469, 18732.573] ms; max 19198.25 ms; fold digest 19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+          "receipt_digest": null,
+          "fold_digest": "19ed24f6582e135bb2a90db36d080cebab0a7735886e451bd59d87a0b75e2357",
+          "preservation": "retained_read_only_never_reused_overwritten_hidden_or_upgraded"
+        }}
+      ],
+      "items": false
+    },
+    "retained_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_path", "sha256", "dependency_sha", "branch", "status", "writer_only_receipt_digest", "fixture_digest", "implementation_sha256", "benchmark_sha256", "test_sha256"],
+      "properties": {
+        "source_path": {"const": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json"},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "dependency_sha": {"$ref": "#/$defs/gitSha"},
+        "branch": {"const": "feature/ck-07r1-lifecycle-preparation"},
+        "status": {"const": "retained_uncommitted_read_only_evidence"},
+        "writer_only_receipt_digest": {"const": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d"},
+        "fixture_digest": {"$ref": "#/$defs/sha256"},
+        "implementation_sha256": {"$ref": "#/$defs/sha256"},
+        "benchmark_sha256": {"$ref": "#/$defs/sha256"},
+        "test_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scope_additions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {"const": {
+          "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+          "sha256": "d619595aa96f6edd9b22605c573cc4607d04fe2702eecd300c8cb118e3c29e3a",
+          "source_of_proof": "retained CK-07R1 uncommitted diff at dependency_sha"
+        }},
+        {"const": {
+          "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+          "sha256": "da6f9a4ed619a6753e28661065eee88ebea91de4e695e90f4954e435b5e02c8d",
+          "source_of_proof": "retained CK-07R1 uncommitted diff at dependency_sha"
+        }}
+      ],
+      "items": false
+    },
+    "dependencies": {
+      "type": "array",
+      "const": ["CK-QG1A0@eb3ded92408d9549d4a4c15c69c045cc3845689c", "CK-07R1A@4d8074952f679877f2b4fbb3e89c51015e96a197", "CK-08R0 accepted", "PR-394 retained read-only", "no CK-08R4/CK-08RG/CK-09 successor"]
+    },
+    "fail_closed_rules": {
+      "type": "array",
+      "minItems": 8,
+      "items": {"type": "string"}
+    }
+  },
+  "$defs": {
+    "gitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -22,9 +22,11 @@ their meaning, R1B/C implement disjoint consumers, and R1 is their
 requalification join. CK-QG1 PR #392 also stays blocked: R2 introduced two
 page-executor C/B/B violations, so QG1A must correct them without changing R2
 behavior or the frozen maintainability baseline.
-CK-07R1 PR #394 likewise stays blocked on CK-07R1A after hosted Python 3.14
-failed the frozen `ordinary.2000_call_tail` case; the first sample and all five
-budgets remain binding.
+CK-07R1A is accepted, merged, and exact-main verified at
+`4d8074952f679877f2b4fbb3e89c51015e96a197`. CK-07R1 PR #394 likewise stays
+blocked on CK-07R1A0 because the retained all-profile receipt was writer-only:
+the first sample and all five budgets remain binding, and a planner-valid
+lifecycle receipt is still required.
 
 ## Delegation law
 
@@ -63,7 +65,7 @@ The machine DAG below controls readiness and dependencies; each child packet con
 - CK-08R0 -> CK-08R2/CK-08R3A; CK-08R1A -> CK-08R1B/R1C
   -> CK-08R1; CK-08R2 -> CK-QG1A0 -> CK-QG1A -> CK-QG1;
   CK-08R3A -> CK-08R3;
-  CK-07R1A -> CK-07R1;
+  CK-07R1A -> CK-07R1A0 -> CK-07R1;
   join at CK-08R4/CK-08RG.
 - CK-09-01 -> CK-09-02/03/04; join at CK-09-05.
 - CK-10-01 -> CK-10-02 and CK-10-04; CK-10-03 follows 10-02; join at 10-05.
@@ -91,11 +93,11 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "duplicate_policy": "one_active_task_per_packet_and_dependency_frontier",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R2", "CK-QG1A0"],
+  "completed": ["CK-08R0", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "This serialized corrective authority correction accepted, merged, and exact-main verified",
-    "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A"]
+    "condition": "Each lane's serialized corrective authority correction accepted, merged, and exact-main verified",
+    "tasks": ["CK-08R1A", "CK-08R3A"]
   }, {
     "condition": "CK-QG1A0 merged and exact-main verified",
     "tasks": ["CK-QG1A"]
@@ -110,7 +112,8 @@ conditions in the table and child files; they are not unconditional DAG edges.
     {"id": "CK-08R3A", "file": "tasks/ck-08r3a-implement-evidence-physical-query.md", "dependencies": ["CK-08R0"]},
     {"id": "CK-08R3", "file": "tasks/ck-08r3-qualify-evidence-scale.md", "dependencies": ["CK-08R3A"]},
     {"id": "CK-07R1A", "file": "tasks/ck-07r1a-correct-hosted-lifecycle-tail.md", "dependencies": ["CK-08R0"]},
-    {"id": "CK-07R1", "file": "tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "dependencies": ["CK-07R1A"]},
+    {"id": "CK-07R1A0", "file": "tasks/ck-07r1a0-freeze-lifecycle-path-authority.md", "dependencies": ["CK-QG1A0", "CK-07R1A"]},
+    {"id": "CK-07R1", "file": "tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "dependencies": ["CK-07R1A0"]},
     {"id": "CK-QG1A0", "file": "tasks/ck-qg1a0-authorize-page-executor-source-supersession.md", "dependencies": ["CK-08R2"]},
     {"id": "CK-QG1A", "file": "tasks/ck-qg1a-correct-page-executor-complexity.md", "dependencies": ["CK-QG1A0"]},
     {"id": "CK-QG1", "file": "tasks/ck-qg1-enforce-agent-kernel-maintainability.md", "dependencies": ["CK-QG1A"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,10 +12,10 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **3 — CK-08R0, CK-08R2, CK-QG1A0**
-- Remaining delegable child tasks: **46**
+- Completed corrective child tasks: **5 — CK-08R0, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **45**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **4 — CK-08R1A, CK-08R3A, CK-07R1A; CK-QG1A after CK-QG1A0 exact-main**
+- Conditional-ready child tasks: **3 — CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
 - Blocked child tasks: **42**
 
 ## Parent packets
@@ -60,8 +60,9 @@ other corrective locks are unchanged.
 - [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
 - [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
-- [ ] **CK-07R1A — Correct hosted lifecycle tail** · Conditional Ready after this corrective authority exact-main verification · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked on CK-07R1A and refresh of existing PR #394 on corrected main · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
+- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verification required before CK-07R1 · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · **BLOCKED** on a planner-valid lifecycle receipt, CK-07R1A0 exact-main verification, and refresh of existing PR #394 · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,6 +1,6 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** Blocked on CK-07R1A
+**Status:** **BLOCKED** on CK-07R1A0 and a planner-valid lifecycle receipt
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -21,8 +21,10 @@ production-shaped preparation attempt exceeded 15 minutes.
 **Controls:** Publication/recovery, lifecycle, canonical fact, and benchmark
 contracts.
 
-**Dependencies:** CK-07R1A accepted, merged, and exact-main verified; existing
-PR #394 refreshed from corrected main and all required CI rerun.
+**Dependencies:** CK-07R1A accepted, merged, and exact-main verified at
+`4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 accepted, merged, and
+exact-main verified; existing PR #394 refreshed from corrected main and all
+required CI rerun.
 
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment.
@@ -49,7 +51,8 @@ standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
 `just v/vc`.
 
 **Acceptance:** Work is linear in observations plus prior transitions and all
-publication-valid scale gates pass.
+publication-valid scale gates pass through the CK-07R1A0 reachable path. Until
+then this packet remains **BLOCKED**, not Ready, active, or accepted.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
 new dominant blocker; never weaken the gate.

--- a/docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md
+++ b/docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md
@@ -3,7 +3,7 @@
 **Release-candidate package ceilings:** sdist remains at most 2,000,000 bytes;
 wheel remains at most 1,000,000 bytes.
 
-**Status:** Conditional Ready after this corrective authority merge is exact-main verified
+**Status:** Completed on merge; exact-main verified at `4d8074952f679877f2b4fbb3e89c51015e96a197`
 
 **Parent:** Corrective prerequisite for CK-07R1
 

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -1,0 +1,96 @@
+# CK-07R1A0 — Freeze lifecycle planner/recovery path authority
+
+**Status:** Completed on merge; exact-main verification required before CK-07R1
+
+**Release-candidate package ceilings:** sdist remains at most 2,000,000
+bytes and wheel remains at most 1,000,000 bytes. The historical 828000/383000
+values remain historical facts in the package-budget supersession evidence.
+
+**Parent:** Corrective prerequisite for CK-07R1
+
+**Recommended owner:** `default lifecycle-path-authority`; Sol-class
+
+**Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md)
+
+**Central plan:** [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md)
+
+**Roadmap:** [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
+
+**Goal:** Freeze the reachable planner/recovery qualification path exposed by
+the CK-07R1 lifecycle-scale blocker.
+
+**Why:** The retained all-profile receipt manually constructed
+`APPEND_SAFE_SMALL` plans and called `PublicationWriter` directly. It proves
+writer behavior only; it does not prove reachable planner selection or
+read-first recovery semantics.
+
+**Dependencies:** CK-QG1A0 accepted, merged, and exact-main verified at
+`eb3ded92408d9549d4a4c15c69c045cc3845689c`; CK-07R1A accepted, merged, and
+exact-main verified at `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-08R0
+remains accepted.
+
+**Owned files/interfaces:** Authority/docs/tests only. The strict Authority v1
+contract is
+[lifecycle-path-authority.json](../../decisions/evidence/ck07r1a0/lifecycle-path-authority.json)
+with its schema. The retained CK-07R1 implementation/profile/evidence diff is
+read-only evidence.
+
+**Produces:** A frozen entry-path contract, APPEND_SAFE_SMALL selection rule,
+independent lifecycle oracle/postconditions, one-run authorization condition,
+preserved attempt ledger, and exact scope bindings.
+
+**Independent truth source:**
+`tests/agent_kernel/contracts/reference/lifecycle.py::fold_lifecycle`,
+independent synthetic transition vectors, and committed publication/recovery
+postconditions; no SQLite-derived expected answers.
+
+**Consumer seam:** The future CK-07R1 requalification harness must enter
+read-first recovery, obtain its plan from `plan_refresh` before the writer lock,
+and pass that selected plan through `PublicationWriter.publish_with_pointer`
+and `publish_small_with_pointer` for small publications. The same run must bind
+`ReadSelection.head.publication_id` to `RefreshIntent.parent_publication_id`,
+`PublicationPlan.parent_publication_id`,
+`SmallPublicationRequest.expected_active_publication_id`, and the committed
+publication chain; any mismatch fails closed rather than allowing stitched
+artifacts.
+
+**Parallelism:** Sole authority owner. Do not create or dispatch CK-07R1,
+CK-08R4, CK-08RG, CK-09, or any other dependent task from this packet.
+
+**Non-goals:** Lifecycle implementation, benchmark correction, production
+qualification, PR #394 changes, writer/planner/recovery code, budgets,
+schemas/DDL/query/evidence services, projections, releases, or real/private
+Codex data.
+
+**Invariants:** CK-07R1A remains accepted at `4d807495…`; CK-07R1 remains
+**BLOCKED**; the five budgets remain `5000/120000/100/500/500` ms; every prior
+attempt and its identity/timestamp/failure remains visible; receipt
+`935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d` remains
+writer-only evidence and is never reused or upgraded.
+
+**Required tests/checks:** Strict authority-schema and negative-mutation tests;
+DAG/ledger/status tests; exact scope-manifest tests; evidence identity and
+`git diff --check`; `just v` and `just vc` as required by repository packet
+rules; one final read-only review; hosted CI; squash merge; attached
+exact-main verification.
+
+**Acceptance:** The authority artifact validates, exact identities and run
+accounting are preserved, only the two retained CK-07R1 scope additions are
+bound, CK-07R1 is still blocked, and all hosted/exact-main gates pass. This
+packet does not run or authorize a production qualification run by itself.
+
+**Failure/rollback:** Preserve the exact candidate, evidence, and failed
+attempts; stop closed on any identity, scope, DAG, schema, review, CI, merge,
+or exact-main mismatch. Do not weaken a budget or infer publication-validity
+from a manually forced plan.
+
+**Handoff:** Coordinator `019fbeb3-00d5-7f22-ba65-ae4672838140` and parent
+`019fbea6-66b5-71e0-b85a-b6654fd414c5` receive the merged SHA, Authority v1
+path, exact scope additions, preserved attempts/digests, validation/reviewer/
+CI/exact-main results, and unchanged downstream gates.
+
+**Cleanup/docs:** CK-07R1 owns the implementation/requalification successor;
+the retained CK-07R1 worktree, PR #394, and historical worktrees remain
+read-only evidence.
+
+**Suggested commit:** `docs: freeze lifecycle path authority`

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -254,6 +254,7 @@ CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS = frozenset(
         "docs/roadmap/tasks/ck-07a-reconcile-fact-backed-oracles-and-qualify-seams.md",
         "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
         "docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md",
+        "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md",
         "docs/roadmap/tasks/ck-08-implement-query-and-evidence.md",
         "docs/roadmap/tasks/ck-08r0-freeze-corrective-contracts.md",
         "docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md",
@@ -743,6 +744,20 @@ PACKAGE_BUDGET_POLICY_ADDITIONS = frozenset(
     }
 )
 
+CK07R1A0_AUTHORITY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json",
+    }
+)
+
+CK07R1_LIFECYCLE_SCOPE_ADDITIONS = frozenset(
+    {
+        "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "tests/agent_kernel/publication/test_lifecycle_scale.py",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -801,6 +816,8 @@ INTEGRATION_ADDITIONS = (
     | CK08R3A_AUTHORITY_ADDITIONS
     | CKQG1A0_AUTHORITY_ADDITIONS
     | PACKAGE_BUDGET_POLICY_ADDITIONS
+    | CK07R1A0_AUTHORITY_ADDITIONS
+    | CK07R1_LIFECYCLE_SCOPE_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
 )

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -542,6 +542,23 @@ def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
     assert authority["reachable_path"]["ordering"] == (
         "recovery_read_first; planner_before_writer_lock; selected_plan_unchanged_through_writer"
     )
+    assert authority["append_safe_small"]["approved_tail_limits"] == {
+        "selected_bytes": 8_388_608,
+        "selected_records": 32,
+        "observations": 12_000,
+        "occurrences": 12_000,
+        "affected_sessions": 2_000,
+        "affected_turns": 4_000,
+        "affected_resources": 4_000,
+        "affected_allowance_cycles": 512,
+        "dirty_keys": 16_000,
+        "projection_rows": 16_000,
+        "expected_wal_bytes": 16_777_216,
+        "planning_staleness_us": 5_000_000,
+        "model_call_tail_rows": 32_000,
+    }
+    assert "planner_tail_limits" in authority["postconditions"]["required_receipt_fields"]
+    assert "planner_change_estimate" in authority["postconditions"]["required_receipt_fields"]
     assert authority["reachable_path"]["identity_binding"] == {
         "same_publication_identity": [
             "ReadSelection.head.publication_id == RefreshIntent.parent_publication_id",
@@ -574,6 +591,23 @@ def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
 
     changed = json.loads(json.dumps(authority))
     changed["reachable_path"]["identity_binding"]["same_publication_identity"][0] = "stitched"
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["append_safe_small"]["approved_tail_limits"]["selected_records"] += 1
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["postconditions"]["required_receipt_fields"].remove("planner_tail_limits")
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["upstream_acceptance"][0]["sha"] = "0" * 40
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["retained_evidence"]["fixture_digest"] = "0" * 64
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["fail_closed_rules"][0] = "allow production qualification"
     assert list(validator.iter_errors(changed))
 
     for path, value in (

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -535,7 +535,7 @@ def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
     validator.validate(authority)
 
     assert authority["owner"] == "CK-07R1A0"
-    assert authority["authority_base_sha"] == "eb3ded92408d9549d4a4c15c69c045cc3845689c"
+    assert authority["authority_base_sha"] == "979f88eca2f23f6225c0c7a530b8f36f793c5748"
     assert authority["blocked_requalification"]["status"] == "BLOCKED"
     assert authority["run_authorization"]["status"] == "not_executed_by_this_packet"
     assert authority["run_authorization"]["maximum_new_end_to_end_runs"] == 1

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -42,6 +42,7 @@ _PACKET_IDS = {
     "CK-07E",
     "CK-07R1",
     "CK-07R1A",
+    "CK-07R1A0",
     "CK-08R0",
     "CK-08R1A",
     "CK-08R1B",
@@ -175,16 +176,22 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     manifest = json.loads(manifest_match.group(1))
     assert manifest["schema"] == "codex-usage-tracker.remaining-delegation-dag.v1"
     assert manifest["orchestration"]["spawn"] == "all_newly_ready_successors"
-    conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-07R1A", "CK-QG1A"}
-    assert manifest["completed"] == ["CK-08R0", "CK-08R2", "CK-QG1A0"]
+    conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-QG1A"}
+    assert manifest["completed"] == [
+        "CK-08R0",
+        "CK-08R2",
+        "CK-QG1A0",
+        "CK-07R1A",
+        "CK-07R1A0",
+    ]
     ready: set[str] = set()
     assert manifest["ready"] == []
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "This serialized corrective authority correction accepted, merged, and exact-main verified"
+                "Each lane's serialized corrective authority correction accepted, merged, and exact-main verified"
             ),
-            "tasks": ["CK-08R1A", "CK-08R3A", "CK-07R1A"],
+            "tasks": ["CK-08R1A", "CK-08R3A"],
         },
         {
             "condition": "CK-QG1A0 merged and exact-main verified",
@@ -201,9 +208,9 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     )
 
     tasks = manifest["tasks"]
-    assert len(tasks) == 49
+    assert len(tasks) == 50
     manifest_by_id = {task["id"]: task for task in tasks}
-    assert len(manifest_by_id) == 49
+    assert len(manifest_by_id) == 50
     assert set(manifest_by_id) == _DELEGATED_PACKET_IDS
     assert manifest_by_id["CK-08R3A"]["dependencies"] == ["CK-08R0"]
     assert manifest_by_id["CK-08R3"]["dependencies"] == ["CK-08R3A"]
@@ -215,7 +222,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest_by_id["CK-QG1A"]["dependencies"] == ["CK-QG1A0"]
     assert manifest_by_id["CK-QG1"]["dependencies"] == ["CK-QG1A"]
     assert manifest_by_id["CK-07R1A"]["dependencies"] == ["CK-08R0"]
-    assert manifest_by_id["CK-07R1"]["dependencies"] == ["CK-07R1A"]
+    assert manifest_by_id["CK-07R1A0"]["dependencies"] == ["CK-QG1A0", "CK-07R1A"]
+    assert manifest_by_id["CK-07R1"]["dependencies"] == ["CK-07R1A0"]
     assert manifest_by_id["CK-08R4"]["dependencies"] == [
         "CK-08R1",
         "CK-08R2",
@@ -237,9 +245,20 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Package-size micro-optimization is no longer a roadmap objective" in package_policy[
         "rationale"
     ]
-    for packet_id in ("CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R3A", "CK-07R1A", "CK-QG1A0", "CK-QG1A"):
+    for packet_id in (
+        "CK-08R1A",
+        "CK-08R1B",
+        "CK-08R1C",
+        "CK-08R3A",
+        "CK-07R1A",
+        "CK-07R1A0",
+        "CK-QG1A0",
+        "CK-QG1A",
+    ):
         packet = _read(f"docs/roadmap/{manifest_by_id[packet_id]['file']}").replace(",", "")
         assert str(release_budget["sdist_bytes"]) in packet
+        if packet_id == "CK-07R1A0":
+            assert str(release_budget["wheel_bytes"]) in packet
 
     ledger_rows = re.findall(
         r"^- \[[ xX]\] \*\*(CK-[A-Z0-9]+(?:-[A-Z0-9]+)*)\b.*?"
@@ -274,8 +293,10 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Conditional Ready after" in body
         elif packet_id in ready:
             assert "**Status:** Ready" in body
-        elif packet_id in {"CK-08R0", "CK-08R2", "CK-QG1A0"}:
+        elif packet_id in {"CK-08R0", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"}:
             assert "**Status:** Completed on merge" in body
+        elif packet_id == "CK-07R1":
+            assert "**Status:** **BLOCKED**" in body
         else:
             assert "**Status:** Blocked" in body
 
@@ -378,6 +399,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     ckqg1a0 = _read("docs/roadmap/tasks/ck-qg1a0-authorize-page-executor-source-supersession.md")
     ckqg1 = _read("docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md")
     ck07r1a = _read("docs/roadmap/tasks/ck-07r1a-correct-hosted-lifecycle-tail.md")
+    ck07r1a0 = _read("docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md")
     ck07r1 = _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
 
     assert "## Cross-packet semantic continuity" in agents
@@ -485,10 +507,94 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
                 "019fbb41-804b-7fe2-8987-3d2b9e94a4d5",
             ),
         ),
+        (
+            ck07r1a0,
+            (
+                "plan_refresh",
+                "PublicationWriter.publish_with_pointer",
+                "fold_lifecycle",
+                "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
+                "one-run authorization condition",
+                "CK-07R1 remains",
+                "**BLOCKED**",
+            ),
+        ),
     ):
         assert all(token in body for token in tokens)
+    assert "exact-main verification required before CK-07R1" in ck07r1a0
     assert "Blocked on CK-QG1A" in ckqg1
-    assert "Blocked on CK-07R1A" in ck07r1
+    assert "**BLOCKED** on CK-07R1A0" in ck07r1
+
+
+def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
+    authority_path = "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json"
+    schema = _json("docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json")
+    authority = _json(authority_path)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    validator.validate(authority)
+
+    assert authority["owner"] == "CK-07R1A0"
+    assert authority["authority_base_sha"] == "eb3ded92408d9549d4a4c15c69c045cc3845689c"
+    assert authority["blocked_requalification"]["status"] == "BLOCKED"
+    assert authority["run_authorization"]["status"] == "not_executed_by_this_packet"
+    assert authority["run_authorization"]["maximum_new_end_to_end_runs"] == 1
+    assert authority["reachable_path"]["ordering"] == (
+        "recovery_read_first; planner_before_writer_lock; selected_plan_unchanged_through_writer"
+    )
+    assert authority["reachable_path"]["identity_binding"] == {
+        "same_publication_identity": [
+            "ReadSelection.head.publication_id == RefreshIntent.parent_publication_id",
+            "RefreshIntent.parent_publication_id == PublicationPlan.parent_publication_id",
+            "PublicationPlan.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+            "SmallPublicationRequest.expected_active_publication_id == pre_commit_pointer.active.publication_id",
+            "committed_AnalyticalHead.parent_publication_id == SmallPublicationRequest.expected_active_publication_id",
+            "post_commit_pointer.active.publication_id == committed_AnalyticalHead.publication_id",
+        ],
+        "mismatch_result": "fail_closed_before_acceptance_no_stitched_artifacts_or_cross_run_identity_binding",
+    }
+    assert authority["independent_truth"]["oracle_symbol"] == "fold_lifecycle"
+    assert authority["retained_evidence"]["writer_only_receipt_digest"] == (
+        "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d"
+    )
+    assert {attempt["run_id"] for attempt in authority["prior_attempts"]} == {
+        "all-profile-initial-serializer",
+        "all-profile-corrected-serializer-tail-oracle",
+        "all-profile-pid-60367-recovery",
+        "production-only-valid-profile",
+    }
+    assert [item["path"] for item in authority["scope_additions"]] == [
+        "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "tests/agent_kernel/publication/test_lifecycle_scale.py",
+    ]
+
+    changed = json.loads(json.dumps(authority))
+    changed["run_authorization"]["status"] = "authorized"
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["reachable_path"]["identity_binding"]["same_publication_identity"][0] = "stitched"
+    assert list(validator.iter_errors(changed))
+
+    for path, value in (
+        ("observed_at_local", "2026-08-01T16:00"),
+        ("failure_or_result", "changed historical cause"),
+    ):
+        changed = json.loads(json.dumps(authority))
+        changed["prior_attempts"][0][path] = value
+        assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["prior_attempts"][2]["pid"] = 60368
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["prior_attempts"][2]["receipt_digest"] = "0" * 64
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["scope_additions"][1] = json.loads(json.dumps(changed["scope_additions"][0]))
+    assert list(validator.iter_errors(changed))
+    changed = json.loads(json.dumps(authority))
+    changed["scope_additions"][0]["sha256"] = "0" * 64
+    assert list(validator.iter_errors(changed))
 
 
 def test_question_catalog_and_diagram_inventory_are_complete() -> None:

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -18,6 +18,8 @@ from scripts.check_kernel_scope import (
     CK07C_PLAN_OPERAND_FACT_ADDITIONS,
     CK07D_EFFECTIVE_DATED_VALUATION_ADDITIONS,
     CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS,
+    CK07R1_LIFECYCLE_SCOPE_ADDITIONS,
+    CK07R1A0_AUTHORITY_ADDITIONS,
     CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CK08_QUERY_EVIDENCE_ADDITIONS,
     CK08R2_PHYSICAL_PAGE_ADDITIONS,
@@ -248,8 +250,8 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         for path in CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS
         if path.startswith("docs/roadmap/tasks/")
     }
-    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 95
-    assert len(task_packets) == 68
+    assert len(CLEAN_CUTOVER_DOCUMENTATION_ADDITIONS) == 96
+    assert len(task_packets) == 69
     assert {
         "docs/INDEX.md",
         "docs/architecture/AGENT_KERNEL_DATABASE_V1_SCHEMA_CONTRACT.md",
@@ -671,6 +673,8 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK08R3A_AUTHORITY_ADDITIONS
         | CKQG1A0_AUTHORITY_ADDITIONS
         | PACKAGE_BUDGET_POLICY_ADDITIONS
+        | CK07R1A0_AUTHORITY_ADDITIONS
+        | CK07R1_LIFECYCLE_SCOPE_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | CI_PERFORMANCE_QUALIFICATION_ADDITIONS
     )
@@ -680,6 +684,17 @@ def test_ck08r3a_authority_additions_are_explicit_and_bounded() -> None:
     assert {
         "docs/decisions/evidence/ck08r3a/evidence-service-supersession-authority.json",
     } == CK08R3A_AUTHORITY_ADDITIONS
+
+
+def test_ck07r1a0_authority_and_lifecycle_scope_additions_are_explicit() -> None:
+    assert {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json",
+    } == CK07R1A0_AUTHORITY_ADDITIONS
+    assert {
+        "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "tests/agent_kernel/publication/test_lifecycle_scale.py",
+    } == CK07R1_LIFECYCLE_SCOPE_ADDITIONS
 
 
 def test_kernel_skeleton_imports_without_legacy_runtime() -> None:


### PR DESCRIPTION
## What changed\n- Reapply the reviewed CK-07R1A0 lifecycle-path authority from PR #398 onto exact package-policy main 979f88e.\n- Preserve the reachable recovery -> planner -> pointer-coordinated writer path, APPEND_SAFE_SMALL selection, publication identity bindings, independent fold oracle, postconditions, prior attempt ledger, and one-run condition.\n- Reconcile active package ceilings to sdist 2,000,000 and wheel 1,000,000; historical 828000/383000 values remain historical evidence only.\n- Harden Authority v1 with exact approved TailLimits, planner estimate/limits receipt fields, and exact upstream/retained-evidence identity consts.\n- Keep CK-07R1 BLOCKED; no production qualification or runtime/product changes.\n\n## Evidence and validation\n- Fresh exact-base retained worktree from 979f88eca2f23f6225c0c7a530b8f36f793c5748.\n- Focused authority/scope/release suite: 39 passed.\n- just v / just vc: 1,367 tests passed, 13 invariants passed, mypy, pyright, Ruff, console checks, build, and release checks passed.\n- Active package artifacts: sdist 2,000,000 ceiling; wheel 1,000,000 ceiling.\n- One final read-only reviewer completed; actionable findings were fixed and focused/full validation rerun.\n- PR #398 remains preserved as historical/read-only evidence; this is its single replacement integration PR.