### PR TITLE
refactor: reduce page executor complexity

### DIFF
--- a/src/codex_usage_tracker/agent_kernel/query/page_executor.py
+++ b/src/codex_usage_tracker/agent_kernel/query/page_executor.py
@@ -58,6 +58,25 @@ class PhysicalPlanGapError(PhysicalPageError):
     """A named plan has no admitted bounded direct-page implementation."""
 
 
+def _validate_request_identity(
+    plan_id: str,
+    publication_id: str,
+    request_digest: str,
+) -> None:
+    for label, value in (
+        ("plan_id", plan_id),
+        ("publication_id", publication_id),
+        ("request_digest", request_digest),
+    ):
+        if not isinstance(value, str) or not value:
+            raise PhysicalPageError(f"{label} must be non-empty text")
+    if (
+        len(request_digest) != 64
+        or any(character not in "0123456789abcdef" for character in request_digest)
+    ):
+        raise PhysicalPageError("request_digest must be a lowercase SHA-256 digest")
+
+
 @dataclass(frozen=True, slots=True)
 class PageExecutionRequest:
     """The frozen CK-08R0 physical page request plus typed plan parameters."""
@@ -73,18 +92,11 @@ class PageExecutionRequest:
     parameters: Mapping[str, Any] = MappingProxyType({})
 
     def __post_init__(self) -> None:
-        for label, value in (
-            ("plan_id", self.plan_id),
-            ("publication_id", self.publication_id),
-            ("request_digest", self.request_digest),
-        ):
-            if not isinstance(value, str) or not value:
-                raise PhysicalPageError(f"{label} must be non-empty text")
-        if (
-            len(self.request_digest) != 64
-            or any(character not in "0123456789abcdef" for character in self.request_digest)
-        ):
-            raise PhysicalPageError("request_digest must be a lowercase SHA-256 digest")
+        _validate_request_identity(
+            self.plan_id,
+            self.publication_id,
+            self.request_digest,
+        )
         if (
             isinstance(self.plan_version, bool)
             or not isinstance(self.plan_version, int)


### PR DESCRIPTION
CK-QG1A exact-main reapplication only.

Source authority:
- Exact base: 62d6cc18f852718b8e2eba6fd0f07a165cc8a414
- Authority packet: docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
- Supersession authority: docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json
- Permitted successor source digest: 9e80c8677dd4ceadc4fbd66681aedef78528b1ad4f50edc7a04f4b1c7ac12f31

Scope:
- One file only: src/codex_usage_tracker/agent_kernel/query/page_executor.py
- Extracts request identity and SHA-256 validation into a private helper, preserving validation order, exception types, messages, and all subsequent request/cursor/order/query-only behavior.
- No baseline, threshold, exemption, shared authority, query admission, EvidenceService, publication, or PR #392 changes.

Evidence:
- Frozen baseline digest: c490d954a5e9d09c61f884d51e3b9d3196af5615887f409c36f8469d1b2b6cf9
- Xenon findings resolved: PageExecutionRequest D/23 to C/17; PageExecutionRequest.__post_init__ D/22 to C/16; helper B/7; no new or worsened finding.
- Focused page-executor, evidence, and service tests: 17 passed.
- Exact frozen-baseline C/B/B check: passed.
- just v: passed, 1368 tests and all checks.
- just vc: passed, including package build and distribution safety.
- GitNexus impact/detect_changes: low risk, one changed file, zero affected processes.
- One independent read-only reviewer: no material findings, safe to commit.

This PR is the single CK-QG1A correction required before any downstream task resumes.