### PR TITLE
docs: record CK-08R1B acceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ Python materialization, projection classification combines execution stages,
 and publication/evidence scale plus replacement maintainability need
 corrective proof. CK-08R0 froze `corrective-gates-v1`; CK-08R2 is complete and
 CK-09 remains blocked. CK-08R1A froze corrected answer meaning and recursive
-closure; R1C is accepted at exact main `fb0c578`, while R1B remains held on
-shared query/evidence/grading integration before final R1 requalification.
+closure; R1C is accepted at exact main `fb0c578`, and R1B is accepted at exact
+main `9e9332b3`; final R1 requalification is the sole Ready packet.
 CK-QG1A removed the two R2 page-executor complexity findings without changing
 behavior or the frozen baseline and is accepted at exact main `30983d4`;
 existing QG1 PR #392 is Ready to resume from corrected main. CK-07R1A corrected

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -76,11 +76,10 @@ closed. The final selected-cohort correction additionally requires direct
 `SessionObserved` reparenting to load and emit the complete persisted
 descendant subtree, treats equal six-part coordinates as idempotent only when
 parent, basis, and occurrence provenance are exact, and selects one
-current-batch winner by that six-part order before logical identity. R1B is
-Ready only for its existing held
-worker and PR #430 after that correction is merged and exact-main verified; the
-authority does not accept the implementation. CK-08R1, CK-08R4, CK-08RG,
-CK-09, and CK-07 remain blocked or held by their existing gates.
+current-batch winner by that six-part order before logical identity. PR #430
+passed hosted CI, squash-merged, and was exact-main verified at `9e9332b3`.
+R1B is complete, R1 is the sole Ready packet, and CK-08R4, CK-08RG, CK-09,
+and CK-07 remain blocked or held by their existing gates.
 CK-QG1A0 gated the selected R2 PageExecutor successor; QG1A removed its two
 C/B/B findings and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`;
 the linked

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -113,9 +113,9 @@ Q-REV-03/Q-WF-02 meaning and executable transitive closure. R1C's independent
 consumer is accepted at exact main
 `fb0c57886097a6b985d2f321b2de858cbdfc0a97`; the exact
 [R1B join authority](../decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
-makes only the existing R1B worker Ready to reconcile its bound shared
-query/evidence/grading seams, and final R1 replays both only after that consumer
-is accepted. Cursor serialization still binds its version, request digest,
+bound the shared query/evidence/grading seams accepted through PR #430 and
+exact-main `9e9332b3`; final R1 is now the sole Ready replay of both accepted
+consumers. Cursor serialization still binds its version, request digest,
 plan, publication, and order; malformed, tampered, stale, replacement, and
 mismatched bindings fail closed.
 

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -47,8 +47,8 @@ paging, so they admit neither projections nor CK-09.
 
 R1A freezes Q-REV-03/Q-WF-02 and executable transitive closure before parallel
 R1C is accepted at exact main `fb0c57886097a6b985d2f321b2de858cbdfc0a97`;
-the exact R1B join authority makes only the existing worker Ready to reconcile
-its bound shared query/evidence/grading seams before final two-lane R1 replay.
+R1B is accepted through PR #430 and exact-main `9e9332b3`, making the final
+two-lane R1 replay the sole Ready packet.
 R3 scale awaits merged/exact-main R3A.
 CK-QG1A removed only R2's two rank-D findings against its unchanged baseline and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`; CK-QG1 PR #392 then passed the exact authorized normalized baseline ratchet, hosted CI, squash merge, and fresh exact-main verification at `68050b93`. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and

--- a/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
+++ b/docs/roadmap/AGENT_FIRST_CLEAN_CUTOVER.md
@@ -127,9 +127,9 @@ consumer replay reconciles published database-v1 facts to independent truth.
 
 ### Gate G4: answer kernel
 
-CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1C is
-accepted, the exact R1B join authority makes only its existing worker Ready,
-and R1 requalifies after R1B. R2 bounds two direct plans while 19 fail
+CK-08 history is provisional. R1A freezes Q-REV-03/Q-WF-02 and closure; R1C
+and R1B are accepted, with R1B exact-main verified at `9e9332b3`; R1 is the
+sole Ready requalification packet. R2 bounds two direct plans while 19 fail
 closed. R3A removes unbounded EvidenceService shape; R3 measures it. 07R1A
 materially corrects the exact hosted tail before PR #394 resumes. QG1A0 authorizes
 only the exact R2 PageExecutor successor; QG1A then removes

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -34,8 +34,13 @@ Retained CK-08R1 work reached
 their meaning and closure. R1C is accepted at exact main
 `fb0c57886097a6b985d2f321b2de858cbdfc0a97`; the exact
 [R1B join authority](../decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
-makes only the existing R1B worker Ready to reconcile the shared
-query/evidence/grading seams. Its exact reviewer correction binds production
+binds the shared query/evidence/grading seams accepted through PR #430;
+CK-08R1B then passed the exact 23-path cohort,
+80/80 production-versus-independent replay, full local/package gates, one
+bounded review, and hosted Python 3.10/3.14 plus Console checks in PR #430;
+it squash-merged and was exact-main verified at
+`9e9332b3ae2be78cedb581ff8f76149ad76f4440`. CK-08R1B is accepted, making
+CK-08R1 the sole Ready packet. Its exact reviewer correction binds production
 publication hierarchy ownership, independent start/terminal window membership,
 duplicate stable-ID rejection, production-compiler replay, and the Q-REV-03
 direct-fact/internal-formula decision. Its exact selected-cohort acceptance
@@ -54,9 +59,9 @@ cohort now also seeds an existing directly reparented session so its complete
 persisted descendants are recomputed, requires parent/basis/occurrence
 provenance equality for equal-coordinate idempotency, and resolves
 current-batch relations by the six-part authority order before logical
-identity with one emitted winner. Only the existing worker may resume after
-that correction merges and exact-main verifies. R1 remains their blocked
-requalification join.
+identity with one emitted winner. PR #430 passed hosted CI, squash-merged, and
+was exact-main verified at `9e9332b3ae2be78cedb581ff8f76149ad76f4440`.
+R1B is complete and R1 is the sole Ready requalification join.
 CK-QG1A removed R2's two page-executor C/B/B violations
 without changing behavior or the frozen maintainability baseline and is
 accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`.
@@ -68,8 +73,9 @@ exact-main verification at `68050b9313ccc5be8e1fcd0ccd5b95cb4173f3ff`.
 CK-QG1 is complete; its v2 [writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json)
 binds current main `dd771073` writer `13da341f…` to reviewed PR #430 writer
 `d163e6c5…` with the unchanged `fda777e2…` baseline and identical normalized
-findings. CK-08R1B remains permitted-not-accepted and may resume only after
-this authority is merged and exact-main verified; CK-08RG remains blocked on
+findings. CK-08R1B is accepted at `9e9332b3`; CK-08R1 is Ready for the
+serialized production-versus-independent answer-truth requalification.
+CK-08RG remains blocked on
 CK-08R4.
 CK-07R1A is accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 was accepted at
@@ -208,8 +214,8 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1C", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
-  "ready": ["CK-08R1B"],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
+  "ready": ["CK-08R1"],
   "conditional_ready": [{
     "condition": "ARGV authority accepted at 479cbdb; coordinator records the preserved prelaunch incident disposition and a clean exact-main reapplication path; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; no replacement, launch, or downstream task",
     "tasks": ["CK-07R1"]

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,11 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **11 — CK-08R0, CK-08R1A, CK-08R1C, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **39**
-- Ready child tasks: **1 — CK-08R1B; resume existing worker only**
+- Completed corrective child tasks: **12 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
+- Remaining delegable child tasks: **38**
+- Ready child tasks: **1 — CK-08R1**
 - Conditional-ready child tasks: **1 — CK-07R1 after coordinator disposition of the preserved prelaunch incident and a clean exact-main reapplication path**
-- Blocked child tasks: **37**
+- Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -50,18 +50,17 @@ parents are accounting umbrellas.
 ## Remaining delegated child tasks
 
 Readiness is controlled by
-[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1C is accepted after R1A;
-R1B has an exact shared query/evidence/grading join authority and is Ready only
-for its existing worker. CK-QG1 is accepted and exact-main
-verified; other corrective locks are unchanged.
+[the machine DAG](REMAINING_EXECUTION_PLAN.md). R1C and R1B are accepted after
+R1A; R1 is the sole Ready serialized requalification join. CK-QG1 is accepted
+and exact-main verified; other corrective locks are unchanged.
 
 ### Corrective gates
 
 - [x] **CK-08R0 — Freeze corrective query and scale contracts** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r0-freeze-corrective-contracts.md)
 - [x] **CK-08R1A — Freeze answer semantics and evidence closure** · Completed on merge; exact-main verification required in handoff · [packet](tasks/ck-08r1a-freeze-answer-semantics.md)
-- [ ] **CK-08R1B — Implement production answer semantics** · Ready under the final 23-path correction and the linked CK-QG1/R1B writer transition authority; after authority merge/exact-main, resume existing worker and PR #430 only · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
+- [x] **CK-08R1B — Implement production answer semantics** · PR #430 hosted-green, squash-merged, and exact-main verified at `9e9332b3`; exact 23-path cohort and 80/80 production-versus-independent replay accepted · [packet](tasks/ck-08r1b-implement-production-answer-semantics.md)
 - [x] **CK-08R1C — Build independent semantic evaluator** · PR #411 merged/exact-main `fb0c578`; independent closure and all 80 variants accepted · [packet](tasks/ck-08r1c-build-independent-semantic-evaluator.md)
-- [ ] **CK-08R1 — Requalify independent answer truth** · Blocked on CK-08R1B; CK-08R1C is accepted · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
+- [ ] **CK-08R1 — Requalify independent answer truth** · Ready after CK-08R1B PR #430 and CK-08R1C acceptance; serialized join only · [packet](tasks/ck-08r1-build-independent-answer-truth.md)
 - [x] **CK-08R2 — Implement bounded physical keyset execution** · Completed on merge; exact-main verification recorded in handoff · [packet](tasks/ck-08r2-implement-physical-keyset-execution.md)
 - [x] **CK-QG1A0 — Authorize PageExecutor source supersession** · Completed on merge; exact-main required before CK-QG1A · [packet](tasks/ck-qg1a0-authorize-page-executor-source-supersession.md)
 - [x] **CK-08R3A — Implement bounded EvidenceService physical queries** · PR #417 hosted-green and squash-merged at `38537f6c`; exact-main identities verified · [packet](tasks/ck-08r3a-implement-evidence-physical-query.md)

--- a/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
+++ b/docs/roadmap/tasks/ck-08r1-build-independent-answer-truth.md
@@ -1,6 +1,6 @@
 # CK-08R1 — Requalify independent answer truth
 
-**Status:** Blocked on CK-08R1B; CK-08R1C accepted
+**Status:** Ready — CK-08R1B and CK-08R1C accepted, merged, and exact-main verified
 
 **Parent:** Corrective prerequisite for CK-09
 

--- a/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
+++ b/docs/roadmap/tasks/ck-08r1b-implement-production-answer-semantics.md
@@ -1,5 +1,5 @@
 # CK-08R1B — Implement production answer semantics
-**Status:** Ready under final 23-path direct-reparent/full-history/equal-coordinate/current-batch correction; resume existing worker and PR #430 only
+**Status:** Completed on merge — PR #430 hosted-green, squash-merged, and exact-main verified at `9e9332b3ae2be78cedb581ff8f76149ad76f4440`
 **Recommended owner:** `worker production-semantics`; Sol-class
 **Accounting:** [TASK_PACKETS.md](../TASK_PACKETS.md); [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md); [AGENT_FIRST_CLEAN_CUTOVER.md](../AGENT_FIRST_CLEAN_CUTOVER.md)
 **Goal:** Implement R1A Q-REV-03/Q-WF-02 semantics.
@@ -19,8 +19,15 @@ across input permutations.
 **Non-goals:** Query/public/projection/R3/R4/RG/09.
 **Invariants:** Production publication owns complete acyclic session hierarchy; no test fallback may manufacture it. Explicit complete tool start/terminal coordinates are selected independently at window boundaries. Canonical-call `measurement_mask` and four token classes remain exact. Q-REV-03 answer objects are direct facts and its named formulas are bound internal diagnostics. No placeholders; malformed/null/mismatch/duplicate fails closed; CK-08R2 and 19 fail-closed residual plans unchanged; synthetic; sdist <=2,000,000.
 **Required tests/checks:** Recompute authority identities; R1A vectors; formula/operand/query/database/closure; deterministic fixture regeneration with unchanged source JSONL; full 80-case independent-versus-production rows/grades/order/provenance/null replay; all authority negative mutations; `just vp`; `just v/vc`; reviewer/CI/merge/exact-main.
-**Acceptance:** Facts alone drive output; no grading source.
+**Acceptance:** Facts alone drive output; no grading source. Exact
+authority-selected 23-path cohort; focused 284; authority/negative 160;
+synthetic production-versus-independent replay 80/80; `just vp`, `just v`, and
+`just vc` green with 1,465 passed and 1 skipped; one bounded reviewer clean;
+hosted Console and Python 3.10/3.14 green.
 **Failure/rollback:** Any cohort, closure, hierarchy, coordinate, measurement, row, grade, provenance, or regeneration mismatch fails closed; keep R1 blocked and request new authority only for a genuinely new policy decision.
-**Handoff:** SHA/R1A digest/R1C closure/23-path cohort/full 80-case production-compiler comparison/gates/risks; R1 remains blocked until implementation acceptance.
-**Cleanup/docs:** Final R1 accounting.
+**Handoff:** PR #430 merge `9e9332b3`; R1A digest/R1C closure/23-path cohort,
+full 80-case production-compiler comparison, gates, and risks accepted. R1 is
+Ready after this coordinator accounting merge.
+**Cleanup/docs:** Completed by this accounting reconciliation; retained
+implementation and exact-main worktrees remain preserved.
 **Suggested commit:** `fix: derive supported answer semantics`

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -214,6 +214,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R1A",
+        "CK-08R1B",
         "CK-08R1C",
         "CK-08R2",
         "CK-08R3A",
@@ -232,8 +233,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         hashlib.sha256(qg1a_source.read_bytes()).hexdigest()
         == (qg1a_authority["selected_successor"]["sha256"])
     )
-    ready: set[str] = {"CK-08R1B"}
-    assert manifest["ready"] == ["CK-08R1B"]
+    ready: set[str] = {"CK-08R1"}
+    assert manifest["ready"] == ["CK-08R1"]
     assert manifest["conditional_ready"] == [
         {
             "condition": (
@@ -245,17 +246,46 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         },
     ]
     assert manifest["blocked"] == []
-    assert "Completed packets: **14 / 22**" in ledger
-    assert "Not started: **8**" in ledger
-    assert "Critical-path completion: **14 / 21**" in ledger
-    assert "Completed corrective child tasks: **11" in ledger
-    assert "Remaining delegable child tasks: **39**" in ledger
-    assert "Blocked child tasks: **37" in ledger
+    parent_section = ledger.split("## Parent packets", 1)[1].split(
+        "## Remaining delegated child tasks", 1
+    )[0]
+    parent_rows = [
+        line
+        for line in parent_section.splitlines()
+        if line.startswith("- [") and "**CK-" in line
+    ]
+    parent_completed = sum(line.startswith("- [x]") for line in parent_rows)
+    assert len(parent_rows) == 22
+    assert parent_completed == 14
+    assert f"Completed packets: **{parent_completed} / {len(parent_rows)}**" in ledger
+    assert f"Not started: **{len(parent_rows) - parent_completed}**" in ledger
+    assert f"Critical-path completion: **{parent_completed} / 21**" in ledger
+    assert "Completed corrective child tasks: **12" in ledger
+    assert "Remaining delegable child tasks: **38**" in ledger
+    assert "Blocked child tasks: **36" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
         in ledger
     )
+    active_status_docs = "\n".join(
+        [
+            (_REPO_ROOT / "AGENTS.md").read_text(),
+            (_DOCS / "INDEX.md").read_text(),
+            (_DOCS / "architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md").read_text(),
+            (_DOCS / "quality/QUALIFICATION_PLAN.md").read_text(),
+            (_DOCS / "roadmap/AGENT_FIRST_CLEAN_CUTOVER.md").read_text(),
+            central,
+            ledger,
+        ]
+    )
+    for stale_claim in (
+        "R1B remains held",
+        "R1B is Ready only",
+        "R1B worker Ready",
+        "R1 remains their blocked",
+    ):
+        assert stale_claim not in active_status_docs
 
     tasks = manifest["tasks"]
     assert len(tasks) == 50
@@ -352,6 +382,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         elif packet_id in {
             "CK-08R0",
             "CK-08R1A",
+            "CK-08R1B",
             "CK-08R1C",
             "CK-08R2",
             "CK-08R3A",


### PR DESCRIPTION
## Summary
- record CK-08R1B PR #430 as accepted at exact main `9e9332b3`
- make CK-08R1 the sole Ready child while preserving CK-07R1 and downstream holds
- derive parent accounting totals from ledger checkboxes and reject stale operational prose

## Validation
- focused documentation/scope: 34 passed
- `just vp`
- `just v` / `just vc`: 1,465 passed, 1 skipped; 13/13 invariants; Pyright/release/package/dist green
- independent bounded reviewer correction pass
- diff/Gitleaks clean

Synthetic/accounting-only; no live or real-data operation.