### PR TITLE
docs: reconcile QG1A completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ and publication/evidence scale plus replacement maintainability need
 corrective proof. CK-08R0 froze `corrective-gates-v1`; CK-08R2 is complete and
 CK-09 remains blocked. CK-08R1A froze corrected answer meaning and recursive
 closure; disjoint R1B/R1C implementation is Ready before final R1 requalification.
-CK-QG1A must
-remove two R2 page-executor complexity findings without changing behavior or
-the frozen baseline before existing QG1 PR #392 resumes. CK-07R1A corrected
+CK-QG1A removed the two R2 page-executor complexity findings without changing
+behavior or the frozen baseline and is accepted at exact main `30983d4`;
+existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A corrected
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`. The
 existing CK-07R1 worker remains stopped pending coordinator disposition of the

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,8 +22,9 @@ before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
 fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
 truth now consumes [`answer-semantics.v1`](../config/agent-kernel/answer-semantics-v1.json);
 disjoint R1B/R1C consumers are Ready before final R1 requalification.
-CK-QG1A0 gates the selected R2 PageExecutor
-successor; QG1A fixes its two C/B/B findings. CK-07R1A separately corrected
+CK-QG1A0 gated the selected R2 PageExecutor successor; QG1A removed its two
+C/B/B findings and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`;
+existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A separately corrected
 PR #394's exact hosted lifecycle-tail failure without a budget waiver.
 CK-07R1A0 is accepted at exact main `519b503aa3b23019033b6481687c08b23fc6c31e`.
 Its transition authority makes the planner-valid receipt a CK-07R1 successor

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -161,8 +161,10 @@ qualify publication-valid lifecycle preparation. CK-08R4 alone may classify a
 plan as direct-page, evidence-page, or projection-required. CK-09 may admit
 only the resulting measured residual list after CK-08RG.
 
-CK-QG1A0 gates the selected PageExecutor successor. Exact-main QG1A then fixes
-R2 rank-D findings; R2 semantics, evidence, thresholds, baseline, and generic-drift
+CK-QG1A0 gated the selected PageExecutor successor. CK-QG1A removed R2's
+rank-D findings and is accepted at exact main
+`30983d4b5005e7e2a507757c76a3c05ab56281e6`; existing QG1 PR #392 is Ready
+to resume. R2 semantics, evidence, thresholds, baseline, and generic-drift
 prohibition remain binding.
 
 CK-07R1A is a separate lifecycle-performance lock: preserve the first hosted

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -47,7 +47,7 @@ paging, so they admit neither projections nor CK-09.
 
 R1A freezes Q-REV-03/Q-WF-02 and executable transitive closure before parallel
 R1B/C and final two-lane R1 replay. R3 scale awaits merged/exact-main R3A.
-QG1 PR #392 awaits CK-QG1A0 exact-main, then QG1A fixes only R2's two rank-D findings against its unchanged baseline. CK-07R1A preserves the first hosted Python
+CK-QG1A removed only R2's two rank-D findings against its unchanged baseline and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`; existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and
 `5000/120000/100/500/500` budgets; only a controlled material correction can
 resume PR #394. Stale, grading-dependent, retried-only, or waived evidence

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -19,9 +19,10 @@ production fix. CK-08R3 must not become Ready or be redelegated until CK-08R3A
 is accepted, merged, and exact-main verified. Retained CK-08R1 work reached
 80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
 their meaning and closure, R1B/C are Ready as disjoint consumers, and R1 is their
-requalification join. CK-QG1 PR #392 also stays blocked: R2 introduced two
-page-executor C/B/B violations, so QG1A must correct them without changing R2
-behavior or the frozen maintainability baseline.
+requalification join. CK-QG1A removed R2's two page-executor C/B/B violations
+without changing behavior or the frozen maintainability baseline and is
+accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`.
+Existing CK-QG1 PR #392 is Ready to resume from that corrected main.
 CK-07R1A is accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 was accepted at
 `519b503aa3b23019033b6481687c08b23fc6c31e`; its linked
@@ -159,14 +160,11 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"],
-  "ready": ["CK-08R1B", "CK-08R1C"],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"],
+  "ready": ["CK-08R1B", "CK-08R1C", "CK-QG1"],
   "conditional_ready": [{
     "condition": "CK-08R3A's serialized corrective authority correction accepted, merged, and exact-main verified",
     "tasks": ["CK-08R3A"]
-  }, {
-    "condition": "CK-QG1A0 merged and exact-main verified",
-    "tasks": ["CK-QG1A"]
   }, {
     "condition": "ARGV authority accepted at 479cbdb; coordinator records the preserved prelaunch incident disposition and a clean exact-main reapplication path; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement, launch, or downstream task",
     "tasks": ["CK-07R1"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,11 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **6 — CK-08R0, CK-08R1A, CK-08R2, CK-QG1A0, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **44**
-- Ready child tasks: **2 — CK-08R1B, CK-08R1C**
-- Conditional-ready child tasks: **3 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path; CK-08R3A; CK-QG1A after CK-QG1A0 exact-main**
-- Blocked child tasks: **39**
+- Completed corrective child tasks: **7 — CK-08R0, CK-08R1A, CK-08R2, CK-QG1A0, CK-QG1A, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **43**
+- Ready child tasks: **3 — CK-08R1B, CK-08R1C, CK-QG1**
+- Conditional-ready child tasks: **2 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path; CK-08R3A**
+- Blocked child tasks: **38**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -68,8 +68,8 @@ unchanged.
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
 - [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after argv authority merge `479cbdb`, coordinator disposition of the preserved `prelaunch_failed` witness incident, and a clean exact-main reapplication path; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
-- [ ] **CK-QG1A — Correct page-executor complexity** · Conditional Ready after CK-QG1A0 exact-main · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
-- [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Blocked on CK-QG1A and refresh of existing PR #392 on corrected main · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
+- [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
+- [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Ready to refresh existing PR #392 from corrected exact main with the frozen baseline unchanged · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
 - [ ] **CK-08RG — Authorize CK-09 resumption** · Blocked on CK-08R4 and CK-QG1 · [packet](tasks/ck-08rg-authorize-ck09-resumption.md)
 

--- a/docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md
+++ b/docs/roadmap/tasks/ck-qg1-enforce-agent-kernel-maintainability.md
@@ -1,6 +1,6 @@
 # CK-QG1 — Enforce replacement-kernel maintainability
 
-**Status:** Blocked on CK-QG1A
+**Status:** Ready after CK-QG1A merge exact-main verification
 
 **Parent:** Corrective quality gate for all remaining packets
 

--- a/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
+++ b/docs/roadmap/tasks/ck-qg1a-correct-page-executor-complexity.md
@@ -1,6 +1,6 @@
 # CK-QG1A — Correct page-executor complexity
 
-**Status:** Conditional Ready after CK-QG1A0 merge is exact-main verified
+**Status:** Completed on merge; PR #408 exact-main verified at `30983d4b5005e7e2a507757c76a3c05ab56281e6`
 
 **Parent:** Corrective prerequisite for CK-QG1
 

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -188,28 +188,32 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
         "blocked_policy": "spawn_none_and_report_to_orchestrator",
     }
-    conditional_ready = {"CK-07R1", "CK-08R3A", "CK-QG1A"}
+    conditional_ready = {"CK-07R1", "CK-08R3A"}
     blocked: set[str] = set()
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R1A",
         "CK-08R2",
         "CK-QG1A0",
+        "CK-QG1A",
         "CK-07R1A",
         "CK-07R1A0",
     ]
-    ready = {"CK-08R1B", "CK-08R1C"}
-    assert manifest["ready"] == ["CK-08R1B", "CK-08R1C"]
+    qg1a_authority = _json(
+        "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json"
+    )
+    qg1a_source = _REPO_ROOT / qg1a_authority["source_path"]
+    assert hashlib.sha256(qg1a_source.read_bytes()).hexdigest() == (
+        qg1a_authority["selected_successor"]["sha256"]
+    )
+    ready = {"CK-08R1B", "CK-08R1C", "CK-QG1"}
+    assert manifest["ready"] == ["CK-08R1B", "CK-08R1C", "CK-QG1"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
                 "CK-08R3A's serialized corrective authority correction accepted, merged, and exact-main verified"
             ),
             "tasks": ["CK-08R3A"],
-        },
-        {
-            "condition": "CK-QG1A0 merged and exact-main verified",
-            "tasks": ["CK-QG1A"],
         },
         {
             "condition": (
@@ -224,7 +228,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Blocked child tasks: **39" in ledger
+    assert "Blocked child tasks: **38" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -319,7 +323,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Ready" in body
         elif packet_id in blocked:
             assert "**Status:** Blocked" in body
-        elif packet_id in {"CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-07R1A", "CK-07R1A0"}:
+        elif packet_id in {"CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"}:
             assert "**Status:** Completed on merge" in body
         else:
             assert "**Status:** Blocked" in body
@@ -551,7 +555,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
     assert "exact-main verified at `519b503aa3b23019033b6481687c08b23fc6c31e`" in ck07r1a0
     assert "strict Authority v2" in ck07r1a0
     assert "supersedes earlier CK-07R1 wording" in central
-    assert "Blocked on CK-QG1A" in ckqg1
+    assert "**Status:** Ready after CK-QG1A merge exact-main verification" in ckqg1
     assert "Conditional Ready after the finite source/runtime state authority" in ck07r1
     assert "720-second wrapper timeout" in ck07r1a0
     assert "revoked, never authoritative, and never used" in ck07r1a0


### PR DESCRIPTION
## Summary
- record CK-QG1A PR #408 as accepted and exact-main verified
- mark the existing CK-QG1 PR #392 lane Ready while preserving its frozen baseline
- bind that readiness to the accepted PageExecutor successor digest
- reconcile central authority narratives and machine ledger counts

## Validation
- focused authority/scope/PageExecutor suite: 40 passed
- `just vc`: 1374 tests plus 13 invariant checks, release and distribution safety passed
- independent read-only review findings addressed
- GitNexus: low risk, 0 affected processes
