### PR TITLE
Reconcile CK-07R1 lifecycle candidate authority

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,13 +31,17 @@ stale failed read-only witness; it is not updated, rerun, or merged. CK-07R1
 is held behind the linked [source-digest authority](decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json)
 and [run-invocation authority](decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json)
 (`docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json`).
-The source authority freezes predecessor `408d18e4…` to the permitted
-successor `d192c858…`; the run authority freezes the exact launch, fixture,
-evidence, token, and no-retry contract. The retained candidate is explicitly
-blocked because it cannot support that launch contract without behavioral
-implementation. CK-07R1 remains blocked, no run token is consumed, no other
-successor is advanced, and the one-run gate remains unspent. Reclassification
-and maintainability remain open. The central authority is
+The source authority reconciles the live predecessor `408d18e4…` to the
+retained successor `d192c858…` without claiming runtime acceptance and binds
+the corrected benchmark `6a864c…`, lifecycle test `a033e1…`, and linked CK-07
+evidence `36eb76…`. The run authority freezes the exact launch, fixture,
+revoked malformed dispatch value, 720-second wrapper timeout, evidence, token,
+and no-retry contract while preserving the 5000/120000/100/500/500 ms budgets.
+The candidate remains runtime-unqualified until the existing worker
+revalidates it from the accepted exact main and produces the planner-valid
+receipt. CK-07R1 remains blocked, no run token is consumed, no other successor
+is advanced, and the one-run gate remains unspent. Reclassification and
+maintainability remain open. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
 ## Authority set

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -6,7 +6,10 @@
   "status": "authority_reconciled_no_run",
   "selected_candidate": {
     "status": "reconciled_no_run",
-    "base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+    "base_sha": "bdf545127b9cda20d22e00e9e9abb74c9550a470",
+    "retained_branch": "feature/ck-07r1-lifecycle-requalification-v3",
+    "retained_worktree": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3",
+    "witness_status": "retained_uncommitted_read_only",
     "source_predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
     "source_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
     "runtime_acceptance": "not_claimed",
@@ -44,9 +47,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "f3fdae3627020008e2362c71a7bce88f38522c61a848c1e45132ed9fd5d1421b",
+      "sha256": "ca5391783df001447a1399c78113fcc26ef818c4bfdfd59e5a28e6e80f81ce16",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "c9051e1480ef3f6580a7eaec9b781678a61cbc07c6b7964f8ec8d5532542b775"
+      "schema_sha256": "e8cc1f0ab316fcb840339c8ce607c8170e94c00f2627bb99a6905f34feff50b2"
     }
   },
   "launch_contract": {
@@ -302,11 +305,14 @@
       "docs/INDEX.md",
       "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
       "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
       "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
       "docs/roadmap/TASK_PACKETS.md",
       "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md",
       "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
       "scripts/check_kernel_scope.py",
+      "tests/kernel/test_documentation_authority.py",
       "tests/kernel/test_lifecycle_run_invocation_authority.py"
     ],
     "forbidden": [

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -3,7 +3,38 @@
   "authority_version": 1,
   "owner": "CK-07R1A0",
   "authority_base_sha": "e0ee9f2cf442399633d93e402d17f527da604f0f",
-  "status": "authority_only_harness_blocked",
+  "status": "authority_reconciled_no_run",
+  "selected_candidate": {
+    "status": "reconciled_no_run",
+    "base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+    "source_predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+    "source_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+    "runtime_acceptance": "not_claimed",
+    "artifacts": [
+      {
+        "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+        "sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "role": "source"
+      },
+      {
+        "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
+        "role": "benchmark"
+      },
+      {
+        "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+        "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac",
+        "role": "lifecycle_test"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+        "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb",
+        "role": "linked_evidence"
+      }
+    ],
+    "binding": "live_source_predecessor_to_selected_successor",
+    "worker_revalidation_required": true
+  },
   "preserved_authorities": {
     "lifecycle_path": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-path-authority.json",
@@ -13,12 +44,27 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "9c9898a05d618c9f14cd0bcc5403987a5029c684ae53dfadaf28ddea77170c58",
+      "sha256": "f3fdae3627020008e2362c71a7bce88f38522c61a848c1e45132ed9fd5d1421b",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "d524b987f76ff534ee3430e26299a574802f19a8cb8ef27322fb7fc3aed1a87f"
+      "schema_sha256": "c9051e1480ef3f6580a7eaec9b781678a61cbc07c6b7964f8ec8d5532542b775"
     }
   },
   "launch_contract": {
+    "aggregate_timeout": {
+      "seconds": 720,
+      "formula": "5 * 120 + 120",
+      "production_sample_count": 5,
+      "production_sample_budget_seconds": 120,
+      "publication_recovery_overhead_seconds": 120,
+      "scope": "wrapper_only",
+      "underlying_runtime_budgets_ms": {
+        "first_publication_30_day": 5000,
+        "production_all_time": 120000,
+        "no_change": 100,
+        "one_call_tail": 500,
+        "one_tool_tail": 500
+      }
+    },
     "repository_relative_command": [
       ".venv/bin/python",
       "scripts/benchmark_ck07r1_lifecycle_scale.py",
@@ -66,6 +112,15 @@
         "fixture_file_sha256": "SHA-256 of exact fixture file bytes at the required relative path; it is not the manifest digest and is not a dynamic digest",
         "workload_transition_digest": "SHA-256 computed during this run from the canonical generated workload and emitted transition vector; it is not supplied as a static fixture identity"
       },
+      "rejected_dispatch_values": [
+        {
+          "value": "e8c79373697ebe2af5385dbb2899ae49cec61037c4a3b0909f91225128e0bc",
+          "length": 62,
+          "status": "revoked_never_authoritative",
+          "use": "never_used",
+          "reason": "malformed dispatch value; the canonical fixture file SHA-256 is 64 hexadecimal characters"
+        }
+      ],
       "manifest": {
         "path": "tests/agent_kernel/fixtures/tiny-v1/manifest.json",
         "schema": "codex-usage-tracker.synthetic-fixture-manifest.v1",
@@ -236,8 +291,8 @@
   },
   "feasibility": {
     "candidate_script": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-    "candidate_status": "cannot_support_one_explicit_launch_without_behavioral_implementation",
-    "exact_blocker": "the retained candidate exposes an optional output argument and an in-process run path, but does not implement the required prelaunch process exclusion, exclusive non-overwrite output preflight, launch-token ledger, child PID/parent PID/timestamp/RSS/disk/evidence capture, or post-launch no-retry/restart/replacement state machine",
+    "candidate_status": "remediated_no_run_runtime_unqualified",
+    "exact_blocker": "the no-run remediation is identity-reconciled but the worker has not revalidated the selected candidate on exact merged main or produced the planner-valid receipt; the sole end-to-end gate remains unconsumed",
     "authority_action": "freeze contract only; do not implement runtime or harness behavior in this authority",
     "run_action": "do not execute production or end-to-end qualification; do not consume the run token; keep CK-07R1 blocked",
     "fixture_identity_status": "proven_for_static_manifest_and_file_values; workload_transition_digest remains a required runtime-produced value"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -30,12 +30,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "status", "base_sha", "source_predecessor_sha256", "source_successor_sha256",
-        "runtime_acceptance", "artifacts", "binding", "worker_revalidation_required"
+        "status", "base_sha", "retained_branch", "retained_worktree", "witness_status",
+        "source_predecessor_sha256", "source_successor_sha256", "runtime_acceptance", "artifacts",
+        "binding", "worker_revalidation_required"
       ],
       "properties": {
         "status": {"const": "reconciled_no_run"},
-        "base_sha": {"const": "d911b1f0d17596890a6a0a608be904330c96e9a6"},
+        "base_sha": {"const": "bdf545127b9cda20d22e00e9e9abb74c9550a470"},
+        "retained_branch": {"const": "feature/ck-07r1-lifecycle-requalification-v3"},
+        "retained_worktree": {"const": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3"},
+        "witness_status": {"const": "retained_uncommitted_read_only"},
         "source_predecessor_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"},
         "source_successor_sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"},
         "runtime_acceptance": {"const": "not_claimed"},
@@ -89,9 +93,9 @@
           "required": ["path", "sha256", "schema_path", "schema_sha256"],
           "properties": {
             "path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"},
-            "sha256": {"const": "f3fdae3627020008e2362c71a7bce88f38522c61a848c1e45132ed9fd5d1421b"},
+            "sha256": {"const": "ca5391783df001447a1399c78113fcc26ef818c4bfdfd59e5a28e6e80f81ce16"},
             "schema_path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"},
-            "schema_sha256": {"const": "c9051e1480ef3f6580a7eaec9b781678a61cbc07c6b7964f8ec8d5532542b775"}
+            "schema_sha256": {"const": "e8cc1f0ab316fcb840339c8ce607c8170e94c00f2627bb99a6905f34feff50b2"}
           }
         }
       }
@@ -306,6 +310,6 @@
   },
   "preserved_history": {"type": "object", "additionalProperties": false, "required": ["writer_only_receipt_digest", "source_predecessor_sha256", "source_successor_sha256", "runtime_budgets_ms", "package_ceilings_bytes", "pr_394", "prior_attempt_ids", "preservation"], "properties": {"writer_only_receipt_digest": {"const": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d"}, "source_predecessor_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"}, "source_successor_sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"}, "runtime_budgets_ms": {"const": {"first_publication_30_day": 5000, "production_all_time": 120000, "no_change": 100, "one_call_tail": 500, "one_tool_tail": 500}}, "package_ceilings_bytes": {"const": {"sdist": 2000000, "wheel": 1000000}}, "pr_394": {"const": {"number": 394, "head_sha": "98a9b5b82951d136644a5fe5f8a70d320131ba08", "workflow_run_id": "30685780055", "failed_job_id": "91331138768", "failure": "ordinary.2000_call_tail", "status": "stale_failed_superseded_read_only", "policy": "do_not_update_rerun_merge_or_reinterpret"}}, "prior_attempt_ids": {"const": ["all-profile-initial-serializer", "all-profile-corrected-serializer-tail-oracle", "all-profile-pid-60367-recovery", "production-only-valid-profile"]}, "preservation": {"const": "all prior run identities, attempts, timestamps, failures, receipts, and digests remain visible and read-only; no old receipt is upgraded"}}},
   "feasibility": {"type": "object", "additionalProperties": false, "required": ["candidate_script", "candidate_status", "exact_blocker", "authority_action", "run_action", "fixture_identity_status"], "properties": {"candidate_script": {"const": "scripts/benchmark_ck07r1_lifecycle_scale.py"}, "candidate_status": {"const": "remediated_no_run_runtime_unqualified"}, "exact_blocker": {"const": "the no-run remediation is identity-reconciled but the worker has not revalidated the selected candidate on exact merged main or produced the planner-valid receipt; the sole end-to-end gate remains unconsumed"}, "authority_action": {"const": "freeze contract only; do not implement runtime or harness behavior in this authority"}, "run_action": {"const": "do not execute production or end-to-end qualification; do not consume the run token; keep CK-07R1 blocked"}, "fixture_identity_status": {"const": "proven_for_static_manifest_and_file_values; workload_transition_digest remains a required runtime-produced value"}}},
-  "scope": {"type": "object", "additionalProperties": false, "required": ["authority_only_files", "forbidden"], "properties": {"authority_only_files": {"const": ["docs/INDEX.md", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json", "docs/roadmap/REMAINING_EXECUTION_PLAN.md", "docs/roadmap/TASK_PACKETS.md", "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md", "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "scripts/check_kernel_scope.py", "tests/kernel/test_lifecycle_run_invocation_authority.py"]}, "forbidden": {"const": ["src/codex_usage_tracker/agent_kernel/", "scripts/benchmark_ck07r1_lifecycle_scale.py", "tests/agent_kernel/publication/test_lifecycle_scale.py", "the two retained witness worktrees", "PR #394", "downstream packets"]}}}
+  "scope": {"type": "object", "additionalProperties": false, "required": ["authority_only_files", "forbidden"], "properties": {"authority_only_files": {"const": ["docs/INDEX.md", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json", "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json", "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json", "docs/roadmap/REMAINING_EXECUTION_PLAN.md", "docs/roadmap/TASK_PACKETS.md", "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md", "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "scripts/check_kernel_scope.py", "tests/kernel/test_documentation_authority.py", "tests/kernel/test_lifecycle_run_invocation_authority.py"]}, "forbidden": {"const": ["src/codex_usage_tracker/agent_kernel/", "scripts/benchmark_ck07r1_lifecycle_scale.py", "tests/agent_kernel/publication/test_lifecycle_scale.py", "the two retained witness worktrees", "PR #394", "downstream packets"]}}}
   }
 }

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -10,6 +10,7 @@
     "owner",
     "authority_base_sha",
     "status",
+    "selected_candidate",
     "preserved_authorities",
     "launch_contract",
     "launch_gates",
@@ -24,7 +25,48 @@
     "authority_version": {"const": 1},
     "owner": {"const": "CK-07R1A0"},
     "authority_base_sha": {"const": "e0ee9f2cf442399633d93e402d17f527da604f0f"},
-    "status": {"const": "authority_only_harness_blocked"},
+    "status": {"const": "authority_reconciled_no_run"},
+    "selected_candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status", "base_sha", "source_predecessor_sha256", "source_successor_sha256",
+        "runtime_acceptance", "artifacts", "binding", "worker_revalidation_required"
+      ],
+      "properties": {
+        "status": {"const": "reconciled_no_run"},
+        "base_sha": {"const": "d911b1f0d17596890a6a0a608be904330c96e9a6"},
+        "source_predecessor_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"},
+        "source_successor_sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"},
+        "runtime_acceptance": {"const": "not_claimed"},
+        "artifacts": {
+          "const": [
+            {
+              "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+              "sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "role": "source"
+            },
+            {
+              "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+              "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
+              "role": "benchmark"
+            },
+            {
+              "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+              "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac",
+              "role": "lifecycle_test"
+            },
+            {
+              "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+              "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb",
+              "role": "linked_evidence"
+            }
+          ]
+        },
+        "binding": {"const": "live_source_predecessor_to_selected_successor"},
+        "worker_revalidation_required": {"const": true}
+      }
+    },
     "preserved_authorities": {
       "type": "object",
       "additionalProperties": false,
@@ -47,17 +89,34 @@
           "required": ["path", "sha256", "schema_path", "schema_sha256"],
           "properties": {
             "path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"},
-            "sha256": {"const": "9c9898a05d618c9f14cd0bcc5403987a5029c684ae53dfadaf28ddea77170c58"},
+            "sha256": {"const": "f3fdae3627020008e2362c71a7bce88f38522c61a848c1e45132ed9fd5d1421b"},
             "schema_path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"},
-            "schema_sha256": {"const": "d524b987f76ff534ee3430e26299a574802f19a8cb8ef27322fb7fc3aed1a87f"}
+            "schema_sha256": {"const": "c9051e1480ef3f6580a7eaec9b781678a61cbc07c6b7964f8ec8d5532542b775"}
           }
         }
       }
     },
     "launch_contract": {
       "type": "object", "additionalProperties": false,
-      "required": ["repository_relative_command", "required_cwd", "cwd_rule", "interpreter", "environment", "output", "fixture_identity", "profiles", "tail_limits", "reachable_path"],
+      "required": ["aggregate_timeout", "repository_relative_command", "required_cwd", "cwd_rule", "interpreter", "environment", "output", "fixture_identity", "profiles", "tail_limits", "reachable_path"],
       "properties": {
+        "aggregate_timeout": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "seconds", "formula", "production_sample_count", "production_sample_budget_seconds",
+            "publication_recovery_overhead_seconds", "scope", "underlying_runtime_budgets_ms"
+          ],
+          "properties": {
+            "seconds": {"const": 720},
+            "formula": {"const": "5 * 120 + 120"},
+            "production_sample_count": {"const": 5},
+            "production_sample_budget_seconds": {"const": 120},
+            "publication_recovery_overhead_seconds": {"const": 120},
+            "scope": {"const": "wrapper_only"},
+            "underlying_runtime_budgets_ms": {"const": {"first_publication_30_day": 5000, "production_all_time": 120000, "no_change": 100, "one_call_tail": 500, "one_tool_tail": 500}}
+          }
+        },
         "repository_relative_command": {
           "const": [".venv/bin/python", "scripts/benchmark_ck07r1_lifecycle_scale.py", "--profile", "all", "--samples", "5", "--output", "output/ck07r1/lifecycle-requalification-v1.json"]
         },
@@ -97,7 +156,7 @@
         },
         "fixture_identity": {
           "type": "object", "additionalProperties": false,
-          "required": ["vocabulary", "manifest", "fixture_files", "dynamic_digest"],
+          "required": ["vocabulary", "rejected_dispatch_values", "manifest", "fixture_files", "dynamic_digest"],
           "properties": {
             "vocabulary": {
               "const": {
@@ -105,6 +164,17 @@
                 "fixture_file_sha256": "SHA-256 of exact fixture file bytes at the required relative path; it is not the manifest digest and is not a dynamic digest",
                 "workload_transition_digest": "SHA-256 computed during this run from the canonical generated workload and emitted transition vector; it is not supplied as a static fixture identity"
               }
+            },
+            "rejected_dispatch_values": {
+              "const": [
+                {
+                  "value": "e8c79373697ebe2af5385dbb2899ae49cec61037c4a3b0909f91225128e0bc",
+                  "length": 62,
+                  "status": "revoked_never_authoritative",
+                  "use": "never_used",
+                  "reason": "malformed dispatch value; the canonical fixture file SHA-256 is 64 hexadecimal characters"
+                }
+              ]
             },
             "manifest": {
               "type": "object", "additionalProperties": false,
@@ -235,7 +305,7 @@
     }
   },
   "preserved_history": {"type": "object", "additionalProperties": false, "required": ["writer_only_receipt_digest", "source_predecessor_sha256", "source_successor_sha256", "runtime_budgets_ms", "package_ceilings_bytes", "pr_394", "prior_attempt_ids", "preservation"], "properties": {"writer_only_receipt_digest": {"const": "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d"}, "source_predecessor_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"}, "source_successor_sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"}, "runtime_budgets_ms": {"const": {"first_publication_30_day": 5000, "production_all_time": 120000, "no_change": 100, "one_call_tail": 500, "one_tool_tail": 500}}, "package_ceilings_bytes": {"const": {"sdist": 2000000, "wheel": 1000000}}, "pr_394": {"const": {"number": 394, "head_sha": "98a9b5b82951d136644a5fe5f8a70d320131ba08", "workflow_run_id": "30685780055", "failed_job_id": "91331138768", "failure": "ordinary.2000_call_tail", "status": "stale_failed_superseded_read_only", "policy": "do_not_update_rerun_merge_or_reinterpret"}}, "prior_attempt_ids": {"const": ["all-profile-initial-serializer", "all-profile-corrected-serializer-tail-oracle", "all-profile-pid-60367-recovery", "production-only-valid-profile"]}, "preservation": {"const": "all prior run identities, attempts, timestamps, failures, receipts, and digests remain visible and read-only; no old receipt is upgraded"}}},
-  "feasibility": {"type": "object", "additionalProperties": false, "required": ["candidate_script", "candidate_status", "exact_blocker", "authority_action", "run_action", "fixture_identity_status"], "properties": {"candidate_script": {"const": "scripts/benchmark_ck07r1_lifecycle_scale.py"}, "candidate_status": {"const": "cannot_support_one_explicit_launch_without_behavioral_implementation"}, "exact_blocker": {"const": "the retained candidate exposes an optional output argument and an in-process run path, but does not implement the required prelaunch process exclusion, exclusive non-overwrite output preflight, launch-token ledger, child PID/parent PID/timestamp/RSS/disk/evidence capture, or post-launch no-retry/restart/replacement state machine"}, "authority_action": {"const": "freeze contract only; do not implement runtime or harness behavior in this authority"}, "run_action": {"const": "do not execute production or end-to-end qualification; do not consume the run token; keep CK-07R1 blocked"}, "fixture_identity_status": {"const": "proven_for_static_manifest_and_file_values; workload_transition_digest remains a required runtime-produced value"}}},
+  "feasibility": {"type": "object", "additionalProperties": false, "required": ["candidate_script", "candidate_status", "exact_blocker", "authority_action", "run_action", "fixture_identity_status"], "properties": {"candidate_script": {"const": "scripts/benchmark_ck07r1_lifecycle_scale.py"}, "candidate_status": {"const": "remediated_no_run_runtime_unqualified"}, "exact_blocker": {"const": "the no-run remediation is identity-reconciled but the worker has not revalidated the selected candidate on exact merged main or produced the planner-valid receipt; the sole end-to-end gate remains unconsumed"}, "authority_action": {"const": "freeze contract only; do not implement runtime or harness behavior in this authority"}, "run_action": {"const": "do not execute production or end-to-end qualification; do not consume the run token; keep CK-07R1 blocked"}, "fixture_identity_status": {"const": "proven_for_static_manifest_and_file_values; workload_transition_digest remains a required runtime-produced value"}}},
   "scope": {"type": "object", "additionalProperties": false, "required": ["authority_only_files", "forbidden"], "properties": {"authority_only_files": {"const": ["docs/INDEX.md", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json", "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json", "docs/roadmap/REMAINING_EXECUTION_PLAN.md", "docs/roadmap/TASK_PACKETS.md", "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md", "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md", "scripts/check_kernel_scope.py", "tests/kernel/test_lifecycle_run_invocation_authority.py"]}, "forbidden": {"const": ["src/codex_usage_tracker/agent_kernel/", "scripts/benchmark_ck07r1_lifecycle_scale.py", "tests/agent_kernel/publication/test_lifecycle_scale.py", "the two retained witness worktrees", "PR #394", "downstream packets"]}}}
   }
 }

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -4,6 +4,19 @@
   "owner": "CK-07R1A0",
   "authority_base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+  "acceptance_state": {
+    "status": "reconciled_no_run",
+    "live_source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+    "predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+    "selected_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+    "binding": "live_source_predecessor_to_selected_successor",
+    "runtime_acceptance": "not_claimed",
+    "worker_revalidation_required": true,
+    "linked_evidence": {
+      "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+      "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"
+    }
+  },
   "predecessor": {
     "sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
     "accepted_merge_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
@@ -32,11 +45,11 @@
       "untracked": [
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "c0cd2d64109b4b39340699b153d6645dc11aaa6185151cd4b38c9320244eaea5"
+          "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "66d464a4348ef83ced7c2bff20c218393e7e2485ca11d40ef84630e06efce608"
+          "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac"
         }
       ]
     }
@@ -150,6 +163,8 @@
   "constraints": [
     "generic_digest_drift_forbidden",
     "any_different_preparation_digest_fails_closed",
+    "authority_reconciled_no_run",
+    "live_source_predecessor_binding_required",
     "selected_successor_is_permitted_not_accepted",
     "candidate_witness_is_retained_uncommitted_read_only",
     "worker_must_revalidate_on_exact_merged_main_before_any_end_to_end_run",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -29,9 +29,9 @@
     "sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
     "status": "permitted_not_accepted",
     "blocked_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
-    "retained_branch": "feature/ck-07r1-lifecycle-path-requalification",
-    "retained_worktree": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-path-requalification",
-    "base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+    "retained_branch": "feature/ck-07r1-lifecycle-requalification-v3",
+    "retained_worktree": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3",
+    "base_sha": "bdf545127b9cda20d22e00e9e9abb74c9550a470",
     "witness_status": "retained_uncommitted_read_only",
     "diff_identity": {
       "modified": [

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -10,6 +10,7 @@
     "owner",
     "authority_base_sha",
     "source_path",
+    "acceptance_state",
     "predecessor",
     "selected_successor",
     "allowed_scope",
@@ -30,6 +31,33 @@
     "owner": {"const": "CK-07R1A0"},
     "authority_base_sha": {"const": "d911b1f0d17596890a6a0a608be904330c96e9a6"},
     "source_path": {"const": "src/codex_usage_tracker/agent_kernel/publication/preparation.py"},
+    "acceptance_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status", "live_source_sha256", "predecessor_sha256",
+        "selected_successor_sha256", "binding", "runtime_acceptance",
+        "worker_revalidation_required", "linked_evidence"
+      ],
+      "properties": {
+        "status": {"const": "reconciled_no_run"},
+        "live_source_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"},
+        "predecessor_sha256": {"const": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"},
+        "selected_successor_sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"},
+        "binding": {"const": "live_source_predecessor_to_selected_successor"},
+        "runtime_acceptance": {"const": "not_claimed"},
+        "worker_revalidation_required": {"const": true},
+        "linked_evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "sha256"],
+          "properties": {
+            "path": {"const": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json"},
+            "sha256": {"const": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"}
+          }
+        }
+      }
+    },
     "predecessor": {
       "type": "object",
       "additionalProperties": false,
@@ -82,11 +110,11 @@
               "const": [
                 {
                   "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                  "sha256": "c0cd2d64109b4b39340699b153d6645dc11aaa6185151cd4b38c9320244eaea5"
+                  "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783"
                 },
                 {
                   "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                  "sha256": "66d464a4348ef83ced7c2bff20c218393e7e2485ca11d40ef84630e06efce608"
+                  "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac"
                 }
               ]
             }
@@ -264,6 +292,8 @@
       "const": [
         "generic_digest_drift_forbidden",
         "any_different_preparation_digest_fails_closed",
+        "authority_reconciled_no_run",
+        "live_source_predecessor_binding_required",
         "selected_successor_is_permitted_not_accepted",
         "candidate_witness_is_retained_uncommitted_read_only",
         "worker_must_revalidate_on_exact_merged_main_before_any_end_to_end_run",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -87,9 +87,9 @@
         "sha256": {"const": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"},
         "status": {"const": "permitted_not_accepted"},
         "blocked_task": {"const": "019fbfe2-8fe4-7de2-9264-d58572366727"},
-        "retained_branch": {"const": "feature/ck-07r1-lifecycle-path-requalification"},
-        "retained_worktree": {"const": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-path-requalification"},
-        "base_sha": {"const": "d911b1f0d17596890a6a0a608be904330c96e9a6"},
+        "retained_branch": {"const": "feature/ck-07r1-lifecycle-requalification-v3"},
+        "retained_worktree": {"const": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3"},
+        "base_sha": {"const": "bdf545127b9cda20d22e00e9e9abb74c9550a470"},
         "witness_status": {"const": "retained_uncommitted_read_only"},
         "diff_identity": {
           "type": "object",

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -25,18 +25,20 @@ behavior or the frozen maintainability baseline.
 CK-07R1A is accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 is accepted at the
 current exact main `519b503aa3b23019033b6481687c08b23fc6c31e`; its linked
-source-digest correction is frozen from exact main `d911b1f` and is not a
-worker implementation. PR #394 is a stale failed witness: head
+source-digest and run-invocation authorities reconcile the no-run candidate
+from exact main `bdf545127b9cda20d22e00e9e9abb74c9550a470` and are authority
+documentation only. PR #394 is a stale failed witness: head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` failed the hosted Python 3.14
 `ordinary.2000_call_tail` gate and is superseded read-only. It must not be
 updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker only after it revalidates the
 retained candidate on the source-digest and run-invocation authorities' exact
 merged main; the run-invocation authority is not a pre-dispatch dependency.
-The first sample, all five
-budgets, one-run ceiling, and every fail-closed rule remain binding. CK-07R1
-is blocked until both authorities are accepted, merged, and exact-main
-verified. Earlier wording that says to resume, refresh, or rerun PR #394 is
+The first sample, 720-second wrapper timeout, all five underlying budgets,
+one-run ceiling, and every fail-closed rule remain binding. CK-07R1 is blocked
+until both authorities are accepted, merged, and exact-main verified; after
+that exact-main handoff only the existing worker may be resumed for its
+required revalidation. Earlier wording that says to resume, refresh, or rerun PR #394 is
 historical provenance and does not authorize action. This source-digest
 authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -16,7 +16,7 @@ parents are accounting umbrellas.
 - Remaining delegable child tasks: **45**
 - Ready child tasks: **0**
 - Conditional-ready child tasks: **3 — CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
-- Blocked child tasks: **42 — CK-07R1 pending the source-digest and the run-invocation authority**
+- Blocked child tasks: **42 — CK-07R1 pending this reconciled source-digest/run-invocation authority merge and exact-main handoff**
 
 ## Parent packets
 
@@ -61,8 +61,8 @@ other corrective locks are unchanged.
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
 - [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
-- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verified at `519b503a`; linked source-digest and run-invocation authorities require their own merge/exact-main verification · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked pending source-digest and run-invocation authority merges/exact-main verification; revalidate the retained candidate only on exact merged main; planner-valid receipt is a successor acceptance output and PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verified at `519b503a`; reconciled source-digest/run-invocation authority is pending its own merge/exact-main verification · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked pending this authority's merge/exact-main handoff; revalidate the retained candidate only on exact merged main; planner-valid receipt is a successor acceptance output and PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,6 +1,6 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** Blocked pending the source-digest and run-invocation authorities merging and exact-main verification; worker pre-run gates remain required
+**Status:** Blocked pending the reconciled source-digest/run-invocation authority merging and exact-main verification; worker pre-run gates remain required
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -24,15 +24,18 @@ contracts.
 **Dependencies:** CK-07R1A accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 path authority accepted
 at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`; and the linked
-source-digest and the run-invocation authority accepted, merged, and exact-main
-verified. The worker
+reconciled source-digest/run-invocation authority accepted, merged, and
+exact-main verified. The worker
 must then start from that exact merged main and reapply the retained candidate,
 revalidating predecessor and successor digests before any end-to-end run. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed read-only
 witness and is not refreshed, rerun, or merged.
 
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
-publication tests, profile/benchmark, and linked CK-07 evidence amendment.
+publication tests, profile/benchmark, and linked CK-07 evidence amendment;
+the authority reconciliation binds preparation `d192c858…`, benchmark
+`6a864c74…`, lifecycle test `a033e1c3…`, linked evidence `36eb76ca…`, and the
+720-second wrapper timeout without executing the worker.
 
 **Produces:** Publication-scale requalification with equivalent fold identity.
 
@@ -57,7 +60,8 @@ bounded RSS; synthetic data; no writer recovery regression.
 
 **Required tests/checks:** Focused lifecycle/publication, equivalent results,
 standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
-`just v/vc`.
+`just v/vc`; authority/schema/DAG/scope negative checks; no E2E run in the
+authority reconciliation.
 
 **Acceptance:** Work is linear in observations plus prior transitions and all
 publication-valid scale gates pass through the CK-07R1A0 reachable path and

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -1,6 +1,6 @@
 # CK-07R1A0 — Freeze lifecycle planner/recovery path authority
 
-**Status:** Completed on merge; exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`; linked source-digest and run-invocation authorities are pending merge and exact-main verification, so the existing CK-07R1 worker remains held
+**Status:** Completed on merge; exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`; reconciled source-digest and run-invocation authority is pending merge and exact-main verification, so the existing CK-07R1 worker remains held
 
 **Release-candidate package ceilings:** sdist remains at most 2,000,000
 bytes and wheel remains at most 1,000,000 bytes. The historical 828000/383000
@@ -34,10 +34,14 @@ contract is
 [lifecycle-path-authority.json](../../decisions/evidence/ck07r1a0/lifecycle-path-authority.json)
 with its schema. The linked [source-digest authority](../../decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json)
 and its schema freeze the exact predecessor/successor transition. The retained
-CK-07R1 implementation/profile/evidence diff is read-only evidence.
+CK-07R1 implementation/profile/evidence diff is read-only evidence;
+the reconciled candidate binds preparation `d192c858…`, benchmark
+`6a864c74…`, lifecycle test `a033e1c3…`, linked evidence `36eb76ca…`, and
+canonical fixture identities without claiming runtime acceptance.
 The linked run-invocation authority is
 `docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json`;
-it adds no runtime implementation and keeps the retained candidate blocked.
+it adds no runtime implementation, freezes the 720-second wrapper timeout, and
+keeps the retained candidate runtime-unqualified.
 
 **Produces:** A frozen entry-path contract, APPEND_SAFE_SMALL selection rule,
 independent lifecycle oracle/postconditions, exact source/diff identity,
@@ -72,9 +76,13 @@ predecessor digest is
 `408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872` and the
 permitted-not-accepted retained successor digest is
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1`; generic
-or different digest drift fails closed; CK-07R1 remains blocked until the
-source-digest and run-invocation authorities are accepted, merged, and
-exact-main verified; the five budgets remain `5000/120000/100/500/500` ms; every prior
+or different digest drift fails closed; linked evidence is
+`36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb`; the
+wrapper timeout is exactly 720 seconds while the five budgets remain
+`5000/120000/100/500/500` ms; the malformed 62-character dispatch value is
+revoked, never authoritative, and never used; CK-07R1 remains blocked until
+the source-digest and run-invocation authorities are accepted, merged, and
+exact-main verified; every prior
 attempt and its identity/timestamp/failure remains visible; receipt
 `935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d` remains
 writer-only evidence and is never reused or upgraded.

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -531,7 +531,9 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     assert "strict Authority v2" in ck07r1a0
     assert "supersedes earlier CK-07R1 wording" in central
     assert "Blocked on CK-QG1A" in ckqg1
-    assert "Blocked pending the source-digest and run-invocation authorities" in ck07r1
+    assert "Blocked pending the reconciled source-digest/run-invocation authority" in ck07r1
+    assert "720-second wrapper timeout" in ck07r1a0
+    assert "revoked, never authoritative, and never used" in ck07r1a0
 
 
 def test_ck07r1a0_authority_is_strict_and_preserves_attempt_identity() -> None:
@@ -698,6 +700,29 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"
     )
     assert authority["selected_successor"]["status"] == "permitted_not_accepted"
+    assert authority["acceptance_state"] == {
+        "status": "reconciled_no_run",
+        "live_source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "selected_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "binding": "live_source_predecessor_to_selected_successor",
+        "runtime_acceptance": "not_claimed",
+        "worker_revalidation_required": True,
+        "linked_evidence": {
+            "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+            "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb",
+        },
+    }
+    assert authority["selected_successor"]["diff_identity"]["untracked"] == [
+        {
+            "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+            "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
+        },
+        {
+            "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+            "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac",
+        },
+    ]
     assert authority["allowed_scope"]["lifecycle_symbols"] == [
         "codex_usage_tracker.agent_kernel.publication.preparation._WriteSetPreparer._build_lifecycle"
     ]
@@ -722,7 +747,10 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     assert authority["package_ceilings_bytes"] == {"sdist": 2_000_000, "wheel": 1_000_000}
 
     source = _REPO_ROOT / authority["source_path"]
-    assert hashlib.sha256(source.read_bytes()).hexdigest() == authority["predecessor"]["sha256"]
+    assert hashlib.sha256(source.read_bytes()).hexdigest() == authority["acceptance_state"]["live_source_sha256"]
+    assert authority["acceptance_state"]["live_source_sha256"] == authority["predecessor"]["sha256"]
+    evidence = _REPO_ROOT / authority["acceptance_state"]["linked_evidence"]["path"]
+    assert hashlib.sha256(evidence.read_bytes()).hexdigest() == authority["acceptance_state"]["linked_evidence"]["sha256"]
     preserved = _REPO_ROOT / authority["preserved_authority"]["path"]
     assert hashlib.sha256(preserved.read_bytes()).hexdigest() == authority["preserved_authority"]["sha256"]
 
@@ -731,6 +759,9 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         ("selected_successor", "sha256", "0" * 64),
         ("selected_successor", "status", "accepted"),
         ("selected_successor", "base_sha", "0" * 40),
+        ("acceptance_state", "status", "accepted"),
+        ("acceptance_state", "selected_successor_sha256", "0" * 64),
+        ("acceptance_state", "runtime_acceptance", "accepted"),
         ("worker_revalidation", "different_digest", "allow"),
         ("preserved_authority", "writer_only_receipt_digest", "0" * 64),
         ("run_status", None, "authorized"),

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -700,6 +700,9 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"
     )
     assert authority["selected_successor"]["status"] == "permitted_not_accepted"
+    assert authority["selected_successor"]["retained_branch"] == "feature/ck-07r1-lifecycle-requalification-v3"
+    assert authority["selected_successor"]["retained_worktree"] == "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3"
+    assert authority["selected_successor"]["base_sha"] == "bdf545127b9cda20d22e00e9e9abb74c9550a470"
     assert authority["acceptance_state"] == {
         "status": "reconciled_no_run",
         "live_source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -73,7 +73,10 @@ def test_selected_candidate_and_aggregate_timeout_are_reconciled_without_runtime
     assert authority["status"] == "authority_reconciled_no_run"
     assert authority["selected_candidate"] == {
         "status": "reconciled_no_run",
-        "base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+        "base_sha": "bdf545127b9cda20d22e00e9e9abb74c9550a470",
+        "retained_branch": "feature/ck-07r1-lifecycle-requalification-v3",
+        "retained_worktree": "2026-08-01/codex-usage-tracker-ck07r1-lifecycle-requalification-v3",
+        "witness_status": "retained_uncommitted_read_only",
         "source_predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
         "source_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
         "runtime_acceptance": "not_claimed",
@@ -326,6 +329,20 @@ def test_dag_ledger_index_and_scope_bind_the_authority_without_new_task() -> Non
     assert "run-invocation authority" in ledger
     assert "CK-07R1" in central and "CK-07R1" in ledger
     assert authority["scope"]["authority_only_files"]
+    assert set(authority["scope"]["authority_only_files"]) == {
+        "docs/INDEX.md",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
+        "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md",
+        "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+        "scripts/check_kernel_scope.py",
+        "tests/kernel/test_documentation_authority.py",
+        "tests/kernel/test_lifecycle_run_invocation_authority.py",
+    }
     assert "scripts/benchmark_ck07r1_lifecycle_scale.py" in authority["scope"]["forbidden"]
     assert CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS == {
         "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -68,6 +68,57 @@ def test_command_cwd_interpreter_environment_and_output_are_exact() -> None:
     assert "fail closed" in launch["output"]["overwrite_rule"]
 
 
+def test_selected_candidate_and_aggregate_timeout_are_reconciled_without_runtime_acceptance() -> None:
+    authority = _authority()
+    assert authority["status"] == "authority_reconciled_no_run"
+    assert authority["selected_candidate"] == {
+        "status": "reconciled_no_run",
+        "base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+        "source_predecessor_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "source_successor_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "runtime_acceptance": "not_claimed",
+        "artifacts": [
+            {
+                "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+                "sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+                "role": "source",
+            },
+            {
+                "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+                "sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
+                "role": "benchmark",
+            },
+            {
+                "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+                "sha256": "a033e1c31f30784e321fdfe6dcce75460f89a02bc29beecfa40475f604deffac",
+                "role": "lifecycle_test",
+            },
+            {
+                "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+                "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb",
+                "role": "linked_evidence",
+            },
+        ],
+        "binding": "live_source_predecessor_to_selected_successor",
+        "worker_revalidation_required": True,
+    }
+    assert authority["launch_contract"]["aggregate_timeout"] == {
+        "seconds": 720,
+        "formula": "5 * 120 + 120",
+        "production_sample_count": 5,
+        "production_sample_budget_seconds": 120,
+        "publication_recovery_overhead_seconds": 120,
+        "scope": "wrapper_only",
+        "underlying_runtime_budgets_ms": {
+            "first_publication_30_day": 5000,
+            "production_all_time": 120000,
+            "no_change": 100,
+            "one_call_tail": 500,
+            "one_tool_tail": 500,
+        },
+    }
+
+
 def test_fixture_identity_vocabulary_and_static_file_shas_are_distinct_and_proven() -> None:
     identity = _authority()["launch_contract"]["fixture_identity"]
     assert set(identity["vocabulary"]) == {
@@ -76,6 +127,15 @@ def test_fixture_identity_vocabulary_and_static_file_shas_are_distinct_and_prove
         "workload_transition_digest",
     }
     assert identity["manifest"]["fixture_manifest_digest"] != identity["manifest"]["fixture_file_sha256"]
+    assert identity["rejected_dispatch_values"] == [
+        {
+            "value": "e8c79373697ebe2af5385dbb2899ae49cec61037c4a3b0909f91225128e0bc",
+            "length": 62,
+            "status": "revoked_never_authoritative",
+            "use": "never_used",
+            "reason": "malformed dispatch value; the canonical fixture file SHA-256 is 64 hexadecimal characters",
+        }
+    ]
     for item in identity["fixture_files"]:
         path = _ROOT / item["path"]
         assert path.is_file()
@@ -217,8 +277,8 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
         after_launch["failures"]
     )
     feasibility = authority["feasibility"]
-    assert feasibility["candidate_status"] == "cannot_support_one_explicit_launch_without_behavioral_implementation"
-    assert "prelaunch process exclusion" in feasibility["exact_blocker"]
+    assert feasibility["candidate_status"] == "remediated_no_run_runtime_unqualified"
+    assert "planner-valid receipt" in feasibility["exact_blocker"]
     assert feasibility["run_action"].startswith("do not execute")
 
 
@@ -229,6 +289,9 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
         ("cwd", ("launch_contract", "required_cwd"), "scripts"),
         ("fixture-vocabulary", ("launch_contract", "fixture_identity", "vocabulary", "fixture_file_sha256"), "manifest"),
         ("fixture-digest-binding", ("launch_contract", "fixture_identity", "manifest", "fixture_file_sha256"), "0" * 64),
+        ("aggregate-timeout", ("launch_contract", "aggregate_timeout", "seconds"), 120),
+        ("candidate-benchmark", ("selected_candidate", "artifacts", 1, "sha256"), "0" * 64),
+        ("rejected-dispatch", ("launch_contract", "fixture_identity", "rejected_dispatch_values", 0, "status"), "used"),
         ("output-overwrite", ("launch_contract", "output", "overwrite_rule"), "overwrite"),
         ("process-exclusion", ("launch_gates", "prelaunch", "required", 2), "process check omitted"),
         ("run-token-timing", ("run_token", "consumption"), "before launch"),


### PR DESCRIPTION

## What changed

- Reconciles the CK-07R1 lifecycle source-digest authority from the live predecessor to the retained successor, binding the supplied preparation, benchmark, lifecycle-test, and linked-evidence hashes.
- Freezes the selected-candidate/no-run state, revoked malformed dispatch value, and exact 720-second wrapper timeout while preserving the existing runtime budgets and historical identities.
- Updates packet/index/scope-facing documentation and exact negative authority tests.

## Why

The completed remediation produced a mechanically identifiable candidate, but it has not been runtime-accepted. This change closes the authority identities without claiming an end-to-end result, consuming the one-run gate, or changing harness/runtime behavior.

## Validation

- Focused authority/scope tests: 54 passed.
- `just v`: passed, including 1,368 tests, console typecheck/tests, invariants lane, Pyright, and release checks.
- `just vc`: passed, including package build and distribution checks.
- Bootstrap and GitNexus freshness checks passed.

## Gating and preservation

- No E2E/lifecycle qualification run was executed; the one-run token remains unspent and CK-07R1 remains blocked pending exact-main worker revalidation.
- PR #394 remains stale failed read-only; the writer-only receipt and all prior run identities remain preserved.
- After hosted CI passes, this PR requires squash merge only. Exact-main verification and any worker resumption remain separate gated steps.
