### PR TITLE
docs: correct CK-08R1B successor identity

### DIFF
--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
@@ -95,6 +95,21 @@
     "witnesses": "read_only_and_retained",
     "authority_pr_candidate_bytes": "forbidden"
   },
+  "identity_correction": {
+    "base_sha": "97ea3aed8f67c7840a34b610e7e0588b7eaf3c4d",
+    "source_pr": 430,
+    "worker_head_sha": "78d01ab9e19b37da776abe638f0feb436b4780bd",
+    "path": "scripts/generate_ck07a_fixture.py",
+    "failure": "hosted_ruff_i001_import_order",
+    "superseded_successor_sha256": "37cfd57351491c25141fde2d6ef0812d3f4e6e6b60921a2ce6e1af670b3cc28d",
+    "selected_successor_sha256": "f7adde83efb963121e841aec8d71ebd2e2be1fa3a1c2745d8e5ec05e6884cb68",
+    "superseded_patch_sha256": "d3ba81015172cd6e0be2dbaa3beb0aa321cc0232c7820d7ce7cba5630c0674d2",
+    "selected_patch_sha256": "38c0db5c2242a962b20fa2abd05c264fb08e36f6d9dc542fe5763ca69986c690",
+    "changed_successor_paths": 1,
+    "unchanged_successor_paths": 17,
+    "semantic_change": "none",
+    "worker_pr_edit": "forbidden"
+  },
   "consumer_join": {
     "query_compiler": {
       "path": "src/codex_usage_tracker/agent_kernel/query/compiler.py",
@@ -136,13 +151,13 @@
     }
   },
   "selected_successor_cohort": {
-    "preflight_base_sha": "f31efbdcb81ae3c3cb77d71eb740af4f4ffdfca4",
-    "patch_sha256": "d3ba81015172cd6e0be2dbaa3beb0aa321cc0232c7820d7ce7cba5630c0674d2",
+    "preflight_base_sha": "97ea3aed8f67c7840a34b610e7e0588b7eaf3c4d",
+    "patch_sha256": "38c0db5c2242a962b20fa2abd05c264fb08e36f6d9dc542fe5763ca69986c690",
     "files": [
       {"path": "config/agent-kernel/logical-contract-v1.json", "predecessor_sha256": "27981ec9bac8c245306e02784b8730e8ff9216b33a81da9efb8409403431fe3d", "sha256": "3d7412156c735a9e1e497049ec86c8130c20632da27e009deed24d19c5836e84"},
       {"path": "config/agent-kernel/plan-operand-contract-v1.json", "predecessor_sha256": "19b9c69f50f67b01321e1f269cee2f70370ca64c0c666ff4dac2cc52efa314b4", "sha256": "0f21a484b66c36bb467bc659f2656fd20c31619e9bc7b6e8edd89250855edffe"},
       {"path": "experiments/physical-architecture/candidate_a/queries.py", "predecessor_sha256": "dd2a121480920cf96cd51ec43084a76a278009a8b72153b15963862d9619fe89", "sha256": "53c947fa8468db211428104aa4276e9138d6c48160de8c99821b5c509ae5929e"},
-      {"path": "scripts/generate_ck07a_fixture.py", "predecessor_sha256": "d24be0a95b302a9c52d413c300f23536d8c0287512c4b446ed03f8d33ce0863f", "sha256": "37cfd57351491c25141fde2d6ef0812d3f4e6e6b60921a2ce6e1af670b3cc28d"},
+      {"path": "scripts/generate_ck07a_fixture.py", "predecessor_sha256": "d24be0a95b302a9c52d413c300f23536d8c0287512c4b446ed03f8d33ce0863f", "sha256": "f7adde83efb963121e841aec8d71ebd2e2be1fa3a1c2745d8e5ec05e6884cb68"},
       {"path": "src/codex_usage_tracker/agent_kernel/domain/plan_derivations_structural.py", "predecessor_sha256": "c63b5ae2528852768c7a0906c2dccd537587192116fd2cec956110bcc8ed1367", "sha256": "1c0441ca1d26c1d774aba9b53e0e10b04fcec2c6de7c1453a3e42aabcffa20ad"},
       {"path": "src/codex_usage_tracker/agent_kernel/query/compiler.py", "predecessor_sha256": "0e57ddb03c5bff28eb74dc2eaa98f35491c649de71e7e9ba680c358a5adc0286", "sha256": "c3c43f044a43b5d2aed18cc03b88f1a5156a6570dd4d1cfc2f47a8b4d1833ffa"},
       {"path": "tests/agent_kernel/contracts/test_plan_derivations_structural.py", "predecessor_sha256": "853f5d6d44d17ef4a19bff0ab383d758d52541ec7c7b8bf92d008d93b3fb40fb", "sha256": "8531e34b4a1c11c4e55c49efbf369ee82126bdf2a4c373896b0142c6acdae915"},

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
@@ -14,6 +14,7 @@
     "producer_authority",
     "independent_truth_authority",
     "held_candidate",
+    "identity_correction",
     "consumer_join",
     "selected_successor_cohort",
     "negative_mutations",
@@ -31,6 +32,40 @@
     "producer_authority": {"$ref": "#/$defs/object"},
     "independent_truth_authority": {"$ref": "#/$defs/object"},
     "held_candidate": {"$ref": "#/$defs/object"},
+    "identity_correction": {
+      "type": "object",
+      "required": [
+        "base_sha",
+        "source_pr",
+        "worker_head_sha",
+        "path",
+        "failure",
+        "superseded_successor_sha256",
+        "selected_successor_sha256",
+        "superseded_patch_sha256",
+        "selected_patch_sha256",
+        "changed_successor_paths",
+        "unchanged_successor_paths",
+        "semantic_change",
+        "worker_pr_edit"
+      ],
+      "properties": {
+        "base_sha": {"const": "97ea3aed8f67c7840a34b610e7e0588b7eaf3c4d"},
+        "source_pr": {"const": 430},
+        "worker_head_sha": {"const": "78d01ab9e19b37da776abe638f0feb436b4780bd"},
+        "path": {"const": "scripts/generate_ck07a_fixture.py"},
+        "failure": {"const": "hosted_ruff_i001_import_order"},
+        "superseded_successor_sha256": {"const": "37cfd57351491c25141fde2d6ef0812d3f4e6e6b60921a2ce6e1af670b3cc28d"},
+        "selected_successor_sha256": {"const": "f7adde83efb963121e841aec8d71ebd2e2be1fa3a1c2745d8e5ec05e6884cb68"},
+        "superseded_patch_sha256": {"const": "d3ba81015172cd6e0be2dbaa3beb0aa321cc0232c7820d7ce7cba5630c0674d2"},
+        "selected_patch_sha256": {"const": "38c0db5c2242a962b20fa2abd05c264fb08e36f6d9dc542fe5763ca69986c690"},
+        "changed_successor_paths": {"const": 1},
+        "unchanged_successor_paths": {"const": 17},
+        "semantic_change": {"const": "none"},
+        "worker_pr_edit": {"const": "forbidden"}
+      },
+      "additionalProperties": false
+    },
     "consumer_join": {"$ref": "#/$defs/object"},
     "selected_successor_cohort": {
       "type": "object",

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -59,7 +59,7 @@ verified; other corrective locks are unchanged.
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Ready after the exact join-authority merge; resume existing worker only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Ready after the exact join-authority import-order identity correction merges; resume existing worker only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
 - [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,10 +1,10 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Ready after exact join-authority merge; resume existing worker only
+**Status:** Ready after exact join-authority import-order identity correction merges; resume existing worker only
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.
 **Dependencies:** R1A accepted/merged/exact-main.
-**Owned files/interfaces:** The exact 18-path successor cohort in the [join authority](../../decisions/evidence/ck08r1b/answer-semantics-join-authority.json), plus focused tests for those paths. Query compiler admission, synthetic materialization, R1C's stale Q-WF-02 seam, deterministic fixture generation, database/reference parity, and Candidate A plan requalification are allowed only as bound there; public API, EvidenceService, cursor, projection, and unrelated evaluator changes remain forbidden.
+**Owned files/interfaces:** The exact 18-path successor cohort in the [join authority](../../decisions/evidence/ck08r1b/answer-semantics-join-authority.json), including its one-path Ruff import-order successor correction and 17 byte-identical successors, plus focused tests for those paths. Query compiler admission, synthetic materialization, R1C's stale Q-WF-02 seam, deterministic fixture generation, database/reference parity, and Candidate A plan requalification are allowed only as bound there; public API, EvidenceService, cursor, projection, and unrelated evaluator changes remain forbidden.
 **Produces:** Exact comparison/boundaries/nulls and closure.
 **Independent truth source:** R1A plus R1C's preserved recursive closure and facts-only evaluator, requalified at the exact stale Q-WF-02 seam; no grading source or copied expected rows in production.
 **Consumer seam:** `compile_plan_operands` emits final-R1 materializations.

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -103,6 +103,49 @@ def test_join_is_exact_non_accepting_and_reuses_only_the_held_worker() -> None:
     }
 
 
+def test_import_order_identity_correction_is_exact_and_non_semantic() -> None:
+    authority = _load(AUTHORITY_PATH)
+    correction = authority["identity_correction"]
+    cohort = authority["selected_successor_cohort"]
+
+    assert isinstance(correction, dict)
+    assert isinstance(cohort, dict)
+    assert correction == {
+        "base_sha": "97ea3aed8f67c7840a34b610e7e0588b7eaf3c4d",
+        "source_pr": 430,
+        "worker_head_sha": "78d01ab9e19b37da776abe638f0feb436b4780bd",
+        "path": "scripts/generate_ck07a_fixture.py",
+        "failure": "hosted_ruff_i001_import_order",
+        "superseded_successor_sha256": (
+            "37cfd57351491c25141fde2d6ef0812d3f4e6e6b60921a2ce6e1af670b3cc28d"
+        ),
+        "selected_successor_sha256": (
+            "f7adde83efb963121e841aec8d71ebd2e2be1fa3a1c2745d8e5ec05e6884cb68"
+        ),
+        "superseded_patch_sha256": (
+            "d3ba81015172cd6e0be2dbaa3beb0aa321cc0232c7820d7ce7cba5630c0674d2"
+        ),
+        "selected_patch_sha256": (
+            "38c0db5c2242a962b20fa2abd05c264fb08e36f6d9dc542fe5763ca69986c690"
+        ),
+        "changed_successor_paths": 1,
+        "unchanged_successor_paths": 17,
+        "semantic_change": "none",
+        "worker_pr_edit": "forbidden",
+    }
+    assert cohort["preflight_base_sha"] == correction["base_sha"]
+    assert cohort["patch_sha256"] == correction["selected_patch_sha256"]
+
+    selected = {
+        item["path"]: item["sha256"]
+        for item in cohort["files"]
+        if isinstance(item, dict)
+    }
+    assert selected[correction["path"]] == correction["selected_successor_sha256"]
+    assert correction["superseded_successor_sha256"] not in selected.values()
+    assert correction["superseded_patch_sha256"] != cohort["patch_sha256"]
+
+
 def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
     authority = _load(AUTHORITY_PATH)
     cohort = authority["selected_successor_cohort"]


### PR DESCRIPTION
## Changed

- preserve PR #430's failed hosted Ruff identity as superseded evidence
- select the one-line import-order successor for `scripts/generate_ck07a_fixture.py`
- update the atomic 18-path cohort patch identity while freezing the other 17 successor bytes
- bind the correction in the authority schema, focused tests, task packet, and roadmap ledger

## Why

PR #430's implementation cohort passed its focused, replay, 80-case, full, package, and review gates locally, but hosted Python 3.10 and 3.14 stopped at Ruff `I001`. The mechanical import reorder changes the generator and aggregate cohort identities, so the existing worker correctly stopped without editing or retrying.

This authority correction remains `permitted_not_accepted`, introduces no production bytes, preserves R1A/R1C truth and all 80 frozen cases, and authorizes only the existing CK-08R1B worker to resume after squash merge and fresh exact-main verification.

## Validation

- `pytest -q tests/kernel/test_ck08r1b_answer_semantics_join_authority.py tests/kernel/test_documentation_authority.py` — 20 passed
- `python scripts/check_release.py`
- corrected preflight: 18/18 selected successor hashes and aggregate patch SHA recomputed exactly
- corrected preflight: targeted consumer/evaluator/replay suite — 200 passed
- corrected preflight: Ruff and deterministic tiny fixture check
- corrected preflight: `just vp`, `just v`, `just vc` — 1,433 passed, 1 skipped; performance invariants, Pyright, package and dist checks green
- one bounded read-only reviewer — no findings

Synthetic data only. PR #430 and all retained witnesses remain untouched.
