### PR TITLE
docs: freeze CK-07R1 lifecycle runtime state

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,10 +39,19 @@ revoked malformed dispatch value, 720-second wrapper timeout, evidence, token,
 and no-retry contract while preserving the 5000/120000/100/500/500 ms budgets.
 The candidate remains runtime-unqualified until the existing worker
 revalidates it from the accepted exact main and produces the planner-valid
-receipt. CK-07R1 remains blocked, no run token is consumed, no other successor
-is advanced, and the one-run gate remains unspent. Reclassification and
-maintainability remain open. The central authority is
+receipt. CK-07R1 is Conditional Ready after this authority's accepted
+merge/exact-main handoff, but no worker resumes from this authority task; no
+run token is consumed, no other successor is advanced, and the one-run gate
+remains unspent. Reclassification and maintainability remain open. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
+
+The finite source/runtime state machine is currently `authority_main`: the live
+predecessor may remain on authority main, while only the exact selected
+successor may enter worker prequalification. `post_single_run` is unavailable
+without a complete planner-valid receipt bound to its exact dynamic receipt and
+evidence identity, and `final_accepted` additionally requires the worker PR to
+be squash-merged and exact-main verified. No state transition claims runtime
+qualification in this authority.
 
 ## Authority set
 

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,9 +1,123 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v1",
-  "authority_version": 1,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v2",
+  "authority_version": 2,
   "owner": "CK-07R1A0",
-  "authority_base_sha": "e0ee9f2cf442399633d93e402d17f527da604f0f",
+  "authority_base_sha": "a0d8770bad7d59b92b3f299186bfefa28bd5457c",
   "status": "authority_reconciled_no_run",
+  "lifecycle_state_machine": {
+    "current_state": "authority_main",
+    "states": [
+      {
+        "name": "authority_main",
+        "source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "source_role": "live_predecessor",
+        "runtime_acceptance": "not_claimed",
+        "receipt_policy": "receipt_absent_and_non_qualifying",
+        "evidence_identity_policy": "not_available",
+        "merge_policy": "current_authority_state"
+      },
+      {
+        "name": "worker_prequalification",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "not_claimed",
+        "receipt_policy": "not_yet_available",
+        "evidence_identity_policy": "not_available",
+        "merge_policy": "authority_merge_and_exact_main_required_before_entry"
+      },
+      {
+        "name": "post_single_run",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "qualified_only_with_complete_planner_valid_receipt",
+        "receipt_policy": "complete_planner_valid_receipt_required",
+        "evidence_identity_policy": "bind_exact_dynamic_receipt_and_evidence_identity",
+        "merge_policy": "worker_merge_and_exact_main_required_for_final_acceptance"
+      },
+      {
+        "name": "final_accepted",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "accepted_only_with_worker_merge_and_exact_main",
+        "receipt_policy": "same_complete_planner_valid_receipt_identity_required",
+        "evidence_identity_policy": "same_exact_dynamic_receipt_and_evidence_identity",
+        "merge_policy": "worker_pr_squash_merge_and_exact_main_verification_required"
+      }
+    ],
+    "transitions": [
+      {
+        "from": "authority_main",
+        "to": "worker_prequalification",
+        "requires": [
+          "this authority is merged and exact-main verified",
+          "the existing worker starts from that exact main in a fresh worktree",
+          "the worker deliberately reapplies only the exact selected successor over the live predecessor",
+          "runtime_acceptance remains not_claimed",
+          "authority-integrity and prelaunch gates pass",
+          "maximum_new_end_to_end_runs remains 1 and unspent"
+        ]
+      },
+      {
+        "from": "worker_prequalification",
+        "to": "post_single_run",
+        "requires": [
+          "only the exact selected successor digest is present",
+          "exact prelaunch gates pass and one child launch consumes the run token",
+          "a complete planner-valid receipt is produced",
+          "receipt schema, static identities, workload_transition_digest, and stdout/stderr/output evidence identities validate",
+          "no retry, restart, or replacement occurs"
+        ]
+      },
+      {
+        "from": "post_single_run",
+        "to": "final_accepted",
+        "requires": [
+          "the worker PR is squash-merged",
+          "exact-main verification matches the merged worker contents",
+          "the same complete receipt and evidence identity remains bound"
+        ]
+      }
+    ],
+    "dynamic_receipt_identity": {
+      "required_fields": [
+        "run_token_id",
+        "receipt_schema",
+        "workload_transition_digest",
+        "publication_digest",
+        "ledger_file_sha256",
+        "stdout_sha256",
+        "stderr_sha256",
+        "output_sha256",
+        "launch_pid",
+        "launch_cwd",
+        "launch_argv"
+      ],
+      "identity_paths": {
+        "run_token_id": "ledger.run_token_id",
+        "receipt_schema": "ledger.receipt.schema",
+        "workload_transition_digest": "ledger.receipt.workload_transition_digest",
+        "publication_digest": "ledger.receipt.publication_digest",
+        "ledger_file_sha256": "sha256(exact ledger file bytes at output/ck07r1/lifecycle-requalification-v1.launch-token.json)",
+        "stdout_sha256": "ledger.evidence.stdout_sha256",
+        "stderr_sha256": "ledger.evidence.stderr_sha256",
+        "output_sha256": "ledger.evidence.output_sha256",
+        "launch_pid": "ledger.process.pid",
+        "launch_cwd": "ledger.process.cwd",
+        "launch_argv": "ledger.process.argv"
+      },
+      "ledger_path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "source": "the frozen launch ledger plus exact stdout, stderr, and output evidence; ledger_file_sha256 is computed from the final ledger bytes",
+      "binding": "post_single_run is unavailable until every required field is present and validated",
+      "mismatch": "fail_closed"
+    },
+    "forbidden_transitions": [
+      "authority_main->post_single_run",
+      "authority_main->final_accepted",
+      "worker_prequalification->final_accepted",
+      "any state with an unbound or incomplete receipt->post_single_run",
+      "any state without worker PR merge and exact-main verification->final_accepted"
+    ]
+  },
   "selected_candidate": {
     "status": "reconciled_no_run",
     "base_sha": "bdf545127b9cda20d22e00e9e9abb74c9550a470",
@@ -47,9 +161,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "ca5391783df001447a1399c78113fcc26ef818c4bfdfd59e5a28e6e80f81ce16",
+      "sha256": "d2c30e11792589c1c66016a253aeaa410247b75f26f5e7be9b258bf7784447d4",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "e8cc1f0ab316fcb840339c8ce607c8170e94c00f2627bb99a6905f34feff50b2"
+      "schema_sha256": "4a171e1ba4d626998a9846cec3c314b304b823e9242e27054a306c2560ddd97c"
     }
   },
   "launch_contract": {

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v1.schema.json",
-  "title": "CK-07R1A0 lifecycle run-invocation authority",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v2.schema.json",
+  "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -10,6 +10,7 @@
     "owner",
     "authority_base_sha",
     "status",
+    "lifecycle_state_machine",
     "selected_candidate",
     "preserved_authorities",
     "launch_contract",
@@ -21,11 +22,123 @@
     "scope"
   ],
   "properties": {
-    "schema": {"const": "codex-usage-tracker.lifecycle-run-invocation-authority.v1"},
-    "authority_version": {"const": 1},
+    "schema": {"const": "codex-usage-tracker.lifecycle-run-invocation-authority.v2"},
+    "authority_version": {"const": 2},
     "owner": {"const": "CK-07R1A0"},
-    "authority_base_sha": {"const": "e0ee9f2cf442399633d93e402d17f527da604f0f"},
+    "authority_base_sha": {"const": "a0d8770bad7d59b92b3f299186bfefa28bd5457c"},
     "status": {"const": "authority_reconciled_no_run"},
+    "lifecycle_state_machine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current_state", "states", "transitions", "dynamic_receipt_identity", "forbidden_transitions"],
+      "properties": {
+        "current_state": {"const": "authority_main"},
+        "states": {
+          "const": [
+            {
+              "name": "authority_main",
+              "source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+              "source_role": "live_predecessor",
+              "runtime_acceptance": "not_claimed",
+              "receipt_policy": "receipt_absent_and_non_qualifying",
+              "evidence_identity_policy": "not_available",
+              "merge_policy": "current_authority_state"
+            },
+            {
+              "name": "worker_prequalification",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "not_claimed",
+              "receipt_policy": "not_yet_available",
+              "evidence_identity_policy": "not_available",
+              "merge_policy": "authority_merge_and_exact_main_required_before_entry"
+            },
+            {
+              "name": "post_single_run",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "qualified_only_with_complete_planner_valid_receipt",
+              "receipt_policy": "complete_planner_valid_receipt_required",
+              "evidence_identity_policy": "bind_exact_dynamic_receipt_and_evidence_identity",
+              "merge_policy": "worker_merge_and_exact_main_required_for_final_acceptance"
+            },
+            {
+              "name": "final_accepted",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "accepted_only_with_worker_merge_and_exact_main",
+              "receipt_policy": "same_complete_planner_valid_receipt_identity_required",
+              "evidence_identity_policy": "same_exact_dynamic_receipt_and_evidence_identity",
+              "merge_policy": "worker_pr_squash_merge_and_exact_main_verification_required"
+            }
+          ]
+        },
+        "transitions": {
+          "const": [
+            {
+              "from": "authority_main",
+              "to": "worker_prequalification",
+              "requires": [
+                "this authority is merged and exact-main verified",
+                "the existing worker starts from that exact main in a fresh worktree",
+                "the worker deliberately reapplies only the exact selected successor over the live predecessor",
+                "runtime_acceptance remains not_claimed",
+                "authority-integrity and prelaunch gates pass",
+                "maximum_new_end_to_end_runs remains 1 and unspent"
+              ]
+            },
+            {
+              "from": "worker_prequalification",
+              "to": "post_single_run",
+              "requires": [
+                "only the exact selected successor digest is present",
+                "exact prelaunch gates pass and one child launch consumes the run token",
+                "a complete planner-valid receipt is produced",
+                "receipt schema, static identities, workload_transition_digest, and stdout/stderr/output evidence identities validate",
+                "no retry, restart, or replacement occurs"
+              ]
+            },
+            {
+              "from": "post_single_run",
+              "to": "final_accepted",
+              "requires": [
+                "the worker PR is squash-merged",
+                "exact-main verification matches the merged worker contents",
+                "the same complete receipt and evidence identity remains bound"
+              ]
+            }
+          ]
+        },
+        "dynamic_receipt_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required_fields", "identity_paths", "ledger_path", "source", "binding", "mismatch"],
+          "properties": {
+            "required_fields": {"const": ["run_token_id", "receipt_schema", "workload_transition_digest", "publication_digest", "ledger_file_sha256", "stdout_sha256", "stderr_sha256", "output_sha256", "launch_pid", "launch_cwd", "launch_argv"]},
+            "identity_paths": {
+              "const": {
+                "run_token_id": "ledger.run_token_id",
+                "receipt_schema": "ledger.receipt.schema",
+                "workload_transition_digest": "ledger.receipt.workload_transition_digest",
+                "publication_digest": "ledger.receipt.publication_digest",
+                "ledger_file_sha256": "sha256(exact ledger file bytes at output/ck07r1/lifecycle-requalification-v1.launch-token.json)",
+                "stdout_sha256": "ledger.evidence.stdout_sha256",
+                "stderr_sha256": "ledger.evidence.stderr_sha256",
+                "output_sha256": "ledger.evidence.output_sha256",
+                "launch_pid": "ledger.process.pid",
+                "launch_cwd": "ledger.process.cwd",
+                "launch_argv": "ledger.process.argv"
+              }
+            },
+            "ledger_path": {"const": "output/ck07r1/lifecycle-requalification-v1.launch-token.json"},
+            "source": {"const": "the frozen launch ledger plus exact stdout, stderr, and output evidence; ledger_file_sha256 is computed from the final ledger bytes"},
+            "binding": {"const": "post_single_run is unavailable until every required field is present and validated"},
+            "mismatch": {"const": "fail_closed"}
+          }
+        },
+        "forbidden_transitions": {"const": ["authority_main->post_single_run", "authority_main->final_accepted", "worker_prequalification->final_accepted", "any state with an unbound or incomplete receipt->post_single_run", "any state without worker PR merge and exact-main verification->final_accepted"]}
+      }
+    },
     "selected_candidate": {
       "type": "object",
       "additionalProperties": false,
@@ -93,9 +206,9 @@
           "required": ["path", "sha256", "schema_path", "schema_sha256"],
           "properties": {
             "path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"},
-            "sha256": {"const": "ca5391783df001447a1399c78113fcc26ef818c4bfdfd59e5a28e6e80f81ce16"},
+            "sha256": {"const": "d2c30e11792589c1c66016a253aeaa410247b75f26f5e7be9b258bf7784447d4"},
             "schema_path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"},
-            "schema_sha256": {"const": "e8cc1f0ab316fcb840339c8ce607c8170e94c00f2627bb99a6905f34feff50b2"}
+            "schema_sha256": {"const": "4a171e1ba4d626998a9846cec3c314b304b823e9242e27054a306c2560ddd97c"}
           }
         }
       }
@@ -192,15 +305,60 @@
               }
             },
             "fixture_files": {
-              "type": "array", "minItems": 13, "maxItems": 13,
-              "items": {
-                "type": "object", "additionalProperties": false,
-                "required": ["path", "fixture_file_sha256"],
-                "properties": {
-                  "path": {"type": "string"},
-                  "fixture_file_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+              "const": [
+                {
+                  "path": "tests/agent_kernel/fixtures/profiles/standard-v1.json",
+                  "fixture_file_sha256": "ef0da880255a0b13ea6055e0f8d748870c075635aa6f199c9521462c681250f3"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/profiles/production-v1.json",
+                  "fixture_file_sha256": "2de0b4dc198603da6c1b0905b8d934e2cd5604e4036ef009d0cd07f1cc81f51b"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0000.jsonl",
+                  "fixture_file_sha256": "bad29500048dcff994d4211ff6de446c48d51184ab00caa134a7d668a6e57191"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0001.jsonl",
+                  "fixture_file_sha256": "d3ddb9592d67f058b7b7b354c7e01ff159d195c3963e0780be7a4cf35ec9a5eb"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0002.jsonl",
+                  "fixture_file_sha256": "114dadd49888fe77bfa1690b0fb810820950dea80d04ff11b233cd14bab54605"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0003.jsonl",
+                  "fixture_file_sha256": "12ccb3114f5f4583e98e6e0d8a485b2c1479762b93cd8e6008c9be14edfd2a5d"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0004.jsonl",
+                  "fixture_file_sha256": "0729952c7d2c250608ac0913a9d4a879c09b3bf252d86ee84b6b333000b66514"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0005.jsonl",
+                  "fixture_file_sha256": "cbfdfbb7f0f463c087c058b0f49cfdb6ec0ff72da5afa14d293b06a3f2ee817f"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/active/source-0006.jsonl",
+                  "fixture_file_sha256": "f7693618223a2de73d5dcfc0c645f13455c480a721641b4d790c278744283729"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/archived/exact-copy.jsonl",
+                  "fixture_file_sha256": "34709a9e5b6c52438f7c5710c9480db9a2641fbd33e25d8e6c767c383502a65f"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/malformed/malformed.jsonl",
+                  "fixture_file_sha256": "cdfbf46b0d9524c5c9b16b6672eb98cd9f1b413703cd75f8ca9b833e96e5ac4d"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/replaced/revision-1.jsonl",
+                  "fixture_file_sha256": "de66394d849cab6e4936af84b4991e36c1cdf6746f0ab90c7c39dd1ca10761e1"
+                },
+                {
+                  "path": "tests/agent_kernel/fixtures/tiny-v1/sources/truncated/truncated.jsonl",
+                  "fixture_file_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 }
-              }
+              ]
             },
             "dynamic_digest": {
               "type": "object", "additionalProperties": false,

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,8 +1,8 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v1",
-  "authority_version": 1,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v2",
+  "authority_version": 2,
   "owner": "CK-07R1A0",
-  "authority_base_sha": "d911b1f0d17596890a6a0a608be904330c96e9a6",
+  "authority_base_sha": "a0d8770bad7d59b92b3f299186bfefa28bd5457c",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
   "acceptance_state": {
     "status": "reconciled_no_run",
@@ -16,6 +16,41 @@
       "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
       "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"
     }
+  },
+  "state_machine_binding": {
+    "run_authority_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+    "run_authority_schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+    "current_state": "authority_main",
+    "states": [
+      {
+        "name": "authority_main",
+        "source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "source_role": "live_predecessor",
+        "runtime_acceptance": "not_claimed"
+      },
+      {
+        "name": "worker_prequalification",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "not_claimed"
+      },
+      {
+        "name": "post_single_run",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "qualified_only_with_complete_planner_valid_receipt"
+      },
+      {
+        "name": "final_accepted",
+        "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+        "source_role": "selected_successor",
+        "runtime_acceptance": "accepted_only_with_worker_merge_and_exact_main"
+      }
+    ],
+    "source_digest_rule": "authority_main may retain only the live predecessor; worker_prequalification and every later state permit only the exact selected successor",
+    "other_digest": "fail_closed",
+    "preserved_path_authority": "lifecycle-path-authority remains retained read-only path semantics and does not advance the current worker state",
+    "current_runtime_claim": "not_claimed"
   },
   "predecessor": {
     "sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v1.schema.json",
-  "title": "CK-07R1A0 lifecycle source-digest supersession authority",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v2.schema.json",
+  "title": "CK-07R1A0 lifecycle source-digest and runtime state authority",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -11,6 +11,7 @@
     "authority_base_sha",
     "source_path",
     "acceptance_state",
+    "state_machine_binding",
     "predecessor",
     "selected_successor",
     "allowed_scope",
@@ -26,10 +27,10 @@
     "constraints"
   ],
   "properties": {
-    "schema": {"const": "codex-usage-tracker.lifecycle-source-digest-authority.v1"},
-    "authority_version": {"const": 1},
+    "schema": {"const": "codex-usage-tracker.lifecycle-source-digest-authority.v2"},
+    "authority_version": {"const": 2},
     "owner": {"const": "CK-07R1A0"},
-    "authority_base_sha": {"const": "d911b1f0d17596890a6a0a608be904330c96e9a6"},
+    "authority_base_sha": {"const": "a0d8770bad7d59b92b3f299186bfefa28bd5457c"},
     "source_path": {"const": "src/codex_usage_tracker/agent_kernel/publication/preparation.py"},
     "acceptance_state": {
       "type": "object",
@@ -56,6 +57,57 @@
             "sha256": {"const": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"}
           }
         }
+      }
+    },
+    "state_machine_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_authority_path",
+        "run_authority_schema_path",
+        "current_state",
+        "states",
+        "source_digest_rule",
+        "other_digest",
+        "preserved_path_authority",
+        "current_runtime_claim"
+      ],
+      "properties": {
+        "run_authority_path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json"},
+        "run_authority_schema_path": {"const": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json"},
+        "current_state": {"const": "authority_main"},
+        "states": {
+          "const": [
+            {
+              "name": "authority_main",
+              "source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+              "source_role": "live_predecessor",
+              "runtime_acceptance": "not_claimed"
+            },
+            {
+              "name": "worker_prequalification",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "not_claimed"
+            },
+            {
+              "name": "post_single_run",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "qualified_only_with_complete_planner_valid_receipt"
+            },
+            {
+              "name": "final_accepted",
+              "source_sha256": "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1",
+              "source_role": "selected_successor",
+              "runtime_acceptance": "accepted_only_with_worker_merge_and_exact_main"
+            }
+          ]
+        },
+        "source_digest_rule": {"const": "authority_main may retain only the live predecessor; worker_prequalification and every later state permit only the exact selected successor"},
+        "other_digest": {"const": "fail_closed"},
+        "preserved_path_authority": {"const": "lifecycle-path-authority remains retained read-only path semantics and does not advance the current worker state"},
+        "current_runtime_claim": {"const": "not_claimed"}
       }
     },
     "predecessor": {

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -25,9 +25,9 @@ behavior or the frozen maintainability baseline.
 CK-07R1A is accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 is accepted at the
 current exact main `519b503aa3b23019033b6481687c08b23fc6c31e`; its linked
-source-digest and run-invocation authorities reconcile the no-run candidate
-from exact main `bdf545127b9cda20d22e00e9e9abb74c9550a470` and are authority
-documentation only. PR #394 is a stale failed witness: head
+path authority remains preserved read-only while the finite source/runtime
+state authority reconciles the no-run candidate from exact main
+`bdf545127b9cda20d22e00e9e9abb74c9550a470`. PR #394 is a stale failed witness: head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` failed the hosted Python 3.14
 `ordinary.2000_call_tail` gate and is superseded read-only. It must not be
 updated, rerun, or merged. The planner-valid lifecycle receipt is an
@@ -35,10 +35,15 @@ acceptance output of the existing CK-07R1 worker only after it revalidates the
 retained candidate on the source-digest and run-invocation authorities' exact
 merged main; the run-invocation authority is not a pre-dispatch dependency.
 The first sample, 720-second wrapper timeout, all five underlying budgets,
-one-run ceiling, and every fail-closed rule remain binding. CK-07R1 is blocked
-until both authorities are accepted, merged, and exact-main verified; after
-that exact-main handoff only the existing worker may be resumed for its
-required revalidation. Earlier wording that says to resume, refresh, or rerun PR #394 is
+one-run ceiling, and every fail-closed rule remain binding. CK-07R1 is
+Conditional Ready only after both authorities are accepted, merged, and
+exact-main verified; until then its current authority state is `authority_main`
+and no worker may resume. After that exact-main handoff only the existing
+worker may be resumed for its required revalidation. The worker may enter
+`worker_prequalification` only with the exact selected successor,
+`post_single_run` only with a complete planner-valid receipt and bound dynamic
+evidence identity, and `final_accepted` only after worker merge and exact-main
+verification. Earlier wording that says to resume, refresh, or rerun PR #394 is
 historical provenance and does not authorize action. This source-digest
 authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not
@@ -117,8 +122,11 @@ conditions in the table and child files; they are not unconditional DAG edges.
   }, {
     "condition": "CK-QG1A0 merged and exact-main verified",
     "tasks": ["CK-QG1A"]
+  }, {
+    "condition": "Finite CK-07R1 source/runtime authority accepted, merged, and exact-main verified; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement or downstream task",
+    "tasks": ["CK-07R1"]
   }],
-  "blocked": ["CK-07R1"],
+  "blocked": [],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},
     {"id": "CK-08R1A", "file": "tasks/ck-08r1a-freeze-answer-semantics.md", "dependencies": ["CK-08R0"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,8 +15,8 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **5 — CK-08R0, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **45**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **3 — CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
-- Blocked child tasks: **42 — CK-07R1 pending this reconciled source-digest/run-invocation authority merge and exact-main handoff**
+- Conditional-ready child tasks: **4 — CK-07R1 after finite source/runtime authority exact-main verification; CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
+- Blocked child tasks: **41**
 
 ## Parent packets
 
@@ -61,8 +61,8 @@ other corrective locks are unchanged.
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
 - [ ] **CK-08R3 — Qualify evidence service scale** · Blocked on CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
-- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Completed on merge; exact-main verified at `519b503a`; reconciled source-digest/run-invocation authority is pending its own merge/exact-main verification · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked pending this authority's merge/exact-main handoff; revalidate the retained candidate only on exact merged main; planner-valid receipt is a successor acceptance output and PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path authority completed on merge; finite source/runtime state remains pending, and the run-invocation authority remains pending its own merge/exact-main verification · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after this authority's merge/exact-main handoff; current state remains `authority_main`; revalidate the retained candidate only on exact merged main; planner-valid receipt is a successor acceptance output and PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,6 +1,6 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** Blocked pending the reconciled source-digest/run-invocation authority merging and exact-main verification; worker pre-run gates remain required
+**Status:** Conditional Ready after the finite source/runtime state authority is accepted, merged, and exact-main verified; current state remains `authority_main` and worker pre-run gates remain required
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -23,9 +23,9 @@ contracts.
 
 **Dependencies:** CK-07R1A accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 path authority accepted
-at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`; and the linked
-reconciled source-digest/run-invocation authority accepted, merged, and
-exact-main verified. The worker
+at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`; and the linked finite
+source/runtime state authority (including the run-invocation authority) accepted,
+merged, and exact-main verified. The worker
 must then start from that exact merged main and reapply the retained candidate,
 revalidating predecessor and successor digests before any end-to-end run. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed read-only
@@ -35,7 +35,9 @@ witness and is not refreshed, rerun, or merged.
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the authority reconciliation binds preparation `d192c858…`, benchmark
 `6a864c74…`, lifecycle test `a033e1c3…`, linked evidence `36eb76ca…`, and the
-720-second wrapper timeout without executing the worker.
+720-second wrapper timeout without executing the worker. The authority state is
+currently `authority_main`; worker prequalification accepts only the exact
+selected successor and does not claim runtime acceptance.
 
 **Produces:** Publication-scale requalification with equivalent fold identity.
 
@@ -60,7 +62,8 @@ bounded RSS; synthetic data; no writer recovery regression.
 
 **Required tests/checks:** Focused lifecycle/publication, equivalent results,
 standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
-`just v/vc`; authority/schema/DAG/scope negative checks; no E2E run in the
+`just v/vc`; authority/schema/DAG/scope negative checks covering the finite
+state transitions; no E2E run in the
 authority reconciliation.
 
 **Acceptance:** Work is linear in observations plus prior transitions and all

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -1,6 +1,6 @@
 # CK-07R1A0 — Freeze lifecycle planner/recovery path authority
 
-**Status:** Completed on merge; exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`; reconciled source-digest and run-invocation authority is pending merge and exact-main verification, so the existing CK-07R1 worker remains held
+**Status:** Completed on merge; path authority exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`; finite source/runtime state authority is pending merge and exact-main verification, so the existing CK-07R1 worker remains held
 
 **Release-candidate package ceilings:** sdist remains at most 2,000,000
 bytes and wheel remains at most 1,000,000 bytes. The historical 828000/383000
@@ -43,7 +43,8 @@ The linked run-invocation authority is
 it adds no runtime implementation, freezes the 720-second wrapper timeout, and
 keeps the retained candidate runtime-unqualified.
 
-**Produces:** A frozen entry-path contract, APPEND_SAFE_SMALL selection rule,
+**Produces:** A frozen entry-path contract, finite source/runtime state machine,
+APPEND_SAFE_SMALL selection rule,
 independent lifecycle oracle/postconditions, exact source/diff identity,
 allowed lifecycle symbol/file scope, one-run authorization condition,
 preserved attempt ledger, and exact worker revalidation requirements.
@@ -80,12 +81,15 @@ or different digest drift fails closed; linked evidence is
 `36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb`; the
 wrapper timeout is exactly 720 seconds while the five budgets remain
 `5000/120000/100/500/500` ms; the malformed 62-character dispatch value is
-revoked, never authoritative, and never used; CK-07R1 remains blocked until
-the source-digest and run-invocation authorities are accepted, merged, and
-exact-main verified; every prior
-attempt and its identity/timestamp/failure remains visible; receipt
+revoked, never authoritative, and never used; the source-digest and
+run-invocation authorities must be accepted, merged, and exact-main verified
+before CK-07R1 is Conditional Ready; every prior attempt and its
+identity/timestamp/failure remains visible; receipt
 `935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d` remains
 writer-only evidence and is never reused or upgraded.
+The current finite state is `authority_main`; no worker resumes from this
+packet, no receipt can claim qualification, and final acceptance additionally
+requires worker PR merge and exact-main verification.
 
 **Required tests/checks:** Strict authority-schema and negative-mutation tests;
 DAG/ledger/status tests; exact scope-manifest tests; evidence identity and
@@ -96,7 +100,7 @@ exact-main verification.
 **Acceptance:** The authority artifact validates, exact identities and run
 accounting are preserved, only the retained CK-07R1 authority additions are
 bound, the stale failed PR #394 is explicitly superseded read-only, and CK-07R1
-remains blocked until the linked authorities merge and exact-main
+is Conditional Ready only after the linked authorities merge and exact-main
 verification. The planner-valid receipt is a future successor acceptance
 output, not a pre-dispatch dependency. This packet does not run or authorize a
 production qualification run by itself.

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -176,8 +176,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     manifest = json.loads(manifest_match.group(1))
     assert manifest["schema"] == "codex-usage-tracker.remaining-delegation-dag.v1"
     assert manifest["orchestration"]["spawn"] == "all_newly_ready_successors"
-    conditional_ready = {"CK-08R1A", "CK-08R3A", "CK-QG1A"}
-    blocked = {"CK-07R1"}
+    conditional_ready = {"CK-07R1", "CK-08R1A", "CK-08R3A", "CK-QG1A"}
+    blocked: set[str] = set()
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R2",
@@ -198,12 +198,19 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             "condition": "CK-QG1A0 merged and exact-main verified",
             "tasks": ["CK-QG1A"],
         },
+        {
+            "condition": (
+                "Finite CK-07R1 source/runtime authority accepted, merged, and exact-main verified; "
+                "resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement or downstream task"
+            ),
+            "tasks": ["CK-07R1"],
+        },
     ]
-    assert manifest["blocked"] == ["CK-07R1"]
+    assert manifest["blocked"] == []
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Blocked child tasks: **42" in ledger
+    assert "Blocked child tasks: **41" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -519,7 +526,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
                 "fold_lifecycle",
                 "935e4427b93e67c5ca649b773b0b3895dafac87f49bc76d7ed8917dff2f0250d",
                 "one-run authorization condition",
-                "CK-07R1 remains blocked",
+                "CK-07R1 is Conditional Ready",
                 "run-invocation authority",
                 "The planner-valid receipt is a future successor acceptance",
                 "stale failed PR #394 is explicitly superseded read-only",
@@ -531,7 +538,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     assert "strict Authority v2" in ck07r1a0
     assert "supersedes earlier CK-07R1 wording" in central
     assert "Blocked on CK-QG1A" in ckqg1
-    assert "Blocked pending the reconciled source-digest/run-invocation authority" in ck07r1
+    assert "Conditional Ready after the finite source/runtime state authority" in ck07r1
     assert "720-second wrapper timeout" in ck07r1a0
     assert "revoked, never authoritative, and never used" in ck07r1a0
 
@@ -693,6 +700,9 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v2"
+    assert authority["authority_version"] == 2
+    assert authority["authority_base_sha"] == "a0d8770bad7d59b92b3f299186bfefa28bd5457c"
     assert authority["predecessor"]["sha256"] == (
         "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872"
     )
@@ -749,6 +759,21 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     }
     assert authority["package_ceilings_bytes"] == {"sdist": 2_000_000, "wheel": 1_000_000}
 
+    binding = authority["state_machine_binding"]
+    assert binding["current_state"] == "authority_main"
+    assert [state["name"] for state in binding["states"]] == [
+        "authority_main",
+        "worker_prequalification",
+        "post_single_run",
+        "final_accepted",
+    ]
+    assert binding["states"][0]["source_sha256"] == authority["predecessor"]["sha256"]
+    assert binding["states"][1]["source_sha256"] == authority["selected_successor"]["sha256"]
+    assert binding["states"][1]["runtime_acceptance"] == "not_claimed"
+    assert binding["other_digest"] == "fail_closed"
+    assert binding["current_runtime_claim"] == "not_claimed"
+    assert "does not advance" in binding["preserved_path_authority"]
+
     source = _REPO_ROOT / authority["source_path"]
     assert hashlib.sha256(source.read_bytes()).hexdigest() == authority["acceptance_state"]["live_source_sha256"]
     assert authority["acceptance_state"]["live_source_sha256"] == authority["predecessor"]["sha256"]
@@ -768,6 +793,8 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         ("worker_revalidation", "different_digest", "allow"),
         ("preserved_authority", "writer_only_receipt_digest", "0" * 64),
         ("run_status", None, "authorized"),
+        ("state_machine_binding", "current_state", "worker_prequalification"),
+        ("state_machine_binding", "other_digest", "allow"),
     ):
         changed = json.loads(json.dumps(authority))
         if field is None:
@@ -775,6 +802,14 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         else:
             changed[section][field] = value
         assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["state_machine_binding"]["states"][0]["source_sha256"] = authority["selected_successor"]["sha256"]
+    assert list(validator.iter_errors(changed))
+
+    changed = json.loads(json.dumps(authority))
+    changed["state_machine_binding"]["states"][1]["source_sha256"] = "0" * 64
+    assert list(validator.iter_errors(changed))
 
     changed = json.loads(json.dumps(authority))
     changed["allowed_scope"]["files"].append(

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -71,6 +71,7 @@ def test_command_cwd_interpreter_environment_and_output_are_exact() -> None:
 def test_selected_candidate_and_aggregate_timeout_are_reconciled_without_runtime_acceptance() -> None:
     authority = _authority()
     assert authority["status"] == "authority_reconciled_no_run"
+    assert authority["authority_base_sha"] == "a0d8770bad7d59b92b3f299186bfefa28bd5457c"
     assert authority["selected_candidate"] == {
         "status": "reconciled_no_run",
         "base_sha": "bdf545127b9cda20d22e00e9e9abb74c9550a470",
@@ -120,6 +121,124 @@ def test_selected_candidate_and_aggregate_timeout_are_reconciled_without_runtime
             "one_tool_tail": 500,
         },
     }
+
+
+def test_finite_source_runtime_state_machine_is_exact_and_currently_unlaunched() -> None:
+    machine = _authority()["lifecycle_state_machine"]
+    assert machine["current_state"] == "authority_main"
+    assert [state["name"] for state in machine["states"]] == [
+        "authority_main",
+        "worker_prequalification",
+        "post_single_run",
+        "final_accepted",
+    ]
+    assert machine["states"][0] == {
+        "name": "authority_main",
+        "source_sha256": "408d18e44c87da234d220c29298ebac1780e9426e2dce767b0bfc3ae65e8a872",
+        "source_role": "live_predecessor",
+        "runtime_acceptance": "not_claimed",
+        "receipt_policy": "receipt_absent_and_non_qualifying",
+        "evidence_identity_policy": "not_available",
+        "merge_policy": "current_authority_state",
+    }
+    assert machine["states"][1]["source_sha256"] == (
+        "d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1"
+    )
+    assert machine["states"][1]["runtime_acceptance"] == "not_claimed"
+    assert machine["states"][2]["receipt_policy"] == "complete_planner_valid_receipt_required"
+    assert machine["states"][2]["evidence_identity_policy"] == (
+        "bind_exact_dynamic_receipt_and_evidence_identity"
+    )
+    assert machine["states"][3]["merge_policy"] == (
+        "worker_pr_squash_merge_and_exact_main_verification_required"
+    )
+    assert [transition["from"] + "->" + transition["to"] for transition in machine["transitions"]] == [
+        "authority_main->worker_prequalification",
+        "worker_prequalification->post_single_run",
+        "post_single_run->final_accepted",
+    ]
+    assert machine["dynamic_receipt_identity"]["required_fields"] == [
+        "run_token_id",
+        "receipt_schema",
+        "workload_transition_digest",
+        "publication_digest",
+        "ledger_file_sha256",
+        "stdout_sha256",
+        "stderr_sha256",
+        "output_sha256",
+        "launch_pid",
+        "launch_cwd",
+        "launch_argv",
+    ]
+    assert machine["dynamic_receipt_identity"]["ledger_path"] == (
+        "output/ck07r1/lifecycle-requalification-v1.launch-token.json"
+    )
+    assert machine["dynamic_receipt_identity"]["identity_paths"] == {
+        "run_token_id": "ledger.run_token_id",
+        "receipt_schema": "ledger.receipt.schema",
+        "workload_transition_digest": "ledger.receipt.workload_transition_digest",
+        "publication_digest": "ledger.receipt.publication_digest",
+        "ledger_file_sha256": (
+            "sha256(exact ledger file bytes at "
+            "output/ck07r1/lifecycle-requalification-v1.launch-token.json)"
+        ),
+        "stdout_sha256": "ledger.evidence.stdout_sha256",
+        "stderr_sha256": "ledger.evidence.stderr_sha256",
+        "output_sha256": "ledger.evidence.output_sha256",
+        "launch_pid": "ledger.process.pid",
+        "launch_cwd": "ledger.process.cwd",
+        "launch_argv": "ledger.process.argv",
+    }
+    assert machine["dynamic_receipt_identity"]["mismatch"] == "fail_closed"
+    assert "authority_main->final_accepted" in machine["forbidden_transitions"]
+
+
+def test_dynamic_receipt_identity_uses_only_frozen_ledger_paths() -> None:
+    identity = _authority()["lifecycle_state_machine"]["dynamic_receipt_identity"]
+    ledger = {
+        "run_token_id": "synthetic-run-token",
+        "receipt": {
+            "schema": "synthetic-receipt-schema",
+            "workload_transition_digest": "a" * 64,
+            "publication_digest": "b" * 64,
+        },
+        "evidence": {
+            "stdout_sha256": "c" * 64,
+            "stderr_sha256": "d" * 64,
+            "output_sha256": "e" * 64,
+        },
+        "process": {
+            "pid": 123,
+            "cwd": "/synthetic/repository",
+            "argv": [".venv/bin/python", "scripts/benchmark_ck07r1_lifecycle_scale.py"],
+        },
+    }
+    resolved_fields = {
+        "run_token_id": ledger["run_token_id"],
+        "receipt_schema": ledger["receipt"]["schema"],
+        "workload_transition_digest": ledger["receipt"]["workload_transition_digest"],
+        "publication_digest": ledger["receipt"]["publication_digest"],
+        "stdout_sha256": ledger["evidence"]["stdout_sha256"],
+        "stderr_sha256": ledger["evidence"]["stderr_sha256"],
+        "output_sha256": ledger["evidence"]["output_sha256"],
+        "launch_pid": ledger["process"]["pid"],
+        "launch_cwd": ledger["process"]["cwd"],
+        "launch_argv": ledger["process"]["argv"],
+    }
+    assert resolved_fields == {
+        "run_token_id": "synthetic-run-token",
+        "receipt_schema": "synthetic-receipt-schema",
+        "workload_transition_digest": "a" * 64,
+        "publication_digest": "b" * 64,
+        "stdout_sha256": "c" * 64,
+        "stderr_sha256": "d" * 64,
+        "output_sha256": "e" * 64,
+        "launch_pid": 123,
+        "launch_cwd": "/synthetic/repository",
+        "launch_argv": [".venv/bin/python", "scripts/benchmark_ck07r1_lifecycle_scale.py"],
+    }
+    assert "ledger_file_sha256" not in ledger
+    assert identity["source"].startswith("the frozen launch ledger")
 
 
 def test_fixture_identity_vocabulary_and_static_file_shas_are_distinct_and_proven() -> None:
@@ -304,13 +423,28 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
         ("seed", ("launch_contract", "profiles", "seed"), 42),
         ("reachable-path", ("launch_contract", "reachable_path", "ordered_steps", 2), "direct writer"),
         ("generic-drift", ("preserved_history", "source_predecessor_sha256"), "0" * 64),
+        ("current-state", ("lifecycle_state_machine", "current_state"), "worker_prequalification"),
+        ("successor-drift", ("lifecycle_state_machine", "states", 1, "source_sha256"), "0" * 64),
+        ("receipt-bypass", ("lifecycle_state_machine", "states", 2, "receipt_policy"), "optional"),
+        ("post-run-no-receipt-qualification", ("lifecycle_state_machine", "states", 2, "runtime_acceptance"), "accepted"),
+        ("final-no-receipt-acceptance", ("lifecycle_state_machine", "states", 3, "receipt_policy"), "optional"),
+        ("final-no-evidence-acceptance", ("lifecycle_state_machine", "states", 3, "evidence_identity_policy"), "not_available"),
+        ("final-merge-bypass", ("lifecycle_state_machine", "states", 3, "merge_policy"), "optional"),
+        ("transition-bypass", ("lifecycle_state_machine", "transitions", 0, "to"), "final_accepted"),
+        ("receipt-path-drift", ("lifecycle_state_machine", "dynamic_receipt_identity", "identity_paths", "output_sha256"), "receipt.output_file_sha256"),
+        ("receipt-ledger-drift", ("lifecycle_state_machine", "dynamic_receipt_identity", "ledger_path"), "output/other.json"),
+        ("fixture-inventory-omission", ("launch_contract", "fixture_identity", "fixture_files", 0), None),
+        ("fixture-inventory-digest", ("launch_contract", "fixture_identity", "fixture_files", 1, "fixture_file_sha256"), "0" * 64),
     ],
 )
 def test_negative_contract_mutations_fail_closed(
     label: str, path: tuple[str | int, ...], replacement: Any
 ) -> None:
     mutated = copy.deepcopy(_authority())
-    _set_path(mutated, path, replacement)
+    if replacement is None:
+        del mutated[path[0]][path[1]][path[2]][path[3]]
+    else:
+        _set_path(mutated, path, replacement)
     assert _errors(mutated), label
 
 


### PR DESCRIPTION
## Summary
- Freeze the finite CK-07R1 source/runtime state machine from `authority_main` through worker prequalification, one receipt-bound post-run state, and merge/exact-main final acceptance.
- Reconcile predecessor `408d18e4…` and exact successor `d192c858…`; keep runtime acceptance unclaimed and the one-run token unspent.
- Bind post-run identity to the frozen launch ledger/evidence paths and freeze the exact 13-file fixture inventory.
- Move CK-07R1 to Conditional Ready in the machine DAG only after this authority is accepted, merged, and exact-main verified; no worker is resumed here.

## Validation
- Focused authority/DAG/schema tests: 51 passed.
- `just v`: passed; 1,368 tests, invariant lane clean, Pyright/release/scope checks clean.
- `just vc`: passed; package build and dist release checks clean.
- No E2E run, no benchmark execution, no token consumption, no witness mutation.

## Scope
Authority/docs/schema/tests only; no preparation.py, benchmark, lifecycle test, linked evidence, or runtime/product code changes.

Merge policy: squash only after all required hosted checks pass.