### PR TITLE
docs: reconcile CK-08R1C completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ Python materialization, projection classification combines execution stages,
 and publication/evidence scale plus replacement maintainability need
 corrective proof. CK-08R0 froze `corrective-gates-v1`; CK-08R2 is complete and
 CK-09 remains blocked. CK-08R1A froze corrected answer meaning and recursive
-closure; disjoint R1B/R1C implementation is Ready before final R1 requalification.
+closure; R1C is accepted at exact main `fb0c578`, while R1B remains held on
+shared query/evidence/grading integration before final R1 requalification.
 CK-QG1A removed the two R2 page-executor complexity findings without changing
 behavior or the frozen baseline and is accepted at exact main `30983d4`;
 existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A corrected

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,7 +21,9 @@ Retained CK-08R3 `a28e9cdbff8e48d334712a449fdcee111c725673` then stopped
 before scale on first/deep EvidenceService EXPLAIN. CK-08R3A owns that separate
 fix; CK-08R3 awaits its accepted merge/exact-main verification. Independent
 truth now consumes [`answer-semantics.v1`](../config/agent-kernel/answer-semantics-v1.json);
-disjoint R1B/R1C consumers are Ready before final R1 requalification.
+R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`;
+R1B remains held on shared query/evidence/grading integration before final R1
+requalification.
 CK-QG1A0 gated the selected R2 PageExecutor successor; QG1A removed its two
 C/B/B findings and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`;
 existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A separately corrected

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -109,8 +109,11 @@ request/comparison digests, and required evidence sequences match across the
 two fact-adapter consumers. A downstream audit found both consumers import
 production `evaluate_plan`; this proves fact-adapter and database replay parity,
 not independent answer semantics. CK-08R1A must freeze corrected
-Q-REV-03/Q-WF-02 meaning and executable transitive closure; R1B/R1C then build
-separate consumers and final R1 replays both. Cursor serialization still binds its version, request digest,
+Q-REV-03/Q-WF-02 meaning and executable transitive closure. R1C's independent
+consumer is accepted at exact main
+`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; R1B remains held on shared
+query/evidence/grading integration, and final R1 replays both only after that
+consumer is accepted. Cursor serialization still binds its version, request digest,
 plan, publication, and order; malformed, tampered, stale, replacement, and
 mismatched bindings fail closed.
 

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -46,7 +46,9 @@ paging, so they admit neither projections nor CK-09.
 ### Corrective interpretation and immutable parallel qualification
 
 R1A freezes Q-REV-03/Q-WF-02 and executable transitive closure before parallel
-R1B/C and final two-lane R1 replay. R3 scale awaits merged/exact-main R3A.
+R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`;
+R1B remains held on shared query/evidence/grading integration before final
+two-lane R1 replay. R3 scale awaits merged/exact-main R3A.
 CK-QG1A removed only R2's two rank-D findings against its unchanged baseline and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`; existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and
 `5000/120000/100/500/500` budgets; only a controlled material correction can

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -127,8 +127,9 @@ consumer replay reconciles published database-v1 facts to independent truth.
 
 ### Gate G4: answer kernel
 
-CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1B/C
-implement separately; R1 requalifies. R2 bounds two direct plans while 19 fail
+CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1C is
+accepted, R1B remains held on its shared integration join, and R1 requalifies
+after R1B. R2 bounds two direct plans while 19 fail
 closed. R3A removes unbounded EvidenceService shape; R3 measures it. 07R1A
 materially corrects the exact hosted tail before PR #394 resumes. QG1A0 authorizes
 only the exact R2 PageExecutor successor; QG1A then removes

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -18,8 +18,10 @@ query physically unbounded independent of scale profile. CK-08R3A owns that
 production fix. CK-08R3 must not become Ready or be redelegated until CK-08R3A
 is accepted, merged, and exact-main verified. Retained CK-08R1 work reached
 80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
-their meaning and closure, R1B/C are Ready as disjoint consumers, and R1 is their
-requalification join. CK-QG1A removed R2's two page-executor C/B/B violations
+their meaning and closure. R1C is accepted at exact main
+`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; R1B remains held on shared
+query/evidence/grading integration, and R1 is their requalification join.
+CK-QG1A removed R2's two page-executor C/B/B violations
 without changing behavior or the frozen maintainability baseline and is
 accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`.
 Existing CK-QG1 PR #392 is Ready to resume from that corrected main.
@@ -160,8 +162,8 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"],
-  "ready": ["CK-08R1B", "CK-08R1C", "CK-QG1"],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"],
+  "ready": ["CK-QG1"],
   "conditional_ready": [{
     "condition": "CK-08R3A's serialized corrective authority correction accepted, merged, and exact-main verified",
     "tasks": ["CK-08R3A"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,11 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **7 — CK-08R0, CK-08R1A, CK-08R2, CK-QG1A0, CK-QG1A, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **43**
-- Ready child tasks: **3 — CK-08R1B, CK-08R1C, CK-QG1**
+- Completed corrective child tasks: **8 — CK-08R0, CK-08R1A, CK-08R1C, CK-08R2, CK-QG1A0, CK-QG1A, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **42**
+- Ready child tasks: **1 — CK-QG1**
 - Conditional-ready child tasks: **2 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path; CK-08R3A**
-- Blocked child tasks: **38**
+- Blocked child tasks: **39**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -50,17 +50,18 @@ parents are accounting umbrellas.
 ## Remaining delegated child tasks
 
 Readiness is controlled by
-[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1B/C are Ready after R1A
-merge/exact-main; QG1A follows CK-QG1A0 exact-main; other corrective locks are
-unchanged.
+[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1C is accepted after R1A;
+R1B is held on shared query/evidence/grading integration and must reuse its
+existing worker after an explicit join path. QG1A follows CK-QG1A0 exact-main;
+other corrective locks are unchanged.
 
 ### Corrective gates
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Ready after CK-08R1A merge exact-main verification · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
-- [ ] **CK-08R1C — Build independent semantic evaluator** · Ready after CK-08R1A merge exact-main verification · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
-- [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B and CK-08R1C · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Blocked on shared query/evidence/grading integration; resume existing worker only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
+- [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
 - [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)
 - [ ] **CK-08R3A — Implement bounded EvidenceService physical queries** · Conditional Ready after corrective authority exact-main verification; CK-08R0 remains accepted · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)

--- a/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
+++ b/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
@@ -1,6 +1,6 @@
 # CK-08R1 — Requalify independent answer truth
 
-**Status:** Blocked on CK-08R1B and CK-08R1C
+**Status:** Blocked on CK-08R1B; CK-08R1C accepted
 
 **Parent:** Corrective prerequisite for CK-09
 

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,5 +1,5 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Ready after CK-08R1A merge exact-main verification
+**Status:** Blocked on shared query/evidence/grading integration; resume existing worker only
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.

--- a/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
+++ b/docs/roadmap/tasks/ck-08r1c-build-independent-semantic-evaluator.md
@@ -1,5 +1,5 @@
 # CK-08R1C — Build independent semantic evaluator
-**Status:** Ready after CK-08R1A merge exact-main verification
+**Status:** Completed on merge; PR #411 exact-main verified at `fb0c57886097a6b985d2f321b2de858cbdfc0a97`
 **Recommended owner:** `worker independent-evaluator`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Independently evaluate all 80 variants.

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -195,6 +195,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R1A",
+        "CK-08R1C",
         "CK-08R2",
         "CK-QG1A0",
         "CK-QG1A",
@@ -208,8 +209,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert hashlib.sha256(qg1a_source.read_bytes()).hexdigest() == (
         qg1a_authority["selected_successor"]["sha256"]
     )
-    ready = {"CK-08R1B", "CK-08R1C", "CK-QG1"}
-    assert manifest["ready"] == ["CK-08R1B", "CK-08R1C", "CK-QG1"]
+    ready = {"CK-QG1"}
+    assert manifest["ready"] == ["CK-QG1"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
@@ -230,7 +231,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Blocked child tasks: **38" in ledger
+    assert "Blocked child tasks: **39" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -325,7 +326,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             assert "**Status:** Ready" in body
         elif packet_id in blocked:
             assert "**Status:** Blocked" in body
-        elif packet_id in {"CK-08R0", "CK-08R1A", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"}:
+        elif packet_id in {"CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"}:
             assert "**Status:** Completed on merge" in body
         else:
             assert "**Status:** Blocked" in body


### PR DESCRIPTION
## Summary
- record CK-08R1C as accepted at PR #411 exact main
- remove CK-08R1C and held CK-08R1B from the Ready set
- preserve CK-08R3A Conditional Ready and downstream fail-closed gates

## Validation
- focused documentation/scope/R1C suite: 44 passed
- just vc: 1,388 tests and 13 invariants passed; build/dist/release safety passed
- one independent reviewer: 2 findings, both corrected
- git diff --check and gitleaks: passed