### PR TITLE
docs: activate CK-07R1 readiness transition

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,9 +24,13 @@ truth is now serialized as R1A contract freeze, disjoint R1B/R1C consumers,
 and final R1 requalification. CK-QG1A0 gates the selected R2 PageExecutor
 successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrected
 PR #394's exact hosted lifecycle-tail failure without a budget waiver.
-CK-07R1A0 now freezes the reachable planner/recovery path because the retained
-all-profile receipt was writer-only; CK-07R1 remains blocked. Reclassification and maintainability
-remain open. The central authority is
+CK-07R1A0 is accepted at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`.
+Its transition authority makes the planner-valid receipt a CK-07R1 successor
+acceptance output rather than a pre-dispatch dependency. PR #394 remains a
+stale failed read-only witness; it is not updated, rerun, or merged. CK-07R1
+is Conditional Ready only after this authority merges and exact-main verifies;
+no other successor is advanced. Reclassification and maintainability remain
+open. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
 ## Authority set

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-path-authority.v1",
-  "authority_version": 1,
+  "schema": "codex-usage-tracker.lifecycle-path-authority.v2",
+  "authority_version": 2,
   "owner": "CK-07R1A0",
   "authority_base_sha": "979f88eca2f23f6225c0c7a530b8f36f793c5748",
   "upstream_acceptance": [
@@ -10,9 +10,36 @@
   ],
   "blocked_requalification": {
     "packet": "CK-07R1",
-    "status": "BLOCKED",
-    "reason": "planner_valid_lifecycle_receipt_and_this_authority",
-    "accepted_receipt_required": true
+    "status": "CONDITIONAL_READY",
+    "reason": "planner_valid_lifecycle_receipt_is_successor_acceptance_output",
+    "accepted_receipt_required": true,
+    "receipt_required_before_dispatch": false
+  },
+  "readiness_transition": {
+    "packet": "CK-07R1",
+    "from_status": "BLOCKED",
+    "conditional_status": "CONDITIONAL_READY",
+    "effective_ready_status": "READY",
+    "activation": "this authority accepted merged and exact-main verified",
+    "authority_base_sha": "519b503aa3b23019033b6481687c08b23fc6c31e",
+    "receipt_role": "successor_acceptance_output_not_pre_dispatch_dependency",
+    "receipt_required_before_dispatch": false,
+    "receipt_required_for_acceptance": true,
+    "maximum_new_end_to_end_runs": 1,
+    "dispatch_rule": "create_exactly_one_fresh_CK-07R1_successor_from_activation_exact_main",
+    "downstream_ready_tasks": []
+  },
+  "pr_394_policy": {
+    "number": 394,
+    "head_sha": "98a9b5b82951d136644a5fe5f8a70d320131ba08",
+    "base_sha": "bbd9eb990969a659376ea584c6d696d1715cc007",
+    "workflow_run_id": "30685780055",
+    "failed_job_id": "91331138768",
+    "failed_check": "Kernel phase and package isolation (3.14)",
+    "failure": "ordinary.2000_call_tail",
+    "status": "stale_failed_superseded_read_only",
+    "policy": "do_not_update_rerun_merge_or_reinterpret",
+    "future_requalification": "fresh_CK-07R1_successor_from_authority_exact_main"
   },
   "reachable_path": {
     "startup_recovery": [
@@ -216,6 +243,8 @@
     "stop if the two scope additions cannot be proven from the retained diff",
     "stop if any authority identity, schema, DAG, ledger, review, hosted CI, merge, or exact-main gate fails",
     "do not update PR-394, historical worktrees, or downstream corrective packets",
-    "do not dispatch CK-07R1 or any dependent successor from this packet"
+    "do not dispatch CK-07R1 or any dependent successor from this packet",
+    "do not treat receipt absence before dispatch as a blocker; receipt absence or invalidity at successor acceptance remains fail-closed",
+    "do not make any downstream packet ready from this transition"
   ]
 }

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-path-authority-v1.schema.json",
-  "title": "CK-07R1A0 lifecycle path authority",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-path-authority-v2.schema.json",
+  "title": "CK-07R1A0 lifecycle path authority and CK-07R1 readiness transition",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -11,6 +11,8 @@
     "authority_base_sha",
     "upstream_acceptance",
     "blocked_requalification",
+    "readiness_transition",
+    "pr_394_policy",
     "reachable_path",
     "append_safe_small",
     "independent_truth",
@@ -23,8 +25,8 @@
     "fail_closed_rules"
   ],
   "properties": {
-    "schema": {"const": "codex-usage-tracker.lifecycle-path-authority.v1"},
-    "authority_version": {"const": 1},
+    "schema": {"const": "codex-usage-tracker.lifecycle-path-authority.v2"},
+    "authority_version": {"const": 2},
     "owner": {"const": "CK-07R1A0"},
     "authority_base_sha": {"const": "979f88eca2f23f6225c0c7a530b8f36f793c5748"},
     "upstream_acceptance": {
@@ -38,12 +40,73 @@
     "blocked_requalification": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["packet", "status", "reason", "accepted_receipt_required"],
+      "required": ["packet", "status", "reason", "accepted_receipt_required", "receipt_required_before_dispatch"],
       "properties": {
         "packet": {"const": "CK-07R1"},
-        "status": {"const": "BLOCKED"},
-        "reason": {"const": "planner_valid_lifecycle_receipt_and_this_authority"},
-        "accepted_receipt_required": {"const": true}
+        "status": {"const": "CONDITIONAL_READY"},
+        "reason": {"const": "planner_valid_lifecycle_receipt_is_successor_acceptance_output"},
+        "accepted_receipt_required": {"const": true},
+        "receipt_required_before_dispatch": {"const": false}
+      }
+    },
+    "readiness_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packet",
+        "from_status",
+        "conditional_status",
+        "effective_ready_status",
+        "activation",
+        "authority_base_sha",
+        "receipt_role",
+        "receipt_required_before_dispatch",
+        "receipt_required_for_acceptance",
+        "maximum_new_end_to_end_runs",
+        "dispatch_rule",
+        "downstream_ready_tasks"
+      ],
+      "properties": {
+        "packet": {"const": "CK-07R1"},
+        "from_status": {"const": "BLOCKED"},
+        "conditional_status": {"const": "CONDITIONAL_READY"},
+        "effective_ready_status": {"const": "READY"},
+        "activation": {"const": "this authority accepted merged and exact-main verified"},
+        "authority_base_sha": {"const": "519b503aa3b23019033b6481687c08b23fc6c31e"},
+        "receipt_role": {"const": "successor_acceptance_output_not_pre_dispatch_dependency"},
+        "receipt_required_before_dispatch": {"const": false},
+        "receipt_required_for_acceptance": {"const": true},
+        "maximum_new_end_to_end_runs": {"const": 1},
+        "dispatch_rule": {"const": "create_exactly_one_fresh_CK-07R1_successor_from_activation_exact_main"},
+        "downstream_ready_tasks": {"const": []}
+      }
+    },
+    "pr_394_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "head_sha",
+        "base_sha",
+        "workflow_run_id",
+        "failed_job_id",
+        "failed_check",
+        "failure",
+        "status",
+        "policy",
+        "future_requalification"
+      ],
+      "properties": {
+        "number": {"const": 394},
+        "head_sha": {"const": "98a9b5b82951d136644a5fe5f8a70d320131ba08"},
+        "base_sha": {"const": "bbd9eb990969a659376ea584c6d696d1715cc007"},
+        "workflow_run_id": {"const": "30685780055"},
+        "failed_job_id": {"const": "91331138768"},
+        "failed_check": {"const": "Kernel phase and package isolation (3.14)"},
+        "failure": {"const": "ordinary.2000_call_tail"},
+        "status": {"const": "stale_failed_superseded_read_only"},
+        "policy": {"const": "do_not_update_rerun_merge_or_reinterpret"},
+        "future_requalification": {"const": "fresh_CK-07R1_successor_from_authority_exact_main"}
       }
     },
     "reachable_path": {
@@ -339,9 +402,11 @@
         "do not weaken budgets, ceilings, first-sample requirements, or synthetic-only data rules",
         "stop if the two scope additions cannot be proven from the retained diff",
         "stop if any authority identity, schema, DAG, ledger, review, hosted CI, merge, or exact-main gate fails",
-        "do not update PR-394, historical worktrees, or downstream corrective packets",
-        "do not dispatch CK-07R1 or any dependent successor from this packet"
-      ]
+          "do not update PR-394, historical worktrees, or downstream corrective packets",
+          "do not dispatch CK-07R1 or any dependent successor from this packet",
+          "do not treat receipt absence before dispatch as a blocker; receipt absence or invalidity at successor acceptance remains fail-closed",
+          "do not make any downstream packet ready from this transition"
+        ]
     }
   },
   "$defs": {

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -23,10 +23,18 @@ requalification join. CK-QG1 PR #392 also stays blocked: R2 introduced two
 page-executor C/B/B violations, so QG1A must correct them without changing R2
 behavior or the frozen maintainability baseline.
 CK-07R1A is accepted, merged, and exact-main verified at
-`4d8074952f679877f2b4fbb3e89c51015e96a197`. CK-07R1 PR #394 likewise stays
-blocked on CK-07R1A0 because the retained all-profile receipt was writer-only:
-the first sample and all five budgets remain binding, and a planner-valid
-lifecycle receipt is still required.
+`4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 is accepted at the
+current exact main `519b503aa3b23019033b6481687c08b23fc6c31e`. PR #394 is a
+stale failed witness: head `98a9b5b82951d136644a5fe5f8a70d320131ba08` failed
+the hosted Python 3.14 `ordinary.2000_call_tail` gate and is superseded
+read-only. It must not be updated, rerun, or merged. The planner-valid
+lifecycle receipt is an acceptance output of the fresh CK-07R1 successor, not
+a pre-dispatch dependency; the first sample, all five budgets, and every
+fail-closed rule remain binding. CK-07R1 is Conditional Ready only after this
+authority is accepted, merged, and exact-main verified. This current authority
+supersedes earlier CK-07R1 wording that says to resume, refresh, or rerun PR
+#394; those retained references are historical provenance and do not authorize
+action.
 
 ## Delegation law
 
@@ -101,6 +109,9 @@ conditions in the table and child files; they are not unconditional DAG edges.
   }, {
     "condition": "CK-QG1A0 merged and exact-main verified",
     "tasks": ["CK-QG1A"]
+  }, {
+    "condition": "CK-07R1 transition authority accepted, merged, and exact-main verified",
+    "tasks": ["CK-07R1"]
   }],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,8 +15,8 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **5 — CK-08R0, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **45**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **3 — CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
-- Blocked child tasks: **42**
+- Conditional-ready child tasks: **4 — CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main; CK-07R1 after this authority exact-main**
+- Blocked child tasks: **41**
 
 ## Parent packets
 
@@ -61,8 +61,8 @@ other corrective locks are unchanged.
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
 - [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
-- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verification required before CK-07R1 · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · **BLOCKED** on a planner-valid lifecycle receipt, CK-07R1A0 exact-main verification, and refresh of existing PR #394 · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verified at `519b503a` · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after this authority merge/exact-main; the planner-valid receipt is a successor acceptance output and PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,6 +1,6 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** **BLOCKED** on CK-07R1A0 and a planner-valid lifecycle receipt
+**Status:** Conditional Ready after this authority merges and exact-main verifies
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -22,9 +22,11 @@ production-shaped preparation attempt exceeded 15 minutes.
 contracts.
 
 **Dependencies:** CK-07R1A accepted, merged, and exact-main verified at
-`4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 accepted, merged, and
-exact-main verified; existing PR #394 refreshed from corrected main and all
-required CI rerun.
+`4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 accepted at exact main
+`519b503aa3b23019033b6481687c08b23fc6c31e`; and this transition authority
+accepted, merged, and exact-main verified. PR #394 head
+`98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed read-only
+witness and is not refreshed, rerun, or merged.
 
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment.
@@ -36,9 +38,11 @@ database postconditions.
 
 **Consumer seam:** Preparation to `PublicationWriter` to read-only publication.
 
-**Parallelism:** Resume existing task
-`019fbb41-804b-7fe2-8987-3d2b9e94a4d5` only after CK-07R1A handoff; other
-corrective locks stay disjoint.
+**Parallelism:** Create exactly one fresh CK-07R1 successor only after this
+authority merges and exact-main verifies, starting from that exact main. The
+planner-valid receipt is produced by that successor and is required for its
+acceptance, not for its creation or dispatch; other corrective locks stay
+disjoint and no downstream packet becomes Ready here.
 
 **Non-goals:** Writer/pointer/schema redesign, facts, projections, or budget
 waivers.
@@ -51,8 +55,11 @@ standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
 `just v/vc`.
 
 **Acceptance:** Work is linear in observations plus prior transitions and all
-publication-valid scale gates pass through the CK-07R1A0 reachable path. Until
-then this packet remains **BLOCKED**, not Ready, active, or accepted.
+publication-valid scale gates pass through the CK-07R1A0 reachable path. The
+successor must produce the planner-valid receipt, bind every frozen path and
+prior identity, and consume at most one new end-to-end run. Receipt absence
+before dispatch is not a blocker; receipt absence or invalidity at successor
+acceptance remains fail-closed.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
 new dominant blocker; never weaken the gate.

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -1,6 +1,6 @@
 # CK-07R1A0 — Freeze lifecycle planner/recovery path authority
 
-**Status:** Completed on merge; exact-main verification required before CK-07R1
+**Status:** Completed on merge; exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`; CK-07R1 is Conditional Ready after this transition authority exact-main
 
 **Release-candidate package ceilings:** sdist remains at most 2,000,000
 bytes and wheel remains at most 1,000,000 bytes. The historical 828000/383000
@@ -29,7 +29,7 @@ read-first recovery semantics.
 exact-main verified at `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-08R0
 remains accepted.
 
-**Owned files/interfaces:** Authority/docs/tests only. The strict Authority v1
+**Owned files/interfaces:** Authority/docs/tests only. The strict Authority v2
 contract is
 [lifecycle-path-authority.json](../../decisions/evidence/ck07r1a0/lifecycle-path-authority.json)
 with its schema. The retained CK-07R1 implementation/profile/evidence diff is
@@ -62,8 +62,9 @@ qualification, PR #394 changes, writer/planner/recovery code, budgets,
 schemas/DDL/query/evidence services, projections, releases, or real/private
 Codex data.
 
-**Invariants:** CK-07R1A remains accepted at `4d807495…`; CK-07R1 remains
-**BLOCKED**; the five budgets remain `5000/120000/100/500/500` ms; every prior
+**Invariants:** CK-07R1A remains accepted at `4d807495…`; CK-07R1 becomes
+Conditional Ready only after this authority is accepted, merged, and exact-main
+verified; the five budgets remain `5000/120000/100/500/500` ms; every prior
 attempt and its identity/timestamp/failure remains visible; receipt
 `935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d` remains
 writer-only evidence and is never reused or upgraded.
@@ -76,8 +77,14 @@ exact-main verification.
 
 **Acceptance:** The authority artifact validates, exact identities and run
 accounting are preserved, only the two retained CK-07R1 scope additions are
-bound, CK-07R1 is still blocked, and all hosted/exact-main gates pass. This
-packet does not run or authorize a production qualification run by itself.
+bound, the stale failed PR #394 is explicitly superseded read-only, and CK-07R1
+becomes Conditional Ready only after this authority's merge and exact-main
+verification. The planner-valid receipt is a future successor acceptance
+output, not a pre-dispatch dependency. This packet does not run or authorize a
+production qualification run by itself.
+
+Earlier CK-07R1 wording that says to resume, refresh, or rerun PR #394 is
+historical provenance and is superseded by this read-only policy.
 
 **Failure/rollback:** Preserve the exact candidate, evidence, and failed
 attempts; stop closed on any identity, scope, DAG, schema, review, CI, merge,
@@ -85,7 +92,7 @@ or exact-main mismatch. Do not weaken a budget or infer publication-validity
 from a manually forced plan.
 
 **Handoff:** Coordinator `019fbeb3-00d5-7f22-ba65-ae4672838140` and parent
-`019fbea6-66b5-71e0-b85a-b6654fd414c5` receive the merged SHA, Authority v1
+`019fbea6-66b5-71e0-b85a-b6654fd414c5` receive the merged SHA, Authority v2
 path, exact scope additions, preserved attempts/digests, validation/reviewer/
 CI/exact-main results, and unchanged downstream gates.
 

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -176,7 +176,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     manifest = json.loads(manifest_match.group(1))
     assert manifest["schema"] == "codex-usage-tracker.remaining-delegation-dag.v1"
     assert manifest["orchestration"]["spawn"] == "all_newly_ready_successors"
-    conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-QG1A"}
+    conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-QG1A", "CK-07R1"}
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R2",
@@ -197,10 +197,15 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             "condition": "CK-QG1A0 merged and exact-main verified",
             "tasks": ["CK-QG1A"],
         },
+        {
+            "condition": "CK-07R1 transition authority accepted, merged, and exact-main verified",
+            "tasks": ["CK-07R1"],
+        },
     ]
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
+    assert "Blocked child tasks: **41**" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -295,8 +300,6 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Ready" in body
         elif packet_id in {"CK-08R0", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"}:
             assert "**Status:** Completed on merge" in body
-        elif packet_id == "CK-07R1":
-            assert "**Status:** **BLOCKED**" in body
         else:
             assert "**Status:** Blocked" in body
 
@@ -377,6 +380,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     agents = _read("AGENTS.md")
     index = _read("docs/INDEX.md")
     roadmap = _read("docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md")
+    central = _read("docs/roadmap/REMAINING_EXECUTION_PLAN.md")
     ledger = _read("docs/roadmap/TASK_PACKETS.md")
     backlog = _read("docs/roadmap/LINEAR_BACKLOG.md")
     qualification = _read("docs/quality/QUALIFICATION_PLAN.md")
@@ -515,15 +519,19 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
                 "fold_lifecycle",
                 "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
                 "one-run authorization condition",
-                "CK-07R1 remains",
-                "**BLOCKED**",
+                "CK-07R1 becomes",
+                "Conditional Ready",
+                "The planner-valid receipt is a future successor acceptance",
+                "stale failed PR #394 is explicitly superseded read-only",
             ),
         ),
     ):
         assert all(token in body for token in tokens)
-    assert "exact-main verification required before CK-07R1" in ck07r1a0
+    assert "exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`" in ck07r1a0
+    assert "strict Authority v2" in ck07r1a0
+    assert "supersedes earlier CK-07R1 wording" in central
     assert "Blocked on CK-QG1A" in ckqg1
-    assert "**BLOCKED** on CK-07R1A0" in ck07r1
+    assert "Conditional Ready after this authority merges and exact-main verifies" in ck07r1
 
 
 def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
@@ -535,8 +543,42 @@ def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
     validator.validate(authority)
 
     assert authority["owner"] == "CK-07R1A0"
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-path-authority.v2"
+    assert authority["authority_version"] == 2
     assert authority["authority_base_sha"] == "979f88eca2f23f6225c0c7a530b8f36f793c5748"
-    assert authority["blocked_requalification"]["status"] == "BLOCKED"
+    assert authority["blocked_requalification"] == {
+        "packet": "CK-07R1",
+        "status": "CONDITIONAL_READY",
+        "reason": "planner_valid_lifecycle_receipt_is_successor_acceptance_output",
+        "accepted_receipt_required": True,
+        "receipt_required_before_dispatch": False,
+    }
+    assert authority["readiness_transition"] == {
+        "packet": "CK-07R1",
+        "from_status": "BLOCKED",
+        "conditional_status": "CONDITIONAL_READY",
+        "effective_ready_status": "READY",
+        "activation": "this authority accepted merged and exact-main verified",
+        "authority_base_sha": "519b503aa3b23019033b6481687c08b23fc6c31e",
+        "receipt_role": "successor_acceptance_output_not_pre_dispatch_dependency",
+        "receipt_required_before_dispatch": False,
+        "receipt_required_for_acceptance": True,
+        "maximum_new_end_to_end_runs": 1,
+        "dispatch_rule": "create_exactly_one_fresh_CK-07R1_successor_from_activation_exact_main",
+        "downstream_ready_tasks": [],
+    }
+    assert authority["pr_394_policy"] == {
+        "number": 394,
+        "head_sha": "98a9b5b82951d136644a5fe5f8a70d320131ba08",
+        "base_sha": "bbd9eb990969a659376ea584c6d696d1715cc007",
+        "workflow_run_id": "30685780055",
+        "failed_job_id": "91331138768",
+        "failed_check": "Kernel phase and package isolation (3.14)",
+        "failure": "ordinary.2000_call_tail",
+        "status": "stale_failed_superseded_read_only",
+        "policy": "do_not_update_rerun_merge_or_reinterpret",
+        "future_requalification": "fresh_CK-07R1_successor_from_authority_exact_main",
+    }
     assert authority["run_authorization"]["status"] == "not_executed_by_this_packet"
     assert authority["run_authorization"]["maximum_new_end_to_end_runs"] == 1
     assert authority["reachable_path"]["ordering"] == (
@@ -587,6 +629,14 @@ def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
 
     changed = json.loads(json.dumps(authority))
     changed["run_authorization"]["status"] = "authorized"
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["readiness_transition"]["receipt_required_before_dispatch"] = True
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["pr_394_policy"]["head_sha"] = "0" * 40
     assert list(validator.iter_errors(changed))
 
     changed = json.loads(json.dumps(authority))


### PR DESCRIPTION
## Summary
- record CK-07R1A0 acceptance at exact main and make CK-07R1 Conditional Ready only after this authority merges and exact-main verifies
- make the planner-valid lifecycle receipt a future CK-07R1 acceptance output, not a pre-dispatch dependency
- classify PR #394 head `98a9b5b82951d136644a5fe5f8a70d320131ba08` and its Python 3.14 `ordinary.2000_call_tail` failure as stale, superseded, read-only

## Safety and scope
- preserves maximum_new_end_to_end_runs=1, all prior attempt identities/timestamps, writer-only receipt digest `935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d`, budgets `5000/120000/100/500/500`, package ceilings sdist 2,000,000 / wheel 1,000,000, and fail-closed rules
- no lifecycle implementation, benchmark, production qualification, PR #394 update, downstream readiness, or worker creation
- exactly one future CK-07R1 successor is gated from exact main after this authority is merged and verified

## Validation
- focused authority/DAG/ledger/scope/schema checks: 28 passed
- `just v`: 1,367 passed; invariant lane 13 passed; pyright/release checks passed
- `just vc`: 1,367 passed; invariant lane 13 passed; pyright/build/dist checks passed
- one final independent read-only reviewer completed; actionable findings addressed within scope