### PR TITLE
Authorize CK-08R1B answer semantics join

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,9 +55,15 @@ safety, and review gates plus hosted CI passed. The duplicate postmerge full
 runtime rerun was environment-limited by ENOSPC before completion; fresh
 exact-main identities and authority/scope/documentation checks passed, and no
 product assertion failed.
-R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`;
-R1B remains held on shared query/evidence/grading integration before final R1
-requalification.
+R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`.
+The [CK-08R1B answer-semantics join authority](decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
+binds the exact R1A producer artifacts, preserves R1C closure independence,
+and permits only the proved query admission, synthetic hierarchy/coordinate
+materialization, Q-WF-02 evaluator requalification, and deterministic 80-case
+fixture transition. R1B is Ready only for its existing held worker after that
+authority is merged and exact-main verified; the authority does not accept the
+implementation. CK-08R1, CK-08R4, CK-08RG, CK-09, and CK-07 remain blocked or
+held by their existing gates.
 CK-QG1A0 gated the selected R2 PageExecutor successor; QG1A removed its two
 C/B/B findings and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`;
 the linked

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -111,9 +111,11 @@ production `evaluate_plan`; this proves fact-adapter and database replay parity,
 not independent answer semantics. CK-08R1A must freeze corrected
 Q-REV-03/Q-WF-02 meaning and executable transitive closure. R1C's independent
 consumer is accepted at exact main
-`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; R1B remains held on shared
-query/evidence/grading integration, and final R1 replays both only after that
-consumer is accepted. Cursor serialization still binds its version, request digest,
+`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; the exact
+[R1B join authority](../decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
+makes only the existing R1B worker Ready to reconcile its bound shared
+query/evidence/grading seams, and final R1 replays both only after that consumer
+is accepted. Cursor serialization still binds its version, request digest,
 plan, publication, and order; malformed, tampered, stale, replacement, and
 mismatched bindings fail closed.
 

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
@@ -1,0 +1,260 @@
+{
+  "schema": "codex-usage-tracker.ck08r1b-answer-semantics-join-authority.v1",
+  "authority_version": 1,
+  "owner": "CK-08R1B-JOIN",
+  "authority_base_sha": "f31efbdcb81ae3c3cb77d71eb740af4f4ffdfca4",
+  "status": "permitted_not_accepted",
+  "decision": "authorize_exact_query_evidence_grading_join_for_existing_worker",
+  "producer_authority": {
+    "packet": "CK-08R1A",
+    "artifacts": [
+      {
+        "path": "config/agent-kernel/answer-semantics-v1.json",
+        "sha256": "4754ef287a704e6c9d41baa1f11e1cd4ef11aad1aefa1fb3b222e4760121ac2f"
+      },
+      {
+        "path": "config/agent-kernel/answer-semantics-v1.schema.json",
+        "sha256": "e32d9b40482af3147aa554dd812689879e2e3e15ad634c6ab14fe0d1e71bd4c7"
+      },
+      {
+        "path": "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json",
+        "sha256": "6a203d4595e7de6e955e50d8d14feda406e18c3f14c9ddb2850f4db75d11bcfc"
+      },
+      {
+        "path": "docs/decisions/evidence/ck08r1a/answer-truth-requalification-v2.schema.json",
+        "sha256": "ea35833d4dcca418f5e2776002249cb55174cb73d2f70a54d1c3f1721ca03fcc"
+      }
+    ],
+    "rules": [
+      "Q-REV-03 uses complete session hierarchy and four exact token classes",
+      "Q-WF-02 action uses tool start, success uses terminal succeeded transition, and mutation uses state-change coordinates",
+      "Q-WF-02 token totals are strictly before the selected boundary",
+      "missing, empty, zero, null, malformed, and unavailable remain distinct and fail closed where required"
+    ],
+    "artifacts_locked": true
+  },
+  "independent_truth_authority": {
+    "packet": "CK-08R1C",
+    "accepted_merge_sha": "fb0c57886097a6b985d2f321b2de858cbdfc0a97",
+    "accepted_roots": [
+      {
+        "path": "tests/agent_kernel/fixtures/independent/closure.py",
+        "sha256": "a81362352d7fdc3d9f0b7b8c63248c5ae1adbf59c7ec5a0259f7353670bbb647"
+      },
+      {
+        "path": "tests/agent_kernel/fixtures/independent/semantic.py",
+        "sha256": "8d46b9f65676087437386c270d975f2be8651a8eb299ee1e6d525b5eda913443"
+      },
+      {
+        "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
+        "sha256": "db9c0dd58dbd24bb28a76cb1a603516686bf552e0303c451b5d1949c4b62e693"
+      }
+    ],
+    "preserved": [
+      "recursive closure and accessibility verification",
+      "forbidden import and role-overlap guards",
+      "grading sentinel and grading-inaccessible behavior",
+      "production-source mutation independence",
+      "facts-only evaluation from R1A declarations"
+    ],
+    "required_requalification": {
+      "path": "tests/agent_kernel/fixtures/independent/semantic.py",
+      "reason": "the accepted actual 80-case Q-WF-02 seam retained three-class totals and one coincident generic tool coordinate",
+      "observed_predecessor_mismatches": [
+        {
+          "case": "Q-WF-02-delayed_mutation",
+          "independent": 228,
+          "r1a_production": 235
+        },
+        {
+          "case": "Q-WF-02-failed_then_success",
+          "independent": 130,
+          "r1a_production": 135
+        }
+      ],
+      "successor_sha256": "8edca141d69cbb89d875d09c7618ce471f04ef41d1c0ecbc8520ed531344e037",
+      "grading_or_expected_rows_import": "forbidden"
+    }
+  },
+  "held_candidate": {
+    "worker_thread": "019fc419-0dab-73e3-a6cc-ce574f18c89f",
+    "role": "existing CK-08R1B implementation worker",
+    "candidate_base_sha": "f3f376fc644a2e3d23c313dd6b7ca4b707c2998b",
+    "binary_patch_sha256": "5e7ba8a825fcea036e360aaeb541f0144c67cb557b70c7d35d49a16a1a40ea8c",
+    "candidate_paths": [
+      "config/agent-kernel/logical-contract-v1.json",
+      "config/agent-kernel/plan-operand-contract-v1.json",
+      "src/codex_usage_tracker/agent_kernel/domain/plan_derivations_structural.py",
+      "tests/agent_kernel/contracts/test_plan_derivations_structural.py",
+      "tests/agent_kernel/contracts/test_plan_operand_contract.py",
+      "tests/agent_kernel/contracts/vectors/plan-operands-v1.json",
+      "tests/agent_kernel/fact_adapters/database.py",
+      "tests/agent_kernel/fact_adapters/support.py",
+      "tests/agent_kernel/fixtures/oracles/cases_v2.py"
+    ],
+    "witnesses": "read_only_and_retained",
+    "authority_pr_candidate_bytes": "forbidden"
+  },
+  "consumer_join": {
+    "query_compiler": {
+      "path": "src/codex_usage_tracker/agent_kernel/query/compiler.py",
+      "owner": "existing CK-08R1B worker",
+      "admit": [
+        "canonical_call.measurement_mask",
+        "tool_invocation start event_at_us/source_rank/source_order/event_kind_order/logical_id",
+        "tool_invocation terminal event_at_us/source_rank/source_order/event_kind_order/logical_id"
+      ],
+      "successor_sha256": "c3c43f044a43b5d2aed18cc03b88f1a5156a6570dd4d1cfc2f47a8b4d1833ffa",
+      "fail_closed": "undeclared, null, partial, or type-mismatched selected fields"
+    },
+    "synthetic_materialization": {
+      "paths": [
+        "tests/agent_kernel/fact_adapters/support.py",
+        "tests/agent_kernel/fixtures/oracles/cases_v2.py",
+        "tests/agent_kernel/fixtures/tiny-v2/question-scenarios.json",
+        "tests/agent_kernel/fixtures/tiny-v2/oracle-bundle.json",
+        "tests/agent_kernel/fixtures/tiny-v2/manifest.json"
+      ],
+      "owner": "existing CK-08R1B worker",
+      "requirements": [
+        "every selected session has one complete acyclic parent chain",
+        "tool starts and terminals materialize their separately declared coordinates",
+        "canonical calls materialize exact measurement_mask and four token classes",
+        "Q-WF-02 session_selector excludes same-window foreign-session facts",
+        "valid tool facts outside the half-open request window are excluded by explicit start coordinate",
+        "fixture manifests retain regenerated artifact identities without legacy overrides"
+      ]
+    },
+    "oracle_requalification": {
+      "generator_path": "scripts/generate_ck07a_fixture.py",
+      "independent_evaluator_path": "tests/agent_kernel/fixtures/independent/semantic.py",
+      "production_evaluator_path": "src/codex_usage_tracker/agent_kernel/domain/plan_derivations_structural.py",
+      "expected_rows_source": "independent_evaluator_from_declared_facts",
+      "production_role": "derive actual rows and compare only",
+      "copied_expected_rows": "forbidden",
+      "grading_source_imported_into_production": "forbidden"
+    }
+  },
+  "selected_successor_cohort": {
+    "preflight_base_sha": "f31efbdcb81ae3c3cb77d71eb740af4f4ffdfca4",
+    "patch_sha256": "d3ba81015172cd6e0be2dbaa3beb0aa321cc0232c7820d7ce7cba5630c0674d2",
+    "files": [
+      {"path": "config/agent-kernel/logical-contract-v1.json", "predecessor_sha256": "27981ec9bac8c245306e02784b8730e8ff9216b33a81da9efb8409403431fe3d", "sha256": "3d7412156c735a9e1e497049ec86c8130c20632da27e009deed24d19c5836e84"},
+      {"path": "config/agent-kernel/plan-operand-contract-v1.json", "predecessor_sha256": "19b9c69f50f67b01321e1f269cee2f70370ca64c0c666ff4dac2cc52efa314b4", "sha256": "0f21a484b66c36bb467bc659f2656fd20c31619e9bc7b6e8edd89250855edffe"},
+      {"path": "experiments/physical-architecture/candidate_a/queries.py", "predecessor_sha256": "dd2a121480920cf96cd51ec43084a76a278009a8b72153b15963862d9619fe89", "sha256": "53c947fa8468db211428104aa4276e9138d6c48160de8c99821b5c509ae5929e"},
+      {"path": "scripts/generate_ck07a_fixture.py", "predecessor_sha256": "d24be0a95b302a9c52d413c300f23536d8c0287512c4b446ed03f8d33ce0863f", "sha256": "37cfd57351491c25141fde2d6ef0812d3f4e6e6b60921a2ce6e1af670b3cc28d"},
+      {"path": "src/codex_usage_tracker/agent_kernel/domain/plan_derivations_structural.py", "predecessor_sha256": "c63b5ae2528852768c7a0906c2dccd537587192116fd2cec956110bcc8ed1367", "sha256": "1c0441ca1d26c1d774aba9b53e0e10b04fcec2c6de7c1453a3e42aabcffa20ad"},
+      {"path": "src/codex_usage_tracker/agent_kernel/query/compiler.py", "predecessor_sha256": "0e57ddb03c5bff28eb74dc2eaa98f35491c649de71e7e9ba680c358a5adc0286", "sha256": "c3c43f044a43b5d2aed18cc03b88f1a5156a6570dd4d1cfc2f47a8b4d1833ffa"},
+      {"path": "tests/agent_kernel/contracts/test_plan_derivations_structural.py", "predecessor_sha256": "853f5d6d44d17ef4a19bff0ab383d758d52541ec7c7b8bf92d008d93b3fb40fb", "sha256": "8531e34b4a1c11c4e55c49efbf369ee82126bdf2a4c373896b0142c6acdae915"},
+      {"path": "tests/agent_kernel/contracts/test_plan_operand_contract.py", "predecessor_sha256": "72e9e205d56623eec9e26cba2fd8877190da1ee9675a779f49d527e989ad0988", "sha256": "b267512d0195c8e461a796af8c29671ce74ad71559ea6b6ffcac96269335ba6d"},
+      {"path": "tests/agent_kernel/contracts/vectors/plan-operands-v1.json", "predecessor_sha256": "cc4d944354356136c45c6a22aa0a289849fe6c4804e4a5d5bd5574cac1ab72c2", "sha256": "8b83417dc5e7cd25ec1711fcd4b1152b90412d3594df918e3b5f2fdd363f845d"},
+      {"path": "tests/agent_kernel/fact_adapters/database.py", "predecessor_sha256": "30c3f34d3847e75faeb5a5d543ec88b30939ad218ae38071e1929acddba6a63e", "sha256": "f81cad1e5c5875f9e6183047911265dbf21cb44266dfe0bfe1838cff8b26df92"},
+      {"path": "tests/agent_kernel/fact_adapters/support.py", "predecessor_sha256": "2e8447613ce12fd0f82cb36af7ddebb2ba1e4eef1b6d53f31a990564b0be94c5", "sha256": "4e9ae26ce21909579bb5ccb1494cd55aaf1c2629ab547a50a8fda049829ad896"},
+      {"path": "tests/agent_kernel/fact_adapters/test_contracts.py", "predecessor_sha256": "11f75a8025374455e90a0c4fb4eb9b2dc78bcce157e362fbe83aa001d6343536", "sha256": "cff89ea3b858df35695641cad6eed3ff2a04bf5dc9f2249b8d29108aa28d79b8"},
+      {"path": "tests/agent_kernel/fixtures/independent/semantic.py", "predecessor_sha256": "8d46b9f65676087437386c270d975f2be8651a8eb299ee1e6d525b5eda913443", "sha256": "4c9729d9d0d7ad17f8ab3c341f5e71e377757bf5d16273aac8274f1efb9837d9"},
+      {"path": "tests/agent_kernel/fixtures/oracles/cases_v2.py", "predecessor_sha256": "4ab32f4f924aef5f71e3b3d48478e5ae33eb86736a3b75de4b52621f4dae679b", "sha256": "7042fd002c1345c555a13148163cef326b3f6b4cf362ea7c922511e80c321b39"},
+      {"path": "tests/agent_kernel/fixtures/tiny-v2/manifest.json", "predecessor_sha256": "fb40a8a91d6ad537171e7a23e3f6fa9bd519080b513981b9483f9791e5e99e7d", "sha256": "4e33fc263f75cdd7d532d2972232b92c5320f58c0628154deaa74380d8875a8c"},
+      {"path": "tests/agent_kernel/fixtures/tiny-v2/oracle-bundle.json", "predecessor_sha256": "97b78d11fa64eb2dac0a5f605bd9056f331ac9dd1fd210703e5f42b23935b40e", "sha256": "e5f682332b7529a85b420f1e1d2c543a5f867eef617fcb484ecc2d04c517da72"},
+      {"path": "tests/agent_kernel/fixtures/tiny-v2/question-scenarios.json", "predecessor_sha256": "6ffca4917386c5bc13237952904d2a560a531e37c6eeba89b69ea53d76f35cd8", "sha256": "986d2f9689f0abf6515247655d75ad8c3587cf7635b201479801de0c94431014"},
+      {"path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py", "predecessor_sha256": "db9c0dd58dbd24bb28a76cb1a603516686bf552e0303c451b5d1949c4b62e693", "sha256": "7fb178208c70c8e83525a0eb09018efa523766c2f8ac8aa8aecb097eb4e900c0"}
+    ],
+    "focused_test_identities": [
+      {
+        "path": "tests/agent_kernel/contracts/test_plan_derivations_structural.py",
+        "sha256": "8531e34b4a1c11c4e55c49efbf369ee82126bdf2a4c373896b0142c6acdae915"
+      },
+      {
+        "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
+        "sha256": "7fb178208c70c8e83525a0eb09018efa523766c2f8ac8aa8aecb097eb4e900c0"
+      }
+    ],
+    "focused_validation": {
+      "result": "182 passed",
+      "case_count": 80,
+      "independent_rows_equal_production_rows": true,
+      "independent_grades_equal_frozen_grades": true,
+      "fixture_source_jsonl_unchanged": true,
+      "review_mutations": [
+        "Q-WF-02 no-match and same-window foreign-session selector isolation",
+        "Q-WF-02 valid before-window and after-window tool exclusion",
+        "Q-REV-03 missing, null, and mask-value mismatch while capability is unavailable"
+      ]
+    }
+  },
+  "negative_mutations": [
+    "missing, null, duplicate, cyclic, or dangling session hierarchy rejects",
+    "missing, null, malformed, or value-mismatched canonical-call measurement_mask rejects even when structural-context capability is unavailable",
+    "Q-WF-02 session selector excludes same-window foreign-session calls, tools, and state changes",
+    "valid Q-WF-02 tools before or after the selected half-open window are excluded",
+    "partial or null start coordinate rejects",
+    "partial or null terminal coordinate rejects",
+    "terminal without start rejects",
+    "succeeded lifecycle without terminal succeeded transition rejects",
+    "terminal ordered before start rejects",
+    "duplicate stable session, turn, call, tool, state-change, or resource identity rejects",
+    "grading sentinel and grading inaccessible leave both evaluators unchanged",
+    "production-source mutation changes production only and exposes a mismatch",
+    "canonical-fact mutation changes both evaluators",
+    "copied expected row or grading import in production rejects",
+    "closure membership, digest, or accessibility drift rejects before evaluation"
+  ],
+  "required_gates": {
+    "implementation": [
+      "recompute all bound digests from repository-relative paths",
+      "R1A contract and vector tests",
+      "query compiler and database declaration tests",
+      "structural derivation and operand tests",
+      "R1C recursive closure, import guards, and independent evaluator tests",
+      "deterministic fixture regeneration with unchanged synthetic source JSONL",
+      "full 80-case independent versus production row, grade, order, provenance, and null comparison",
+      "all negative mutations",
+      "just vp",
+      "just v",
+      "just vc",
+      "hosted CI and fresh exact-main verification"
+    ],
+    "downstream": [
+      "CK-08R1 recomputes both production and independent closures and all 80 cases after CK-08R1B acceptance",
+      "CK-08R4 remains blocked until CK-08R1 and CK-07R1 are accepted",
+      "CK-08RG and CK-09 remain blocked until CK-08R4 and their existing prerequisites are accepted"
+    ]
+  },
+  "scope": {
+    "authority_write_scope": [
+      "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json",
+      "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json",
+      "docs/INDEX.md",
+      "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md",
+      "docs/quality/QUALIFICATION_PLAN.md",
+      "docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md",
+      "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+      "docs/roadmap/TASK_PACKETS.md",
+      "docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md",
+      "scripts/check_kernel_scope.py",
+      "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
+      "tests/kernel/test_documentation_authority.py",
+      "tests/kernel/test_kernel_scope.py"
+    ],
+    "implementation_allowlist": [
+      "the exact eighteen selected_successor_cohort paths",
+      "focused tests for query compiler, fact adapters, structural derivation, R1C evaluator, fixture reconciliation, and fixture generation"
+    ],
+    "locks": [
+      "R1A producer artifacts",
+      "R1C closure architecture and forbidden-import boundaries",
+      "grading and frozen expected rows as production inputs",
+      "query public API, evidence service, cursor behavior, and projections",
+      "CK-08R2, CK-08R3, CK-08R4, CK-08RG, CK-09, and CK-07",
+      "live operation, real Codex data, local databases, prompts, responses, commands, tool bodies, secrets, and credentials"
+    ]
+  },
+  "worker_handoff": {
+    "resume_existing_worker": "019fc419-0dab-73e3-a6cc-ce574f18c89f",
+    "resume_after": "this authority is squash-merged and fresh exact-main identities are verified",
+    "next_authorized_action": "reconstruct the held candidate in a fresh latest-exact-main worktree, apply only the bound consumer/evaluator/materialization corrections, and run the complete implementation gates",
+    "replacement_worker": "forbidden",
+    "implementation_acceptance": "not_granted_by_this_authority",
+    "new_authority_task": "forbidden",
+    "downstream_dispatch": "forbidden"
+  }
+}

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex-usage-tracker.invalid/schemas/ck08r1b-answer-semantics-join-authority-v1.schema.json",
+  "title": "CK-08R1B answer-semantics join authority",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "authority_version",
+    "owner",
+    "authority_base_sha",
+    "status",
+    "decision",
+    "producer_authority",
+    "independent_truth_authority",
+    "held_candidate",
+    "consumer_join",
+    "selected_successor_cohort",
+    "negative_mutations",
+    "required_gates",
+    "scope",
+    "worker_handoff"
+  ],
+  "properties": {
+    "schema": {"const": "codex-usage-tracker.ck08r1b-answer-semantics-join-authority.v1"},
+    "authority_version": {"const": 1},
+    "owner": {"const": "CK-08R1B-JOIN"},
+    "authority_base_sha": {"const": "f31efbdcb81ae3c3cb77d71eb740af4f4ffdfca4"},
+    "status": {"const": "permitted_not_accepted"},
+    "decision": {"const": "authorize_exact_query_evidence_grading_join_for_existing_worker"},
+    "producer_authority": {"$ref": "#/$defs/object"},
+    "independent_truth_authority": {"$ref": "#/$defs/object"},
+    "held_candidate": {"$ref": "#/$defs/object"},
+    "consumer_join": {"$ref": "#/$defs/object"},
+    "selected_successor_cohort": {
+      "type": "object",
+      "required": ["preflight_base_sha", "patch_sha256", "files", "focused_test_identities", "focused_validation"],
+      "properties": {
+        "preflight_base_sha": {"$ref": "#/$defs/gitSha"},
+        "patch_sha256": {"$ref": "#/$defs/sha"},
+        "files": {
+          "type": "array",
+          "minItems": 18,
+          "maxItems": 18,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/transitionPathDigest"}
+        },
+        "focused_test_identities": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/pathDigest"}
+        },
+        "focused_validation": {"$ref": "#/$defs/object"}
+      },
+      "additionalProperties": false
+    },
+    "negative_mutations": {
+      "type": "array",
+      "minItems": 12,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "required_gates": {
+      "type": "object",
+      "required": ["implementation", "downstream"],
+      "properties": {
+        "implementation": {"$ref": "#/$defs/nonEmptyStrings"},
+        "downstream": {"$ref": "#/$defs/nonEmptyStrings"}
+      },
+      "additionalProperties": false
+    },
+    "scope": {"$ref": "#/$defs/object"},
+    "worker_handoff": {
+      "type": "object",
+      "required": [
+        "resume_existing_worker",
+        "resume_after",
+        "next_authorized_action",
+        "replacement_worker",
+        "implementation_acceptance",
+        "new_authority_task",
+        "downstream_dispatch"
+      ],
+      "properties": {
+        "resume_existing_worker": {"const": "019fc419-0dab-73e3-a6cc-ce574f18c89f"},
+        "resume_after": {"type": "string", "minLength": 1},
+        "next_authorized_action": {"type": "string", "minLength": 1},
+        "replacement_worker": {"const": "forbidden"},
+        "implementation_acceptance": {"const": "not_granted_by_this_authority"},
+        "new_authority_task": {"const": "forbidden"},
+        "downstream_dispatch": {"const": "forbidden"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sha": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "gitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "pathDigest": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/sha"}
+      },
+      "additionalProperties": false
+    },
+    "transitionPathDigest": {
+      "type": "object",
+      "required": ["path", "predecessor_sha256", "sha256"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "predecessor_sha256": {"$ref": "#/$defs/sha"},
+        "sha256": {"$ref": "#/$defs/sha"}
+      },
+      "additionalProperties": false
+    },
+    "nonEmptyStrings": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "object": {"type": "object", "minProperties": 1}
+  }
+}

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -47,8 +47,9 @@ paging, so they admit neither projections nor CK-09.
 
 R1A freezes Q-REV-03/Q-WF-02 and executable transitive closure before parallel
 R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`;
-R1B remains held on shared query/evidence/grading integration before final
-two-lane R1 replay. R3 scale awaits merged/exact-main R3A.
+the exact R1B join authority makes only the existing worker Ready to reconcile
+its bound shared query/evidence/grading seams before final two-lane R1 replay.
+R3 scale awaits merged/exact-main R3A.
 CK-QG1A removed only R2's two rank-D findings against its unchanged baseline and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`; CK-QG1 PR #392 then passed the exact authorized normalized baseline ratchet, hosted CI, squash merge, and fresh exact-main verification at `68050b93`. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and
 `5000/120000/100/500/500` budgets; only a controlled material correction can

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -128,8 +128,8 @@ consumer replay reconciles published database-v1 facts to independent truth.
 ### Gate G4: answer kernel
 
 CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1C is
-accepted, R1B remains held on its shared integration join, and R1 requalifies
-after R1B. R2 bounds two direct plans while 19 fail
+accepted, the exact R1B join authority makes only its existing worker Ready,
+and R1 requalifies after R1B. R2 bounds two direct plans while 19 fail
 closed. R3A removes unbounded EvidenceService shape; R3 measures it. 07R1A
 materially corrects the exact hosted tail before PR #394 resumes. QG1A0 authorizes
 only the exact R2 PageExecutor successor; QG1A then removes

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -32,8 +32,10 @@ CK-08R3 is complete; CK-08R4 remains blocked on CK-08R1 and CK-07R1.
 Retained CK-08R1 work reached
 80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
 their meaning and closure. R1C is accepted at exact main
-`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; R1B remains held on shared
-query/evidence/grading integration, and R1 is their requalification join.
+`fb0c57886097a6b985d2f321b2de858cbdfc0a97`; the exact
+[R1B join authority](../decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
+makes only the existing R1B worker Ready to reconcile the shared
+query/evidence/grading seams, and R1 remains their blocked requalification join.
 CK-QG1A removed R2's two page-executor C/B/B violations
 without changing behavior or the frozen maintainability baseline and is
 accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`.
@@ -181,7 +183,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
-  "ready": [],
+  "ready": ["CK-08R1B"],
   "conditional_ready": [{
     "condition": "ARGV authority accepted at 479cbdb; coordinator records the preserved prelaunch incident disposition and a clean exact-main reapplication path; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement, launch, or downstream task",
     "tasks": ["CK-07R1"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -14,9 +14,9 @@ parents are accounting umbrellas.
 - Optional packets: **CK-15**
 - Completed corrective child tasks: **11 — CK-08R0, CK-08R1A, CK-08R1C, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **39**
-- Ready child tasks: **0 — None**
+- Ready child tasks: **1 — CK-08R1B; resume existing worker only**
 - Conditional-ready child tasks: **1 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path**
-- Blocked child tasks: **38**
+- Blocked child tasks: **37**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -51,15 +51,15 @@ parents are accounting umbrellas.
 
 Readiness is controlled by
 [the machine DAG](REMAINING_EXECUTION_PLAN.md). R1C is accepted after R1A;
-R1B is held on shared query/evidence/grading integration and must reuse its
-existing worker after an explicit join path. CK-QG1 is accepted and exact-main
+R1B has an exact shared query/evidence/grading join authority and is Ready only
+for its existing worker. CK-QG1 is accepted and exact-main
 verified; other corrective locks are unchanged.
 
 ### Corrective gates
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Blocked on shared query/evidence/grading integration; resume existing worker only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Ready after the exact join-authority merge; resume existing worker only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
 - [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,19 +1,19 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Blocked on shared query/evidence/grading integration; resume existing worker only
+**Status:** Ready after exact join-authority merge; resume existing worker only
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.
 **Dependencies:** R1A accepted/merged/exact-main.
-**Owned files/interfaces:** Structural derivations/domain tests only; query/evidence/cursor/public/evaluator forbidden.
+**Owned files/interfaces:** The exact 18-path successor cohort in the [join authority](../../decisions/evidence/ck08r1b/answer-semantics-join-authority.json), plus focused tests for those paths. Query compiler admission, synthetic materialization, R1C's stale Q-WF-02 seam, deterministic fixture generation, database/reference parity, and Candidate A plan requalification are allowed only as bound there; public API, EvidenceService, cursor, projection, and unrelated evaluator changes remain forbidden.
 **Produces:** Exact comparison/boundaries/nulls and closure.
-**Independent truth source:** R1A plus synthetic facts; no grading/SQLite/R1C.
+**Independent truth source:** R1A plus R1C's preserved recursive closure and facts-only evaluator, requalified at the exact stale Q-WF-02 seam; no grading source or copied expected rows in production.
 **Consumer seam:** `compile_plan_operands` emits final-R1 materializations.
-**Parallelism:** R1C after R1A; disjoint locks.
+**Parallelism:** Resume only existing worker `019fc419-0dab-73e3-a6cc-ce574f18c89f`; no replacement implementation or authority task.
 **Non-goals:** Query/public/projection/R3/R4/RG/09.
-**Invariants:** No placeholders; unsupported fails closed; CK-08R2 and 19 fail-closed residual plans unchanged; synthetic; sdist <=2,000,000.
-**Required tests/checks:** R1A vectors; formula/operand/query/closure; `just v/vc`; reviewer/CI/merge/exact-main.
+**Invariants:** Complete acyclic session hierarchy; explicit complete tool start/terminal coordinates; exact canonical-call `measurement_mask` and four token classes; no placeholders; malformed/null/mismatch fails closed; CK-08R2 and 19 fail-closed residual plans unchanged; synthetic; sdist <=2,000,000.
+**Required tests/checks:** Recompute authority identities; R1A vectors; formula/operand/query/database/closure; deterministic fixture regeneration with unchanged source JSONL; full 80-case independent-versus-production rows/grades/order/provenance/null replay; all authority negative mutations; `just vp`; `just v/vc`; reviewer/CI/merge/exact-main.
 **Acceptance:** Facts alone drive output; no grading source.
-**Failure/rollback:** Revert lock; keep R1 blocked.
-**Handoff:** SHA/R1A digest/closure/gates/risks.
+**Failure/rollback:** Any cohort, closure, hierarchy, coordinate, measurement, row, grade, provenance, or regeneration mismatch fails closed; keep R1 blocked and request new authority only for a genuinely new policy decision.
+**Handoff:** SHA/R1A digest/R1C closure/18-path cohort/full 80-case comparison/gates/risks; R1 remains blocked until implementation acceptance.
 **Cleanup/docs:** Final R1 accounting.
 **Suggested commit:** `fix: derive supported answer semantics`

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -764,6 +764,24 @@ CK08R1C_INDEPENDENT_EVALUATOR_ADDITIONS = frozenset(
     }
 )
 
+CK08R1B_JOIN_AUTHORITY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json",
+        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json",
+        "docs/INDEX.md",
+        "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md",
+        "docs/quality/QUALIFICATION_PLAN.md",
+        "docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md",
+        "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md",
+        "scripts/check_kernel_scope.py",
+        "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
+        "tests/kernel/test_documentation_authority.py",
+        "tests/kernel/test_kernel_scope.py",
+    }
+)
+
 CKQG1A0_AUTHORITY_ADDITIONS = frozenset(
     [
         "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json",
@@ -881,6 +899,7 @@ INTEGRATION_ADDITIONS = (
     | CK08R2_PHYSICAL_PAGE_ADDITIONS
     | CK08R1A_ANSWER_SEMANTICS_ADDITIONS
     | CK08R1C_INDEPENDENT_EVALUATOR_ADDITIONS
+    | CK08R1B_JOIN_AUTHORITY_ADDITIONS
     | CK08R3A_AUTHORITY_ADDITIONS
     | CK08R3_EVIDENCE_SCALE_ADDITIONS
     | CKQG1A0_AUTHORITY_ADDITIONS

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -54,7 +54,15 @@ def test_authority_validates_and_binds_live_r1a_and_r1c_inputs() -> None:
     assert isinstance(independent, dict)
     roots = independent["accepted_roots"]
     assert isinstance(roots, list)
-    assert all(_sha256(item["path"]) == item["sha256"] for item in roots)
+    successor_by_path = {
+        item["path"]: item["sha256"]
+        for item in authority["selected_successor_cohort"]["files"]
+    }
+    assert all(
+        _sha256(item["path"])
+        in {item["sha256"], successor_by_path.get(item["path"], item["sha256"])}
+        for item in roots
+    )
     assert independent["preserved"] == [
         "recursive closure and accessibility verification",
         "forbidden import and role-overlap guards",
@@ -140,10 +148,15 @@ def test_successor_cohort_is_all_or_none_and_rejects_unbound_bytes() -> None:
     files = authority["selected_successor_cohort"]["files"]
     assert isinstance(files, list)
     observed = {item["path"]: _sha256(item["path"]) for item in files}
-    assert _cohort_state(files, observed) == "predecessor"
+    state = _cohort_state(files, observed)
+    assert state in {"predecessor", "successor"}
 
     mixed = dict(observed)
-    mixed[files[0]["path"]] = files[0]["sha256"]
+    mixed[files[0]["path"]] = (
+        files[0]["sha256"]
+        if state == "predecessor"
+        else files[0]["predecessor_sha256"]
+    )
     with pytest.raises(AssertionError, match="mixed predecessor/successor"):
         _cohort_state(files, mixed)
 

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[2]
+AUTHORITY_PATH = (
+    ROOT / "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json"
+)
+SCHEMA_PATH = AUTHORITY_PATH.with_name("answer-semantics-join-authority.schema.json")
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: str) -> str:
+    return hashlib.sha256((ROOT / path).read_bytes()).hexdigest()
+
+
+def _cohort_state(
+    files: list[dict[str, str]],
+    observed: dict[str, str],
+) -> str:
+    states: set[str] = set()
+    for item in files:
+        actual = observed[item["path"]]
+        if actual == item["predecessor_sha256"]:
+            states.add("predecessor")
+        elif actual == item["sha256"]:
+            states.add("successor")
+        else:
+            raise AssertionError(f"unbound cohort identity: {item['path']}")
+    assert len(states) == 1, "mixed predecessor/successor cohort is forbidden"
+    return states.pop()
+
+
+def test_authority_validates_and_binds_live_r1a_and_r1c_inputs() -> None:
+    authority = _load(AUTHORITY_PATH)
+    Draft202012Validator(_load(SCHEMA_PATH)).validate(authority)
+
+    producer = authority["producer_authority"]
+    assert isinstance(producer, dict)
+    artifacts = producer["artifacts"]
+    assert isinstance(artifacts, list)
+    assert all(_sha256(item["path"]) == item["sha256"] for item in artifacts)
+
+    independent = authority["independent_truth_authority"]
+    assert isinstance(independent, dict)
+    roots = independent["accepted_roots"]
+    assert isinstance(roots, list)
+    assert all(_sha256(item["path"]) == item["sha256"] for item in roots)
+    assert independent["preserved"] == [
+        "recursive closure and accessibility verification",
+        "forbidden import and role-overlap guards",
+        "grading sentinel and grading-inaccessible behavior",
+        "production-source mutation independence",
+        "facts-only evaluation from R1A declarations",
+    ]
+
+
+def test_join_is_exact_non_accepting_and_reuses_only_the_held_worker() -> None:
+    authority = _load(AUTHORITY_PATH)
+    assert authority["status"] == "permitted_not_accepted"
+    held = authority["held_candidate"]
+    handoff = authority["worker_handoff"]
+    assert isinstance(held, dict)
+    assert isinstance(handoff, dict)
+    assert held["worker_thread"] == "019fc419-0dab-73e3-a6cc-ce574f18c89f"
+    assert len(held["candidate_paths"]) == 9
+    assert held["authority_pr_candidate_bytes"] == "forbidden"
+    subprocess.run(
+        ["git", "cat-file", "-e", f"{held['candidate_base_sha']}^{{commit}}"],
+        cwd=ROOT,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "merge-base", "--is-ancestor", held["candidate_base_sha"], "HEAD"],
+        cwd=ROOT,
+        check=True,
+    )
+    assert handoff == {
+        "resume_existing_worker": "019fc419-0dab-73e3-a6cc-ce574f18c89f",
+        "resume_after": "this authority is squash-merged and fresh exact-main identities are verified",
+        "next_authorized_action": "reconstruct the held candidate in a fresh latest-exact-main worktree, apply only the bound consumer/evaluator/materialization corrections, and run the complete implementation gates",
+        "replacement_worker": "forbidden",
+        "implementation_acceptance": "not_granted_by_this_authority",
+        "new_authority_task": "forbidden",
+        "downstream_dispatch": "forbidden",
+    }
+
+
+def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
+    authority = _load(AUTHORITY_PATH)
+    cohort = authority["selected_successor_cohort"]
+    join = authority["consumer_join"]
+    assert isinstance(cohort, dict)
+    assert isinstance(join, dict)
+    files = cohort["files"]
+    assert isinstance(files, list)
+    assert len(files) == 18
+    paths = {item["path"] for item in files}
+    assert {
+        "src/codex_usage_tracker/agent_kernel/query/compiler.py",
+        "experiments/physical-architecture/candidate_a/queries.py",
+        "tests/agent_kernel/fact_adapters/test_contracts.py",
+        "tests/agent_kernel/fixtures/independent/semantic.py",
+        "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
+        "scripts/generate_ck07a_fixture.py",
+        "tests/agent_kernel/fixtures/tiny-v2/manifest.json",
+        "tests/agent_kernel/fixtures/tiny-v2/oracle-bundle.json",
+        "tests/agent_kernel/fixtures/tiny-v2/question-scenarios.json",
+    } <= paths
+    assert join["oracle_requalification"]["copied_expected_rows"] == "forbidden"
+    assert (
+        join["oracle_requalification"]["grading_source_imported_into_production"]
+        == "forbidden"
+    )
+    assert cohort["focused_validation"] == {
+        "result": "182 passed",
+        "case_count": 80,
+        "independent_rows_equal_production_rows": True,
+        "independent_grades_equal_frozen_grades": True,
+        "fixture_source_jsonl_unchanged": True,
+        "review_mutations": [
+            "Q-WF-02 no-match and same-window foreign-session selector isolation",
+            "Q-WF-02 valid before-window and after-window tool exclusion",
+            "Q-REV-03 missing, null, and mask-value mismatch while capability is unavailable",
+        ],
+    }
+
+
+def test_successor_cohort_is_all_or_none_and_rejects_unbound_bytes() -> None:
+    authority = _load(AUTHORITY_PATH)
+    files = authority["selected_successor_cohort"]["files"]
+    assert isinstance(files, list)
+    observed = {item["path"]: _sha256(item["path"]) for item in files}
+    assert _cohort_state(files, observed) == "predecessor"
+
+    mixed = dict(observed)
+    mixed[files[0]["path"]] = files[0]["sha256"]
+    with pytest.raises(AssertionError, match="mixed predecessor/successor"):
+        _cohort_state(files, mixed)
+
+    unbound = dict(observed)
+    unbound[files[0]["path"]] = "0" * 64
+    with pytest.raises(AssertionError, match="unbound cohort identity"):
+        _cohort_state(files, unbound)
+
+
+def test_fail_closed_mutations_and_downstream_locks_are_complete() -> None:
+    authority = _load(AUTHORITY_PATH)
+    mutations = authority["negative_mutations"]
+    assert isinstance(mutations, list)
+    text = "\n".join(mutations)
+    for required in (
+        "session hierarchy",
+        "measurement_mask",
+        "session selector",
+        "half-open window",
+        "start coordinate",
+        "terminal coordinate",
+        "terminal without start",
+        "terminal ordered before start",
+        "grading sentinel",
+        "production-source mutation",
+        "canonical-fact mutation",
+        "copied expected row",
+        "closure membership",
+    ):
+        assert required in text
+
+    scope = authority["scope"]
+    gates = authority["required_gates"]
+    assert isinstance(scope, dict)
+    assert isinstance(gates, dict)
+    locks = "\n".join(scope["locks"])
+    assert all(packet in locks for packet in ("CK-08R4", "CK-08RG", "CK-09", "CK-07"))
+    assert "full 80-case" in "\n".join(gates["implementation"])

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -95,6 +95,16 @@ def _portable_selected_support_hashes() -> dict[str, str]:
     }
 
 
+def _ck08r1b_selected_hashes() -> dict[str, str]:
+    authority = _json(
+        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json"
+    )
+    return {
+        item["path"]: item["sha256"]
+        for item in authority["selected_successor_cohort"]["files"]
+    }
+
+
 def _active_markdown() -> list[Path]:
     return [path for path in _DOCS.rglob("*.md") if "archive" not in path.relative_to(_DOCS).parts]
 
@@ -222,8 +232,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         hashlib.sha256(qg1a_source.read_bytes()).hexdigest()
         == (qg1a_authority["selected_successor"]["sha256"])
     )
-    ready: set[str] = set()
-    assert manifest["ready"] == []
+    ready: set[str] = {"CK-08R1B"}
+    assert manifest["ready"] == ["CK-08R1B"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
@@ -240,7 +250,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert "Critical-path completion: **14 / 21**" in ledger
     assert "Completed corrective child tasks: **11" in ledger
     assert "Remaining delegable child tasks: **39**" in ledger
-    assert "Blocked child tasks: **38" in ledger
+    assert "Blocked child tasks: **37" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -426,6 +436,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
                 transition["publication_fixture_transition"]["selected"]["question_scenarios"][
                     "sha256"
                 ],
+                _ck08r1b_selected_hashes()[artifact["path"]],
             }
         elif artifact["path"] == "src/codex_usage_tracker/agent_kernel/publication/preparation.py":
             final = _json("docs/decisions/evidence/ck08r3a/final-shared-authority.json")
@@ -437,10 +448,17 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
                     + final["r3a"]["selected"]["support_identities"]
                 ):
                     required_path = _REPO_ROOT / required["path"]
-                    expected = required["sha256"]
+                    expected = {required["sha256"]}
                     if required["path"] == "tests/agent_kernel/evidence/test_service.py":
-                        expected = _portable_selected_support_hashes()[required["path"]]
-                    assert hashlib.sha256(required_path.read_bytes()).hexdigest() == expected
+                        expected = {_portable_selected_support_hashes()[required["path"]]}
+                    elif required["path"] == "tests/agent_kernel/fact_adapters/support.py":
+                        expected.add(_ck08r1b_selected_hashes()[required["path"]])
+                    assert hashlib.sha256(required_path.read_bytes()).hexdigest() in expected
+        elif artifact["path"] == "config/agent-kernel/plan-operand-contract-v1.json":
+            assert actual in {
+                artifact["sha256"],
+                _ck08r1b_selected_hashes()[artifact["path"]],
+            }
         else:
             assert actual == artifact["sha256"]
     locks = [lock for lane in contract["lanes"] for lock in lane["owned_lock"]]
@@ -1017,10 +1035,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             + final["r3a"]["selected"]["support_identities"]
         ):
             required_path = _REPO_ROOT / required["path"]
-            expected = required["sha256"]
+            expected = {required["sha256"]}
             if required["path"] == "tests/agent_kernel/evidence/test_service.py":
-                expected = _portable_selected_support_hashes()[required["path"]]
-            assert hashlib.sha256(required_path.read_bytes()).hexdigest() == expected
+                expected = {_portable_selected_support_hashes()[required["path"]]}
+            elif required["path"] == "tests/agent_kernel/fact_adapters/support.py":
+                expected.add(_ck08r1b_selected_hashes()[required["path"]])
+            assert hashlib.sha256(required_path.read_bytes()).hexdigest() in expected
 
     mutations = [
         ("selected_successor", "sha256", "0" * 64),

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -24,6 +24,7 @@ from scripts.check_kernel_scope import (
     CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CK08_QUERY_EVIDENCE_ADDITIONS,
     CK08R1A_ANSWER_SEMANTICS_ADDITIONS,
+    CK08R1B_JOIN_AUTHORITY_ADDITIONS,
     CK08R1C_INDEPENDENT_EVALUATOR_ADDITIONS,
     CK08R2_PHYSICAL_PAGE_ADDITIONS,
     CK08R3_EVIDENCE_SCALE_ADDITIONS,
@@ -678,6 +679,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK08R3_EVIDENCE_SCALE_ADDITIONS
         | CK08R1A_ANSWER_SEMANTICS_ADDITIONS
         | CK08R1C_INDEPENDENT_EVALUATOR_ADDITIONS
+        | CK08R1B_JOIN_AUTHORITY_ADDITIONS
         | CK08R3A_AUTHORITY_ADDITIONS
         | CKQG1A0_AUTHORITY_ADDITIONS
         | CKQG1_AUTHORITY_ADDITIONS
@@ -728,6 +730,24 @@ def test_ck08r1a_answer_semantics_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/contracts/test_answer_semantics_contract.py",
         "tests/agent_kernel/fixtures/contracts/answer-semantics-v1-vectors.json",
     } == CK08R1A_ANSWER_SEMANTICS_ADDITIONS
+
+
+def test_ck08r1b_join_authority_additions_are_explicit_and_bounded() -> None:
+    assert {
+        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json",
+        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json",
+        "docs/INDEX.md",
+        "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md",
+        "docs/quality/QUALIFICATION_PLAN.md",
+        "docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md",
+        "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md",
+        "scripts/check_kernel_scope.py",
+        "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
+        "tests/kernel/test_documentation_authority.py",
+        "tests/kernel/test_kernel_scope.py",
+    } == CK08R1B_JOIN_AUTHORITY_ADDITIONS
 
 
 def test_ckqg1_authority_additions_are_explicit_and_bounded() -> None:


### PR DESCRIPTION
## What changed

- freezes the exact R1A producer and R1C independent-truth join for CK-08R1B
- binds an atomic 18-path predecessor/successor implementation cohort with exact file and aggregate patch identities
- assigns query compiler/database admission, synthetic hierarchy/coordinate materialization, independent Q-WF-02 requalification, and Candidate A budget requalification to the existing held CK-08R1B worker
- marks only CK-08R1B Ready after this authority merge while keeping CK-08R1, CK-08R4, CK-08RG, CK-09, and CK-07 held/blocked

## Why

Merged R1A semantics crossed query, fixture, evaluator, and grading ownership boundaries. This authority resolves that shared contract without accepting implementation bytes or weakening the frozen 80-case truth.

## Validation

- authority-focused: 39 passed
- exact authority-plus-18-path preflight: 221 passed
- authority `just vc`: 1,407 passed, 1 skipped; 13 invariant-performance checks; package/release checks green
- combined successor `just vc`: 1,433 passed, 1 skipped; 13 invariant-performance checks; package/release checks green
- independent bounded reviewer: approved, no remaining P0-P3 findings

Synthetic data only. No production candidate bytes, public/projection/R3/R4/RG/CK-09/live/real-data changes.