### PR TITLE
Freeze CK-08R1A answer semantics and evidence closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@ shares production evaluation, runtime keyset pagination follows complete
 Python materialization, projection classification combines execution stages,
 and publication/evidence scale plus replacement maintainability need
 corrective proof. CK-08R0 froze `corrective-gates-v1`; CK-08R2 is complete and
-CK-09 remains blocked. CK-08R1A freezes corrected answer meaning before
-disjoint R1B/R1C implementation and final R1 requalification. CK-QG1A must
+CK-09 remains blocked. CK-08R1A froze corrected answer meaning and recursive
+closure; disjoint R1B/R1C implementation is Ready before final R1 requalification.
+CK-QG1A must
 remove two R2 page-executor complexity findings without changing behavior or
 the frozen baseline before existing QG1 PR #392 resumes. CK-07R1A corrected
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0

--- a/config/agent-kernel/answer-semantics-v1.json
+++ b/config/agent-kernel/answer-semantics-v1.json
@@ -1,0 +1,459 @@
+{
+  "schema": "codex-usage-tracker.answer-semantics.v1",
+  "version": 1,
+  "packet": "CK-08R1A",
+  "status": "frozen",
+  "source_authority": {
+    "question_catalog": "config/agent-kernel/question-catalog-v1.json",
+    "formula_contract": "config/agent-kernel/formula-contract-v1.json",
+    "logical_contract": "config/agent-kernel/logical-contract-v1.json",
+    "operand_contract": "config/agent-kernel/plan-operand-contract-v1.json",
+    "selector_contract": "config/agent-kernel/selector-provenance-v1.json"
+  },
+  "questions": {
+    "Q-REV-03": {
+      "plan_id": "compare_sessions",
+      "side_scope": {
+        "identity": "requested_stable_session_id",
+        "window": "[start_us,end_us)"
+      },
+      "required_gates": [
+        "capability",
+        "comparison",
+        "completion",
+        "hierarchy",
+        "measurement",
+        "publication"
+      ],
+      "available_empty": "typed_zero_or_empty",
+      "missing_required": "fail_closed",
+      "fields": {
+        "completion_state": {
+          "shape": {
+            "left": ["lifecycle_state", "completion_basis"],
+            "right": ["lifecycle_state", "completion_basis"]
+          },
+          "sources": [
+            {
+              "relation": "session",
+              "fields": ["session_id", "lifecycle_state", "completion_basis"]
+            }
+          ],
+          "joins": ["exactly_one_session_row_per_requested_session_id"],
+          "missing_empty": {
+            "open": "preserve_exact_open_lifecycle_and_basis",
+            "absent_duplicate_malformed": "fail_closed"
+          },
+          "sensitivity": "swap_session_lifecycle_and_basis_between_sides"
+        },
+        "context_features": {
+          "shape": {
+            "left": ["observed_call_count", "distinct_context_window_tokens"],
+            "right": ["observed_call_count", "distinct_context_window_tokens"]
+          },
+          "sources": [
+            {
+              "relation": "publication",
+              "fields": ["publication_id", "capabilities.structural_context"]
+            },
+            {
+              "relation": "canonical_call",
+              "fields": [
+                "call_id",
+                "session_id",
+                "context_window_tokens",
+                "measurement_mask.context_window_tokens"
+              ]
+            }
+          ],
+          "joins": [
+            "publication_capability_is_global_empty_cohort_authority",
+            "canonical_call.session_id_equals_selected_session_id",
+            "per_side_measurement_mask_is_context_availability_authority"
+          ],
+          "missing_empty": {
+            "capability_unavailable": "side_null",
+            "capability_available_empty": {
+              "observed_call_count": 0,
+              "distinct_context_window_tokens": []
+            },
+            "mixed_missing_context_window_tokens": "fail_closed"
+          },
+          "sensitivity": "swap_context_window_token_value_between_sides"
+        },
+        "delegation_metrics": {
+          "shape": {
+            "left": ["exclusive_tokens", "descendant_tokens", "inclusive_tokens"],
+            "right": ["exclusive_tokens", "descendant_tokens", "inclusive_tokens"]
+          },
+          "sources": [
+            {
+              "relation": "session",
+              "fields": [
+                "session_id",
+                "root_session_id",
+                "parent_session_id",
+                "delegation_depth"
+              ]
+            },
+            {
+              "relation": "canonical_call",
+              "fields": [
+                "call_id",
+                "session_id",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens"
+              ]
+            }
+          ],
+          "joins": [
+            "exclusive_is_selected_session_calls",
+            "descendant_is_transitive_strict_session_descendants",
+            "inclusive_uses_exclusive_inclusive_scope_v1"
+          ],
+          "missing_empty": {
+            "empty": {
+              "exclusive_tokens": 0,
+              "descendant_tokens": 0,
+              "inclusive_tokens": 0
+            },
+            "missing_hierarchy_or_affected_token_class": "affected_value_null",
+            "malformed_or_cyclic_hierarchy": "fail_closed"
+          },
+          "sensitivity": "swap_parent_edge_and_compensated_descendant_tokens_between_sides"
+        },
+        "resource_metrics": {
+          "shape": {
+            "left": ["count", "by_kind"],
+            "right": ["count", "by_kind"]
+          },
+          "sources": [
+            {
+              "relation": "tool_invocation",
+              "fields": ["tool_id", "session_id", "resource_id", "resource_links"]
+            },
+            {
+              "relation": "state_change",
+              "fields": ["state_change_id", "session_id", "resource_id"]
+            },
+            {
+              "relation": "resource",
+              "fields": ["resource_id", "resource_kind"]
+            }
+          ],
+          "joins": [
+            "union_distinct_resource_ids_linked_by_side_tools_or_state_changes",
+            "exactly_one_resource_kind_per_resource_id"
+          ],
+          "missing_empty": {
+            "empty": {"count": 0, "by_kind": {}},
+            "dangling_or_conflicting_resource_join": "fail_closed",
+            "by_kind_key_order": "unicode_codepoint_ascending"
+          },
+          "sensitivity": "swap_linked_resource_kind_between_sides"
+        },
+        "state_change_metrics": {
+          "shape": {
+            "left": ["count", "by_mutation_kind"],
+            "right": ["count", "by_mutation_kind"]
+          },
+          "sources": [
+            {
+              "relation": "state_change",
+              "fields": ["state_change_id", "session_id", "mutation_kind"]
+            }
+          ],
+          "joins": [
+            "state_change.session_id_equals_selected_session_id",
+            "count_distinct_state_change_id"
+          ],
+          "missing_empty": {
+            "empty": {"count": 0, "by_mutation_kind": {}},
+            "absent_duplicate_malformed_id_or_kind": "fail_closed",
+            "by_mutation_kind_key_order": "unicode_codepoint_ascending"
+          },
+          "sensitivity": "swap_state_change_mutation_kind_between_sides"
+        },
+        "token_deltas": {
+          "shape": [
+            "uncached_input_tokens",
+            "cached_input_tokens",
+            "reasoning_tokens",
+            "output_tokens",
+            "total_tokens"
+          ],
+          "sources": [
+            {
+              "relation": "canonical_call",
+              "fields": [
+                "call_id",
+                "session_id",
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens"
+              ]
+            }
+          ],
+          "joins": [
+            "sum_each_class_per_selected_session",
+            "right_minus_left_via_side_by_side_delta_v1",
+            "total_is_sum_of_all_four_classes"
+          ],
+          "missing_empty": {
+            "empty": {
+              "uncached_input_tokens": 0,
+              "cached_input_tokens": 0,
+              "reasoning_tokens": 0,
+              "output_tokens": 0,
+              "total_tokens": 0
+            },
+            "missing_class": "that_class_and_total_null",
+            "malformed_token": "fail_closed"
+          },
+          "sensitivity": "swap_one_token_class_value_between_sides"
+        },
+        "tool_metrics": {
+          "shape": {
+            "left": [
+              "invocation_count",
+              "succeeded_count",
+              "failed_count",
+              "open_count"
+            ],
+            "right": [
+              "invocation_count",
+              "succeeded_count",
+              "failed_count",
+              "open_count"
+            ]
+          },
+          "sources": [
+            {
+              "relation": "tool_invocation",
+              "fields": ["tool_id", "session_id", "lifecycle"]
+            }
+          ],
+          "joins": [
+            "tool_invocation.session_id_equals_selected_session_id",
+            "count_distinct_tool_id"
+          ],
+          "missing_empty": {
+            "empty": {
+              "invocation_count": 0,
+              "succeeded_count": 0,
+              "failed_count": 0,
+              "open_count": 0
+            },
+            "succeeded": ["succeeded"],
+            "failed": ["failed"],
+            "open": ["pending", "running", "open"],
+            "cancelled_rolled_back_unknown_or_malformed": "fail_closed"
+          },
+          "sensitivity": "swap_supported_tool_lifecycle_between_sides"
+        },
+        "turn_call_counts": {
+          "shape": {
+            "left": ["turn_count", "call_count"],
+            "right": ["turn_count", "call_count"]
+          },
+          "sources": [
+            {"relation": "turn", "fields": ["turn_id", "session_id"]},
+            {
+              "relation": "canonical_call",
+              "fields": ["call_id", "session_id"]
+            }
+          ],
+          "joins": [
+            "turn.session_id_equals_selected_session_id",
+            "canonical_call.session_id_equals_selected_session_id",
+            "count_distinct_stable_ids"
+          ],
+          "missing_empty": {
+            "empty": {"turn_count": 0, "call_count": 0},
+            "absent_duplicate_malformed_stable_id": "fail_closed"
+          },
+          "sensitivity": "swap_compensated_turn_and_call_membership_between_sides"
+        }
+      }
+    },
+    "Q-WF-02": {
+      "plan_id": "first_action_mutation",
+      "selected_cohort": "request_gated_half_open_window_and_optional_session_selector",
+      "boundary_order": [
+        "event_at_us_is_null",
+        "event_at_us",
+        "source_rank",
+        "source_order",
+        "event_kind_order",
+        "logical_id",
+        "transition_rank"
+      ],
+      "boundaries": {
+        "action": "earliest_tool_start",
+        "success": "earliest_terminal_succeeded_transition",
+        "mutation": "earliest_state_change"
+      },
+      "tool_coordinates": {
+        "start": "complete_seven_part_coordinate",
+        "terminal": "complete_seven_part_coordinate"
+      },
+      "coordinate_sources": {
+        "tool_start": {
+          "relation": "tool_invocation",
+          "logical_id": "tool_id",
+          "fields": [
+            "start_at_us",
+            "start_source_rank",
+            "start_source_order",
+            "start_event_kind_order",
+            "start_transition_rank"
+          ]
+        },
+        "tool_terminal": {
+          "relation": "tool_invocation",
+          "logical_id": "tool_id",
+          "fields": [
+            "terminal_at_us",
+            "terminal_source_rank",
+            "terminal_source_order",
+            "terminal_event_kind_order",
+            "terminal_transition_rank",
+            "lifecycle"
+          ]
+        },
+        "state_change": {
+          "relation": "state_change",
+          "logical_id": "state_change_id",
+          "fields": [
+            "event_at_us",
+            "source_rank",
+            "source_order",
+            "event_kind_order",
+            "transition_rank"
+          ]
+        }
+      },
+      "token_sum": {
+        "relation": "canonical_call",
+        "identity": "call_id",
+        "classes": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "comparison": "strictly_before_boundary",
+        "present_boundary_without_prior_call": 0,
+        "absent_boundary": null,
+        "missing_prior_token_class": null
+      },
+      "output_fields": [
+        "first_action_tokens",
+        "first_success_tokens",
+        "first_mutation_tokens",
+        "mutation_observed"
+      ],
+      "fail_closed": [
+        "incomplete_start_coordinate",
+        "incomplete_terminal_coordinate",
+        "terminal_without_start",
+        "succeeded_without_terminal_coordinate",
+        "malformed_lifecycle",
+        "malformed_or_duplicate_logical_id",
+        "malformed_order_coordinate",
+        "missing_required_gate_or_fact"
+      ]
+    }
+  },
+  "closure": {
+    "membership": "harness_consumer_roots_and_recursive_transitive_local_imports",
+    "roots_required": ["harness", "consumer"],
+    "path_order": "unicode_codepoint_ascending",
+    "file_digest": "sha256_exact_bytes",
+    "canonical_json": "utf8_sort_keys_no_whitespace_ensure_ascii_false",
+    "closure_digest": "sha256_canonical_json_utf8",
+    "recompute_before_grading": true,
+    "drift": "fail_before_grading",
+    "inaccessible": "fail_before_grading",
+    "unlisted_transitive_import": "fail_before_grading"
+  },
+  "lanes": {
+    "production": {
+      "producer": "answer-semantics-v1_and_vectors",
+      "consumer_role": "r1b_production_derivation",
+      "required_root_roles": ["harness", "consumer", "r1b_root"],
+      "records_all_recursive_local_imports": true,
+      "grading_inputs_forbidden": true
+    },
+    "independent": {
+      "producer": "answer-semantics-v1_and_vectors",
+      "consumer_role": "r1c_independent_evaluator",
+      "required_root_roles": ["harness", "consumer"],
+      "records_all_recursive_local_imports": true,
+      "forbidden_module_prefixes": [
+        "codex_usage_tracker.agent_kernel.domain.formulas",
+        "codex_usage_tracker.agent_kernel.domain.plan_derivations",
+        "codex_usage_tracker.agent_kernel.domain.plan_operands",
+        "codex_usage_tracker.agent_kernel.query",
+        "codex_usage_tracker.agent_kernel.storage",
+        "sqlite3",
+        "tests.agent_kernel.fact_adapters.database",
+        "tests.agent_kernel.fixtures.oracles.database",
+        "tests.agent_kernel.fixtures.oracles.reference"
+      ],
+      "forbidden_data_keys": [
+        "answer_rows",
+        "comparison_rows",
+        "expected_rows",
+        "grades",
+        "grading",
+        "oracle_case"
+      ],
+      "forbidden_overlap_roles": [
+        "r1b_root",
+        "r1b_transitive_import",
+        "r1b_data_source"
+      ],
+      "only_shared_authority": [
+        "config/agent-kernel/answer-semantics-v1.json",
+        "config/agent-kernel/answer-semantics-v1.schema.json",
+        "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json",
+        "typed_request_and_result_contracts"
+      ]
+    }
+  },
+  "gate_order": [
+    "closure_membership",
+    "closure_digest",
+    "closure_accessibility",
+    "grading_independence",
+    "answer_comparison"
+  ],
+  "grading_checks": {
+    "lanes": ["production", "independent"],
+    "sentinel_mutated": "baseline_answers_unchanged",
+    "inaccessible": "baseline_answers_unchanged"
+  },
+  "mutation_checks": {
+    "canonical_fact": "both_lanes_change",
+    "production_source": "independent_truth_unchanged"
+  },
+  "privacy": {
+    "synthetic_only": true,
+    "real_codex_bodies_forbidden": true,
+    "local_database_forbidden": true,
+    "secrets_forbidden": true
+  },
+  "preserved_boundaries": [
+    "CK-08R2",
+    "CK-08R3A",
+    "CK-08R3",
+    "CK-07R1A",
+    "CK-QG1A",
+    "public_and_projection_boundaries"
+  ],
+  "sdist_ceiling_bytes": 2000000
+}

--- a/config/agent-kernel/answer-semantics-v1.schema.json
+++ b/config/agent-kernel/answer-semantics-v1.schema.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://douglasmonsky.github.io/codex-usage-tracker/schemas/answer-semantics-v1.schema.json",
+  "title": "CK-08R1A answer semantics and vectors",
+  "oneOf": [
+    {"$ref": "#/$defs/contract"},
+    {"$ref": "#/$defs/vectors"}
+  ],
+  "$defs": {
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "nonEmpty": {"type": "string", "minLength": 1},
+    "strings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/nonEmpty"}
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relation", "fields"],
+      "properties": {
+        "relation": {"$ref": "#/$defs/nonEmpty"},
+        "fields": {"$ref": "#/$defs/strings"}
+      }
+    },
+    "fieldSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shape", "sources", "joins", "missing_empty", "sensitivity"],
+      "properties": {
+        "shape": {"type": ["object", "array"]},
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/source"}
+        },
+        "joins": {"$ref": "#/$defs/strings"},
+        "missing_empty": {"type": "object", "minProperties": 1},
+        "sensitivity": {"$ref": "#/$defs/nonEmpty"}
+      }
+    },
+    "qRev": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "plan_id",
+        "side_scope",
+        "required_gates",
+        "available_empty",
+        "missing_required",
+        "fields"
+      ],
+      "properties": {
+        "plan_id": {"const": "compare_sessions"},
+        "side_scope": {
+          "const": {
+            "identity": "requested_stable_session_id",
+            "window": "[start_us,end_us)"
+          }
+        },
+        "required_gates": {"$ref": "#/$defs/strings"},
+        "available_empty": {"const": "typed_zero_or_empty"},
+        "missing_required": {"const": "fail_closed"},
+        "fields": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "completion_state",
+            "context_features",
+            "delegation_metrics",
+            "resource_metrics",
+            "state_change_metrics",
+            "token_deltas",
+            "tool_metrics",
+            "turn_call_counts"
+          ],
+          "properties": {
+            "completion_state": {"$ref": "#/$defs/fieldSemantic"},
+            "context_features": {"$ref": "#/$defs/fieldSemantic"},
+            "delegation_metrics": {"$ref": "#/$defs/fieldSemantic"},
+            "resource_metrics": {"$ref": "#/$defs/fieldSemantic"},
+            "state_change_metrics": {"$ref": "#/$defs/fieldSemantic"},
+            "token_deltas": {"$ref": "#/$defs/fieldSemantic"},
+            "tool_metrics": {"$ref": "#/$defs/fieldSemantic"},
+            "turn_call_counts": {"$ref": "#/$defs/fieldSemantic"}
+          }
+        }
+      }
+    },
+    "qWf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "plan_id",
+        "selected_cohort",
+        "boundary_order",
+        "boundaries",
+        "tool_coordinates",
+        "coordinate_sources",
+        "token_sum",
+        "output_fields",
+        "fail_closed"
+      ],
+      "properties": {
+        "plan_id": {"const": "first_action_mutation"},
+        "selected_cohort": {"$ref": "#/$defs/nonEmpty"},
+        "boundary_order": {
+          "const": [
+            "event_at_us_is_null",
+            "event_at_us",
+            "source_rank",
+            "source_order",
+            "event_kind_order",
+            "logical_id",
+            "transition_rank"
+          ]
+        },
+        "boundaries": {
+          "const": {
+            "action": "earliest_tool_start",
+            "success": "earliest_terminal_succeeded_transition",
+            "mutation": "earliest_state_change"
+          }
+        },
+        "tool_coordinates": {
+          "const": {
+            "start": "complete_seven_part_coordinate",
+            "terminal": "complete_seven_part_coordinate"
+          }
+        },
+        "coordinate_sources": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["tool_start", "tool_terminal", "state_change"],
+          "properties": {
+            "tool_start": {"type": "object"},
+            "tool_terminal": {"type": "object"},
+            "state_change": {"type": "object"}
+          }
+        },
+        "token_sum": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "relation",
+            "identity",
+            "classes",
+            "comparison",
+            "present_boundary_without_prior_call",
+            "absent_boundary",
+            "missing_prior_token_class"
+          ],
+          "properties": {
+            "relation": {"const": "canonical_call"},
+            "identity": {"const": "call_id"},
+            "classes": {
+              "const": [
+                "uncached_input_tokens",
+                "cached_input_tokens",
+                "reasoning_tokens",
+                "output_tokens"
+              ]
+            },
+            "comparison": {"const": "strictly_before_boundary"},
+            "present_boundary_without_prior_call": {"const": 0},
+            "absent_boundary": {"type": "null"},
+            "missing_prior_token_class": {"type": "null"}
+          }
+        },
+        "output_fields": {"$ref": "#/$defs/strings"},
+        "fail_closed": {"$ref": "#/$defs/strings"}
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "version",
+        "packet",
+        "status",
+        "source_authority",
+        "questions",
+        "closure",
+        "lanes",
+        "gate_order",
+        "grading_checks",
+        "mutation_checks",
+        "privacy",
+        "preserved_boundaries",
+        "sdist_ceiling_bytes"
+      ],
+      "properties": {
+        "schema": {"const": "codex-usage-tracker.answer-semantics.v1"},
+        "version": {"const": 1},
+        "packet": {"const": "CK-08R1A"},
+        "status": {"const": "frozen"},
+        "source_authority": {
+          "type": "object",
+          "minProperties": 5,
+          "additionalProperties": {"$ref": "#/$defs/nonEmpty"}
+        },
+        "questions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["Q-REV-03", "Q-WF-02"],
+          "properties": {
+            "Q-REV-03": {"$ref": "#/$defs/qRev"},
+            "Q-WF-02": {"$ref": "#/$defs/qWf"}
+          }
+        },
+        "closure": {"type": "object", "minProperties": 10},
+        "lanes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["production", "independent"],
+          "properties": {
+            "production": {"type": "object", "minProperties": 5},
+            "independent": {"type": "object", "minProperties": 8}
+          }
+        },
+        "gate_order": {
+          "const": [
+            "closure_membership",
+            "closure_digest",
+            "closure_accessibility",
+            "grading_independence",
+            "answer_comparison"
+          ]
+        },
+        "grading_checks": {
+          "const": {
+            "lanes": ["production", "independent"],
+            "sentinel_mutated": "baseline_answers_unchanged",
+            "inaccessible": "baseline_answers_unchanged"
+          }
+        },
+        "mutation_checks": {
+          "const": {
+            "canonical_fact": "both_lanes_change",
+            "production_source": "independent_truth_unchanged"
+          }
+        },
+        "privacy": {
+          "const": {
+            "synthetic_only": true,
+            "real_codex_bodies_forbidden": true,
+            "local_database_forbidden": true,
+            "secrets_forbidden": true
+          }
+        },
+        "preserved_boundaries": {"$ref": "#/$defs/strings"},
+        "sdist_ceiling_bytes": {"const": 2000000}
+      }
+    },
+    "vectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "version",
+        "contract_sha256",
+        "q_rev_03",
+        "q_wf_02",
+        "grading",
+        "closure"
+      ],
+      "properties": {
+        "schema": {"const": "codex-usage-tracker.answer-semantics-vectors.v1"},
+        "version": {"const": 1},
+        "contract_sha256": {"$ref": "#/$defs/sha"},
+        "q_rev_03": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["field_isolation", "missing_empty"],
+          "properties": {
+            "field_isolation": {
+              "type": "array",
+              "minItems": 8,
+              "maxItems": 8,
+              "items": {"type": "object", "minProperties": 7}
+            },
+            "missing_empty": {
+              "type": "array",
+              "minItems": 11,
+              "maxItems": 11,
+              "items": {"type": "object", "minProperties": 2}
+            }
+          }
+        },
+        "q_wf_02": {
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "events", "expected"],
+            "properties": {
+              "id": {"$ref": "#/$defs/nonEmpty"},
+              "events": {"type": "array"},
+              "expected": {"type": "object", "minProperties": 4}
+            }
+          }
+        },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sentinel_mutated", "inaccessible", "mutations"],
+          "properties": {
+            "sentinel_mutated": {
+              "const": [
+                {
+                  "id": "production_grading_sentinel",
+                  "lane": "production",
+                  "outcome": "baseline_answers_unchanged"
+                },
+                {
+                  "id": "independent_grading_sentinel",
+                  "lane": "independent",
+                  "outcome": "baseline_answers_unchanged"
+                }
+              ]
+            },
+            "inaccessible": {
+              "const": [
+                {
+                  "id": "production_grading_inaccessible",
+                  "lane": "production",
+                  "outcome": "baseline_answers_unchanged"
+                },
+                {
+                  "id": "independent_grading_inaccessible",
+                  "lane": "independent",
+                  "outcome": "baseline_answers_unchanged"
+                }
+              ]
+            },
+            "mutations": {
+              "const": [
+                {
+                  "id": "canonical_fact",
+                  "production": "changed",
+                  "independent": "changed"
+                },
+                {
+                  "id": "production_source",
+                  "production": "changed",
+                  "independent": "unchanged"
+                }
+              ]
+            }
+          }
+        },
+        "closure": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["canonical", "negative"],
+          "properties": {
+            "canonical": {"type": "object", "minProperties": 5},
+            "negative": {
+              "const": [
+                {"id": "drift", "outcome": "reject_before_grading"},
+                {"id": "inaccessible", "outcome": "reject_before_grading"}
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,8 +20,9 @@ physical keyset SQL; 19 plans retain explicit gaps without projection.
 Retained CK-08R3 `a28e9cdbff8e48d334712a449fdcee111c725673` then stopped
 before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
 fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
-truth is now serialized as R1A contract freeze, disjoint R1B/R1C consumers,
-and final R1 requalification. CK-QG1A0 gates the selected R2 PageExecutor
+truth now consumes [`answer-semantics.v1`](../config/agent-kernel/answer-semantics-v1.json);
+disjoint R1B/R1C consumers are Ready before final R1 requalification.
+CK-QG1A0 gates the selected R2 PageExecutor
 successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrected
 PR #394's exact hosted lifecycle-tail failure without a budget waiver.
 CK-07R1A0 is accepted at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`.

--- a/docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json
+++ b/docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://douglasmonsky.github.io/codex-usage-tracker/schemas/answer-truth-requalification-v2.schema.json",
+  "title": "CK-08R1 answer truth requalification v2",
+  "$ref": "#/$defs/answerTruth",
+  "$defs": {
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "gitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "nonEmpty": {"type": "string", "minLength": 1},
+    "pathDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"$ref": "#/$defs/nonEmpty"},
+        "sha256": {"$ref": "#/$defs/sha"}
+      }
+    },
+    "rootDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "role", "sha256"],
+      "properties": {
+        "path": {"$ref": "#/$defs/nonEmpty"},
+        "role": {
+          "enum": [
+            "harness",
+            "consumer",
+            "r1b_root",
+            "r1b_data_source"
+          ]
+        },
+        "sha256": {"$ref": "#/$defs/sha"}
+      }
+    },
+    "lane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lane",
+        "harness",
+        "consumer",
+        "roots",
+        "transitive_local_imports",
+        "closure_digest",
+        "closure_checks",
+        "grading_checks"
+      ],
+      "properties": {
+        "lane": {"enum": ["production", "independent"]},
+        "harness": {"$ref": "#/$defs/nonEmpty"},
+        "consumer": {"$ref": "#/$defs/nonEmpty"},
+        "roots": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/rootDigest"}
+        },
+        "transitive_local_imports": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/pathDigest"}
+        },
+        "closure_digest": {"$ref": "#/$defs/sha"},
+        "closure_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "membership_recomputed",
+            "digests_recomputed",
+            "all_files_accessible",
+            "forbidden_dependencies_absent",
+            "passed_before_grading"
+          ],
+          "properties": {
+            "membership_recomputed": {"const": true},
+            "digests_recomputed": {"const": true},
+            "all_files_accessible": {"const": true},
+            "forbidden_dependencies_absent": {"const": true},
+            "passed_before_grading": {"const": true}
+          }
+        },
+        "grading_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sentinel_mutated", "inaccessible"],
+          "properties": {
+            "sentinel_mutated": {"const": "baseline_answers_unchanged"},
+            "inaccessible": {"const": "baseline_answers_unchanged"}
+          }
+        }
+      }
+    },
+    "variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "oracle_id",
+        "request",
+        "independent_rows",
+        "production_rows",
+        "independent_grades",
+        "production_grades",
+        "total_order",
+        "ordered_evidence",
+        "provenance",
+        "matches"
+      ],
+      "properties": {
+        "oracle_id": {"$ref": "#/$defs/nonEmpty"},
+        "request": {"type": "object"},
+        "independent_rows": {"type": "array"},
+        "production_rows": {"type": "array"},
+        "independent_grades": {"type": "object"},
+        "production_grades": {"type": "object"},
+        "total_order": {"type": "array"},
+        "ordered_evidence": {"type": "array"},
+        "provenance": {"type": "array"},
+        "matches": {"const": true}
+      }
+    },
+    "answerTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "dependency_shas",
+        "authority_digests",
+        "gate_order",
+        "lanes",
+        "variant_results",
+        "mutation_results",
+        "superseded_evidence_links"
+      ],
+      "properties": {
+        "schema": {
+          "const": "codex-usage-tracker.answer-truth-requalification.v2"
+        },
+        "dependency_shas": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["CK-08R1A", "CK-08R1B", "CK-08R1C"],
+          "properties": {
+            "CK-08R1A": {"$ref": "#/$defs/gitSha"},
+            "CK-08R1B": {"$ref": "#/$defs/gitSha"},
+            "CK-08R1C": {"$ref": "#/$defs/gitSha"}
+          }
+        },
+        "authority_digests": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "answer_semantics",
+            "answer_semantics_schema",
+            "answer_semantics_vectors",
+            "evidence_schema"
+          ],
+          "properties": {
+            "answer_semantics": {"$ref": "#/$defs/sha"},
+            "answer_semantics_schema": {"$ref": "#/$defs/sha"},
+            "answer_semantics_vectors": {"$ref": "#/$defs/sha"},
+            "evidence_schema": {"$ref": "#/$defs/sha"}
+          }
+        },
+        "gate_order": {
+          "const": [
+            "closure_membership",
+            "closure_digest",
+            "closure_accessibility",
+            "grading_independence",
+            "answer_comparison"
+          ]
+        },
+        "lanes": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {
+              "allOf": [
+                {"$ref": "#/$defs/lane"},
+                {"properties": {"lane": {"const": "production"}}}
+              ]
+            },
+            {
+              "allOf": [
+                {"$ref": "#/$defs/lane"},
+                {"properties": {"lane": {"const": "independent"}}}
+              ]
+            }
+          ],
+          "items": false
+        },
+        "variant_results": {
+          "type": "array",
+          "minItems": 80,
+          "maxItems": 80,
+          "items": {"$ref": "#/$defs/variant"}
+        },
+        "mutation_results": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["canonical_fact", "production_source"],
+          "properties": {
+            "canonical_fact": {
+              "const": {
+                "production_changed": true,
+                "independent_changed": true
+              }
+            },
+            "production_source": {
+              "const": {
+                "production_changed": true,
+                "independent_unchanged": true
+              }
+            }
+          }
+        },
+        "superseded_evidence_links": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nonEmpty"}
+        }
+      }
+    }
+  }
+}

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -17,8 +17,8 @@ Retained CK-08R3 pre-scale evidence at commit
 query physically unbounded independent of scale profile. CK-08R3A owns that
 production fix. CK-08R3 must not become Ready or be redelegated until CK-08R3A
 is accepted, merged, and exact-main verified. Retained CK-08R1 work reached
-80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A freezes
-their meaning, R1B/C implement disjoint consumers, and R1 is their
+80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
+their meaning and closure, R1B/C are Ready as disjoint consumers, and R1 is their
 requalification join. CK-QG1 PR #392 also stays blocked: R2 introduced two
 page-executor C/B/B violations, so QG1A must correct them without changing R2
 behavior or the frozen maintainability baseline.
@@ -159,11 +159,11 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"],
-  "ready": [],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"],
+  "ready": ["CK-08R1B", "CK-08R1C"],
   "conditional_ready": [{
-    "condition": "Each lane's serialized corrective authority correction accepted, merged, and exact-main verified",
-    "tasks": ["CK-08R1A", "CK-08R3A"]
+    "condition": "CK-08R3A's serialized corrective authority correction accepted, merged, and exact-main verified",
+    "tasks": ["CK-08R3A"]
   }, {
     "condition": "CK-QG1A0 merged and exact-main verified",
     "tasks": ["CK-QG1A"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,11 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **5 — CK-08R0, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **45**
-- Ready child tasks: **0**
-- Conditional-ready child tasks: **4 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path; CK-08R1A, CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
-- Blocked child tasks: **41**
+- Completed corrective child tasks: **6 — CK-08R0, CK-08R1A, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **44**
+- Ready child tasks: **2 — CK-08R1B, CK-08R1C**
+- Conditional-ready child tasks: **3 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path; CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
+- Blocked child tasks: **39**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -50,15 +50,16 @@ parents are accounting umbrellas.
 ## Remaining delegated child tasks
 
 Readiness is controlled by
-[the machine DAG](REMAINING_EXECUTION_PLAN.md). QG1A follows CK-QG1A0 exact-main;
-other corrective locks are unchanged.
+[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1B/C are Ready after R1A
+merge/exact-main; QG1A follows CK-QG1A0 exact-main; other corrective locks are
+unchanged.
 
 ### Corrective gates
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
-- [ ] **CK-08R1A — Freeze answer semantics and evidence closure** · Conditional Ready after this corrective authority exact-main verification · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Blocked on CK-08R1A · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
-- [ ] **CK-08R1C — Build independent semantic evaluator** · Blocked on CK-08R1A · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
+- [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Ready after CK-08R1A merge exact-main verification · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [ ] **CK-08R1C — Build independent semantic evaluator** · Ready after CK-08R1A merge exact-main verification · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B and CK-08R1C · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
 - [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)

--- a/docs/roadmap/tasks/ck-08r1a-freeze-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1a-freeze-answer-semantics.md
@@ -1,14 +1,14 @@
 # CK-08R1A — Freeze answer semantics and evidence closure
-**Status:** Conditional Ready after this authority merge exact-main
+**Status:** Completed on merge — exact-main verification required in handoff
 **Recommended owner:** `default answer-contracts`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Freeze `answer-semantics.v1` and `answer-truth-requalification.v2` before implementation.
 **Dependencies:** This correction accepted/merged/exact-main.
 **Owned files/interfaces:** New semantic/evidence contracts/schemas, Q-REV-03/Q-WF-02 operand sources, vectors/tests/links; no consumer/evaluator.
-**Produces:** Exact semantics, lane exclusions, recursive digest closure, drift/grading enforcement.
+**Produces:** [`answer-semantics.v1`](../../../config/agent-kernel/answer-semantics-v1.json), its schema/vectors, and [`answer-truth-requalification.v2`](../../decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json).
 **Independent truth source:** Existing contracts plus retained reproductions; dirty code/grading is non-authoritative.
-**Consumer seam:** R1B/C independently consume one digest; R1 recomputes both closures.
-**Parallelism:** Serialized freeze; R1B/C fan out after merge/exact-main.
+**Consumer seam:** R1B/C independently consume the exact semantic/vector digests; R1 recomputes both closures.
+**Parallelism:** Serialized freeze complete; R1B/C fan out after merge/exact-main.
 **Non-goals:** Implementations, stored answers, SQLite/query, projections/public/R3/R4/RG/09.
 
 ## Q-REV-03

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,5 +1,5 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Blocked on CK-08R1A
+**Status:** Ready after CK-08R1A merge exact-main verification
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.

--- a/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
+++ b/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
@@ -1,5 +1,5 @@
 # CK-08R1C — Build independent semantic evaluator
-**Status:** Blocked on CK-08R1A
+**Status:** Ready after CK-08R1A merge exact-main verification
 **Recommended owner:** `worker independent-evaluator`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Independently evaluate all 80 variants.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -731,6 +731,16 @@ CK08R3A_AUTHORITY_ADDITIONS = frozenset(
     }
 )
 
+CK08R1A_ANSWER_SEMANTICS_ADDITIONS = frozenset(
+    {
+        "config/agent-kernel/answer-semantics-v1.json",
+        "config/agent-kernel/answer-semantics-v1.schema.json",
+        "docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json",
+        "tests/agent_kernel/contracts/test_answer_semantics_contract.py",
+        "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json",
+    }
+)
+
 CKQG1A0_AUTHORITY_ADDITIONS = frozenset(
     [
         "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json",
@@ -823,6 +833,7 @@ INTEGRATION_ADDITIONS = (
     | CK07A_FACT_BACKED_REQUALIFICATION_ADDITIONS
     | CK08_QUERY_EVIDENCE_ADDITIONS
     | CK08R2_PHYSICAL_PAGE_ADDITIONS
+    | CK08R1A_ANSWER_SEMANTICS_ADDITIONS
     | CK08R3A_AUTHORITY_ADDITIONS
     | CKQG1A0_AUTHORITY_ADDITIONS
     | PACKAGE_BUDGET_POLICY_ADDITIONS

--- a/tests/agent_kernel/contracts/test_answer_semantics_contract.py
+++ b/tests/agent_kernel/contracts/test_answer_semantics_contract.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACT_PATH = ROOT / "config/agent-kernel/answer-semantics-v1.json"
+SCHEMA_PATH = ROOT / "config/agent-kernel/answer-semantics-v1.schema.json"
+VECTORS_PATH = ROOT / "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json"
+EVIDENCE_SCHEMA_PATH = (
+    ROOT
+    / "docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json"
+)
+
+Q_REV_FIELDS = (
+    "completion_state",
+    "context_features",
+    "delegation_metrics",
+    "resource_metrics",
+    "state_change_metrics",
+    "token_deltas",
+    "tool_metrics",
+    "turn_call_counts",
+)
+BOUNDARY_ORDER = (
+    "event_at_us_is_null",
+    "event_at_us",
+    "source_rank",
+    "source_order",
+    "event_kind_order",
+    "logical_id",
+    "transition_rank",
+)
+TOKEN_CLASSES = (
+    "uncached_input_tokens",
+    "cached_input_tokens",
+    "reasoning_tokens",
+    "output_tokens",
+)
+
+
+def _json(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def test_answer_semantics_contract_and_vectors_are_schema_valid_and_digest_bound() -> None:
+    schema = _json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    contract = _json(CONTRACT_PATH)
+    vectors = _json(VECTORS_PATH)
+
+    validator.validate(contract)
+    validator.validate(vectors)
+    assert vectors["contract_sha256"] == hashlib.sha256(CONTRACT_PATH.read_bytes()).hexdigest()
+    assert contract["packet"] == "CK-08R1A"
+    assert contract["status"] == "frozen"
+    assert contract["sdist_ceiling_bytes"] == 2000000
+
+
+def test_q_rev_03_freezes_all_fields_sources_joins_missingness_and_sensitivity() -> None:
+    contract = _json(CONTRACT_PATH)
+    vectors = _json(VECTORS_PATH)
+    question = contract["questions"]["Q-REV-03"]  # type: ignore[index]
+    fields = question["fields"]  # type: ignore[index]
+
+    assert tuple(fields) == Q_REV_FIELDS
+    assert all(
+        set(fields[field])  # type: ignore[index]
+        == {"shape", "sources", "joins", "missing_empty", "sensitivity"}
+        for field in Q_REV_FIELDS
+    )
+    assert all(
+        fields[field]["shape"]  # type: ignore[index]
+        and fields[field]["sources"]  # type: ignore[index]
+        and fields[field]["joins"]  # type: ignore[index]
+        and fields[field]["missing_empty"]  # type: ignore[index]
+        and fields[field]["sensitivity"]  # type: ignore[index]
+        for field in Q_REV_FIELDS
+    )
+    assert all(
+        source["relation"] and source["fields"]  # type: ignore[index]
+        for field in Q_REV_FIELDS
+        for source in fields[field]["sources"]  # type: ignore[index]
+    )
+    assert question["side_scope"] == {  # type: ignore[index]
+        "identity": "requested_stable_session_id",
+        "window": "[start_us,end_us)",
+    }
+    assert question["available_empty"] == "typed_zero_or_empty"  # type: ignore[index]
+    assert question["missing_required"] == "fail_closed"  # type: ignore[index]
+
+    isolation = vectors["q_rev_03"]["field_isolation"]  # type: ignore[index]
+    assert tuple(item["field"] for item in isolation) == Q_REV_FIELDS
+    assert all(item["expected_changed_fields"] == [item["field"]] for item in isolation)
+    assert all(
+        item["expected_unchanged_fields"]
+        == [field for field in Q_REV_FIELDS if field != item["field"]]
+        for item in isolation
+    )
+    assert {
+        item["id"] for item in vectors["q_rev_03"]["missing_empty"]  # type: ignore[index]
+    } == {
+        "available_empty",
+        "context_capability_unavailable",
+        "mixed_context_missing",
+        "missing_hierarchy",
+        "missing_token_class",
+        "absent_session",
+        "duplicate_session",
+        "malformed_session",
+        "dangling_resource",
+        "conflicting_resource",
+        "unknown_tool_lifecycle",
+    }
+
+
+def test_q_wf_02_freezes_complete_boundaries_and_required_vectors() -> None:
+    contract = _json(CONTRACT_PATH)
+    vectors = _json(VECTORS_PATH)
+    question = contract["questions"]["Q-WF-02"]  # type: ignore[index]
+
+    assert tuple(question["boundary_order"]) == BOUNDARY_ORDER  # type: ignore[index]
+    assert question["boundaries"] == {  # type: ignore[index]
+        "action": "earliest_tool_start",
+        "success": "earliest_terminal_succeeded_transition",
+        "mutation": "earliest_state_change",
+    }
+    assert tuple(question["token_sum"]["classes"]) == TOKEN_CLASSES  # type: ignore[index]
+    assert question["token_sum"]["comparison"] == "strictly_before_boundary"  # type: ignore[index]
+    assert question["tool_coordinates"] == {  # type: ignore[index]
+        "start": "complete_seven_part_coordinate",
+        "terminal": "complete_seven_part_coordinate",
+    }
+    assert question["coordinate_sources"] == {  # type: ignore[index]
+        "tool_start": {
+            "relation": "tool_invocation",
+            "logical_id": "tool_id",
+            "fields": [
+                "start_at_us",
+                "start_source_rank",
+                "start_source_order",
+                "start_event_kind_order",
+                "start_transition_rank",
+            ],
+        },
+        "tool_terminal": {
+            "relation": "tool_invocation",
+            "logical_id": "tool_id",
+            "fields": [
+                "terminal_at_us",
+                "terminal_source_rank",
+                "terminal_source_order",
+                "terminal_event_kind_order",
+                "terminal_transition_rank",
+                "lifecycle",
+            ],
+        },
+        "state_change": {
+            "relation": "state_change",
+            "logical_id": "state_change_id",
+            "fields": [
+                "event_at_us",
+                "source_rank",
+                "source_order",
+                "event_kind_order",
+                "transition_rank",
+            ],
+        },
+    }
+    assert question["token_sum"]["present_boundary_without_prior_call"] == 0  # type: ignore[index]
+    assert question["token_sum"]["absent_boundary"] is None  # type: ignore[index]
+    assert question["token_sum"]["missing_prior_token_class"] is None  # type: ignore[index]
+    assert {
+        item["id"] for item in vectors["q_wf_02"]  # type: ignore[index]
+    } == {
+        "between_start_success",
+        "failed_then_success",
+        "absent_boundaries",
+        "present_without_prior_call",
+        "missing_prior_token",
+        "seven_part_tie",
+        "delayed_mutation",
+    }
+    between = next(
+        item
+        for item in vectors["q_wf_02"]  # type: ignore[index]
+        if item["id"] == "between_start_success"
+    )
+    assert between["expected"]["first_action_tokens"] == 4
+    assert between["expected"]["first_success_tokens"] == 12
+    assert between["expected"]["first_mutation_tokens"] == 12
+
+
+def test_recursive_closure_and_grading_gates_are_enforceable_and_ordered() -> None:
+    contract = _json(CONTRACT_PATH)
+    vectors = _json(VECTORS_PATH)
+    closure = contract["closure"]  # type: ignore[index]
+    example = vectors["closure"]["canonical"]  # type: ignore[index]
+    digest_input = {
+        "consumer": example["consumer"],
+        "harness": example["harness"],
+        "imports": example["imports"],
+        "roots": example["roots"],
+    }
+
+    assert closure["path_order"] == "unicode_codepoint_ascending"  # type: ignore[index]
+    assert closure["file_digest"] == "sha256_exact_bytes"  # type: ignore[index]
+    assert closure["closure_digest"] == "sha256_canonical_json_utf8"  # type: ignore[index]
+    assert [item["path"] for item in example["roots"]] == sorted(  # type: ignore[index]
+        item["path"] for item in example["roots"]  # type: ignore[index]
+    )
+    assert [item["path"] for item in example["imports"]] == sorted(  # type: ignore[index]
+        item["path"] for item in example["imports"]  # type: ignore[index]
+    )
+    assert example["closure_digest"] == _canonical_digest(digest_input)
+    assert contract["gate_order"] == [  # type: ignore[index]
+        "closure_membership",
+        "closure_digest",
+        "closure_accessibility",
+        "grading_independence",
+        "answer_comparison",
+    ]
+    assert vectors["closure"]["negative"] == [  # type: ignore[index]
+        {"id": "drift", "outcome": "reject_before_grading"},
+        {"id": "inaccessible", "outcome": "reject_before_grading"},
+    ]
+    assert vectors["grading"] == {  # type: ignore[index]
+        "sentinel_mutated": [
+            {
+                "id": "production_grading_sentinel",
+                "lane": "production",
+                "outcome": "baseline_answers_unchanged",
+            },
+            {
+                "id": "independent_grading_sentinel",
+                "lane": "independent",
+                "outcome": "baseline_answers_unchanged",
+            },
+        ],
+        "inaccessible": [
+            {
+                "id": "production_grading_inaccessible",
+                "lane": "production",
+                "outcome": "baseline_answers_unchanged",
+            },
+            {
+                "id": "independent_grading_inaccessible",
+                "lane": "independent",
+                "outcome": "baseline_answers_unchanged",
+            },
+        ],
+        "mutations": [
+            {"id": "canonical_fact", "production": "changed", "independent": "changed"},
+            {"id": "production_source", "production": "changed", "independent": "unchanged"},
+        ],
+    }
+
+    evidence_schema = _json(EVIDENCE_SCHEMA_PATH)
+    Draft202012Validator.check_schema(evidence_schema)
+    evidence = evidence_schema["$defs"]["answerTruth"]  # type: ignore[index]
+    assert evidence["properties"]["schema"]["const"] == (  # type: ignore[index]
+        "codex-usage-tracker.answer-truth-requalification.v2"
+    )
+    assert evidence["properties"]["variant_results"]["minItems"] == 80  # type: ignore[index]
+    assert evidence["properties"]["variant_results"]["maxItems"] == 80  # type: ignore[index]
+    assert evidence["properties"]["gate_order"]["const"] == contract["gate_order"]  # type: ignore[index]
+
+
+def test_independent_lane_excludes_production_database_replay_and_grading_truth() -> None:
+    contract = _json(CONTRACT_PATH)
+    lane = contract["lanes"]["independent"]  # type: ignore[index]
+
+    assert lane["forbidden_module_prefixes"] == [
+        "codex_usage_tracker.agent_kernel.domain.formulas",
+        "codex_usage_tracker.agent_kernel.domain.plan_derivations",
+        "codex_usage_tracker.agent_kernel.domain.plan_operands",
+        "codex_usage_tracker.agent_kernel.query",
+        "codex_usage_tracker.agent_kernel.storage",
+        "sqlite3",
+        "tests.agent_kernel.fact_adapters.database",
+        "tests.agent_kernel.fixtures.oracles.database",
+        "tests.agent_kernel.fixtures.oracles.reference",
+    ]
+    assert lane["forbidden_data_keys"] == [
+        "answer_rows",
+        "comparison_rows",
+        "expected_rows",
+        "grades",
+        "grading",
+        "oracle_case",
+    ]
+    assert lane["forbidden_overlap_roles"] == [
+        "r1b_root",
+        "r1b_transitive_import",
+        "r1b_data_source",
+    ]
+    assert contract["grading_checks"] == {  # type: ignore[index]
+        "lanes": ["production", "independent"],
+        "sentinel_mutated": "baseline_answers_unchanged",
+        "inaccessible": "baseline_answers_unchanged",
+    }
+    assert contract["mutation_checks"] == {  # type: ignore[index]
+        "canonical_fact": "both_lanes_change",
+        "production_source": "independent_truth_unchanged",
+    }

--- a/tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json
+++ b/tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json
@@ -1,0 +1,350 @@
+{
+  "schema": "codex-usage-tracker.answer-semantics-vectors.v1",
+  "version": 1,
+  "contract_sha256": "4754ef287a704e6c9d41baa1f11e1cd4ef11aad1aefa1fb3b222e4760121ac2f",
+  "q_rev_03": {
+    "field_isolation": [
+      {
+        "id": "completion_state_side_swap",
+        "field": "completion_state",
+        "action": "swap_source_value_between_sides",
+        "relation": "session",
+        "stable_ids": ["session-left", "session-right"],
+        "source_fields": ["lifecycle_state", "completion_basis"],
+        "expected_changed_fields": ["completion_state"],
+        "expected_unchanged_fields": [
+          "context_features",
+          "delegation_metrics",
+          "resource_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "context_features_side_swap",
+        "field": "context_features",
+        "action": "swap_source_value_between_sides",
+        "relation": "canonical_call",
+        "stable_ids": ["call-left-context", "call-right-context"],
+        "source_fields": ["context_window_tokens"],
+        "expected_changed_fields": ["context_features"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "delegation_metrics",
+          "resource_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "delegation_metrics_side_swap",
+        "field": "delegation_metrics",
+        "action": "swap_source_value_between_sides_with_compensated_counts",
+        "relation": "session",
+        "stable_ids": ["child-left", "child-right"],
+        "source_fields": ["parent_session_id", "delegation_depth"],
+        "expected_changed_fields": ["delegation_metrics"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "resource_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "resource_metrics_side_swap",
+        "field": "resource_metrics",
+        "action": "swap_source_value_between_sides",
+        "relation": "resource",
+        "stable_ids": ["resource-left", "resource-right"],
+        "source_fields": ["resource_kind"],
+        "expected_changed_fields": ["resource_metrics"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "delegation_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "state_change_metrics_side_swap",
+        "field": "state_change_metrics",
+        "action": "swap_source_value_between_sides",
+        "relation": "state_change",
+        "stable_ids": ["state-left", "state-right"],
+        "source_fields": ["mutation_kind"],
+        "expected_changed_fields": ["state_change_metrics"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "delegation_metrics",
+          "resource_metrics",
+          "token_deltas",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "token_deltas_side_swap",
+        "field": "token_deltas",
+        "action": "swap_source_value_between_sides",
+        "relation": "canonical_call",
+        "stable_ids": ["call-left-tokens", "call-right-tokens"],
+        "source_fields": [
+          "uncached_input_tokens",
+          "cached_input_tokens",
+          "reasoning_tokens",
+          "output_tokens"
+        ],
+        "expected_changed_fields": ["token_deltas"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "delegation_metrics",
+          "resource_metrics",
+          "state_change_metrics",
+          "tool_metrics",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "tool_metrics_side_swap",
+        "field": "tool_metrics",
+        "action": "swap_source_value_between_sides",
+        "relation": "tool_invocation",
+        "stable_ids": ["tool-left", "tool-right"],
+        "source_fields": ["lifecycle"],
+        "expected_changed_fields": ["tool_metrics"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "delegation_metrics",
+          "resource_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "turn_call_counts"
+        ]
+      },
+      {
+        "id": "turn_call_counts_side_swap",
+        "field": "turn_call_counts",
+        "action": "swap_membership_between_sides_with_compensated_metrics",
+        "relation": "turn_and_canonical_call",
+        "stable_ids": ["turn-left", "turn-right", "call-left-count", "call-right-count"],
+        "source_fields": ["session_id"],
+        "expected_changed_fields": ["turn_call_counts"],
+        "expected_unchanged_fields": [
+          "completion_state",
+          "context_features",
+          "delegation_metrics",
+          "resource_metrics",
+          "state_change_metrics",
+          "token_deltas",
+          "tool_metrics"
+        ]
+      }
+    ],
+    "missing_empty": [
+      {"id": "available_empty", "outcome": "typed_zero_or_empty"},
+      {"id": "context_capability_unavailable", "outcome": "context_side_null"},
+      {"id": "mixed_context_missing", "outcome": "fail_closed"},
+      {"id": "missing_hierarchy", "outcome": "affected_delegation_value_null"},
+      {"id": "missing_token_class", "outcome": "class_and_total_null"},
+      {"id": "absent_session", "outcome": "fail_closed"},
+      {"id": "duplicate_session", "outcome": "fail_closed"},
+      {"id": "malformed_session", "outcome": "fail_closed"},
+      {"id": "dangling_resource", "outcome": "fail_closed"},
+      {"id": "conflicting_resource", "outcome": "fail_closed"},
+      {"id": "unknown_tool_lifecycle", "outcome": "fail_closed"}
+    ]
+  },
+  "q_wf_02": [
+    {
+      "id": "between_start_success",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, 1, 1]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-0", 0]},
+        {"kind": "call", "coordinate": [false, 3, 0, 3, 30, "call-1", 0], "tokens": [2, 2, 2, 2]},
+        {"kind": "tool_terminal", "coordinate": [false, 4, 0, 4, 40, "tool-0", 1], "lifecycle": "succeeded"},
+        {"kind": "state_change", "coordinate": [false, 5, 0, 5, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": 4,
+        "first_success_tokens": 12,
+        "first_mutation_tokens": 12,
+        "mutation_observed": true
+      }
+    },
+    {
+      "id": "failed_then_success",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, 1, 1]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-failed", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 3, 0, 3, 40, "tool-failed", 1], "lifecycle": "failed"},
+        {"kind": "call", "coordinate": [false, 4, 0, 4, 30, "call-1", 0], "tokens": [2, 2, 2, 2]},
+        {"kind": "tool_start", "coordinate": [false, 5, 0, 5, 40, "tool-success", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 6, 0, 6, 40, "tool-success", 1], "lifecycle": "succeeded"},
+        {"kind": "state_change", "coordinate": [false, 7, 0, 7, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": 4,
+        "first_success_tokens": 12,
+        "first_mutation_tokens": 12,
+        "mutation_observed": true
+      }
+    },
+    {
+      "id": "absent_boundaries",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, 1, 1]}
+      ],
+      "expected": {
+        "first_action_tokens": null,
+        "first_success_tokens": null,
+        "first_mutation_tokens": null,
+        "mutation_observed": false
+      }
+    },
+    {
+      "id": "present_without_prior_call",
+      "events": [
+        {"kind": "tool_start", "coordinate": [false, 1, 0, 1, 40, "tool-0", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 2, 0, 2, 40, "tool-0", 1], "lifecycle": "succeeded"},
+        {"kind": "state_change", "coordinate": [false, 3, 0, 3, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": 0,
+        "first_success_tokens": 0,
+        "first_mutation_tokens": 0,
+        "mutation_observed": true
+      }
+    },
+    {
+      "id": "missing_prior_token",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, null, 1]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-0", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 3, 0, 3, 40, "tool-0", 1], "lifecycle": "succeeded"},
+        {"kind": "state_change", "coordinate": [false, 4, 0, 4, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": null,
+        "first_success_tokens": null,
+        "first_mutation_tokens": null,
+        "mutation_observed": true
+      }
+    },
+    {
+      "id": "seven_part_tie",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, 1, 1]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-b", 0]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-a", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 3, 0, 3, 40, "tool-a", 1], "lifecycle": "failed"},
+        {"kind": "tool_terminal", "coordinate": [false, 3, 0, 3, 40, "tool-b", 2], "lifecycle": "succeeded"},
+        {"kind": "state_change", "coordinate": [false, 4, 0, 4, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": 4,
+        "first_success_tokens": 4,
+        "first_mutation_tokens": 4,
+        "mutation_observed": true,
+        "action_boundary_id": "tool-a",
+        "success_boundary_id": "tool-b"
+      }
+    },
+    {
+      "id": "delayed_mutation",
+      "events": [
+        {"kind": "call", "coordinate": [false, 1, 0, 1, 30, "call-0", 0], "tokens": [1, 1, 1, 1]},
+        {"kind": "tool_start", "coordinate": [false, 2, 0, 2, 40, "tool-0", 0]},
+        {"kind": "tool_terminal", "coordinate": [false, 3, 0, 3, 40, "tool-0", 1], "lifecycle": "succeeded"},
+        {"kind": "call", "coordinate": [false, 4, 0, 4, 30, "call-1", 0], "tokens": [2, 2, 2, 2]},
+        {"kind": "state_change", "coordinate": [false, 5, 0, 5, 60, "state-0", 0]}
+      ],
+      "expected": {
+        "first_action_tokens": 4,
+        "first_success_tokens": 4,
+        "first_mutation_tokens": 12,
+        "mutation_observed": true
+      }
+    }
+  ],
+  "grading": {
+    "sentinel_mutated": [
+      {
+        "id": "production_grading_sentinel",
+        "lane": "production",
+        "outcome": "baseline_answers_unchanged"
+      },
+      {
+        "id": "independent_grading_sentinel",
+        "lane": "independent",
+        "outcome": "baseline_answers_unchanged"
+      }
+    ],
+    "inaccessible": [
+      {
+        "id": "production_grading_inaccessible",
+        "lane": "production",
+        "outcome": "baseline_answers_unchanged"
+      },
+      {
+        "id": "independent_grading_inaccessible",
+        "lane": "independent",
+        "outcome": "baseline_answers_unchanged"
+      }
+    ],
+    "mutations": [
+      {
+        "id": "canonical_fact",
+        "production": "changed",
+        "independent": "changed"
+      },
+      {
+        "id": "production_source",
+        "production": "changed",
+        "independent": "unchanged"
+      }
+    ]
+  },
+  "closure": {
+    "canonical": {
+      "consumer": "b/consumer.py",
+      "harness": "a/harness.py",
+      "roots": [
+        {
+          "path": "a/harness.py",
+          "role": "harness",
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "path": "b/consumer.py",
+          "role": "consumer",
+          "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ],
+      "imports": [
+        {
+          "path": "c/import.py",
+          "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        }
+      ],
+      "closure_digest": "8b4642a25a8802771eab683cd632b0a029203f3d06f6594e57faa7e50f15dc42"
+    },
+    "negative": [
+      {"id": "drift", "outcome": "reject_before_grading"},
+      {"id": "inaccessible", "outcome": "reject_before_grading"}
+    ]
+  }
+}

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -188,23 +188,24 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
         "blocked_policy": "spawn_none_and_report_to_orchestrator",
     }
-    conditional_ready = {"CK-07R1", "CK-08R1A", "CK-08R3A", "CK-QG1A"}
+    conditional_ready = {"CK-07R1", "CK-08R3A", "CK-QG1A"}
     blocked: set[str] = set()
     assert manifest["completed"] == [
         "CK-08R0",
+        "CK-08R1A",
         "CK-08R2",
         "CK-QG1A0",
         "CK-07R1A",
         "CK-07R1A0",
     ]
-    ready: set[str] = set()
-    assert manifest["ready"] == []
+    ready = {"CK-08R1B", "CK-08R1C"}
+    assert manifest["ready"] == ["CK-08R1B", "CK-08R1C"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "Each lane's serialized corrective authority correction accepted, merged, and exact-main verified"
+                "CK-08R3A's serialized corrective authority correction accepted, merged, and exact-main verified"
             ),
-            "tasks": ["CK-08R1A", "CK-08R3A"],
+            "tasks": ["CK-08R3A"],
         },
         {
             "condition": "CK-QG1A0 merged and exact-main verified",
@@ -223,7 +224,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Blocked child tasks: **41" in ledger
+    assert "Blocked child tasks: **39" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -318,7 +319,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Ready" in body
         elif packet_id in blocked:
             assert "**Status:** Blocked" in body
-        elif packet_id in {"CK-08R0", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"}:
+        elif packet_id in {"CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"}:
             assert "**Status:** Completed on merge" in body
         else:
             assert "**Status:** Blocked" in body

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -23,6 +23,7 @@ from scripts.check_kernel_scope import (
     CK07R1A0_AUTHORITY_ADDITIONS,
     CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CK08_QUERY_EVIDENCE_ADDITIONS,
+    CK08R1A_ANSWER_SEMANTICS_ADDITIONS,
     CK08R2_PHYSICAL_PAGE_ADDITIONS,
     CK08R3A_AUTHORITY_ADDITIONS,
     CKQG1A0_AUTHORITY_ADDITIONS,
@@ -671,6 +672,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK07A_FACT_BACKED_REQUALIFICATION_ADDITIONS
         | CK08_QUERY_EVIDENCE_ADDITIONS
         | CK08R2_PHYSICAL_PAGE_ADDITIONS
+        | CK08R1A_ANSWER_SEMANTICS_ADDITIONS
         | CK08R3A_AUTHORITY_ADDITIONS
         | CKQG1A0_AUTHORITY_ADDITIONS
         | PACKAGE_BUDGET_POLICY_ADDITIONS
@@ -686,6 +688,16 @@ def test_ck08r3a_authority_additions_are_explicit_and_bounded() -> None:
     assert {
         "docs/decisions/evidence/ck08r3a/evidence-service-supersession-authority.json",
     } == CK08R3A_AUTHORITY_ADDITIONS
+
+
+def test_ck08r1a_answer_semantics_additions_are_explicit_and_bounded() -> None:
+    assert {
+        "config/agent-kernel/answer-semantics-v1.json",
+        "config/agent-kernel/answer-semantics-v1.schema.json",
+        "docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json",
+        "tests/agent_kernel/contracts/test_answer_semantics_contract.py",
+        "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json",
+    } == CK08R1A_ANSWER_SEMANTICS_ADDITIONS
 
 
 def test_ck07r1a0_authority_and_lifecycle_scope_additions_are_explicit() -> None:


### PR DESCRIPTION
## What changed

- Freeze the CK-08R1A `answer-semantics.v1` contract and JSON Schema, including all eight Q-REV-03 fields, source/missingness/sensitivity rules, and the seven-part Q-WF-02 ordering.
- Add answer-truth requalification evidence schema, contract vectors, grading-independence vectors, and focused contract tests.
- Register the bounded additions in kernel scope and advance only the CK-08R1A authority ledger/DAG; R1B and R1C remain separate implementation lanes and are not dispatched here.

## Why

The prior crash witness contained valid answer-semantics work but was stale against the current package ceiling and lacked explicit grading vectors. This reapplication was rebuilt from the requested exact START base `62d6cc18f852718b8e2eba6fd0f07a165cc8a414`, with the current `2,000,000` sdist policy and recomputed artifact identities.

## Scope boundaries

No production answer implementation, independent evaluator, QueryService/SQLite/grading imports, projections, public surfaces, or downstream task dispatch are included.

## Validation

- `python3 scripts/bootstrap_dev_environment.py --check`
- Focused contract/authority/scope tests: 35 passed
- `just v`: 1374 passed; invariant suite 13 passed; static/type/release checks passed
- `just vc`: wheel/sdist build and distribution release-safety checks passed
- `git diff --check` and GitNexus `detect_changes`: low risk, 0 affected processes

The current remote `main` advanced independently to `30983d4b5005e7e2a507757c76a3c05ab56281e6` after the requested START base; its change is disjoint from this branch.
