### PR TITLE
docs: freeze final CK-08R1B multipublication cohort

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,7 +72,12 @@ and unaffected rows remain exact. The final multi-publication correction keeps
 the same 23 paths and binds native-parent snapshot seeding plus authoritative
 late-parent ordering: newer event/source coordinates win, exact replay is
 idempotent, and conflicting equal-order parent or basis declarations fail
-closed. R1B is Ready only for its existing held
+closed. The final selected-cohort correction additionally requires direct
+`SessionObserved` reparenting to load and emit the complete persisted
+descendant subtree, treats equal six-part coordinates as idempotent only when
+parent, basis, and occurrence provenance are exact, and selects one
+current-batch winner by that six-part order before logical identity. R1B is
+Ready only for its existing held
 worker and PR #430 after that correction is merged and exact-main verified; the
 authority does not accept the implementation. CK-08R1, CK-08R4, CK-08RG,
 CK-09, and CK-07 remain blocked or held by their existing gates.

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
@@ -183,7 +183,7 @@
     "worker_state": "dirty_exact_23_path_reapplication_preserved_no_post_review_edits_or_pr_update",
     "superseded_selected_patch_sha256": "5ea9275830146875cd60cdf28372d5bbb4deeafe0b170c29ecd3118a70390fc2",
     "superseded_authority_patch_sha256": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c",
-    "selected_patch_sha256": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa",
+    "selected_patch_sha256": "d64e930928f6fc913b25c2b889ecd5588289edb8410e19188ddf7172c8126bba",
     "selected_successor_paths": 23,
     "changed_successor_paths": [
       "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -206,7 +206,8 @@
       "four-publication stale replay preserves the newer reparented subtree, every changed descendant, unaffected components, and production write-set parity",
       "direct SessionObserved reparent seeds the existing session and loads its complete persisted descendant subtree before hierarchy recomputation",
       "equal six-part coordinates require exact parent basis and occurrence provenance identity; distinct evidence fails closed and exact duplicate remains idempotent",
-      "current-batch relationship winner uses the six-part authority order before logical identity, emits one winner, and rejects equal-order ties"
+      "current-batch relationship winner uses the six-part authority order before logical identity, emits one winner, and rejects equal-order ties",
+      "persisted relationship history retains every occurrence so older exact replay is idempotent and distinct evidence at the same older coordinate fails closed"
     ],
     "worker_pr_edit": "forbidden",
     "implementation_acceptance": "not_granted"
@@ -275,7 +276,7 @@
   },
   "selected_successor_cohort": {
     "preflight_base_sha": "5eb9ffb4afc35e20db57ee936388c345d3c2c609",
-    "patch_sha256": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa",
+    "patch_sha256": "d64e930928f6fc913b25c2b889ecd5588289edb8410e19188ddf7172c8126bba",
     "files": [
       {
         "path": "config/agent-kernel/formula-contract-v1.json",
@@ -310,12 +311,12 @@
       {
         "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
         "predecessor_sha256": "6689d61fbf6d7948e1958a9d0bc58b4ea326a7f04221914b74c0651e0be1e37c",
-        "sha256": "65016a3463861634320eca2b9b3d774c35aa18176c6ebd62430a47356007a7a9"
+        "sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
       },
       {
         "path": "src/codex_usage_tracker/agent_kernel/publication/writer.py",
         "predecessor_sha256": "13da341fc2a3c50d8d7de7fd6a6fc2b0aca0dbc832a9b56597cd96ab67d17488",
-        "sha256": "1ba92de3716d3c7a1339e86dd569c688cccbc16c1c56a208473aa91b7e68a908"
+        "sha256": "d163e6c566665a65062952be1618b9f2c4032eabd841408e2f274bcd29748a73"
       },
       {
         "path": "src/codex_usage_tracker/agent_kernel/query/compiler.py",
@@ -385,7 +386,7 @@
       {
         "path": "tests/agent_kernel/publication/test_writer.py",
         "predecessor_sha256": "28dce47dfe32717a937079f068e9c1f1abcfbdfa6d65a15db6faba1b0c914b26",
-        "sha256": "488f322a8fb2910f3a57e98be850ba41e1642b9bd0efb74483869723aa33ce80"
+        "sha256": "7ce9712aaed6464c579d4bdb94c858fcf064393124b5ded9116bd49b1f83b67d"
       },
       {
         "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
@@ -404,7 +405,7 @@
       },
       {
         "path": "tests/agent_kernel/publication/test_writer.py",
-        "sha256": "488f322a8fb2910f3a57e98be850ba41e1642b9bd0efb74483869723aa33ce80"
+        "sha256": "7ce9712aaed6464c579d4bdb94c858fcf064393124b5ded9116bd49b1f83b67d"
       },
       {
         "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
@@ -416,7 +417,7 @@
       }
     ],
     "focused_validation": {
-      "result": "266 passed focused semantic, publication, compiler, replay, and writer preflight",
+      "result": "267 passed focused semantic, publication, compiler, replay, and writer preflight",
       "case_count": 80,
       "independent_rows_equal_production_rows": true,
       "independent_grades_equal_frozen_grades": true,
@@ -433,7 +434,8 @@
         "four-publication newer reparent, stale replay, exact duplicate, equal-order conflict, descendant recomputation, and unaffected-component preservation",
         "direct SessionObserved reparent with complete persisted descendant write set and unaffected-component parity",
         "equal six-part same-parent different-basis or provenance conflict plus exact duplicate idempotency",
-        "current-batch transition-rank winner over inverse logical-id order across permutations with one emitted edge"
+        "current-batch transition-rank winner over inverse logical-id order across permutations with one emitted edge",
+        "three-publication older same-relation exact replay plus distinct-occurrence equal-order conflict"
       ]
     }
   },

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json
@@ -177,12 +177,13 @@
     "implementation_acceptance": "not_granted"
   },
   "multi_publication_correction": {
-    "base_sha": "e5b6321f406e10770b1caa96639f90f47cca2221",
+    "base_sha": "5eb9ffb4afc35e20db57ee936388c345d3c2c609",
     "source_pr": 430,
     "worker_head_sha": "3a86a10b12122d6ff9bec70f5f62105157af25c8",
-    "worker_state": "dirty_exact_23_path_reapplication_preserved_no_post_review_edits",
+    "worker_state": "dirty_exact_23_path_reapplication_preserved_no_post_review_edits_or_pr_update",
     "superseded_selected_patch_sha256": "5ea9275830146875cd60cdf28372d5bbb4deeafe0b170c29ecd3118a70390fc2",
-    "selected_patch_sha256": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c",
+    "superseded_authority_patch_sha256": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c",
+    "selected_patch_sha256": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa",
     "selected_successor_paths": 23,
     "changed_successor_paths": [
       "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -202,7 +203,10 @@
       "SessionObserved native parent identity is normalized to the exact session semantic identity before writer snapshot seeding loads its complete ancestor and descendant component",
       "persisted and incoming late-parent relations compare exact event and source coordinates so a newer authoritative relation wins independent of publication arrival order",
       "exact same-parent same-basis coordinate replay is idempotent, while a different parent or basis at equal coordinates fails closed",
-      "four-publication stale replay preserves the newer reparented subtree, every changed descendant, unaffected components, and production write-set parity"
+      "four-publication stale replay preserves the newer reparented subtree, every changed descendant, unaffected components, and production write-set parity",
+      "direct SessionObserved reparent seeds the existing session and loads its complete persisted descendant subtree before hierarchy recomputation",
+      "equal six-part coordinates require exact parent basis and occurrence provenance identity; distinct evidence fails closed and exact duplicate remains idempotent",
+      "current-batch relationship winner uses the six-part authority order before logical identity, emits one winner, and rejects equal-order ties"
     ],
     "worker_pr_edit": "forbidden",
     "implementation_acceptance": "not_granted"
@@ -270,8 +274,8 @@
     }
   },
   "selected_successor_cohort": {
-    "preflight_base_sha": "e5b6321f406e10770b1caa96639f90f47cca2221",
-    "patch_sha256": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c",
+    "preflight_base_sha": "5eb9ffb4afc35e20db57ee936388c345d3c2c609",
+    "patch_sha256": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa",
     "files": [
       {
         "path": "config/agent-kernel/formula-contract-v1.json",
@@ -306,12 +310,12 @@
       {
         "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
         "predecessor_sha256": "6689d61fbf6d7948e1958a9d0bc58b4ea326a7f04221914b74c0651e0be1e37c",
-        "sha256": "382e486932064735e990794fb111362a02572bcf42e33dbe757b37f2b53f71a7"
+        "sha256": "65016a3463861634320eca2b9b3d774c35aa18176c6ebd62430a47356007a7a9"
       },
       {
         "path": "src/codex_usage_tracker/agent_kernel/publication/writer.py",
         "predecessor_sha256": "13da341fc2a3c50d8d7de7fd6a6fc2b0aca0dbc832a9b56597cd96ab67d17488",
-        "sha256": "b23428f58040db06fc46eb938103f6e2844db6ee52843b169867c58bb0226997"
+        "sha256": "1ba92de3716d3c7a1339e86dd569c688cccbc16c1c56a208473aa91b7e68a908"
       },
       {
         "path": "src/codex_usage_tracker/agent_kernel/query/compiler.py",
@@ -376,12 +380,12 @@
       {
         "path": "tests/agent_kernel/publication/test_preparation.py",
         "predecessor_sha256": "2b43cdfca0d935d4f08aa44a16bd176713ddf3ef7083ff3e76b42d4d0c8687e3",
-        "sha256": "df73de981b1675a0ae250daeecf2196d51889f4552a535538b80b628038b0f61"
+        "sha256": "8fd386f1189ff13fea3dd2edadff1e1efc2535ab4f20a215db8037bc6cb61e43"
       },
       {
         "path": "tests/agent_kernel/publication/test_writer.py",
         "predecessor_sha256": "28dce47dfe32717a937079f068e9c1f1abcfbdfa6d65a15db6faba1b0c914b26",
-        "sha256": "67db39217a617361a9d5bf66cde5adcc41433e79ff3031a3c104caa8e052d34f"
+        "sha256": "488f322a8fb2910f3a57e98be850ba41e1642b9bd0efb74483869723aa33ce80"
       },
       {
         "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
@@ -396,11 +400,11 @@
       },
       {
         "path": "tests/agent_kernel/publication/test_preparation.py",
-        "sha256": "df73de981b1675a0ae250daeecf2196d51889f4552a535538b80b628038b0f61"
+        "sha256": "8fd386f1189ff13fea3dd2edadff1e1efc2535ab4f20a215db8037bc6cb61e43"
       },
       {
         "path": "tests/agent_kernel/publication/test_writer.py",
-        "sha256": "67db39217a617361a9d5bf66cde5adcc41433e79ff3031a3c104caa8e052d34f"
+        "sha256": "488f322a8fb2910f3a57e98be850ba41e1642b9bd0efb74483869723aa33ce80"
       },
       {
         "path": "tests/agent_kernel/test_ck08r1c_independent_evaluator.py",
@@ -412,7 +416,7 @@
       }
     ],
     "focused_validation": {
-      "result": "261 passed focused semantic, publication, compiler, replay, and writer preflight",
+      "result": "266 passed focused semantic, publication, compiler, replay, and writer preflight",
       "case_count": 80,
       "independent_rows_equal_production_rows": true,
       "independent_grades_equal_frozen_grades": true,
@@ -426,7 +430,10 @@
         "production and independent required tool start/terminal null timestamp rejection",
         "writer-owned existing non-root closure, reverse late chain, reparented descendants, unaffected-row preservation, and write-set parity",
         "two-publication native-parent closure plus unknown-parent dangling rejection",
-        "four-publication newer reparent, stale replay, exact duplicate, equal-order conflict, descendant recomputation, and unaffected-component preservation"
+        "four-publication newer reparent, stale replay, exact duplicate, equal-order conflict, descendant recomputation, and unaffected-component preservation",
+        "direct SessionObserved reparent with complete persisted descendant write set and unaffected-component parity",
+        "equal six-part same-parent different-basis or provenance conflict plus exact duplicate idempotency",
+        "current-batch transition-rank winner over inverse logical-id order across permutations with one emitted edge"
       ]
     }
   },

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
@@ -320,6 +320,7 @@
         "worker_head_sha",
         "worker_state",
         "superseded_selected_patch_sha256",
+        "superseded_authority_patch_sha256",
         "selected_patch_sha256",
         "selected_successor_paths",
         "changed_successor_paths",
@@ -330,7 +331,7 @@
       ],
       "properties": {
         "base_sha": {
-          "const": "e5b6321f406e10770b1caa96639f90f47cca2221"
+          "const": "5eb9ffb4afc35e20db57ee936388c345d3c2c609"
         },
         "source_pr": {
           "const": 430
@@ -339,13 +340,16 @@
           "const": "3a86a10b12122d6ff9bec70f5f62105157af25c8"
         },
         "worker_state": {
-          "const": "dirty_exact_23_path_reapplication_preserved_no_post_review_edits"
+          "const": "dirty_exact_23_path_reapplication_preserved_no_post_review_edits_or_pr_update"
         },
         "superseded_selected_patch_sha256": {
           "const": "5ea9275830146875cd60cdf28372d5bbb4deeafe0b170c29ecd3118a70390fc2"
         },
-        "selected_patch_sha256": {
+        "superseded_authority_patch_sha256": {
           "const": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c"
+        },
+        "selected_patch_sha256": {
+          "const": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa"
         },
         "selected_successor_paths": {
           "const": 23
@@ -370,8 +374,8 @@
         },
         "findings": {
           "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
+          "minItems": 7,
+          "maxItems": 7,
           "uniqueItems": true,
           "items": {
             "type": "string",

--- a/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
+++ b/docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.schema.json
@@ -349,7 +349,7 @@
           "const": "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c"
         },
         "selected_patch_sha256": {
-          "const": "cde2a7a9095e62f4abbc8db31dc40b929cb44446a9f3bb07f316149782c621fa"
+              "const": "d64e930928f6fc913b25c2b889ecd5588289edb8410e19188ddf7172c8126bba"
         },
         "selected_successor_paths": {
           "const": 23
@@ -374,8 +374,8 @@
         },
         "findings": {
           "type": "array",
-          "minItems": 7,
-          "maxItems": 7,
+            "minItems": 8,
+            "maxItems": 8,
           "uniqueItems": true,
           "items": {
             "type": "string",

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -49,8 +49,12 @@ retains those 23 paths and binds the remaining closure seam:
 `SessionObserved` native parents seed their exact semantic parent component,
 and persisted/incoming late-parent relations compare event/source coordinates
 so stale replay cannot reverse a newer reparent. Exact replay is idempotent;
-conflicting equal-order parent or basis declarations fail closed. Only the
-existing worker may resume after
+conflicting equal-order parent or basis declarations fail closed. The selected
+cohort now also seeds an existing directly reparented session so its complete
+persisted descendants are recomputed, requires parent/basis/occurrence
+provenance equality for equal-coordinate idempotency, and resolves
+current-batch relations by the six-part authority order before logical
+identity with one emitted winner. Only the existing worker may resume after
 that correction merges and exact-main verifies. R1 remains their blocked
 requalification join.
 CK-QG1A removed R2's two page-executor C/B/B violations

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -59,7 +59,7 @@ verified; other corrective locks are unchanged.
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Ready under the final 23-path direct-reparent/equal-coordinate/current-batch correction; resume existing worker and PR #430 only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Ready under the final 23-path direct-reparent/full-history/equal-coordinate/current-batch correction; resume existing worker and PR #430 only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
 - [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -59,7 +59,7 @@ verified; other corrective locks are unchanged.
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Ready under the final 23-path multi-publication closure correction; resume existing worker and PR #430 only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [ ] **CK-08R1B — Implement production answer semantics** · Ready under the final 23-path direct-reparent/equal-coordinate/current-batch correction; resume existing worker and PR #430 only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
 - [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
 - [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,11 +1,17 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Ready under final 23-path multi-publication closure correction; resume existing worker and PR #430 only
+**Status:** Ready under final 23-path direct-reparent/equal-coordinate/current-batch correction; resume existing worker and PR #430 only
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.
 **Dependencies:** R1A accepted/merged/exact-main.
 **Owned files/interfaces:** The exact 23-path successor cohort in the [join authority](../../decisions/evidence/ck08r1b/answer-semantics-join-authority.json), superseding the preserved PR #430 head after reviewer findings. It adds production publication hierarchy ownership, production-compiler 80-case replay, Q-WF-02 straddling lifecycle correction, independent duplicate-ID rejection, and the explicit Q-REV-03 direct-fact/internal-formula binding decision. The selected-cohort acceptance correction requires every authoritative late relationship to apply before one complete acyclic hierarchy computation, rejects late cycles and ambiguous or missing parents, proves reverse-order chains through production publication and compiler replay, and rejects explicit null required start or terminal timestamps in production and independent truth. The final correction explicitly owns `publication/writer.py`: writer prior-state loading supplies the complete connected ancestor/descendant session component, preparation emits every changed descendant after reparenting, and unaffected rows remain exact. Query compiler admission, synthetic materialization, R1C's exact seams, deterministic fixture generation, database/reference parity, and Candidate A plan requalification are allowed only as bound there; public API, EvidenceService, cursor, projection, and unrelated evaluator changes remain forbidden.
 **Multi-publication closure:** Writer seeding normalizes a `SessionObserved` native parent to the exact semantic session identity and loads its complete existing component. Persisted and incoming late-parent relations compare exact event/source coordinates: newer authority wins, exact replay is idempotent, and conflicting equal-order parent or basis declarations fail closed. Reparented descendants recompute; unaffected components remain exact.
+**Selected-cohort closure:** Direct reparent of an existing `SessionObserved`
+seeds that session and its complete persisted descendants. Equal six-part
+coordinates are idempotent only for exact parent, relationship basis, and
+occurrence provenance; other evidence fails closed. Current-batch relations
+use the six-part authority order before logical identity and emit one winner
+across input permutations.
 **Produces:** Exact comparison/boundaries/nulls and closure.
 **Independent truth source:** R1A plus R1C's preserved recursive closure and facts-only evaluator, requalified at the exact stale Q-WF-02 seam; no grading source or copied expected rows in production.
 **Consumer seam:** `compile_plan_operands` emits final-R1 materializations.

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,5 +1,5 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Ready under final 23-path direct-reparent/equal-coordinate/current-batch correction; resume existing worker and PR #430 only
+**Status:** Ready under final 23-path direct-reparent/full-history/equal-coordinate/current-batch correction; resume existing worker and PR #430 only
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -159,6 +159,10 @@ def test_import_order_identity_correction_is_exact_and_non_semantic() -> None:
         multi_publication_correction["superseded_selected_patch_sha256"]
         == writer_closure_correction["selected_patch_sha256"]
     )
+    assert (
+        multi_publication_correction["superseded_authority_patch_sha256"]
+        == "e424294a083b7f8f4c61dd57ac11400f3f6bdf63469f3d43154931c9c9c1939c"
+    )
     assert set(writer_closure_correction["added_successor_paths"]) == {
         "src/codex_usage_tracker/agent_kernel/publication/writer.py",
         "tests/agent_kernel/publication/test_writer.py",
@@ -235,7 +239,7 @@ def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
         == "forbidden"
     )
     assert cohort["focused_validation"] == {
-        "result": "261 passed focused semantic, publication, compiler, replay, and writer preflight",
+        "result": "266 passed focused semantic, publication, compiler, replay, and writer preflight",
         "case_count": 80,
         "independent_rows_equal_production_rows": True,
         "independent_grades_equal_frozen_grades": True,
@@ -250,6 +254,9 @@ def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
             "writer-owned existing non-root closure, reverse late chain, reparented descendants, unaffected-row preservation, and write-set parity",
             "two-publication native-parent closure plus unknown-parent dangling rejection",
             "four-publication newer reparent, stale replay, exact duplicate, equal-order conflict, descendant recomputation, and unaffected-component preservation",
+            "direct SessionObserved reparent with complete persisted descendant write set and unaffected-component parity",
+            "equal six-part same-parent different-basis or provenance conflict plus exact duplicate idempotency",
+            "current-batch transition-rank winner over inverse logical-id order across permutations with one emitted edge",
         ],
     }
 

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -239,7 +239,7 @@ def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
         == "forbidden"
     )
     assert cohort["focused_validation"] == {
-        "result": "266 passed focused semantic, publication, compiler, replay, and writer preflight",
+        "result": "267 passed focused semantic, publication, compiler, replay, and writer preflight",
         "case_count": 80,
         "independent_rows_equal_production_rows": True,
         "independent_grades_equal_frozen_grades": True,
@@ -257,6 +257,7 @@ def test_successor_cohort_and_consumer_ownership_are_bounded() -> None:
             "direct SessionObserved reparent with complete persisted descendant write set and unaffected-component parity",
             "equal six-part same-parent different-basis or provenance conflict plus exact duplicate idempotency",
             "current-batch transition-rank winner over inverse logical-id order across permutations with one emitted edge",
+            "three-publication older same-relation exact replay plus distinct-occurrence equal-order conflict",
         ],
     }
 


### PR DESCRIPTION
## Summary

- freeze the final 23-path CK-08R1B successor cohort for direct existing-session reparenting, complete persisted descendant recomputation, and unaffected-component preservation
- bind equal six-part relationship evidence identity, full persisted relationship history, exact replay idempotency, equal-coordinate provenance rejection, and six-part current-batch winner ordering
- preserve PR #430 and all R1A/R1C roots, frozen 80-case truth, downstream holds, and explicit non-acceptance

## Validation

- corrected combined preflight: 267 focused semantic/publication/compiler/replay/writer cases; 80/80 replay
- `just vp`
- `just vc`: 1,465 passed, 1 skipped; performance invariants, package build, and release-safety green
- deterministic CK-07A fixture regeneration: 80 cases / 174 source records, byte-identical
- authority/schema tests: 6 passed in authority and combined preflight
- bounded independent reviewer: prior persisted-history finding reproduced, corrected, and closed with no material residual findings

Synthetic fixtures only. This authority PR changes no production candidate bytes and does not accept CK-08R1B implementation.