### PR TITLE
docs: record CK-08R3 acceptance

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,8 +20,12 @@ physical keyset SQL; 19 plans retain explicit gaps without projection.
 Retained CK-08R3 `a28e9cdbff8e48d334712a449fdcee111c725673` then stopped
 before scale on first/deep EvidenceService EXPLAIN. CK-08R3A corrected that
 physical path in PR #417 and was hosted-green, squash-merged, and exact-main
-identity verified at `38537f6cee42ad4ba2fb6e45354e410053c7a7cd`;
-CK-08R3 is now Ready for separate scale qualification. Independent
+identity verified at `38537f6cee42ad4ba2fb6e45354e410053c7a7cd`.
+CK-08R3 then passed both frozen synthetic profiles, all selector/view/direction
+outcomes, typed seven-part truth, late-event, truncation, cursor, and
+query-only contracts. PR #425 was hosted-green, squash-merged, and exact-main
+verified at `0fad272b3205614fb254398c9c9dc0a56d5ba7cd`. CK-08R3 is complete;
+CK-08R4 remains blocked on CK-08R1 and CK-07R1. Independent
 truth now consumes [`answer-semantics.v1`](../config/agent-kernel/answer-semantics-v1.json);
 The linked [CK-08R3A schema/publication requalification authority](decisions/evidence/ck08r3a/schema-publication-requalification-authority.json)
 binds the resulting 57-index schema digest, synthetic publication fixture

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -22,8 +22,14 @@ focused, dual-SQLite, full, package, safety, and review gates. A duplicate
 postmerge full runtime rerun did not complete because the host exhausted disk
 space and SQLite could not create temporary files; no product assertion
 failed, and this environment-only limitation does not override the exact-tree
-and hosted acceptance evidence. CK-08R3 is now Ready for its separate
-synthetic scale qualification. Retained CK-08R1 work reached
+and hosted acceptance evidence. CK-08R3 then qualified the separate
+synthetic 100,000-call and 1,316,864-call profiles with `first_failure=null`,
+all 196 selector/view/direction outcomes per profile, typed seven-part truth,
+late-event, truncation, cursor, and query-only contracts. PR #425 passed hosted
+Python 3.10/3.14 and Console, squash-merged at
+`0fad272b3205614fb254398c9c9dc0a56d5ba7cd`, and was exact-main verified.
+CK-08R3 is complete; CK-08R4 remains blocked on CK-08R1 and CK-07R1.
+Retained CK-08R1 work reached
 80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
 their meaning and closure. R1C is accepted at exact main
 `fb0c57886097a6b985d2f321b2de858cbdfc0a97`; R1B remains held on shared
@@ -169,8 +175,8 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-08R3A", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"],
-  "ready": ["CK-QG1", "CK-08R3"],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-07R1A", "CK-07R1A0"],
+  "ready": ["CK-QG1"],
   "conditional_ready": [{
     "condition": "ARGV authority accepted at 479cbdb; coordinator records the preserved prelaunch incident disposition and a clean exact-main reapplication path; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement, launch, or downstream task",
     "tasks": ["CK-07R1"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,9 +12,9 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **9 — CK-08R0, CK-08R1A, CK-08R1C, CK-08R2, CK-08R3A, CK-QG1A0, CK-QG1A, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **41**
-- Ready child tasks: **2 — CK-QG1, CK-08R3**
+- Completed corrective child tasks: **10 — CK-08R0, CK-08R1A, CK-08R1C, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **40**
+- Ready child tasks: **1 — CK-QG1**
 - Conditional-ready child tasks: **1 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path**
 - Blocked child tasks: **38**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
@@ -65,13 +65,13 @@ other corrective locks are unchanged.
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
 - [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)
 - [x] **CK-08R3A — Implement bounded EvidenceService physical queries** · PR #417 hosted-green and squash-merged at `38537f6c`; exact-main identities verified · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)
-- [ ] **CK-08R3 — Qualify evidence service scale** · Ready after CK-08R3A accepted merge and exact-main verification · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
+- [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
 - [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after argv authority merge `479cbdb`, coordinator disposition of the preserved `prelaunch_failed` witness incident, and a clean exact-main reapplication path; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [ ] **CK-QG1 — Enforce replacement-kernel maintainability** · Ready to refresh existing PR #392 from corrected exact main with the frozen baseline unchanged · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
-- [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1/R2/R3 and CK-07R1 · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
+- [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-08R1 and CK-07R1; CK-08R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
 - [ ] **CK-08RG — Authorize CK-09 resumption** · Blocked on CK-08R4 and CK-QG1 · [packet](tasks/ck-08rg-authorize-ck09-resumption.md)
 
 ### CK-09 children

--- a/docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md
+++ b/docs/roadmap/tasks/ck-08r3-qualify-evidence-scale.md
@@ -1,6 +1,7 @@
 # CK-08R3 — Qualify evidence service scale
 
-**Status:** Ready after CK-08R3A PR #417 acceptance, merge, and exact-main verification
+**Status:** Completed on merge — PR #425 hosted-green, squash-merged at
+`0fad272b`, and exact-main verified
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -38,6 +39,15 @@ byte truncation, 100,000 and 1,316,864-call fixtures, first/deep plans and
 budgets at both scales, `just v/vc`.
 
 **Acceptance:** All preceding invariants/tests pass at both scales.
+
+**Accepted evidence:** The committed
+`docs/decisions/evidence/ck08r3/evidence-scale-qualification.json` records
+`first_failure=null` for the synthetic 100,000-call and 1,316,864-call
+profiles. Each profile covers 14 selector scopes, seven views, two directions,
+first/deep pages, typed seven-part truth, one late event, byte truncation,
+cursor tamper/replacement rejection, query-only execution, and bounded
+physical plans. PR #425 passed hosted Console and Python 3.10/3.14 before
+squash merge and exact-main verification.
 
 **Failure/rollback:** Retain first failure; stop scale/admission and route
 physical defects separately. Never weaken gates, create R4, or invent

--- a/docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md
+++ b/docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md
@@ -1,6 +1,6 @@
 # CK-08R4 — Reclassify physical named plans
 
-**Status:** Blocked on CK-08R1, CK-08R2, CK-08R3, and CK-07R1
+**Status:** Blocked on CK-08R1 and CK-07R1; CK-08R2 and CK-08R3 are complete
 
 **Parent:** Corrective prerequisite for CK-09
 

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -207,6 +207,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "CK-08R1C",
         "CK-08R2",
         "CK-08R3A",
+        "CK-08R3",
         "CK-QG1A0",
         "CK-QG1A",
         "CK-07R1A",
@@ -220,8 +221,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         hashlib.sha256(qg1a_source.read_bytes()).hexdigest()
         == (qg1a_authority["selected_successor"]["sha256"])
     )
-    ready = {"CK-QG1", "CK-08R3"}
-    assert manifest["ready"] == ["CK-QG1", "CK-08R3"]
+    ready = {"CK-QG1"}
+    assert manifest["ready"] == ["CK-QG1"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
@@ -236,8 +237,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Completed packets: **14 / 22**" in ledger
     assert "Not started: **8**" in ledger
     assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Completed corrective child tasks: **9" in ledger
-    assert "Remaining delegable child tasks: **41**" in ledger
+    assert "Completed corrective child tasks: **10" in ledger
+    assert "Remaining delegable child tasks: **40**" in ledger
     assert "Blocked child tasks: **38" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
@@ -343,6 +344,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
             "CK-08R1C",
             "CK-08R2",
             "CK-08R3A",
+            "CK-08R3",
             "CK-QG1A0",
             "CK-QG1A",
             "CK-07R1A",


### PR DESCRIPTION
## Summary

- record CK-08R3 as accepted after PR #425 and exact-main verification
- move CK-08R3 from Ready to completed in the machine DAG and ledger
- keep CK-08R4 blocked on CK-08R1 and CK-07R1, with existing CK-07R1, R1B, and QG1 holds unchanged

## Validation

- focused documentation and scope tests: 32 passed
- `just vc`: 1405 passed, 1 skipped; 13 invariant checks; type, release, wheel, sdist, and distribution safety passed
- GitNexus: 6 files, 12 symbols, 0 affected processes, low risk
- one independent read-only reviewer: PASS, zero findings