### PR TITLE
Bind CK-07R1 fallback-persistence successor authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,19 +42,22 @@ QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`.
 Coordinator disposition and clean exact-main reapplication from `6c08ecd9`
-derived the exact `66c015de…` / `98aac35d…` / `7914d993…` candidate cohort.
+derived the exact `66c015de…` / `2125d127…` / `a4163ffb…` candidate cohort.
 The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
 that complete cohort as CK-07 `worker_prequalification`.
 The existing CK-07R1 worker remains stopped until that authority transition is
 merged and exact-main verified; no launch or token use is authorized. The
-candidate must construct and validate its exact overlay-bound receipt before the
-first durable `completed` finalization; construction, validation, or
-finalization failure is terminal `failed_after_launch`. Its interpreter must be
-the lexical repository-worktree `.venv/bin/python` with matching lexical venv
-`sys.prefix`; base interpreters, resolved/symlink equivalence, wrong-worktree
-venvs, and prefix mismatch fail closed. PR #394 remains stale failed read-only.
+candidate must construct and validate its exact overlay-bound receipt and
+non-null stdout/stderr/output evidence before the first durable `completed`
+finalization; any evidence read/hash/parse/validation/finalization failure is
+terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM handlers must
+route every wait interruption/error through bounded TERM/KILL/reap before
+terminal failure persistence. Its interpreter must be the lexical
+repository-worktree `.venv/bin/python` with matching lexical venv `sys.prefix`;
+base interpreters, resolved/symlink equivalence, wrong-worktree venvs, and prefix
+mismatch fail closed. PR #394 remains stale failed read-only.
 Retained R3 evidence proved the EvidenceService outer query
 physically unbounded; CK-08R3A owns that isolated fix and R3 awaits its
 accepted, merged, exact-main-verified result.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`.
 Coordinator disposition and clean exact-main reapplication from `6c08ecd9`
-derived the exact `66c015de…` / `2125d127…` / `a4163ffb…` candidate cohort.
+derived the exact `66c015de…` / `c922b59f…` / `5e9cb014…` candidate cohort.
 The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
@@ -54,7 +54,12 @@ non-null stdout/stderr/output evidence before the first durable `completed`
 finalization; any evidence read/hash/parse/validation/finalization failure is
 terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM handlers must
 route every wait interruption/error through bounded TERM/KILL/reap before
-terminal failure persistence. Its interpreter must be the lexical
+terminal failure persistence. The fork child ignores SIGINT/SIGTERM while
+waiting for parent release and routes every pre-release failure to
+`os._exit(71)`; parent cleanup rejects nonpositive PIDs. Ledger updates use a
+unique same-directory `mkstemp`, close and unlink every failed or interrupted
+path, and persist durable consumed/no-retry `failed_after_launch` evidence
+without temporary residue. Its interpreter must be the lexical
 repository-worktree `.venv/bin/python` with matching lexical venv `sys.prefix`;
 base interpreters, resolved/symlink equivalence, wrong-worktree venvs, and prefix
 mismatch fail closed. PR #394 remains stale failed read-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,15 +41,20 @@ QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
 `68050b93`. CK-07R1A corrected
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`.
-Coordinator disposition and clean exact-main reapplication from `cf44f4fd`
-derived the exact `66c015de…` / `4b1c62b2…` / `75d03f53…` candidate cohort.
+Coordinator disposition and clean exact-main reapplication from `6c08ecd9`
+derived the exact `66c015de…` / `98aac35d…` / `7914d993…` candidate cohort.
 The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
 that complete cohort as CK-07 `worker_prequalification`.
 The existing CK-07R1 worker remains stopped until that authority transition is
-merged and exact-main verified; no launch or token use is authorized. PR #394
-remains stale failed read-only.
+merged and exact-main verified; no launch or token use is authorized. The
+candidate must construct and validate its exact overlay-bound receipt before the
+first durable `completed` finalization; construction, validation, or
+finalization failure is terminal `failed_after_launch`. Its interpreter must be
+the lexical repository-worktree `.venv/bin/python` with matching lexical venv
+`sys.prefix`; base interpreters, resolved/symlink equivalence, wrong-worktree
+venvs, and prefix mismatch fail closed. PR #394 remains stale failed read-only.
 Retained R3 evidence proved the EvidenceService outer query
 physically unbounded; CK-08R3A owns that isolated fix and R3 awaits its
 accepted, merged, exact-main-verified result.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`.
 Coordinator disposition and clean exact-main reapplication from `6c08ecd9`
-derived the exact `66c015de…` / `1c7e1ea7…` / `a8de9667…` candidate cohort.
+derived the exact `66c015de…` / `f108dbb4…` / `4c514889…` candidate cohort.
 The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
@@ -56,7 +56,10 @@ terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM handlers must
 route every wait interruption/error through bounded TERM/KILL/reap before
 terminal failure persistence and remain installed through evidence, receipt,
 and terminal ledger finalization; originals restore only after the terminal
-state attempt. The fork child ignores SIGINT/SIGTERM while
+state attempt. Every terminal fallback persistence call masks SIGINT/SIGTERM
+with the existing ignore guard and restores the prior temporary handlers
+afterward; the outer final restoration of original handlers remains last. The
+fork child ignores SIGINT/SIGTERM while
 waiting for parent release and routes every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Ledger updates use a
 unique same-directory `mkstemp`, close and unlink every failed or interrupted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
 the exact hosted Python 3.14 lifecycle-tail blocker; the linked CK-07R1A0
 authorities, including argv correction, are merged through `479cbdb`.
 Coordinator disposition and clean exact-main reapplication from `6c08ecd9`
-derived the exact `66c015de…` / `c922b59f…` / `5e9cb014…` candidate cohort.
+derived the exact `66c015de…` / `1c7e1ea7…` / `a8de9667…` candidate cohort.
 The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
@@ -54,7 +54,9 @@ non-null stdout/stderr/output evidence before the first durable `completed`
 finalization; any evidence read/hash/parse/validation/finalization failure is
 terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM handlers must
 route every wait interruption/error through bounded TERM/KILL/reap before
-terminal failure persistence. The fork child ignores SIGINT/SIGTERM while
+terminal failure persistence and remain installed through evidence, receipt,
+and terminal ledger finalization; originals restore only after the terminal
+state attempt. The fork child ignores SIGINT/SIGTERM while
 waiting for parent release and routes every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Ledger updates use a
 unique same-directory `mkstemp`, close and unlink every failed or interrupted

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,7 +112,7 @@ keep CK-07R1 `blocked_hold`
 The accepted source history retains R3A preparation `6689d61f…` as a
 historical predecessor and R1B/current exact-main preparation `7d1831ff…` as
 the live predecessor. The sole CK-07 worker-prequalification successor is the
-atomic `66c015de…` preparation, `98aac35d…` benchmark, and `7914d993…`
+atomic `66c015de…` preparation, `2125d127…` benchmark, and `a4163ffb…`
 lifecycle-test cohort derived from exact main `6c08ecd9`. Mixed or incomplete
 cohorts, prior candidate `e204e0da…`, and historical candidate `d192c858…`
 fail closed. PR #394 remains a stale failed
@@ -134,12 +134,15 @@ launch/output, or advance another successor. The one-run gate remains unspent
 and unavailable. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
-The V9 candidate must construct and validate the exact overlay/cohort-bound
-receipt before its first durable `completed` finalization; construction,
-validation, or finalization failures are terminal `failed_after_launch`.
-Interpreter identity is the lexical repository-worktree `.venv/bin/python` plus
-the matching lexical venv `sys.prefix`; base interpreters, symlink/resolved
-equivalence, wrong-worktree venvs, and prefix mismatch are rejected.
+The V10 candidate must construct and validate the exact overlay/cohort-bound
+receipt and non-null stdout/stderr/output evidence before its first durable
+`completed` finalization. Evidence read/hash/parse/validation/finalization
+failures are terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM
+handlers route every wait interruption/error through bounded TERM/KILL/reap
+before terminal persistence. Interpreter identity is the lexical
+repository-worktree `.venv/bin/python` plus the matching lexical venv
+`sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
+venvs, and prefix mismatch are rejected.
 
 The finite source/runtime state machine is currently `authority_main`: the live
 predecessor may remain on authority main, while only the exact selected

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,8 +112,8 @@ keep CK-07R1 `blocked_hold`
 The accepted source history retains R3A preparation `6689d61f…` as a
 historical predecessor and R1B/current exact-main preparation `7d1831ff…` as
 the live predecessor. The sole CK-07 worker-prequalification successor is the
-atomic `66c015de…` preparation, `4b1c62b2…` benchmark, and `75d03f53…`
-lifecycle-test cohort derived from exact main `cf44f4fd`. Mixed or incomplete
+atomic `66c015de…` preparation, `98aac35d…` benchmark, and `7914d993…`
+lifecycle-test cohort derived from exact main `6c08ecd9`. Mixed or incomplete
 cohorts, prior candidate `e204e0da…`, and historical candidate `d192c858…`
 fail closed. PR #394 remains a stale failed
 read-only witness; it is not updated, rerun, or merged. The old argv-guard attempt remains the historical
@@ -133,6 +133,13 @@ authority task does not resume the worker, consume the run token, authorize
 launch/output, or advance another successor. The one-run gate remains unspent
 and unavailable. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
+
+The V9 candidate must construct and validate the exact overlay/cohort-bound
+receipt before its first durable `completed` finalization; construction,
+validation, or finalization failures are terminal `failed_after_launch`.
+Interpreter identity is the lexical repository-worktree `.venv/bin/python` plus
+the matching lexical venv `sys.prefix`; base interpreters, symlink/resolved
+equivalence, wrong-worktree venvs, and prefix mismatch are rejected.
 
 The finite source/runtime state machine is currently `authority_main`: the live
 predecessor may remain on authority main, while only the exact selected

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,7 +112,7 @@ keep CK-07R1 `blocked_hold`
 The accepted source history retains R3A preparation `6689d61f…` as a
 historical predecessor and R1B/current exact-main preparation `7d1831ff…` as
 the live predecessor. The sole CK-07 worker-prequalification successor is the
-atomic `66c015de…` preparation, `1c7e1ea7…` benchmark, and `a8de9667…`
+atomic `66c015de…` preparation, `f108dbb4…` benchmark, and `4c514889…`
 lifecycle-test cohort derived from exact main `6c08ecd9`. Mixed or incomplete
 cohorts, prior candidate `e204e0da…`, and historical candidate `d192c858…`
 fail closed. PR #394 remains a stale failed
@@ -141,7 +141,10 @@ failures are terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM
 handlers route every wait interruption/error through bounded TERM/KILL/reap
 before terminal persistence and remain installed through evidence, receipt,
 and terminal ledger finalization; originals restore only after the terminal
-state attempt. The fork child ignores SIGINT/SIGTERM while
+state attempt. Every terminal fallback persistence call masks SIGINT/SIGTERM
+with the existing ignore guard and restores the prior temporary handlers
+afterward; the outer final restoration of original handlers remains last. The
+fork child ignores SIGINT/SIGTERM while
 waiting for parent release and maps every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
 `mkstemp` ledger updates close and unlink on failed or interrupted

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,7 +112,7 @@ keep CK-07R1 `blocked_hold`
 The accepted source history retains R3A preparation `6689d61f…` as a
 historical predecessor and R1B/current exact-main preparation `7d1831ff…` as
 the live predecessor. The sole CK-07 worker-prequalification successor is the
-atomic `66c015de…` preparation, `c922b59f…` benchmark, and `5e9cb014…`
+atomic `66c015de…` preparation, `1c7e1ea7…` benchmark, and `a8de9667…`
 lifecycle-test cohort derived from exact main `6c08ecd9`. Mixed or incomplete
 cohorts, prior candidate `e204e0da…`, and historical candidate `d192c858…`
 fail closed. PR #394 remains a stale failed
@@ -139,7 +139,9 @@ receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failures are terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM
 handlers route every wait interruption/error through bounded TERM/KILL/reap
-before terminal persistence. The fork child ignores SIGINT/SIGTERM while
+before terminal persistence and remain installed through evidence, receipt,
+and terminal ledger finalization; originals restore only after the terminal
+state attempt. The fork child ignores SIGINT/SIGTERM while
 waiting for parent release and maps every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
 `mkstemp` ledger updates close and unlink on failed or interrupted

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,7 +112,7 @@ keep CK-07R1 `blocked_hold`
 The accepted source history retains R3A preparation `6689d61f…` as a
 historical predecessor and R1B/current exact-main preparation `7d1831ff…` as
 the live predecessor. The sole CK-07 worker-prequalification successor is the
-atomic `66c015de…` preparation, `2125d127…` benchmark, and `a4163ffb…`
+atomic `66c015de…` preparation, `c922b59f…` benchmark, and `5e9cb014…`
 lifecycle-test cohort derived from exact main `6c08ecd9`. Mixed or incomplete
 cohorts, prior candidate `e204e0da…`, and historical candidate `d192c858…`
 fail closed. PR #394 remains a stale failed
@@ -134,13 +134,18 @@ launch/output, or advance another successor. The one-run gate remains unspent
 and unavailable. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
-The V10 candidate must construct and validate the exact overlay/cohort-bound
+The V11 candidate must construct and validate the exact overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failures are terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM
 handlers route every wait interruption/error through bounded TERM/KILL/reap
-before terminal persistence. Interpreter identity is the lexical
-repository-worktree `.venv/bin/python` plus the matching lexical venv
+before terminal persistence. The fork child ignores SIGINT/SIGTERM while
+waiting for parent release and maps every pre-release failure to
+`os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
+`mkstemp` ledger updates close and unlink on failed or interrupted
+write/fsync/replace/post-replace paths and retain durable consumed/no-retry
+`failed_after_launch` evidence without temporary residue. Interpreter identity
+is the lexical repository-worktree `.venv/bin/python` plus the matching lexical venv
 `sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
 venvs, and prefix mismatch are rejected.
 

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,8 +1,8 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v6",
-  "authority_version": 6,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v7",
+  "authority_version": 7,
   "owner": "CK-07R1A0",
-  "authority_base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+  "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "blocked_no_run",
   "shared_preparation_binding": {
     "authority_main_sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb",
@@ -27,8 +27,8 @@
     "corrected_guard": "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]",
     "corrected_candidate_status": "frozen_not_run",
     "corrected_candidate_artifacts": {
-      "benchmark_sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
-      "lifecycle_test_sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2"
+      "benchmark_sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+      "lifecycle_test_sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f"
     },
     "old_candidate_artifacts": {
       "benchmark_sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
@@ -134,7 +134,7 @@
         "requires": [
           "this authority is merged and exact-main verified",
           "the existing worker resumes only the preserved exact candidate worktree",
-          "the worker presents the byte-exact 66c015de/4b1c62b2/75d03f53 cohort over the 7d1831ff predecessor",
+          "the worker presents the byte-exact 66c015de/98aac35d/7914d993 cohort over the 7d1831ff predecessor",
           "runtime_acceptance remains not_claimed",
           "authority-integrity and prelaunch gates pass",
           "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -205,9 +205,9 @@
   },
   "selected_candidate": {
     "status": "exact_ck07_successor_permitted_not_accepted",
-    "base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
-    "retained_branch": "feature/ck-07r1-launcher-correction-v7",
-    "retained_worktree": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v7",
+    "base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
+    "retained_branch": "feature/ck-07r1-launcher-correction-v9",
+    "retained_worktree": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v9",
     "witness_status": "retained_uncommitted_read_only_exact_candidate",
     "source_predecessor_sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb",
     "source_successor_sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
@@ -223,12 +223,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+        "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+        "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
         "role": "lifecycle_test"
       },
       {
@@ -237,7 +237,7 @@
         "role": "linked_evidence"
       }
     ],
-    "binding": "only the byte-exact 66c015de/4b1c62b2/75d03f53 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
+    "binding": "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
     "worker_revalidation_required": true
   },
   "preserved_authorities": {
@@ -249,9 +249,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "6156780a7e8663859658bb5309f13eb6bf5283704784d8270edf0512c167d70b",
+      "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "4026a4e971c1b6b177b467440a36931bc6a15a0b376918bdc4169b732a0d489c"
+      "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
     }
   },
   "launch_contract": {
@@ -273,6 +273,16 @@
     "launcher_safety": {
       "overlay_and_cohort_verification": "must_complete_before_ledger_fork_child_release_or_token_consumption",
       "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
+      "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
+      "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+      "interpreter_identity": {
+        "executable": "lexical_repository_worktree_.venv/bin/python_required",
+        "sys_prefix": "lexical_repository_worktree_.venv_required",
+        "base_interpreter": "rejected",
+        "symlink_or_resolved_equivalence": "rejected",
+        "wrong_worktree_venv": "rejected",
+        "prefix_mismatch": "rejected"
+      },
       "post_token_or_release_failure_state": "failed_after_launch",
       "termination_sequence": [
         "SIGTERM",
@@ -580,7 +590,7 @@
     "refund": false,
     "prior_identities_reused": false,
     "concurrent_processes_allowed": false,
-    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/4b1c62b2/75d03f53 candidate cohort, and all gates pass",
+    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass",
     "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
     "old_candidate_reuse": "forbidden"
   },

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v8",
-  "authority_version": 8,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v9",
+  "authority_version": 9,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "blocked_no_run",
@@ -27,8 +27,8 @@
     "corrected_guard": "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]",
     "corrected_candidate_status": "frozen_not_run",
     "corrected_candidate_artifacts": {
-      "benchmark_sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
-      "lifecycle_test_sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6"
+      "benchmark_sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+      "lifecycle_test_sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e"
     },
     "old_candidate_artifacts": {
       "benchmark_sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
@@ -134,7 +134,7 @@
         "requires": [
           "this authority is merged and exact-main verified",
           "the existing worker resumes only the preserved exact candidate worktree",
-          "the worker presents the byte-exact 66c015de/2125d127/a4163ffb cohort over the 7d1831ff predecessor",
+          "the worker presents the byte-exact 66c015de/c922b59f/5e9cb014 cohort over the 7d1831ff predecessor",
           "runtime_acceptance remains not_claimed",
           "authority-integrity and prelaunch gates pass",
           "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -223,12 +223,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+        "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+        "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
         "role": "lifecycle_test"
       },
       {
@@ -237,7 +237,7 @@
         "role": "linked_evidence"
       }
     ],
-    "binding": "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter worker_prequalification after this authority merges and exact-main verifies",
+    "binding": "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
     "worker_revalidation_required": true
   },
   "preserved_authorities": {
@@ -275,6 +275,11 @@
       "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
       "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
       "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+      "child_pre_release_failure": "every_pre_release_child_failure_routes_to_os._exit_71",
+      "child_wait_signal_handling": "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release",
+      "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
+      "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
+      "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
       "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
       "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
       "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
@@ -595,7 +600,7 @@
     "refund": false,
     "prior_identities_reused": false,
     "concurrent_processes_allowed": false,
-    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass",
+    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass",
     "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
     "old_candidate_reuse": "forbidden"
   },

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -249,9 +249,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
+      "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
+      "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
     }
   },
   "launch_contract": {

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v9",
-  "authority_version": 9,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v10",
+  "authority_version": 10,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "blocked_no_run",
@@ -27,8 +27,8 @@
     "corrected_guard": "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]",
     "corrected_candidate_status": "frozen_not_run",
     "corrected_candidate_artifacts": {
-      "benchmark_sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
-      "lifecycle_test_sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e"
+      "benchmark_sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+      "lifecycle_test_sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b"
     },
     "old_candidate_artifacts": {
       "benchmark_sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
@@ -134,7 +134,7 @@
         "requires": [
           "this authority is merged and exact-main verified",
           "the existing worker resumes only the preserved exact candidate worktree",
-          "the worker presents the byte-exact 66c015de/c922b59f/5e9cb014 cohort over the 7d1831ff predecessor",
+          "the worker presents the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort over the 7d1831ff predecessor",
           "runtime_acceptance remains not_claimed",
           "authority-integrity and prelaunch gates pass",
           "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -223,12 +223,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+        "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+        "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
         "role": "lifecycle_test"
       },
       {
@@ -237,7 +237,7 @@
         "role": "linked_evidence"
       }
     ],
-    "binding": "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
+    "binding": "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
     "worker_revalidation_required": true
   },
   "preserved_authorities": {
@@ -249,9 +249,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
+      "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
+      "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
     }
   },
   "launch_contract": {
@@ -280,7 +280,7 @@
       "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
       "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
       "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
-      "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+      "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
       "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
       "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
       "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
@@ -600,7 +600,7 @@
     "refund": false,
     "prior_identities_reused": false,
     "concurrent_processes_allowed": false,
-    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass",
+    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass",
     "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
     "old_candidate_reuse": "forbidden"
   },

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v10",
-  "authority_version": 10,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v11",
+  "authority_version": 11,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "blocked_no_run",
@@ -27,8 +27,8 @@
     "corrected_guard": "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]",
     "corrected_candidate_status": "frozen_not_run",
     "corrected_candidate_artifacts": {
-      "benchmark_sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
-      "lifecycle_test_sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b"
+      "benchmark_sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
+      "lifecycle_test_sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a"
     },
     "old_candidate_artifacts": {
       "benchmark_sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
@@ -134,7 +134,7 @@
         "requires": [
           "this authority is merged and exact-main verified",
           "the existing worker resumes only the preserved exact candidate worktree",
-          "the worker presents the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort over the 7d1831ff predecessor",
+          "the worker presents the byte-exact 66c015de/f108dbb4/4c514889 cohort over the 7d1831ff predecessor",
           "runtime_acceptance remains not_claimed",
           "authority-integrity and prelaunch gates pass",
           "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -223,12 +223,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+        "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+        "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
         "role": "lifecycle_test"
       },
       {
@@ -237,7 +237,7 @@
         "role": "linked_evidence"
       }
     ],
-    "binding": "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
+    "binding": "only the byte-exact 66c015de/f108dbb4/4c514889 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
     "worker_revalidation_required": true
   },
   "preserved_authorities": {
@@ -249,9 +249,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
+      "sha256": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
+      "schema_sha256": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
     }
   },
   "launch_contract": {
@@ -283,6 +283,7 @@
       "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
       "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
       "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+      "terminal_fallback_signal_mask": "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_then_prior_temporary_handlers_restored",
       "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
       "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
       "interpreter_identity": {
@@ -600,7 +601,7 @@
     "refund": false,
     "prior_identities_reused": false,
     "concurrent_processes_allowed": false,
-    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass",
+    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/f108dbb4/4c514889 candidate cohort, and all gates pass",
     "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
     "old_candidate_reuse": "forbidden"
   },

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v7",
-  "authority_version": 7,
+  "schema": "codex-usage-tracker.lifecycle-run-invocation-authority.v8",
+  "authority_version": 8,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "blocked_no_run",
@@ -27,8 +27,8 @@
     "corrected_guard": "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]",
     "corrected_candidate_status": "frozen_not_run",
     "corrected_candidate_artifacts": {
-      "benchmark_sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
-      "lifecycle_test_sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f"
+      "benchmark_sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+      "lifecycle_test_sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6"
     },
     "old_candidate_artifacts": {
       "benchmark_sha256": "6a864c74a403da3edb671d9750fc2b2a59b73899102075ee0cec89fbb429b783",
@@ -134,7 +134,7 @@
         "requires": [
           "this authority is merged and exact-main verified",
           "the existing worker resumes only the preserved exact candidate worktree",
-          "the worker presents the byte-exact 66c015de/98aac35d/7914d993 cohort over the 7d1831ff predecessor",
+          "the worker presents the byte-exact 66c015de/2125d127/a4163ffb cohort over the 7d1831ff predecessor",
           "runtime_acceptance remains not_claimed",
           "authority-integrity and prelaunch gates pass",
           "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -206,8 +206,8 @@
   "selected_candidate": {
     "status": "exact_ck07_successor_permitted_not_accepted",
     "base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
-    "retained_branch": "feature/ck-07r1-launcher-correction-v9",
-    "retained_worktree": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v9",
+    "retained_branch": "feature/ck-07r1-launcher-correction-v10",
+    "retained_worktree": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v10",
     "witness_status": "retained_uncommitted_read_only_exact_candidate",
     "source_predecessor_sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb",
     "source_successor_sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
@@ -223,12 +223,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+        "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+        "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
         "role": "lifecycle_test"
       },
       {
@@ -237,7 +237,7 @@
         "role": "linked_evidence"
       }
     ],
-    "binding": "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter worker_prequalification after this authority merges and exact-main verifies",
+    "binding": "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter worker_prequalification after this authority merges and exact-main verifies",
     "worker_revalidation_required": true
   },
   "preserved_authorities": {
@@ -249,9 +249,9 @@
     },
     "lifecycle_source_digest": {
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
+      "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
+      "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
     }
   },
   "launch_contract": {
@@ -275,6 +275,11 @@
       "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
       "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
       "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+      "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+      "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
+      "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+      "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
+      "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
       "interpreter_identity": {
         "executable": "lexical_repository_worktree_.venv/bin/python_required",
         "sys_prefix": "lexical_repository_worktree_.venv_required",
@@ -590,7 +595,7 @@
     "refund": false,
     "prior_identities_reused": false,
     "concurrent_processes_allowed": false,
-    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass",
+    "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass",
     "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
     "old_candidate_reuse": "forbidden"
   },

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -595,13 +595,13 @@
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"
             },
             "sha256": {
-              "const": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3"
+              "const": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca"
             },
             "schema_path": {
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"
             },
             "schema_sha256": {
-              "const": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
+              "const": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
             }
           }
         }

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v10.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v11.schema.json",
   "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
@@ -29,10 +29,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v10"
+      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v11"
     },
     "authority_version": {
-      "const": 10
+      "const": 11
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -99,10 +99,10 @@
           ],
           "properties": {
             "benchmark_sha256": {
-              "const": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5"
+              "const": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c"
             },
             "lifecycle_test_sha256": {
-              "const": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b"
+              "const": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a"
             }
           }
         },
@@ -367,7 +367,7 @@
               "requires": [
                 "this authority is merged and exact-main verified",
                 "the existing worker resumes only the preserved exact candidate worktree",
-                "the worker presents the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort over the 7d1831ff predecessor",
+                "the worker presents the byte-exact 66c015de/f108dbb4/4c514889 cohort over the 7d1831ff predecessor",
                 "runtime_acceptance remains not_claimed",
                 "authority-integrity and prelaunch gates pass",
                 "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -526,12 +526,12 @@
             },
             {
               "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-              "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+              "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
               "role": "benchmark"
             },
             {
               "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-              "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+              "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
               "role": "lifecycle_test"
             },
             {
@@ -542,7 +542,7 @@
           ]
         },
         "binding": {
-          "const": "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
+          "const": "only the byte-exact 66c015de/f108dbb4/4c514889 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
         },
         "worker_revalidation_required": {
           "const": true
@@ -595,13 +595,13 @@
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"
             },
             "sha256": {
-              "const": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875"
+              "const": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74"
             },
             "schema_path": {
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"
             },
             "schema_sha256": {
-              "const": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
+              "const": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
             }
           }
         }
@@ -681,6 +681,7 @@
             "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
             "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
             "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+            "terminal_fallback_signal_mask": "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_then_prior_temporary_handlers_restored",
             "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
             "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
             "interpreter_identity": {
@@ -1285,7 +1286,7 @@
           "const": false
         },
         "eligibility": {
-          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass"
+          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/f108dbb4/4c514889 candidate cohort, and all gates pass"
         },
         "first_successful_launch": {
           "const": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v7.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v8.schema.json",
   "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
@@ -29,10 +29,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v7"
+      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v8"
     },
     "authority_version": {
-      "const": 7
+      "const": 8
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -99,10 +99,10 @@
           ],
           "properties": {
             "benchmark_sha256": {
-              "const": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc"
+              "const": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97"
             },
             "lifecycle_test_sha256": {
-              "const": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f"
+              "const": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6"
             }
           }
         },
@@ -367,7 +367,7 @@
               "requires": [
                 "this authority is merged and exact-main verified",
                 "the existing worker resumes only the preserved exact candidate worktree",
-                "the worker presents the byte-exact 66c015de/98aac35d/7914d993 cohort over the 7d1831ff predecessor",
+                "the worker presents the byte-exact 66c015de/2125d127/a4163ffb cohort over the 7d1831ff predecessor",
                 "runtime_acceptance remains not_claimed",
                 "authority-integrity and prelaunch gates pass",
                 "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -491,10 +491,10 @@
           "const": "6c08ecd92a2c5166c1585be426e1ed437309a910"
         },
         "retained_branch": {
-          "const": "feature/ck-07r1-launcher-correction-v9"
+          "const": "feature/ck-07r1-launcher-correction-v10"
         },
         "retained_worktree": {
-          "const": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v9"
+          "const": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v10"
         },
         "witness_status": {
           "const": "retained_uncommitted_read_only_exact_candidate"
@@ -526,12 +526,12 @@
             },
             {
               "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-              "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+              "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
               "role": "benchmark"
             },
             {
               "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-              "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+              "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
               "role": "lifecycle_test"
             },
             {
@@ -542,7 +542,7 @@
           ]
         },
         "binding": {
-          "const": "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
+          "const": "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter worker_prequalification after this authority merges and exact-main verifies"
         },
         "worker_revalidation_required": {
           "const": true
@@ -595,13 +595,13 @@
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"
             },
             "sha256": {
-              "const": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3"
+              "const": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3"
             },
             "schema_path": {
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"
             },
             "schema_sha256": {
-              "const": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
+              "const": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
             }
           }
         }
@@ -673,6 +673,11 @@
             "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
             "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
             "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+            "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+            "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
+            "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+            "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
+            "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
             "interpreter_identity": {
               "executable": "lexical_repository_worktree_.venv/bin/python_required",
               "sys_prefix": "lexical_repository_worktree_.venv_required",
@@ -1275,7 +1280,7 @@
           "const": false
         },
         "eligibility": {
-          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass"
+          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass"
         },
         "first_successful_launch": {
           "const": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v9.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v10.schema.json",
   "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
@@ -29,10 +29,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v9"
+      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v10"
     },
     "authority_version": {
-      "const": 9
+      "const": 10
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -99,10 +99,10 @@
           ],
           "properties": {
             "benchmark_sha256": {
-              "const": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32"
+              "const": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5"
             },
             "lifecycle_test_sha256": {
-              "const": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e"
+              "const": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b"
             }
           }
         },
@@ -367,7 +367,7 @@
               "requires": [
                 "this authority is merged and exact-main verified",
                 "the existing worker resumes only the preserved exact candidate worktree",
-                "the worker presents the byte-exact 66c015de/c922b59f/5e9cb014 cohort over the 7d1831ff predecessor",
+                "the worker presents the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort over the 7d1831ff predecessor",
                 "runtime_acceptance remains not_claimed",
                 "authority-integrity and prelaunch gates pass",
                 "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -526,12 +526,12 @@
             },
             {
               "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-              "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+              "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
               "role": "benchmark"
             },
             {
               "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-              "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+              "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
               "role": "lifecycle_test"
             },
             {
@@ -542,7 +542,7 @@
           ]
         },
         "binding": {
-          "const": "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
+          "const": "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
         },
         "worker_revalidation_required": {
           "const": true
@@ -595,13 +595,13 @@
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"
             },
             "sha256": {
-              "const": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca"
+              "const": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875"
             },
             "schema_path": {
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"
             },
             "schema_sha256": {
-              "const": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
+              "const": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
             }
           }
         }
@@ -678,7 +678,7 @@
             "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
             "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
             "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
-            "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+            "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
             "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
             "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
             "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
@@ -1285,7 +1285,7 @@
           "const": false
         },
         "eligibility": {
-          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass"
+          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass"
         },
         "first_successful_launch": {
           "const": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v6.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v7.schema.json",
   "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
@@ -29,16 +29,16 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v6"
+      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v7"
     },
     "authority_version": {
-      "const": 6
+      "const": 7
     },
     "owner": {
       "const": "CK-07R1A0"
     },
     "authority_base_sha": {
-      "const": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+      "const": "6c08ecd92a2c5166c1585be426e1ed437309a910"
     },
     "status": {
       "const": "blocked_no_run"
@@ -99,10 +99,10 @@
           ],
           "properties": {
             "benchmark_sha256": {
-              "const": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde"
+              "const": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc"
             },
             "lifecycle_test_sha256": {
-              "const": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2"
+              "const": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f"
             }
           }
         },
@@ -367,7 +367,7 @@
               "requires": [
                 "this authority is merged and exact-main verified",
                 "the existing worker resumes only the preserved exact candidate worktree",
-                "the worker presents the byte-exact 66c015de/4b1c62b2/75d03f53 cohort over the 7d1831ff predecessor",
+                "the worker presents the byte-exact 66c015de/98aac35d/7914d993 cohort over the 7d1831ff predecessor",
                 "runtime_acceptance remains not_claimed",
                 "authority-integrity and prelaunch gates pass",
                 "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -488,13 +488,13 @@
           "const": "exact_ck07_successor_permitted_not_accepted"
         },
         "base_sha": {
-          "const": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+          "const": "6c08ecd92a2c5166c1585be426e1ed437309a910"
         },
         "retained_branch": {
-          "const": "feature/ck-07r1-launcher-correction-v7"
+          "const": "feature/ck-07r1-launcher-correction-v9"
         },
         "retained_worktree": {
-          "const": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v7"
+          "const": "2026-08-11/codex-usage-tracker-ck07r1-launcher-correction-v9"
         },
         "witness_status": {
           "const": "retained_uncommitted_read_only_exact_candidate"
@@ -526,12 +526,12 @@
             },
             {
               "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-              "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+              "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
               "role": "benchmark"
             },
             {
               "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-              "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+              "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
               "role": "lifecycle_test"
             },
             {
@@ -542,7 +542,7 @@
           ]
         },
         "binding": {
-          "const": "only the byte-exact 66c015de/4b1c62b2/75d03f53 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
+          "const": "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
         },
         "worker_revalidation_required": {
           "const": true
@@ -595,13 +595,13 @@
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json"
             },
             "sha256": {
-              "const": "6156780a7e8663859658bb5309f13eb6bf5283704784d8270edf0512c167d70b"
+              "const": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3"
             },
             "schema_path": {
               "const": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json"
             },
             "schema_sha256": {
-              "const": "4026a4e971c1b6b177b467440a36931bc6a15a0b376918bdc4169b732a0d489c"
+              "const": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
             }
           }
         }
@@ -671,6 +671,16 @@
           "const": {
             "overlay_and_cohort_verification": "must_complete_before_ledger_fork_child_release_or_token_consumption",
             "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
+            "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
+            "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+            "interpreter_identity": {
+              "executable": "lexical_repository_worktree_.venv/bin/python_required",
+              "sys_prefix": "lexical_repository_worktree_.venv_required",
+              "base_interpreter": "rejected",
+              "symlink_or_resolved_equivalence": "rejected",
+              "wrong_worktree_venv": "rejected",
+              "prefix_mismatch": "rejected"
+            },
             "post_token_or_release_failure_state": "failed_after_launch",
             "termination_sequence": [
               "SIGTERM",
@@ -1265,7 +1275,7 @@
           "const": false
         },
         "eligibility": {
-          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/4b1c62b2/75d03f53 candidate cohort, and all gates pass"
+          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass"
         },
         "first_successful_launch": {
           "const": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v8.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-run-invocation-authority-v9.schema.json",
   "title": "CK-07R1A0 finite lifecycle source/runtime authority",
   "type": "object",
   "additionalProperties": false,
@@ -29,10 +29,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v8"
+      "const": "codex-usage-tracker.lifecycle-run-invocation-authority.v9"
     },
     "authority_version": {
-      "const": 8
+      "const": 9
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -99,10 +99,10 @@
           ],
           "properties": {
             "benchmark_sha256": {
-              "const": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97"
+              "const": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32"
             },
             "lifecycle_test_sha256": {
-              "const": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6"
+              "const": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e"
             }
           }
         },
@@ -367,7 +367,7 @@
               "requires": [
                 "this authority is merged and exact-main verified",
                 "the existing worker resumes only the preserved exact candidate worktree",
-                "the worker presents the byte-exact 66c015de/2125d127/a4163ffb cohort over the 7d1831ff predecessor",
+                "the worker presents the byte-exact 66c015de/c922b59f/5e9cb014 cohort over the 7d1831ff predecessor",
                 "runtime_acceptance remains not_claimed",
                 "authority-integrity and prelaunch gates pass",
                 "maximum_new_end_to_end_runs remains 1 and unspent_unavailable",
@@ -526,12 +526,12 @@
             },
             {
               "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-              "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+              "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
               "role": "benchmark"
             },
             {
               "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-              "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+              "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
               "role": "lifecycle_test"
             },
             {
@@ -542,7 +542,7 @@
           ]
         },
         "binding": {
-          "const": "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter worker_prequalification after this authority merges and exact-main verifies"
+          "const": "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter worker_prequalification after this authority merges and exact-main verifies"
         },
         "worker_revalidation_required": {
           "const": true
@@ -673,6 +673,11 @@
             "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
             "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
             "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+            "child_pre_release_failure": "every_pre_release_child_failure_routes_to_os._exit_71",
+            "child_wait_signal_handling": "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release",
+            "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
+            "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
+            "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
             "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
             "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
             "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
@@ -1280,7 +1285,7 @@
           "const": false
         },
         "eligibility": {
-          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass"
+          "const": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass"
         },
         "first_successful_launch": {
           "const": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v11",
-  "authority_version": 11,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v12",
+  "authority_version": 12,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -42,7 +42,7 @@
         "requires_complete_candidate_cohort": true
       }
     ],
-    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 1c7e1ea7 benchmark and a8de9667 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact f108dbb4 benchmark and 4c514889 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
     "other_digest": "fail_closed",
     "current_runtime_claim": "not_claimed",
     "launch_state": "blocked_hold_no_run"
@@ -73,12 +73,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+        "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+        "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
         "role": "lifecycle_test"
       }
     ]
@@ -115,7 +115,7 @@
     "required": true,
     "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
     "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-    "reapply": "use only the already-derived atomic 66c015de/1c7e1ea7/a8de9667 candidate cohort; do not mutate any historical witness or substitute another digest",
+    "reapply": "use only the already-derived atomic 66c015de/f108dbb4/4c514889 candidate cohort; do not mutate any historical witness or substitute another digest",
     "derive_new_digest": false,
     "update_source_authority_before_run": false,
     "old_d192_reuse": "fail_closed",
@@ -148,7 +148,7 @@
     "any_different_preparation_digest_fails_closed",
     "7d1831ff_is_current_exact_main_predecessor",
     "6689d61f_is_historical_accepted_r3a_predecessor_only",
-    "66c015de_requires_atomic_1c7e1ea7_and_a8de9667_cohort",
+    "66c015de_requires_atomic_f108dbb4_and_4c514889_cohort",
     "mixed_or_incomplete_candidate_cohort_fails_closed",
     "e204e0da_superseded_and_direct_use_forbidden",
     "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,8 +1,8 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v7",
-  "authority_version": 7,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v8",
+  "authority_version": 8,
   "owner": "CK-07R1A0",
-  "authority_base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+  "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
   "status": "blocked_hold",
   "acceptance_state": {
@@ -42,7 +42,7 @@
         "requires_complete_candidate_cohort": true
       }
     ],
-    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 4b1c62b2 benchmark and 75d03f53 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 98aac35d benchmark and 7914d993 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
     "other_digest": "fail_closed",
     "current_runtime_claim": "not_claimed",
     "launch_state": "blocked_hold_no_run"
@@ -59,7 +59,7 @@
     "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
     "status": "permitted_not_accepted",
     "role": "selected_ck07_exact_candidate",
-    "base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+    "base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
     "requires_full_candidate_cohort": true,
     "direct_ck07_use": "worker_prequalification_only_after_authority_exact_main",
     "mixed_state": "fail_closed",
@@ -73,12 +73,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+        "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+        "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
         "role": "lifecycle_test"
       }
     ]
@@ -115,7 +115,7 @@
     "required": true,
     "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
     "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-    "reapply": "use only the already-derived atomic 66c015de/4b1c62b2/75d03f53 candidate cohort; do not mutate any historical witness or substitute another digest",
+    "reapply": "use only the already-derived atomic 66c015de/98aac35d/7914d993 candidate cohort; do not mutate any historical witness or substitute another digest",
     "derive_new_digest": false,
     "update_source_authority_before_run": false,
     "old_d192_reuse": "fail_closed",
@@ -148,7 +148,7 @@
     "any_different_preparation_digest_fails_closed",
     "7d1831ff_is_current_exact_main_predecessor",
     "6689d61f_is_historical_accepted_r3a_predecessor_only",
-    "66c015de_requires_atomic_4b1c62b2_and_75d03f53_cohort",
+    "66c015de_requires_atomic_98aac35d_and_7914d993_cohort",
     "mixed_or_incomplete_candidate_cohort_fails_closed",
     "e204e0da_superseded_and_direct_use_forbidden",
     "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v8",
-  "authority_version": 8,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v9",
+  "authority_version": 9,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -42,7 +42,7 @@
         "requires_complete_candidate_cohort": true
       }
     ],
-    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 98aac35d benchmark and 7914d993 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 2125d127 benchmark and a4163ffb lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
     "other_digest": "fail_closed",
     "current_runtime_claim": "not_claimed",
     "launch_state": "blocked_hold_no_run"
@@ -73,12 +73,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+        "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+        "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
         "role": "lifecycle_test"
       }
     ]
@@ -115,7 +115,7 @@
     "required": true,
     "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
     "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-    "reapply": "use only the already-derived atomic 66c015de/98aac35d/7914d993 candidate cohort; do not mutate any historical witness or substitute another digest",
+    "reapply": "use only the already-derived atomic 66c015de/2125d127/a4163ffb candidate cohort; do not mutate any historical witness or substitute another digest",
     "derive_new_digest": false,
     "update_source_authority_before_run": false,
     "old_d192_reuse": "fail_closed",
@@ -148,7 +148,7 @@
     "any_different_preparation_digest_fails_closed",
     "7d1831ff_is_current_exact_main_predecessor",
     "6689d61f_is_historical_accepted_r3a_predecessor_only",
-    "66c015de_requires_atomic_98aac35d_and_7914d993_cohort",
+    "66c015de_requires_atomic_2125d127_and_a4163ffb_cohort",
     "mixed_or_incomplete_candidate_cohort_fails_closed",
     "e204e0da_superseded_and_direct_use_forbidden",
     "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v9",
-  "authority_version": 9,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v10",
+  "authority_version": 10,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -42,7 +42,7 @@
         "requires_complete_candidate_cohort": true
       }
     ],
-    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 2125d127 benchmark and a4163ffb lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact c922b59f benchmark and 5e9cb014 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
     "other_digest": "fail_closed",
     "current_runtime_claim": "not_claimed",
     "launch_state": "blocked_hold_no_run"
@@ -73,12 +73,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+        "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+        "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
         "role": "lifecycle_test"
       }
     ]
@@ -115,7 +115,7 @@
     "required": true,
     "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
     "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-    "reapply": "use only the already-derived atomic 66c015de/2125d127/a4163ffb candidate cohort; do not mutate any historical witness or substitute another digest",
+    "reapply": "use only the already-derived atomic 66c015de/c922b59f/5e9cb014 candidate cohort; do not mutate any historical witness or substitute another digest",
     "derive_new_digest": false,
     "update_source_authority_before_run": false,
     "old_d192_reuse": "fail_closed",
@@ -148,7 +148,7 @@
     "any_different_preparation_digest_fails_closed",
     "7d1831ff_is_current_exact_main_predecessor",
     "6689d61f_is_historical_accepted_r3a_predecessor_only",
-    "66c015de_requires_atomic_2125d127_and_a4163ffb_cohort",
+    "66c015de_requires_atomic_c922b59f_and_5e9cb014_cohort",
     "mixed_or_incomplete_candidate_cohort_fails_closed",
     "e204e0da_superseded_and_direct_use_forbidden",
     "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json
@@ -1,6 +1,6 @@
 {
-  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v10",
-  "authority_version": 10,
+  "schema": "codex-usage-tracker.lifecycle-source-digest-authority.v11",
+  "authority_version": 11,
   "owner": "CK-07R1A0",
   "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "source_path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
@@ -42,7 +42,7 @@
         "requires_complete_candidate_cohort": true
       }
     ],
-    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact c922b59f benchmark and 5e9cb014 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+    "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 1c7e1ea7 benchmark and a8de9667 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
     "other_digest": "fail_closed",
     "current_runtime_claim": "not_claimed",
     "launch_state": "blocked_hold_no_run"
@@ -73,12 +73,12 @@
       },
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-        "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+        "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
         "role": "benchmark"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-        "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+        "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
         "role": "lifecycle_test"
       }
     ]
@@ -115,7 +115,7 @@
     "required": true,
     "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
     "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-    "reapply": "use only the already-derived atomic 66c015de/c922b59f/5e9cb014 candidate cohort; do not mutate any historical witness or substitute another digest",
+    "reapply": "use only the already-derived atomic 66c015de/1c7e1ea7/a8de9667 candidate cohort; do not mutate any historical witness or substitute another digest",
     "derive_new_digest": false,
     "update_source_authority_before_run": false,
     "old_d192_reuse": "fail_closed",
@@ -148,7 +148,7 @@
     "any_different_preparation_digest_fails_closed",
     "7d1831ff_is_current_exact_main_predecessor",
     "6689d61f_is_historical_accepted_r3a_predecessor_only",
-    "66c015de_requires_atomic_c922b59f_and_5e9cb014_cohort",
+    "66c015de_requires_atomic_1c7e1ea7_and_a8de9667_cohort",
     "mixed_or_incomplete_candidate_cohort_fails_closed",
     "e204e0da_superseded_and_direct_use_forbidden",
     "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v7.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v8.schema.json",
   "title": "CK-07R1A0 shared-preparation source digest authority",
   "type": "object",
   "additionalProperties": false,
@@ -28,16 +28,16 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v7"
+      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v8"
     },
     "authority_version": {
-      "const": 7
+      "const": 8
     },
     "owner": {
       "const": "CK-07R1A0"
     },
     "authority_base_sha": {
-      "const": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+      "const": "6c08ecd92a2c5166c1585be426e1ed437309a910"
     },
     "source_path": {
       "const": "src/codex_usage_tracker/agent_kernel/publication/preparation.py"
@@ -85,7 +85,7 @@
               "requires_complete_candidate_cohort": true
             }
           ],
-        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 4b1c62b2 benchmark and 75d03f53 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 98aac35d benchmark and 7914d993 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
         "other_digest": "fail_closed",
         "current_runtime_claim": "not_claimed",
         "launch_state": "blocked_hold_no_run"
@@ -106,7 +106,7 @@
         "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
         "status": "permitted_not_accepted",
         "role": "selected_ck07_exact_candidate",
-        "base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+        "base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
         "requires_full_candidate_cohort": true,
         "direct_ck07_use": "worker_prequalification_only_after_authority_exact_main",
         "mixed_state": "fail_closed",
@@ -120,12 +120,12 @@
           },
           {
             "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-            "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+            "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
             "role": "benchmark"
           },
           {
             "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-            "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+            "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
             "role": "lifecycle_test"
           }
         ]
@@ -168,7 +168,7 @@
         "required": true,
         "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
         "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-        "reapply": "use only the already-derived atomic 66c015de/4b1c62b2/75d03f53 candidate cohort; do not mutate any historical witness or substitute another digest",
+        "reapply": "use only the already-derived atomic 66c015de/98aac35d/7914d993 candidate cohort; do not mutate any historical witness or substitute another digest",
         "derive_new_digest": false,
         "update_source_authority_before_run": false,
         "old_d192_reuse": "fail_closed",
@@ -213,7 +213,7 @@
         "any_different_preparation_digest_fails_closed",
         "7d1831ff_is_current_exact_main_predecessor",
         "6689d61f_is_historical_accepted_r3a_predecessor_only",
-        "66c015de_requires_atomic_4b1c62b2_and_75d03f53_cohort",
+        "66c015de_requires_atomic_98aac35d_and_7914d993_cohort",
         "mixed_or_incomplete_candidate_cohort_fails_closed",
         "e204e0da_superseded_and_direct_use_forbidden",
         "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v10.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v11.schema.json",
   "title": "CK-07R1A0 shared-preparation source digest authority",
   "type": "object",
   "additionalProperties": false,
@@ -28,10 +28,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v10"
+      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v11"
     },
     "authority_version": {
-      "const": 10
+      "const": 11
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -85,7 +85,7 @@
               "requires_complete_candidate_cohort": true
             }
           ],
-        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact c922b59f benchmark and 5e9cb014 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 1c7e1ea7 benchmark and a8de9667 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
         "other_digest": "fail_closed",
         "current_runtime_claim": "not_claimed",
         "launch_state": "blocked_hold_no_run"
@@ -120,12 +120,12 @@
           },
           {
             "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-            "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+            "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
             "role": "benchmark"
           },
           {
             "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-            "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+            "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
             "role": "lifecycle_test"
           }
         ]
@@ -168,7 +168,7 @@
         "required": true,
         "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
         "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-        "reapply": "use only the already-derived atomic 66c015de/c922b59f/5e9cb014 candidate cohort; do not mutate any historical witness or substitute another digest",
+        "reapply": "use only the already-derived atomic 66c015de/1c7e1ea7/a8de9667 candidate cohort; do not mutate any historical witness or substitute another digest",
         "derive_new_digest": false,
         "update_source_authority_before_run": false,
         "old_d192_reuse": "fail_closed",
@@ -213,7 +213,7 @@
         "any_different_preparation_digest_fails_closed",
         "7d1831ff_is_current_exact_main_predecessor",
         "6689d61f_is_historical_accepted_r3a_predecessor_only",
-        "66c015de_requires_atomic_c922b59f_and_5e9cb014_cohort",
+        "66c015de_requires_atomic_1c7e1ea7_and_a8de9667_cohort",
         "mixed_or_incomplete_candidate_cohort_fails_closed",
         "e204e0da_superseded_and_direct_use_forbidden",
         "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v11.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v12.schema.json",
   "title": "CK-07R1A0 shared-preparation source digest authority",
   "type": "object",
   "additionalProperties": false,
@@ -28,10 +28,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v11"
+      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v12"
     },
     "authority_version": {
-      "const": 11
+      "const": 12
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -85,7 +85,7 @@
               "requires_complete_candidate_cohort": true
             }
           ],
-        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 1c7e1ea7 benchmark and a8de9667 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact f108dbb4 benchmark and 4c514889 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
         "other_digest": "fail_closed",
         "current_runtime_claim": "not_claimed",
         "launch_state": "blocked_hold_no_run"
@@ -120,12 +120,12 @@
           },
           {
             "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-            "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+            "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
             "role": "benchmark"
           },
           {
             "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-            "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+            "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
             "role": "lifecycle_test"
           }
         ]
@@ -168,7 +168,7 @@
         "required": true,
         "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
         "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-        "reapply": "use only the already-derived atomic 66c015de/1c7e1ea7/a8de9667 candidate cohort; do not mutate any historical witness or substitute another digest",
+        "reapply": "use only the already-derived atomic 66c015de/f108dbb4/4c514889 candidate cohort; do not mutate any historical witness or substitute another digest",
         "derive_new_digest": false,
         "update_source_authority_before_run": false,
         "old_d192_reuse": "fail_closed",
@@ -213,7 +213,7 @@
         "any_different_preparation_digest_fails_closed",
         "7d1831ff_is_current_exact_main_predecessor",
         "6689d61f_is_historical_accepted_r3a_predecessor_only",
-        "66c015de_requires_atomic_1c7e1ea7_and_a8de9667_cohort",
+        "66c015de_requires_atomic_f108dbb4_and_4c514889_cohort",
         "mixed_or_incomplete_candidate_cohort_fails_closed",
         "e204e0da_superseded_and_direct_use_forbidden",
         "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v8.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v9.schema.json",
   "title": "CK-07R1A0 shared-preparation source digest authority",
   "type": "object",
   "additionalProperties": false,
@@ -28,10 +28,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v8"
+      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v9"
     },
     "authority_version": {
-      "const": 8
+      "const": 9
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -85,7 +85,7 @@
               "requires_complete_candidate_cohort": true
             }
           ],
-        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 98aac35d benchmark and 7914d993 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 2125d127 benchmark and a4163ffb lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
         "other_digest": "fail_closed",
         "current_runtime_claim": "not_claimed",
         "launch_state": "blocked_hold_no_run"
@@ -120,12 +120,12 @@
           },
           {
             "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-            "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+            "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
             "role": "benchmark"
           },
           {
             "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-            "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+            "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
             "role": "lifecycle_test"
           }
         ]
@@ -168,7 +168,7 @@
         "required": true,
         "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
         "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-        "reapply": "use only the already-derived atomic 66c015de/98aac35d/7914d993 candidate cohort; do not mutate any historical witness or substitute another digest",
+        "reapply": "use only the already-derived atomic 66c015de/2125d127/a4163ffb candidate cohort; do not mutate any historical witness or substitute another digest",
         "derive_new_digest": false,
         "update_source_authority_before_run": false,
         "old_d192_reuse": "fail_closed",
@@ -213,7 +213,7 @@
         "any_different_preparation_digest_fails_closed",
         "7d1831ff_is_current_exact_main_predecessor",
         "6689d61f_is_historical_accepted_r3a_predecessor_only",
-        "66c015de_requires_atomic_98aac35d_and_7914d993_cohort",
+        "66c015de_requires_atomic_2125d127_and_a4163ffb_cohort",
         "mixed_or_incomplete_candidate_cohort_fails_closed",
         "e204e0da_superseded_and_direct_use_forbidden",
         "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v9.schema.json",
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-source-digest-authority-v10.schema.json",
   "title": "CK-07R1A0 shared-preparation source digest authority",
   "type": "object",
   "additionalProperties": false,
@@ -28,10 +28,10 @@
   ],
   "properties": {
     "schema": {
-      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v9"
+      "const": "codex-usage-tracker.lifecycle-source-digest-authority.v10"
     },
     "authority_version": {
-      "const": 9
+      "const": 10
     },
     "owner": {
       "const": "CK-07R1A0"
@@ -85,7 +85,7 @@
               "requires_complete_candidate_cohort": true
             }
           ],
-        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact 2125d127 benchmark and a4163ffb lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
+        "source_digest_rule": "authority_main remains exact 7d1831ff; historical accepted 6689d61f remains predecessor-only; worker_prequalification admits only 66c015de with byte-exact c922b59f benchmark and 5e9cb014 lifecycle test; every mixed, incomplete, historical, or other digest state fails closed",
         "other_digest": "fail_closed",
         "current_runtime_claim": "not_claimed",
         "launch_state": "blocked_hold_no_run"
@@ -120,12 +120,12 @@
           },
           {
             "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-            "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+            "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
             "role": "benchmark"
           },
           {
             "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-            "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+            "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
             "role": "lifecycle_test"
           }
         ]
@@ -168,7 +168,7 @@
         "required": true,
         "worker_task": "019fbfe2-8fe4-7de2-9264-d58572366727",
         "start": "resume the preserved exact-main candidate worktree only after this authority merges and exact-main verifies",
-        "reapply": "use only the already-derived atomic 66c015de/2125d127/a4163ffb candidate cohort; do not mutate any historical witness or substitute another digest",
+        "reapply": "use only the already-derived atomic 66c015de/c922b59f/5e9cb014 candidate cohort; do not mutate any historical witness or substitute another digest",
         "derive_new_digest": false,
         "update_source_authority_before_run": false,
         "old_d192_reuse": "fail_closed",
@@ -213,7 +213,7 @@
         "any_different_preparation_digest_fails_closed",
         "7d1831ff_is_current_exact_main_predecessor",
         "6689d61f_is_historical_accepted_r3a_predecessor_only",
-        "66c015de_requires_atomic_2125d127_and_a4163ffb_cohort",
+        "66c015de_requires_atomic_c922b59f_and_5e9cb014_cohort",
         "mixed_or_incomplete_candidate_cohort_fails_closed",
         "e204e0da_superseded_and_direct_use_forbidden",
         "historical_d192_direct_use_forbidden",

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -39,9 +39,9 @@
     {
       "id": "lifecycle-run-invocation-v9",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "7500c965698e6c8784b74c9ee01dfe9db7dbbbef8e1ab5a9bfd2a1b8f7211d89",
+      "sha256": "5a216f497c8f24e69655b58b9a93e71407dbff8ce462b20519d10df4fb3580df",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "70542bcbc8bfd484b0297c617cde65dbcea1d41d914d12bdb54aa9cefad833d2"
+      "schema_sha256": "cdf9e7ed6662adfef7c4fa2695928a8d98b9e1f9965a8f9fb02333d05c317004"
     }
   ],
   "states": {

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -30,18 +30,18 @@
   ],
   "ck07_authorities": [
     {
-      "id": "lifecycle-source-digest-v8",
+      "id": "lifecycle-source-digest-v9",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
+      "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
+      "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
     },
     {
-      "id": "lifecycle-run-invocation-v7",
+      "id": "lifecycle-run-invocation-v8",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "b850a063878c15234083c8e9e7fc1502d633691c391506b76a92b07a77ebbea1",
+      "sha256": "eaccc1d8d55d004a4a051351c2f3e69b5e5798cfbc273d4ab6c7982015186a3d",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "c7d9d2518816c15bcf5e93fec241aeaa8d719d433fd7f91f0873ad7b1aa21c78"
+      "schema_sha256": "f0de24878de81038efba2285a454a9b90a67b35f2383e8515743e66e306cdaaa"
     }
   ],
   "states": {
@@ -75,12 +75,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+          "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
           "presence": "required"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+          "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
           "presence": "required"
         }
       ],
@@ -112,6 +112,11 @@
     "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
     "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
     "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+    "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+    "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
+    "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+    "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
+    "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
     "interpreter_identity": {
       "executable": "lexical_repository_worktree_.venv/bin/python_required",
       "sys_prefix": "lexical_repository_worktree_.venv_required",
@@ -197,7 +202,7 @@
     "present any extra dirty or CK-QG1-allowed path in combined preflight",
     "claim post_single_run or final_accepted",
     "claim runtime acceptance, launch authorization, or token consumption",
-    "weaken launcher overlay, receipt construction, validation, completion ordering, failure classification, interpreter identity, or timeout binding",
+    "weaken launcher overlay, receipt or evidence construction, validation, completion ordering, signal handling, wait cleanup, failure classification, interpreter identity, or timeout binding",
     "fabricate a receipt or any output path",
     "weaken the exact authority or preflight scope"
   ]

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -30,18 +30,18 @@
   ],
   "ck07_authorities": [
     {
-      "id": "lifecycle-source-digest-v10",
+      "id": "lifecycle-source-digest-v11",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
+      "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
+      "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
     },
     {
-      "id": "lifecycle-run-invocation-v9",
+      "id": "lifecycle-run-invocation-v10",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "5a216f497c8f24e69655b58b9a93e71407dbff8ce462b20519d10df4fb3580df",
+      "sha256": "c64b9b540bfce6bab615d1707dd6c648e4f07b7e97e56349ac80be2020a4b4b6",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "cdf9e7ed6662adfef7c4fa2695928a8d98b9e1f9965a8f9fb02333d05c317004"
+      "schema_sha256": "0cd157c48e0dc0c2867b6c5de89c7075f49ba22940a6f84a408b9e3c110b6e57"
     }
   ],
   "states": {
@@ -75,12 +75,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+          "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
           "presence": "required"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+          "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
           "presence": "required"
         }
       ],
@@ -117,7 +117,7 @@
     "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
     "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
     "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
-    "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+    "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
     "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
     "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
     "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -30,18 +30,18 @@
   ],
   "ck07_authorities": [
     {
-      "id": "lifecycle-source-digest-v9",
+      "id": "lifecycle-source-digest-v10",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
+      "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
+      "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
     },
     {
-      "id": "lifecycle-run-invocation-v8",
+      "id": "lifecycle-run-invocation-v9",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "eaccc1d8d55d004a4a051351c2f3e69b5e5798cfbc273d4ab6c7982015186a3d",
+      "sha256": "7500c965698e6c8784b74c9ee01dfe9db7dbbbef8e1ab5a9bfd2a1b8f7211d89",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "f0de24878de81038efba2285a454a9b90a67b35f2383e8515743e66e306cdaaa"
+      "schema_sha256": "70542bcbc8bfd484b0297c617cde65dbcea1d41d914d12bdb54aa9cefad833d2"
     }
   ],
   "states": {
@@ -75,12 +75,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+          "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
           "presence": "required"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+          "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
           "presence": "required"
         }
       ],
@@ -112,6 +112,11 @@
     "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
     "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
     "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+    "child_pre_release_failure": "every_pre_release_child_failure_routes_to_os._exit_71",
+    "child_wait_signal_handling": "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release",
+    "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
+    "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
+    "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
     "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
     "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
     "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -30,18 +30,18 @@
   ],
   "ck07_authorities": [
     {
-      "id": "lifecycle-source-digest-v11",
+      "id": "lifecycle-source-digest-v12",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
+      "sha256": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
+      "schema_sha256": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
     },
     {
-      "id": "lifecycle-run-invocation-v10",
+      "id": "lifecycle-run-invocation-v11",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "c64b9b540bfce6bab615d1707dd6c648e4f07b7e97e56349ac80be2020a4b4b6",
+      "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "0cd157c48e0dc0c2867b6c5de89c7075f49ba22940a6f84a408b9e3c110b6e57"
+      "schema_sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
     }
   ],
   "states": {
@@ -75,12 +75,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+          "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
           "presence": "required"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+          "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
           "presence": "required"
         }
       ],
@@ -120,6 +120,7 @@
     "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
     "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
     "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+    "terminal_fallback_signal_mask": "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_then_prior_temporary_handlers_restored",
     "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
     "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
     "interpreter_identity": {

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json
@@ -2,7 +2,7 @@
   "schema": "codex-usage-tracker.ck07r1-shared-successor-overlay.v1",
   "authority_version": 1,
   "owner": "CK-07R1-SHARED-OVERLAY",
-  "authority_base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+  "authority_base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
   "status": "permitted_not_accepted",
   "decision": "authorize_exact_ck07_worker_prequalification_overlay_only",
   "immutable_authorities": [
@@ -30,18 +30,18 @@
   ],
   "ck07_authorities": [
     {
-      "id": "lifecycle-source-digest-v7",
+      "id": "lifecycle-source-digest-v8",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-      "sha256": "6156780a7e8663859658bb5309f13eb6bf5283704784d8270edf0512c167d70b",
+      "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-      "schema_sha256": "4026a4e971c1b6b177b467440a36931bc6a15a0b376918bdc4169b732a0d489c"
+      "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
     },
     {
-      "id": "lifecycle-run-invocation-v6",
+      "id": "lifecycle-run-invocation-v7",
       "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-      "sha256": "6b1a2753e935da9a9c0121e4f1691957b06b388c1bc55631920725ae6d9089be",
+      "sha256": "b850a063878c15234083c8e9e7fc1502d633691c391506b76a92b07a77ebbea1",
       "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-      "schema_sha256": "e3f24adc98078524523dcb404b9cf9d934fe6c68637abb8a5c40e2eb97ea7e74"
+      "schema_sha256": "c7d9d2518816c15bcf5e93fec241aeaa8d719d433fd7f91f0873ad7b1aa21c78"
     }
   ],
   "states": {
@@ -75,12 +75,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+          "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
           "presence": "required"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+          "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
           "presence": "required"
         }
       ],
@@ -110,6 +110,16 @@
   "launcher_safety": {
     "overlay_and_cohort_verification": "must_complete_before_ledger_fork_child_release_or_token_consumption",
     "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
+    "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
+    "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+    "interpreter_identity": {
+      "executable": "lexical_repository_worktree_.venv/bin/python_required",
+      "sys_prefix": "lexical_repository_worktree_.venv_required",
+      "base_interpreter": "rejected",
+      "symlink_or_resolved_equivalence": "rejected",
+      "wrong_worktree_venv": "rejected",
+      "prefix_mismatch": "rejected"
+    },
     "post_token_or_release_failure_state": "failed_after_launch",
     "aggregate_timeout_seconds": 720,
     "termination_sequence": [
@@ -157,14 +167,9 @@
       "docs/roadmap/TASK_PACKETS.md",
       "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
       "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md",
-      "scripts/check_kernel_scope.py",
       "scripts/ck07r1_shared_successor_overlay.py",
-      "scripts/qualify_ck08r1_answer_truth.py",
       "tests/kernel/test_ck07r1_shared_successor_overlay.py",
-      "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
-      "tests/kernel/test_ckqg1_maintainability_baseline_authority.py",
       "tests/kernel/test_documentation_authority.py",
-      "tests/kernel/test_kernel_scope.py",
       "tests/kernel/test_lifecycle_run_invocation_authority.py"
     ],
     "combined_preflight_candidate_scope": [
@@ -192,7 +197,7 @@
     "present any extra dirty or CK-QG1-allowed path in combined preflight",
     "claim post_single_run or final_accepted",
     "claim runtime acceptance, launch authorization, or token consumption",
-    "weaken launcher overlay, receipt, failure classification, or timeout binding",
+    "weaken launcher overlay, receipt construction, validation, completion ordering, failure classification, interpreter identity, or timeout binding",
     "fabricate a receipt or any output path",
     "weaken the exact authority or preflight scope"
   ]

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -66,18 +66,18 @@
     "ck07_authorities": {
       "const": [
         {
-          "id": "lifecycle-source-digest-v11",
+          "id": "lifecycle-source-digest-v12",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-          "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
+          "sha256": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-          "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
+          "schema_sha256": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
         },
         {
-          "id": "lifecycle-run-invocation-v10",
+          "id": "lifecycle-run-invocation-v11",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "c64b9b540bfce6bab615d1707dd6c648e4f07b7e97e56349ac80be2020a4b4b6",
+          "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "0cd157c48e0dc0c2867b6c5de89c7075f49ba22940a6f84a408b9e3c110b6e57"
+          "schema_sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
         }
       ]
     },
@@ -123,12 +123,12 @@
               },
               {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+                "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
                 "presence": "required"
               },
               {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+                "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
                 "presence": "required"
               }
             ],
@@ -194,6 +194,7 @@
         "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
         "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
         "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+        "terminal_fallback_signal_mask": "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_then_prior_temporary_handlers_restored",
         "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
         "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
         "interpreter_identity": {

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -66,18 +66,18 @@
     "ck07_authorities": {
       "const": [
         {
-          "id": "lifecycle-source-digest-v8",
+          "id": "lifecycle-source-digest-v9",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-          "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
+          "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-          "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
+          "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
         },
         {
-          "id": "lifecycle-run-invocation-v7",
+          "id": "lifecycle-run-invocation-v8",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "b850a063878c15234083c8e9e7fc1502d633691c391506b76a92b07a77ebbea1",
+          "sha256": "eaccc1d8d55d004a4a051351c2f3e69b5e5798cfbc273d4ab6c7982015186a3d",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "c7d9d2518816c15bcf5e93fec241aeaa8d719d433fd7f91f0873ad7b1aa21c78"
+          "schema_sha256": "f0de24878de81038efba2285a454a9b90a67b35f2383e8515743e66e306cdaaa"
         }
       ]
     },
@@ -123,12 +123,12 @@
               },
               {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+                "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
                 "presence": "required"
               },
               {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+                "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
                 "presence": "required"
               }
             ],
@@ -186,6 +186,11 @@
         "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
         "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
         "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+        "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+        "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
+        "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
+        "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",
+        "evidence_failure_state": "missing_read_hash_parse_validation_or_finalization_failure_is_failed_after_launch_never_completed",
         "interpreter_identity": {
           "executable": "lexical_repository_worktree_.venv/bin/python_required",
           "sys_prefix": "lexical_repository_worktree_.venv_required",
@@ -290,7 +295,7 @@
         "present any extra dirty or CK-QG1-allowed path in combined preflight",
         "claim post_single_run or final_accepted",
         "claim runtime acceptance, launch authorization, or token consumption",
-        "weaken launcher overlay, receipt construction, validation, completion ordering, failure classification, interpreter identity, or timeout binding",
+        "weaken launcher overlay, receipt or evidence construction, validation, completion ordering, signal handling, wait cleanup, failure classification, interpreter identity, or timeout binding",
         "fabricate a receipt or any output path",
         "weaken the exact authority or preflight scope"
       ]

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -75,9 +75,9 @@
         {
           "id": "lifecycle-run-invocation-v9",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "7500c965698e6c8784b74c9ee01dfe9db7dbbbef8e1ab5a9bfd2a1b8f7211d89",
+          "sha256": "5a216f497c8f24e69655b58b9a93e71407dbff8ce462b20519d10df4fb3580df",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "70542bcbc8bfd484b0297c617cde65dbcea1d41d914d12bdb54aa9cefad833d2"
+          "schema_sha256": "cdf9e7ed6662adfef7c4fa2695928a8d98b9e1f9965a8f9fb02333d05c317004"
         }
       ]
     },

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -30,7 +30,7 @@
       "const": "CK-07R1-SHARED-OVERLAY"
     },
     "authority_base_sha": {
-      "const": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+      "const": "6c08ecd92a2c5166c1585be426e1ed437309a910"
     },
     "status": {
       "const": "permitted_not_accepted"
@@ -66,18 +66,18 @@
     "ck07_authorities": {
       "const": [
         {
-          "id": "lifecycle-source-digest-v7",
+          "id": "lifecycle-source-digest-v8",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-          "sha256": "6156780a7e8663859658bb5309f13eb6bf5283704784d8270edf0512c167d70b",
+          "sha256": "8c244b1afae072468ea8a91da12a9a2d1b65728d01da25e5924441b6f84d27e3",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-          "schema_sha256": "4026a4e971c1b6b177b467440a36931bc6a15a0b376918bdc4169b732a0d489c"
+          "schema_sha256": "4e4ebe429f624ce0b2e3236c97ea56c0231f5c9481b446906bd4eee494d55683"
         },
         {
-          "id": "lifecycle-run-invocation-v6",
+          "id": "lifecycle-run-invocation-v7",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "6b1a2753e935da9a9c0121e4f1691957b06b388c1bc55631920725ae6d9089be",
+          "sha256": "b850a063878c15234083c8e9e7fc1502d633691c391506b76a92b07a77ebbea1",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "e3f24adc98078524523dcb404b9cf9d934fe6c68637abb8a5c40e2eb97ea7e74"
+          "schema_sha256": "c7d9d2518816c15bcf5e93fec241aeaa8d719d433fd7f91f0873ad7b1aa21c78"
         }
       ]
     },
@@ -123,12 +123,12 @@
               },
               {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+                "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
                 "presence": "required"
               },
               {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+                "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
                 "presence": "required"
               }
             ],
@@ -184,6 +184,16 @@
       "const": {
         "overlay_and_cohort_verification": "must_complete_before_ledger_fork_child_release_or_token_consumption",
         "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
+        "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
+        "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+        "interpreter_identity": {
+          "executable": "lexical_repository_worktree_.venv/bin/python_required",
+          "sys_prefix": "lexical_repository_worktree_.venv_required",
+          "base_interpreter": "rejected",
+          "symlink_or_resolved_equivalence": "rejected",
+          "wrong_worktree_venv": "rejected",
+          "prefix_mismatch": "rejected"
+        },
         "post_token_or_release_failure_state": "failed_after_launch",
         "aggregate_timeout_seconds": 720,
         "termination_sequence": [
@@ -243,14 +253,9 @@
             "docs/roadmap/TASK_PACKETS.md",
             "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
             "docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md",
-            "scripts/check_kernel_scope.py",
             "scripts/ck07r1_shared_successor_overlay.py",
-            "scripts/qualify_ck08r1_answer_truth.py",
             "tests/kernel/test_ck07r1_shared_successor_overlay.py",
-            "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
-            "tests/kernel/test_ckqg1_maintainability_baseline_authority.py",
             "tests/kernel/test_documentation_authority.py",
-            "tests/kernel/test_kernel_scope.py",
             "tests/kernel/test_lifecycle_run_invocation_authority.py"
           ]
         },
@@ -285,7 +290,7 @@
         "present any extra dirty or CK-QG1-allowed path in combined preflight",
         "claim post_single_run or final_accepted",
         "claim runtime acceptance, launch authorization, or token consumption",
-        "weaken launcher overlay, receipt, failure classification, or timeout binding",
+        "weaken launcher overlay, receipt construction, validation, completion ordering, failure classification, interpreter identity, or timeout binding",
         "fabricate a receipt or any output path",
         "weaken the exact authority or preflight scope"
       ]

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -66,18 +66,18 @@
     "ck07_authorities": {
       "const": [
         {
-          "id": "lifecycle-source-digest-v9",
+          "id": "lifecycle-source-digest-v10",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-          "sha256": "18e497a76676aa8997bc7d16da9da9f4f13fa0a97e02097f8e9dd8b67cdaabb3",
+          "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-          "schema_sha256": "00968ffa7f146b8e9a4ce06517b1327d420f5586a61cc967f9abd0921b8c344e"
+          "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
         },
         {
-          "id": "lifecycle-run-invocation-v8",
+          "id": "lifecycle-run-invocation-v9",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "eaccc1d8d55d004a4a051351c2f3e69b5e5798cfbc273d4ab6c7982015186a3d",
+          "sha256": "7500c965698e6c8784b74c9ee01dfe9db7dbbbef8e1ab5a9bfd2a1b8f7211d89",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "f0de24878de81038efba2285a454a9b90a67b35f2383e8515743e66e306cdaaa"
+          "schema_sha256": "70542bcbc8bfd484b0297c617cde65dbcea1d41d914d12bdb54aa9cefad833d2"
         }
       ]
     },
@@ -123,12 +123,12 @@
               },
               {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+                "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
                 "presence": "required"
               },
               {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+                "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
                 "presence": "required"
               }
             ],
@@ -186,6 +186,11 @@
         "receipt_binding": "must_equal_exact_overlay_verification_result_and_three_artifact_cohort",
         "receipt_completion_ordering": "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_completed_finalization",
         "receipt_failure_state": "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed",
+        "child_pre_release_failure": "every_pre_release_child_failure_routes_to_os._exit_71",
+        "child_wait_signal_handling": "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release",
+        "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
+        "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
+        "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
         "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
         "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
         "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",

--- a/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json
@@ -66,18 +66,18 @@
     "ck07_authorities": {
       "const": [
         {
-          "id": "lifecycle-source-digest-v10",
+          "id": "lifecycle-source-digest-v11",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
-          "sha256": "db92ebf1a24fcbfbc6efb6acadedea24155d37c1dbae8bf67cba1ea530ffd9ca",
+          "sha256": "74768468a00cf37d3908b196f6c1f6577c95bf037957500a05493fd93b92e875",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
-          "schema_sha256": "d7724b92fac1e7823bfcd6c5c5ce068cee94d14ac97435444ef3614fa6cd4edc"
+          "schema_sha256": "69e887566838a3fc2e6f85483da848aa90556861f84817e817d66d950c97b676"
         },
         {
-          "id": "lifecycle-run-invocation-v9",
+          "id": "lifecycle-run-invocation-v10",
           "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
-          "sha256": "5a216f497c8f24e69655b58b9a93e71407dbff8ce462b20519d10df4fb3580df",
+          "sha256": "c64b9b540bfce6bab615d1707dd6c648e4f07b7e97e56349ac80be2020a4b4b6",
           "schema_path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
-          "schema_sha256": "cdf9e7ed6662adfef7c4fa2695928a8d98b9e1f9965a8f9fb02333d05c317004"
+          "schema_sha256": "0cd157c48e0dc0c2867b6c5de89c7075f49ba22940a6f84a408b9e3c110b6e57"
         }
       ]
     },
@@ -123,12 +123,12 @@
               },
               {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+                "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
                 "presence": "required"
               },
               {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+                "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
                 "presence": "required"
               }
             ],
@@ -191,7 +191,7 @@
         "parent_cleanup_pid_guard": "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap",
         "atomic_ledger_update": "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_interrupted_write_fsync_replace_or_post_replace_path",
         "atomic_failure_state": "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue",
-        "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_and_restored_after_wait",
+        "parent_signal_handling": "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_held_through_bounded_reap_evidence_receipt_and_terminal_ledger_persistence_then_restored",
         "wait_interruption_cleanup": "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_SIGKILL_then_reap_before_terminal_failure",
         "signal_cleanup_mask": "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup",
         "evidence_completion_ordering": "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_first_durable_completed_finalization",

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -96,7 +96,7 @@ updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker. The coordinator recorded the
 preserved incident disposition and the worker derived the exact candidate
 cohort from exact main `6c08ecd9`: preparation `66c015de…`, benchmark
-`c922b59f…`, and lifecycle test `5e9cb014…`. That cohort remains
+`1c7e1ea7…`, and lifecycle test `a8de9667…`. That cohort remains
 permitted-not-accepted and cannot enter `worker_prequalification` until this
 authority transition merges and exact-main verifies.
 The versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -122,7 +122,7 @@ Conditional Ready pending merge and exact-main verification of the exact
 successor authority. Until then its current authority state is
 `authority_main` at preparation `7d1831ff…` and no worker may resume. After
 that handoff only the existing stopped worker may resume with the complete
-`66c015de…` / `c922b59f…` / `5e9cb014…` cohort. Historical accepted R3A
+`66c015de…` / `1c7e1ea7…` / `a8de9667…` cohort. Historical accepted R3A
 `6689d61f…`, revoked `d192c858…`, mixed cohorts, and every other digest are
 predecessor-only or fail-closed and cannot enter `worker_prequalification`.
 The worker may enter `worker_prequalification` only with the exact selected
@@ -142,7 +142,9 @@ any first durable `completed` finalization. Evidence
 read/hash/parse/validation/finalization failure is terminal
 `failed_after_launch`, never false `completed`. Temporary parent SIGINT/SIGTERM
 handlers route every wait interruption/error through bounded TERM/KILL/reap
-before terminal persistence. The fork child ignores SIGINT/SIGTERM while
+before terminal persistence and remain installed through evidence, receipt,
+and terminal ledger finalization; originals restore only after the terminal
+state attempt. The fork child ignores SIGINT/SIGTERM while
 waiting for parent release and maps every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
 `mkstemp` ledger updates close and unlink on failed or interrupted
@@ -247,7 +249,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
+    "condition": "exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -96,7 +96,7 @@ updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker. The coordinator recorded the
 preserved incident disposition and the worker derived the exact candidate
 cohort from exact main `6c08ecd9`: preparation `66c015de…`, benchmark
-`98aac35d…`, and lifecycle test `7914d993…`. That cohort remains
+`2125d127…`, and lifecycle test `a4163ffb…`. That cohort remains
 permitted-not-accepted and cannot enter `worker_prequalification` until this
 authority transition merges and exact-main verifies.
 The versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -122,7 +122,7 @@ Conditional Ready pending merge and exact-main verification of the exact
 successor authority. Until then its current authority state is
 `authority_main` at preparation `7d1831ff…` and no worker may resume. After
 that handoff only the existing stopped worker may resume with the complete
-`66c015de…` / `98aac35d…` / `7914d993…` cohort. Historical accepted R3A
+`66c015de…` / `2125d127…` / `a4163ffb…` cohort. Historical accepted R3A
 `6689d61f…`, revoked `d192c858…`, mixed cohorts, and every other digest are
 predecessor-only or fail-closed and cannot enter `worker_prequalification`.
 The worker may enter `worker_prequalification` only with the exact selected
@@ -136,13 +136,16 @@ authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not
 authorize action.
 
-The exact V9 launcher contract constructs and validates the fully
-overlay/cohort-bound receipt before any first durable `completed` finalization.
-Receipt construction, validation, or finalization failure is terminal
-`failed_after_launch`, never false `completed`. It also requires the lexical
-repository-worktree `.venv/bin/python` and matching lexical venv `sys.prefix`;
-base interpreters, symlink/resolved equivalence, wrong-worktree venvs, and prefix
-mismatch fail closed.
+The exact V10 launcher contract constructs and validates the fully
+overlay/cohort-bound receipt and non-null stdout/stderr/output evidence before
+any first durable `completed` finalization. Evidence
+read/hash/parse/validation/finalization failure is terminal
+`failed_after_launch`, never false `completed`. Temporary parent SIGINT/SIGTERM
+handlers route every wait interruption/error through bounded TERM/KILL/reap
+before terminal persistence. It also requires the lexical repository-worktree
+`.venv/bin/python` and matching lexical venv `sys.prefix`; base interpreters,
+symlink/resolved equivalence, wrong-worktree venvs, and prefix mismatch fail
+closed.
 
 ## Delegation law
 
@@ -239,7 +242,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
+    "condition": "exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -96,7 +96,7 @@ updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker. The coordinator recorded the
 preserved incident disposition and the worker derived the exact candidate
 cohort from exact main `6c08ecd9`: preparation `66c015de…`, benchmark
-`2125d127…`, and lifecycle test `a4163ffb…`. That cohort remains
+`c922b59f…`, and lifecycle test `5e9cb014…`. That cohort remains
 permitted-not-accepted and cannot enter `worker_prequalification` until this
 authority transition merges and exact-main verifies.
 The versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -122,7 +122,7 @@ Conditional Ready pending merge and exact-main verification of the exact
 successor authority. Until then its current authority state is
 `authority_main` at preparation `7d1831ff…` and no worker may resume. After
 that handoff only the existing stopped worker may resume with the complete
-`66c015de…` / `2125d127…` / `a4163ffb…` cohort. Historical accepted R3A
+`66c015de…` / `c922b59f…` / `5e9cb014…` cohort. Historical accepted R3A
 `6689d61f…`, revoked `d192c858…`, mixed cohorts, and every other digest are
 predecessor-only or fail-closed and cannot enter `worker_prequalification`.
 The worker may enter `worker_prequalification` only with the exact selected
@@ -136,14 +136,19 @@ authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not
 authorize action.
 
-The exact V10 launcher contract constructs and validates the fully
+The exact V11 launcher contract constructs and validates the fully
 overlay/cohort-bound receipt and non-null stdout/stderr/output evidence before
 any first durable `completed` finalization. Evidence
 read/hash/parse/validation/finalization failure is terminal
 `failed_after_launch`, never false `completed`. Temporary parent SIGINT/SIGTERM
 handlers route every wait interruption/error through bounded TERM/KILL/reap
-before terminal persistence. It also requires the lexical repository-worktree
-`.venv/bin/python` and matching lexical venv `sys.prefix`; base interpreters,
+before terminal persistence. The fork child ignores SIGINT/SIGTERM while
+waiting for parent release and maps every pre-release failure to
+`os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
+`mkstemp` ledger updates close and unlink on failed or interrupted
+write/fsync/replace/post-replace paths and persist durable consumed/no-retry
+`failed_after_launch` evidence without temporary residue. It also requires the
+lexical repository-worktree `.venv/bin/python` and matching lexical venv `sys.prefix`; base interpreters,
 symlink/resolved equivalence, wrong-worktree venvs, and prefix mismatch fail
 closed.
 
@@ -242,7 +247,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
+    "condition": "exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -96,7 +96,7 @@ updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker. The coordinator recorded the
 preserved incident disposition and the worker derived the exact candidate
 cohort from exact main `6c08ecd9`: preparation `66c015de…`, benchmark
-`1c7e1ea7…`, and lifecycle test `a8de9667…`. That cohort remains
+`f108dbb4…`, and lifecycle test `4c514889…`. That cohort remains
 permitted-not-accepted and cannot enter `worker_prequalification` until this
 authority transition merges and exact-main verifies.
 The versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -122,7 +122,7 @@ Conditional Ready pending merge and exact-main verification of the exact
 successor authority. Until then its current authority state is
 `authority_main` at preparation `7d1831ff…` and no worker may resume. After
 that handoff only the existing stopped worker may resume with the complete
-`66c015de…` / `1c7e1ea7…` / `a8de9667…` cohort. Historical accepted R3A
+`66c015de…` / `f108dbb4…` / `4c514889…` cohort. Historical accepted R3A
 `6689d61f…`, revoked `d192c858…`, mixed cohorts, and every other digest are
 predecessor-only or fail-closed and cannot enter `worker_prequalification`.
 The worker may enter `worker_prequalification` only with the exact selected
@@ -144,7 +144,10 @@ read/hash/parse/validation/finalization failure is terminal
 handlers route every wait interruption/error through bounded TERM/KILL/reap
 before terminal persistence and remain installed through evidence, receipt,
 and terminal ledger finalization; originals restore only after the terminal
-state attempt. The fork child ignores SIGINT/SIGTERM while
+state attempt. Every terminal fallback persistence call masks SIGINT/SIGTERM
+with the existing ignore guard and restores the prior temporary handlers
+afterward; the outer final restoration of original handlers remains last. The
+fork child ignores SIGINT/SIGTERM while
 waiting for parent release and maps every pre-release failure to
 `os._exit(71)`; parent cleanup rejects nonpositive PIDs. Unique same-directory
 `mkstemp` ledger updates close and unlink on failed or interrupted
@@ -249,7 +252,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
+    "condition": "exact 66c015de/f108dbb4/4c514889 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -95,8 +95,8 @@ run-invocation authority, and argv-correction authority are merged through
 updated, rerun, or merged. The planner-valid lifecycle receipt is an
 acceptance output of the existing CK-07R1 worker. The coordinator recorded the
 preserved incident disposition and the worker derived the exact candidate
-cohort from exact main `cf44f4fd`: preparation `66c015de…`, benchmark
-`4b1c62b2…`, and lifecycle test `75d03f53…`. That cohort remains
+cohort from exact main `6c08ecd9`: preparation `66c015de…`, benchmark
+`98aac35d…`, and lifecycle test `7914d993…`. That cohort remains
 permitted-not-accepted and cannot enter `worker_prequalification` until this
 authority transition merges and exact-main verifies.
 The versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -122,7 +122,7 @@ Conditional Ready pending merge and exact-main verification of the exact
 successor authority. Until then its current authority state is
 `authority_main` at preparation `7d1831ff…` and no worker may resume. After
 that handoff only the existing stopped worker may resume with the complete
-`66c015de…` / `4b1c62b2…` / `75d03f53…` cohort. Historical accepted R3A
+`66c015de…` / `98aac35d…` / `7914d993…` cohort. Historical accepted R3A
 `6689d61f…`, revoked `d192c858…`, mixed cohorts, and every other digest are
 predecessor-only or fail-closed and cannot enter `worker_prequalification`.
 The worker may enter `worker_prequalification` only with the exact selected
@@ -135,6 +135,14 @@ historical provenance and does not authorize action. This source-digest
 authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not
 authorize action.
+
+The exact V9 launcher contract constructs and validates the fully
+overlay/cohort-bound receipt before any first durable `completed` finalization.
+Receipt construction, validation, or finalization failure is terminal
+`failed_after_launch`, never false `completed`. It also requires the lexical
+repository-worktree `.venv/bin/python` and matching lexical venv `sys.prefix`;
+base interpreters, symlink/resolved equivalence, wrong-worktree venvs, and prefix
+mismatch fail closed.
 
 ## Delegation law
 
@@ -231,7 +239,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "exact 66c015de/4b1c62b2/75d03f53 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
+    "condition": "exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic cohort; no replacement, launch, token consumption, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main verifies**
+- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main verifies**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `2125d127…` / `a4163ffb…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `c922b59f…` / `5e9cb014…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main verifies**
+- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main verifies**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `98aac35d…` / `7914d993…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `2125d127…` / `a4163ffb…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main verifies**
+- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/f108dbb4/4c514889 successor authority merges and exact-main verifies**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `1c7e1ea7…` / `a8de9667…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `f108dbb4…` / `4c514889…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/4b1c62b2/75d03f53 successor authority merges and exact-main verifies**
+- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main verifies**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `4b1c62b2…` / `75d03f53…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `98aac35d…` / `7914d993…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main verifies**
+- Conditional-ready child tasks: **1 — CK-07R1 after the exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main verifies**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `c922b59f…` / `5e9cb014…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready after the versioned [shared successor overlay](../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json) for the exact `66c015de…` / `1c7e1ea7…` / `a8de9667…` cohort merges and exact-main verifies; only the existing worker may resume and no launch is yet authorized; PR #394 is stale read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -31,9 +31,9 @@ historical; and the linked finite source/runtime authorities remain
 `blocked_hold` with the one-run token unspent/unavailable. Accepted R3A
 preparation `6689d61f…` remains a historical predecessor and accepted
 R1B/current exact-main preparation `7d1831ff…` is the live predecessor. The
-existing worker's fresh exact-main `cf44f4fd` reapplication derived the sole
-candidate cohort: preparation `66c015de…`, benchmark `4b1c62b2…`, and lifecycle
-test `75d03f53…`. Historical `d192c858…`, mixed or incomplete cohorts, and
+existing worker's fresh exact-main `6c08ecd9` reapplication derived the sole
+candidate cohort: preparation `66c015de…`, benchmark `98aac35d…`, and lifecycle
+test `7914d993…`. Historical `d192c858…`, mixed or incomplete cohorts, and
 every other digest fail closed. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed
 read-only witness and is not refreshed, rerun, or merged.
@@ -41,7 +41,7 @@ read-only witness and is not refreshed, rerun, or merged.
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the current authority binds predecessor preparation `7d1831ff…` to the atomic
-`66c015de…` / `4b1c62b2…` / `75d03f53…` successor cohort, linked evidence
+`66c015de…` / `98aac35d…` / `7914d993…` successor cohort, linked evidence
 `36eb76ca…`, and the 720-second wrapper timeout without executing the worker.
 The successor is permitted-not-accepted and launch remains unauthorized.
 The versioned [shared successor overlay](../../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -90,6 +90,14 @@ worker gates pass; this is not a retry, restart, or replacement of a launched
 process. Receipt
 absence before dispatch is not a blocker; receipt absence or invalidity at
 successor acceptance remains fail-closed.
+
+The V9 candidate must construct and validate the fully overlay/cohort-bound
+receipt before its first durable `completed` finalization. Construction,
+validation, or finalization failure is terminal `failed_after_launch`, never
+false `completed`. Launch identity requires the lexical repository-worktree
+`.venv/bin/python` plus matching lexical venv `sys.prefix`; base interpreters,
+symlink/resolved equivalence, wrong-worktree venvs, and prefix mismatch are
+rejected before side effects.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
 new dominant blocker; never weaken the gate.

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -32,8 +32,8 @@ historical; and the linked finite source/runtime authorities remain
 preparation `6689d61f…` remains a historical predecessor and accepted
 R1B/current exact-main preparation `7d1831ff…` is the live predecessor. The
 existing worker's fresh exact-main `6c08ecd9` reapplication derived the sole
-candidate cohort: preparation `66c015de…`, benchmark `98aac35d…`, and lifecycle
-test `7914d993…`. Historical `d192c858…`, mixed or incomplete cohorts, and
+candidate cohort: preparation `66c015de…`, benchmark `2125d127…`, and lifecycle
+test `a4163ffb…`. Historical `d192c858…`, mixed or incomplete cohorts, and
 every other digest fail closed. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed
 read-only witness and is not refreshed, rerun, or merged.
@@ -41,7 +41,7 @@ read-only witness and is not refreshed, rerun, or merged.
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the current authority binds predecessor preparation `7d1831ff…` to the atomic
-`66c015de…` / `98aac35d…` / `7914d993…` successor cohort, linked evidence
+`66c015de…` / `2125d127…` / `a4163ffb…` successor cohort, linked evidence
 `36eb76ca…`, and the 720-second wrapper timeout without executing the worker.
 The successor is permitted-not-accepted and launch remains unauthorized.
 The versioned [shared successor overlay](../../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -91,13 +91,15 @@ process. Receipt
 absence before dispatch is not a blocker; receipt absence or invalidity at
 successor acceptance remains fail-closed.
 
-The V9 candidate must construct and validate the fully overlay/cohort-bound
-receipt before its first durable `completed` finalization. Construction,
-validation, or finalization failure is terminal `failed_after_launch`, never
-false `completed`. Launch identity requires the lexical repository-worktree
-`.venv/bin/python` plus matching lexical venv `sys.prefix`; base interpreters,
-symlink/resolved equivalence, wrong-worktree venvs, and prefix mismatch are
-rejected before side effects.
+The V10 candidate must construct and validate the fully overlay/cohort-bound
+receipt and non-null stdout/stderr/output evidence before its first durable
+`completed` finalization. Evidence read/hash/parse/validation/finalization
+failure is terminal `failed_after_launch`, never false `completed`. Temporary
+parent SIGINT/SIGTERM handlers route every wait interruption/error through
+bounded TERM/KILL/reap before terminal persistence. Launch identity requires the
+lexical repository-worktree `.venv/bin/python` plus matching lexical venv
+`sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
+venvs, and prefix mismatch are rejected before side effects.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
 new dominant blocker; never weaken the gate.

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -32,8 +32,8 @@ historical; and the linked finite source/runtime authorities remain
 preparation `6689d61f…` remains a historical predecessor and accepted
 R1B/current exact-main preparation `7d1831ff…` is the live predecessor. The
 existing worker's fresh exact-main `6c08ecd9` reapplication derived the sole
-candidate cohort: preparation `66c015de…`, benchmark `2125d127…`, and lifecycle
-test `a4163ffb…`. Historical `d192c858…`, mixed or incomplete cohorts, and
+candidate cohort: preparation `66c015de…`, benchmark `c922b59f…`, and lifecycle
+test `5e9cb014…`. Historical `d192c858…`, mixed or incomplete cohorts, and
 every other digest fail closed. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed
 read-only witness and is not refreshed, rerun, or merged.
@@ -41,7 +41,7 @@ read-only witness and is not refreshed, rerun, or merged.
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the current authority binds predecessor preparation `7d1831ff…` to the atomic
-`66c015de…` / `2125d127…` / `a4163ffb…` successor cohort, linked evidence
+`66c015de…` / `c922b59f…` / `5e9cb014…` successor cohort, linked evidence
 `36eb76ca…`, and the 720-second wrapper timeout without executing the worker.
 The successor is permitted-not-accepted and launch remains unauthorized.
 The versioned [shared successor overlay](../../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -91,13 +91,19 @@ process. Receipt
 absence before dispatch is not a blocker; receipt absence or invalidity at
 successor acceptance remains fail-closed.
 
-The V10 candidate must construct and validate the fully overlay/cohort-bound
+The V11 candidate must construct and validate the fully overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failure is terminal `failed_after_launch`, never false `completed`. Temporary
 parent SIGINT/SIGTERM handlers route every wait interruption/error through
-bounded TERM/KILL/reap before terminal persistence. Launch identity requires the
-lexical repository-worktree `.venv/bin/python` plus matching lexical venv
+bounded TERM/KILL/reap before terminal persistence. The launch contract
+requires the fork child to ignore SIGINT/SIGTERM while waiting for parent release and route
+every pre-release failure to `os._exit(71)`; parent cleanup rejects nonpositive
+PIDs. Unique same-directory `mkstemp` ledger updates close and unlink on every
+failed or interrupted write/fsync/replace/post-replace path and retain durable
+consumed/no-retry `failed_after_launch` evidence without temporary residue.
+Interpreter identity requires the lexical repository-worktree
+`.venv/bin/python` plus matching lexical venv
 `sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
 venvs, and prefix mismatch are rejected before side effects.
 

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -32,8 +32,8 @@ historical; and the linked finite source/runtime authorities remain
 preparation `6689d61f…` remains a historical predecessor and accepted
 R1B/current exact-main preparation `7d1831ff…` is the live predecessor. The
 existing worker's fresh exact-main `6c08ecd9` reapplication derived the sole
-candidate cohort: preparation `66c015de…`, benchmark `1c7e1ea7…`, and lifecycle
-test `a8de9667…`. Historical `d192c858…`, mixed or incomplete cohorts, and
+candidate cohort: preparation `66c015de…`, benchmark `f108dbb4…`, and lifecycle
+test `4c514889…`. Historical `d192c858…`, mixed or incomplete cohorts, and
 every other digest fail closed. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed
 read-only witness and is not refreshed, rerun, or merged.
@@ -41,7 +41,7 @@ read-only witness and is not refreshed, rerun, or merged.
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the current authority binds predecessor preparation `7d1831ff…` to the atomic
-`66c015de…` / `1c7e1ea7…` / `a8de9667…` successor cohort, linked evidence
+`66c015de…` / `f108dbb4…` / `4c514889…` successor cohort, linked evidence
 `36eb76ca…`, and the 720-second wrapper timeout without executing the worker.
 The successor is permitted-not-accepted and launch remains unauthorized.
 The versioned [shared successor overlay](../../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -98,7 +98,10 @@ failure is terminal `failed_after_launch`, never false `completed`. Temporary
 parent SIGINT/SIGTERM handlers route every wait interruption/error through
 bounded TERM/KILL/reap before terminal persistence and remain installed
 through evidence, receipt, and terminal ledger finalization; originals restore
-only after the terminal-state attempt. The launch contract
+only after the terminal-state attempt. Every terminal fallback persistence
+call masks SIGINT/SIGTERM with the existing ignore guard and restores the prior
+temporary handlers afterward; the outer final restoration of original
+handlers remains last. The launch contract
 requires the fork child to ignore SIGINT/SIGTERM while waiting for parent release and route
 every pre-release failure to `os._exit(71)`; parent cleanup rejects nonpositive
 PIDs. Unique same-directory `mkstemp` ledger updates close and unlink on every

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -32,8 +32,8 @@ historical; and the linked finite source/runtime authorities remain
 preparation `6689d61f…` remains a historical predecessor and accepted
 R1B/current exact-main preparation `7d1831ff…` is the live predecessor. The
 existing worker's fresh exact-main `6c08ecd9` reapplication derived the sole
-candidate cohort: preparation `66c015de…`, benchmark `c922b59f…`, and lifecycle
-test `5e9cb014…`. Historical `d192c858…`, mixed or incomplete cohorts, and
+candidate cohort: preparation `66c015de…`, benchmark `1c7e1ea7…`, and lifecycle
+test `a8de9667…`. Historical `d192c858…`, mixed or incomplete cohorts, and
 every other digest fail closed. PR #394 head
 `98a9b5b82951d136644a5fe5f8a70d320131ba08` is a stale failed
 read-only witness and is not refreshed, rerun, or merged.
@@ -41,7 +41,7 @@ read-only witness and is not refreshed, rerun, or merged.
 **Owned files/interfaces:** Lifecycle preparation implementation, focused
 publication tests, profile/benchmark, and linked CK-07 evidence amendment;
 the current authority binds predecessor preparation `7d1831ff…` to the atomic
-`66c015de…` / `c922b59f…` / `5e9cb014…` successor cohort, linked evidence
+`66c015de…` / `1c7e1ea7…` / `a8de9667…` successor cohort, linked evidence
 `36eb76ca…`, and the 720-second wrapper timeout without executing the worker.
 The successor is permitted-not-accepted and launch remains unauthorized.
 The versioned [shared successor overlay](../../decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
@@ -96,7 +96,9 @@ receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failure is terminal `failed_after_launch`, never false `completed`. Temporary
 parent SIGINT/SIGTERM handlers route every wait interruption/error through
-bounded TERM/KILL/reap before terminal persistence. The launch contract
+bounded TERM/KILL/reap before terminal persistence and remain installed
+through evidence, receipt, and terminal ledger finalization; originals restore
+only after the terminal-state attempt. The launch contract
 requires the fork child to ignore SIGINT/SIGTERM while waiting for parent release and route
 every pre-release failure to `os._exit(71)`; parent cleanup rejects nonpositive
 PIDs. Unique same-directory `mkstemp` ledger updates close and unlink on every

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -43,7 +43,7 @@ while reconciling their consumers with only the complete exact successor. The re
 CK-07R1 implementation/profile/evidence diff is read-only evidence;
 accepted R3A preparation `6689d61f…` remains historical, current R1B
 preparation `7d1831ff…` is the live predecessor, and only the exact
-`66c015de…` preparation plus `1c7e1ea7…` benchmark and `a8de9667…` lifecycle
+`66c015de…` preparation plus `f108dbb4…` benchmark and `4c514889…` lifecycle
 test may enter worker prequalification. Historical `d192c858…`, mixed cohorts,
 and every other digest fail closed; prior R3A candidate `e204e0da…` remains
 superseded and forbidden. The selected cohort does not claim runtime acceptance.
@@ -56,7 +56,10 @@ child `os._exit(71)` isolation with ignored wait signals, positive-PID cleanup,
 and unique same-directory temporary-ledger cleanup with durable consumed/no-retry
 terminal evidence. Temporary parent signal handlers remain installed through
 bounded reap, evidence, receipt, and terminal persistence and restore only
-after the terminal-state attempt. The authority keeps the
+after the terminal-state attempt. Every terminal fallback persistence call
+masks SIGINT/SIGTERM with the existing ignore guard, restores the prior
+temporary handlers afterward, and leaves the outer original-handler
+restoration last. The authority keeps the
 retained candidate runtime-unqualified.
 
 **Produces:** A frozen entry-path contract, finite source/runtime state machine,
@@ -94,7 +97,7 @@ predecessor digest is
 `7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb` and the
 permitted-not-accepted retained successor digest is
 `66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea`
-only with benchmark `1c7e1ea7…` and lifecycle test `a8de9667…`; historical
+only with benchmark `f108dbb4…` and lifecycle test `4c514889…`; historical
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1` is
 revoked and direct use fails closed; generic or different digest drift fails
 closed; linked evidence is

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -43,7 +43,7 @@ while reconciling their consumers with only the complete exact successor. The re
 CK-07R1 implementation/profile/evidence diff is read-only evidence;
 accepted R3A preparation `6689d61f…` remains historical, current R1B
 preparation `7d1831ff…` is the live predecessor, and only the exact
-`66c015de…` preparation plus `c922b59f…` benchmark and `5e9cb014…` lifecycle
+`66c015de…` preparation plus `1c7e1ea7…` benchmark and `a8de9667…` lifecycle
 test may enter worker prequalification. Historical `d192c858…`, mixed cohorts,
 and every other digest fail closed; prior R3A candidate `e204e0da…` remains
 superseded and forbidden. The selected cohort does not claim runtime acceptance.
@@ -54,7 +54,9 @@ it adds no runtime implementation, freezes the corrected argv guard,
 720-second wrapper timeout, four-path non-overwriting preflight, pre-release
 child `os._exit(71)` isolation with ignored wait signals, positive-PID cleanup,
 and unique same-directory temporary-ledger cleanup with durable consumed/no-retry
-terminal evidence, and keeps the
+terminal evidence. Temporary parent signal handlers remain installed through
+bounded reap, evidence, receipt, and terminal persistence and restore only
+after the terminal-state attempt. The authority keeps the
 retained candidate runtime-unqualified.
 
 **Produces:** A frozen entry-path contract, finite source/runtime state machine,
@@ -92,7 +94,7 @@ predecessor digest is
 `7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb` and the
 permitted-not-accepted retained successor digest is
 `66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea`
-only with benchmark `c922b59f…` and lifecycle test `5e9cb014…`; historical
+only with benchmark `1c7e1ea7…` and lifecycle test `a8de9667…`; historical
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1` is
 revoked and direct use fails closed; generic or different digest drift fails
 closed; linked evidence is

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -43,7 +43,7 @@ while reconciling their consumers with only the complete exact successor. The re
 CK-07R1 implementation/profile/evidence diff is read-only evidence;
 accepted R3A preparation `6689d61f…` remains historical, current R1B
 preparation `7d1831ff…` is the live predecessor, and only the exact
-`66c015de…` preparation plus `4b1c62b2…` benchmark and `75d03f53…` lifecycle
+`66c015de…` preparation plus `98aac35d…` benchmark and `7914d993…` lifecycle
 test may enter worker prequalification. Historical `d192c858…`, mixed cohorts,
 and every other digest fail closed; prior R3A candidate `e204e0da…` remains
 superseded and forbidden. The selected cohort does not claim runtime acceptance.
@@ -89,7 +89,7 @@ predecessor digest is
 `7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb` and the
 permitted-not-accepted retained successor digest is
 `66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea`
-only with benchmark `4b1c62b2…` and lifecycle test `75d03f53…`; historical
+only with benchmark `98aac35d…` and lifecycle test `7914d993…`; historical
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1` is
 revoked and direct use fails closed; generic or different digest drift fails
 closed; linked evidence is

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -43,7 +43,7 @@ while reconciling their consumers with only the complete exact successor. The re
 CK-07R1 implementation/profile/evidence diff is read-only evidence;
 accepted R3A preparation `6689d61f…` remains historical, current R1B
 preparation `7d1831ff…` is the live predecessor, and only the exact
-`66c015de…` preparation plus `98aac35d…` benchmark and `7914d993…` lifecycle
+`66c015de…` preparation plus `2125d127…` benchmark and `a4163ffb…` lifecycle
 test may enter worker prequalification. Historical `d192c858…`, mixed cohorts,
 and every other digest fail closed; prior R3A candidate `e204e0da…` remains
 superseded and forbidden. The selected cohort does not claim runtime acceptance.
@@ -89,7 +89,7 @@ predecessor digest is
 `7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb` and the
 permitted-not-accepted retained successor digest is
 `66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea`
-only with benchmark `98aac35d…` and lifecycle test `7914d993…`; historical
+only with benchmark `2125d127…` and lifecycle test `a4163ffb…`; historical
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1` is
 revoked and direct use fails closed; generic or different digest drift fails
 closed; linked evidence is

--- a/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
+++ b/docs/roadmap/tasks/ck-07r1a0-freeze-lifecycle-path-authority.md
@@ -43,7 +43,7 @@ while reconciling their consumers with only the complete exact successor. The re
 CK-07R1 implementation/profile/evidence diff is read-only evidence;
 accepted R3A preparation `6689d61f…` remains historical, current R1B
 preparation `7d1831ff…` is the live predecessor, and only the exact
-`66c015de…` preparation plus `2125d127…` benchmark and `a4163ffb…` lifecycle
+`66c015de…` preparation plus `c922b59f…` benchmark and `5e9cb014…` lifecycle
 test may enter worker prequalification. Historical `d192c858…`, mixed cohorts,
 and every other digest fail closed; prior R3A candidate `e204e0da…` remains
 superseded and forbidden. The selected cohort does not claim runtime acceptance.
@@ -51,7 +51,10 @@ Linked evidence `36eb76ca…` and canonical fixture identities remain unchanged.
 The linked run-invocation authority is
 `docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json`;
 it adds no runtime implementation, freezes the corrected argv guard,
-720-second wrapper timeout, four-path non-overwriting preflight, and keeps the
+720-second wrapper timeout, four-path non-overwriting preflight, pre-release
+child `os._exit(71)` isolation with ignored wait signals, positive-PID cleanup,
+and unique same-directory temporary-ledger cleanup with durable consumed/no-retry
+terminal evidence, and keeps the
 retained candidate runtime-unqualified.
 
 **Produces:** A frozen entry-path contract, finite source/runtime state machine,
@@ -89,7 +92,7 @@ predecessor digest is
 `7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb` and the
 permitted-not-accepted retained successor digest is
 `66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea`
-only with benchmark `2125d127…` and lifecycle test `a4163ffb…`; historical
+only with benchmark `c922b59f…` and lifecycle test `5e9cb014…`; historical
 `d192c858b48e44b5aa7a7e39ef524e5ec2f08085655fe485639f5e875a727aa1` is
 revoked and direct use fails closed; generic or different digest drift fails
 closed; linked evidence is

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -302,7 +302,8 @@ def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
         ),
         "parent_signal_handling": (
             "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
-            "and_restored_after_wait"
+            "held_through_bounded_reap_evidence_receipt_and_terminal_ledger_"
+            "persistence_then_restored"
         ),
         "wait_interruption_cleanup": (
             "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_"

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -213,6 +213,59 @@ def verify_exact_worktree_delta(
         )
 
 
+def verify_exact_committed_delta(
+    authority: Mapping[str, Any],
+    root: Path = ROOT,
+    *,
+    observed: set[str] | None = None,
+    base_is_ancestor: bool | None = None,
+) -> None:
+    """Reject any committed path outside the exact versioned authority scope."""
+
+    base = authority.get("authority_base_sha")
+    scope = authority.get("scope")
+    if not isinstance(base, str) or len(base) != 40:
+        raise SharedSuccessorOverlayError("authority base SHA is malformed")
+    if not isinstance(scope, Mapping):
+        raise SharedSuccessorOverlayError("overlay scope missing")
+    authority_paths = scope.get("authority_write_scope")
+    if not isinstance(authority_paths, list) or not all(
+        isinstance(path, str) for path in authority_paths
+    ):
+        raise SharedSuccessorOverlayError("authority write scope malformed")
+
+    if base_is_ancestor is None:
+        try:
+            result = subprocess.run(
+                ("git", "merge-base", "--is-ancestor", base, "HEAD"),
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            raise SharedSuccessorOverlayError(
+                "cannot verify authority base ancestry"
+            ) from exc
+        base_is_ancestor = result.returncode == 0
+    if not base_is_ancestor:
+        raise SharedSuccessorOverlayError("authority base is not an ancestor of HEAD")
+
+    actual = (
+        _git_paths(root, "diff", "--name-only", "--no-renames", f"{base}...HEAD")
+        if observed is None
+        else set(observed)
+    )
+    expected = set(authority_paths)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise SharedSuccessorOverlayError(
+            f"exact committed authority delta mismatch; missing={missing!r}; "
+            f"extra={extra!r}"
+        )
+
+
 def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
     """Pin the corrected candidate's non-consuming launcher semantics."""
 
@@ -294,6 +347,7 @@ def verify_shared_successor_overlay(
     authority = load_overlay(root)
     verify_bound_authority_bytes(authority, root)
     verify_launcher_safety_contract(authority)
+    verify_exact_committed_delta(authority, root)
     state = classify_observed_state(
         authority,
         observed_candidate_artifacts(authority, root),

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -231,6 +231,22 @@ def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
             "construction_validation_or_finalization_failure_is_failed_after_launch_"
             "never_completed"
         ),
+        "child_pre_release_failure": (
+            "every_pre_release_child_failure_routes_to_os._exit_71"
+        ),
+        "child_wait_signal_handling": (
+            "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release"
+        ),
+        "parent_cleanup_pid_guard": (
+            "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap"
+        ),
+        "atomic_ledger_update": (
+            "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_"
+            "interrupted_write_fsync_replace_or_post_replace_path"
+        ),
+        "atomic_failure_state": (
+            "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue"
+        ),
         "parent_signal_handling": (
             "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
             "and_restored_after_wait"

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -231,6 +231,25 @@ def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
             "construction_validation_or_finalization_failure_is_failed_after_launch_"
             "never_completed"
         ),
+        "parent_signal_handling": (
+            "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
+            "and_restored_after_wait"
+        ),
+        "wait_interruption_cleanup": (
+            "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_"
+            "SIGKILL_then_reap_before_terminal_failure"
+        ),
+        "signal_cleanup_mask": (
+            "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"
+        ),
+        "evidence_completion_ordering": (
+            "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_"
+            "first_durable_completed_finalization"
+        ),
+        "evidence_failure_state": (
+            "missing_read_hash_parse_validation_or_finalization_failure_is_failed_"
+            "after_launch_never_completed"
+        ),
         "interpreter_identity": {
             "executable": "lexical_repository_worktree_.venv/bin/python_required",
             "sys_prefix": "lexical_repository_worktree_.venv_required",

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -312,6 +312,10 @@ def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
         "signal_cleanup_mask": (
             "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"
         ),
+        "terminal_fallback_signal_mask": (
+            "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_"
+            "then_prior_temporary_handlers_restored"
+        ),
         "evidence_completion_ordering": (
             "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_"
             "first_durable_completed_finalization"

--- a/scripts/ck07r1_shared_successor_overlay.py
+++ b/scripts/ck07r1_shared_successor_overlay.py
@@ -223,6 +223,22 @@ def verify_launcher_safety_contract(authority: Mapping[str, Any]) -> None:
         "receipt_binding": (
             "must_equal_exact_overlay_verification_result_and_three_artifact_cohort"
         ),
+        "receipt_completion_ordering": (
+            "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_"
+            "completed_finalization"
+        ),
+        "receipt_failure_state": (
+            "construction_validation_or_finalization_failure_is_failed_after_launch_"
+            "never_completed"
+        ),
+        "interpreter_identity": {
+            "executable": "lexical_repository_worktree_.venv/bin/python_required",
+            "sys_prefix": "lexical_repository_worktree_.venv_required",
+            "base_interpreter": "rejected",
+            "symlink_or_resolved_equivalence": "rejected",
+            "wrong_worktree_venv": "rejected",
+            "prefix_mismatch": "rejected",
+        },
         "post_token_or_release_failure_state": "failed_after_launch",
         "aggregate_timeout_seconds": 720,
         "termination_sequence": ["SIGTERM", "wait_up_to_5_seconds", "SIGKILL"],

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -144,6 +144,9 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
             "parent_signal_handling", "not_installed"
         ),
         lambda value: value["launcher_safety"].__setitem__(
+            "parent_signal_handling", "restored_after_wait"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
             "wait_interruption_cleanup", "persist_without_reap"
         ),
         lambda value: value["launcher_safety"].__setitem__(

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -124,6 +124,21 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
         lambda value: value["launcher_safety"].__setitem__(
             "receipt_failure_state", "completed"
         ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "parent_signal_handling", "not_installed"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "wait_interruption_cleanup", "persist_without_reap"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "signal_cleanup_mask", "signals_remain_actionable"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "evidence_completion_ordering", "nullable_hashes_allowed"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "evidence_failure_state", "launched_consumed"
+        ),
         lambda value: value["launcher_safety"]["interpreter_identity"].__setitem__(
             "executable", "resolved_equivalent_python_allowed"
         ),

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -153,6 +153,9 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
             "signal_cleanup_mask", "signals_remain_actionable"
         ),
         lambda value: value["launcher_safety"].__setitem__(
+            "terminal_fallback_signal_mask", "signals_remain_actionable"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
             "evidence_completion_ordering", "nullable_hashes_allowed"
         ),
         lambda value: value["launcher_safety"].__setitem__(

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -119,6 +119,18 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
         ),
         lambda value: value["launcher_safety"].__setitem__("receipt_binding", "optional"),
         lambda value: value["launcher_safety"].__setitem__(
+            "receipt_completion_ordering", "durable_completed_before_validation"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "receipt_failure_state", "completed"
+        ),
+        lambda value: value["launcher_safety"]["interpreter_identity"].__setitem__(
+            "executable", "resolved_equivalent_python_allowed"
+        ),
+        lambda value: value["launcher_safety"]["interpreter_identity"].__setitem__(
+            "sys_prefix", "optional"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
             "post_token_or_release_failure_state", "prelaunch_failed"
         ),
         lambda value: value["launcher_safety"].__setitem__("final_reap_timeout_seconds", 0),
@@ -196,5 +208,12 @@ def test_overlay_scope_and_launcher_contract_are_exact() -> None:
 
     weakened = deepcopy(authority)
     weakened["launcher_safety"]["termination_sequence"] = ["SIGTERM"]
+    with pytest.raises(SharedSuccessorOverlayError, match="safety"):
+        verify_launcher_safety_contract(weakened)
+
+    weakened = deepcopy(authority)
+    weakened["launcher_safety"]["interpreter_identity"][
+        "symlink_or_resolved_equivalence"
+    ] = "accepted"
     with pytest.raises(SharedSuccessorOverlayError, match="safety"):
         verify_launcher_safety_contract(weakened)

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -125,6 +125,21 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
             "receipt_failure_state", "completed"
         ),
         lambda value: value["launcher_safety"].__setitem__(
+            "child_pre_release_failure", "exception_returns_to_parent_path"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "child_wait_signal_handling", "signals_actionable_while_waiting"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "parent_cleanup_pid_guard", "pid_zero_allowed"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "atomic_ledger_update", "fixed_temp_without_cleanup"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
+            "atomic_failure_state", "retry_or_temp_residue_allowed"
+        ),
+        lambda value: value["launcher_safety"].__setitem__(
             "parent_signal_handling", "not_installed"
         ),
         lambda value: value["launcher_safety"].__setitem__(

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -18,6 +18,7 @@ from scripts.ck07r1_shared_successor_overlay import (
     overlay_changed_path_allowance,
     sha256_path,
     verify_bound_authority_bytes,
+    verify_exact_committed_delta,
     verify_exact_worktree_delta,
     verify_launcher_safety_contract,
     verify_shared_successor_overlay,
@@ -222,6 +223,36 @@ def test_overlay_requires_exact_all_or_none_git_delta() -> None:
             "worker_prequalification",
             observed=candidate
             | {"docs/decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json"},
+        )
+
+
+def test_overlay_requires_exact_committed_authority_delta() -> None:
+    authority = load_overlay()
+    expected = set(authority["scope"]["authority_write_scope"])
+
+    verify_exact_committed_delta(
+        authority,
+        observed=expected,
+        base_is_ancestor=True,
+    )
+    with pytest.raises(SharedSuccessorOverlayError, match="not an ancestor"):
+        verify_exact_committed_delta(
+            authority,
+            observed=expected,
+            base_is_ancestor=False,
+        )
+    with pytest.raises(SharedSuccessorOverlayError, match="missing="):
+        verify_exact_committed_delta(
+            authority,
+            observed=expected - {next(iter(expected))},
+            base_is_ancestor=True,
+        )
+    with pytest.raises(SharedSuccessorOverlayError, match="extra="):
+        verify_exact_committed_delta(
+            authority,
+            observed=expected
+            | {"src/codex_usage_tracker/agent_kernel/publication/writer.py"},
+            base_is_ancestor=True,
         )
 
 

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -239,7 +239,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main "
+                "exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main "
                 "verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 "
                 "with the atomic cohort; no replacement, launch, token consumption, or downstream task"
             ),
@@ -1040,8 +1040,8 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v8"
-    assert authority["authority_version"] == 8
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v9"
+    assert authority["authority_version"] == 9
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_hold"
     assert authority["predecessor"]["sha256"] == (
@@ -1065,12 +1065,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             },
             {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+                "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
                 "role": "benchmark",
             },
             {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+                "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
                 "role": "lifecycle_test",
             },
         ],

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -239,7 +239,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main "
+                "exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main "
                 "verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 "
                 "with the atomic cohort; no replacement, launch, token consumption, or downstream task"
             ),
@@ -1040,8 +1040,8 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v10"
-    assert authority["authority_version"] == 10
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v11"
+    assert authority["authority_version"] == 11
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_hold"
     assert authority["predecessor"]["sha256"] == (
@@ -1065,12 +1065,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             },
             {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+                "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
                 "role": "benchmark",
             },
             {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+                "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
                 "role": "lifecycle_test",
             },
         ],

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -239,7 +239,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "exact 66c015de/1c7e1ea7/a8de9667 successor authority merges and exact-main "
+                "exact 66c015de/f108dbb4/4c514889 successor authority merges and exact-main "
                 "verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 "
                 "with the atomic cohort; no replacement, launch, token consumption, or downstream task"
             ),
@@ -1040,8 +1040,8 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v11"
-    assert authority["authority_version"] == 11
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v12"
+    assert authority["authority_version"] == 12
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_hold"
     assert authority["predecessor"]["sha256"] == (
@@ -1065,12 +1065,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             },
             {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+                "sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
                 "role": "benchmark",
             },
             {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+                "sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
                 "role": "lifecycle_test",
             },
         ],

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -239,7 +239,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "exact 66c015de/4b1c62b2/75d03f53 successor authority merges and exact-main "
+                "exact 66c015de/98aac35d/7914d993 successor authority merges and exact-main "
                 "verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 "
                 "with the atomic cohort; no replacement, launch, token consumption, or downstream task"
             ),
@@ -1040,9 +1040,9 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v7"
-    assert authority["authority_version"] == 7
-    assert authority["authority_base_sha"] == "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v8"
+    assert authority["authority_version"] == 8
+    assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_hold"
     assert authority["predecessor"]["sha256"] == (
         "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
@@ -1051,7 +1051,7 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
         "status": "permitted_not_accepted",
         "role": "selected_ck07_exact_candidate",
-        "base_sha": "cf44f4fdd3f54ad53263b5e744203be468fbe5ca",
+        "base_sha": "6c08ecd92a2c5166c1585be426e1ed437309a910",
         "requires_full_candidate_cohort": True,
         "direct_ck07_use": "worker_prequalification_only_after_authority_exact_main",
         "mixed_state": "fail_closed",
@@ -1065,12 +1065,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             },
             {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
+                "sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
                 "role": "benchmark",
             },
             {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+                "sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
                 "role": "lifecycle_test",
             },
         ],

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -239,7 +239,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "exact 66c015de/2125d127/a4163ffb successor authority merges and exact-main "
+                "exact 66c015de/c922b59f/5e9cb014 successor authority merges and exact-main "
                 "verifies; resume only existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 "
                 "with the atomic cohort; no replacement, launch, token consumption, or downstream task"
             ),
@@ -1040,8 +1040,8 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
     validator = Draft202012Validator(schema)
     validator.validate(authority)
 
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v9"
-    assert authority["authority_version"] == 9
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-source-digest-authority.v10"
+    assert authority["authority_version"] == 10
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_hold"
     assert authority["predecessor"]["sha256"] == (
@@ -1065,12 +1065,12 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
             },
             {
                 "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-                "sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+                "sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
                 "role": "benchmark",
             },
             {
                 "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-                "sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+                "sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
                 "role": "lifecycle_test",
             },
         ],

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -174,8 +174,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
     assert correction["old_guard"] == "sys.argv[1:] == LAUNCH_COMMAND[1:]"
     assert correction["corrected_guard"] == "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]"
     assert correction["corrected_candidate_artifacts"] == {
-        "benchmark_sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
-        "lifecycle_test_sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
+        "benchmark_sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
+        "lifecycle_test_sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
     }
     assert correction["old_candidate_artifacts"]["reuse"] == "forbidden"
     assert correction["non_launching_subprocess_test"]["required"] is True
@@ -204,8 +204,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
 def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> None:
     authority = _authority()
     candidate = authority["selected_candidate"]
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v8"
-    assert authority["authority_version"] == 8
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v9"
+    assert authority["authority_version"] == 9
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_no_run"
     assert authority["shared_preparation_binding"] == {
@@ -236,7 +236,7 @@ def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> 
         "role": "source",
     }
     assert candidate["binding"] == (
-        "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter "
+        "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter "
         "worker_prequalification after this authority merges and exact-main verifies"
     )
     assert authority["run_token"]["status"] == "unspent_unavailable"
@@ -504,6 +504,22 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
             "construction_validation_or_finalization_failure_is_failed_after_launch_"
             "never_completed"
         ),
+        "child_pre_release_failure": (
+            "every_pre_release_child_failure_routes_to_os._exit_71"
+        ),
+        "child_wait_signal_handling": (
+            "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release"
+        ),
+        "parent_cleanup_pid_guard": (
+            "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap"
+        ),
+        "atomic_ledger_update": (
+            "unique_same_directory_mkstemp_close_and_unlink_on_every_failed_or_"
+            "interrupted_write_fsync_replace_or_post_replace_path"
+        ),
+        "atomic_failure_state": (
+            "durable_failed_after_launch_token_consumed_no_retry_no_temp_residue"
+        ),
         "parent_signal_handling": (
             "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
             "and_restored_after_wait"
@@ -571,7 +587,7 @@ def test_process_exclusion_launch_token_and_evidence_capture_are_required() -> N
         "refund": False,
         "prior_identities_reused": False,
         "concurrent_processes_allowed": False,
-        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass",
+        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass",
         "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
         "old_candidate_reuse": "forbidden",
     }
@@ -656,6 +672,31 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
             "receipt-construction-false-completed",
             ("launch_contract", "launcher_safety", "receipt_failure_state"),
             "completed",
+        ),
+        (
+            "child-pre-release-return",
+            ("launch_contract", "launcher_safety", "child_pre_release_failure"),
+            "exception_returns_to_parent_path",
+        ),
+        (
+            "child-wait-signals-actionable",
+            ("launch_contract", "launcher_safety", "child_wait_signal_handling"),
+            "signals_actionable_while_waiting",
+        ),
+        (
+            "nonpositive-child-pid",
+            ("launch_contract", "launcher_safety", "parent_cleanup_pid_guard"),
+            "pid_zero_allowed",
+        ),
+        (
+            "fixed-atomic-temp",
+            ("launch_contract", "launcher_safety", "atomic_ledger_update"),
+            "fixed_temp_without_cleanup",
+        ),
+        (
+            "atomic-failure-retry",
+            ("launch_contract", "launcher_safety", "atomic_failure_state"),
+            "retry_or_temp_residue_allowed",
         ),
         (
             "parent-signals-not-installed",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -174,8 +174,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
     assert correction["old_guard"] == "sys.argv[1:] == LAUNCH_COMMAND[1:]"
     assert correction["corrected_guard"] == "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]"
     assert correction["corrected_candidate_artifacts"] == {
-        "benchmark_sha256": "4b1c62b2d56bf808b66f47c71b1bb1fa3595e2d590d0fa0192b5f7be3b2b4dde",
-        "lifecycle_test_sha256": "75d03f5346ffe2d02ffedc5df007ce45bef5533b324202ccf41b535de8b33cd2",
+        "benchmark_sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
+        "lifecycle_test_sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
     }
     assert correction["old_candidate_artifacts"]["reuse"] == "forbidden"
     assert correction["non_launching_subprocess_test"]["required"] is True
@@ -204,9 +204,9 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
 def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> None:
     authority = _authority()
     candidate = authority["selected_candidate"]
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v6"
-    assert authority["authority_version"] == 6
-    assert authority["authority_base_sha"] == "cf44f4fdd3f54ad53263b5e744203be468fbe5ca"
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v7"
+    assert authority["authority_version"] == 7
+    assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_no_run"
     assert authority["shared_preparation_binding"] == {
         "authority_main_sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb",
@@ -236,7 +236,7 @@ def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> 
         "role": "source",
     }
     assert candidate["binding"] == (
-        "only the byte-exact 66c015de/4b1c62b2/75d03f53 cohort may enter "
+        "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter "
         "worker_prequalification after this authority merges and exact-main verifies"
     )
     assert authority["run_token"]["status"] == "unspent_unavailable"
@@ -496,6 +496,22 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
         "receipt_binding": (
             "must_equal_exact_overlay_verification_result_and_three_artifact_cohort"
         ),
+        "receipt_completion_ordering": (
+            "construct_exact_overlay_bound_receipt_then_validate_then_first_durable_"
+            "completed_finalization"
+        ),
+        "receipt_failure_state": (
+            "construction_validation_or_finalization_failure_is_failed_after_launch_"
+            "never_completed"
+        ),
+        "interpreter_identity": {
+            "executable": "lexical_repository_worktree_.venv/bin/python_required",
+            "sys_prefix": "lexical_repository_worktree_.venv_required",
+            "base_interpreter": "rejected",
+            "symlink_or_resolved_equivalence": "rejected",
+            "wrong_worktree_venv": "rejected",
+            "prefix_mismatch": "rejected",
+        },
         "post_token_or_release_failure_state": "failed_after_launch",
         "termination_sequence": [
             "SIGTERM",
@@ -536,7 +552,7 @@ def test_process_exclusion_launch_token_and_evidence_capture_are_required() -> N
         "refund": False,
         "prior_identities_reused": False,
         "concurrent_processes_allowed": False,
-        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/4b1c62b2/75d03f53 candidate cohort, and all gates pass",
+        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass",
         "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
         "old_candidate_reuse": "forbidden",
     }
@@ -611,6 +627,36 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
             "receipt-unbound",
             ("launch_contract", "launcher_safety", "receipt_binding"),
             "optional",
+        ),
+        (
+            "receipt-finalized-before-validation",
+            ("launch_contract", "launcher_safety", "receipt_completion_ordering"),
+            "durable_completed_before_validation",
+        ),
+        (
+            "receipt-construction-false-completed",
+            ("launch_contract", "launcher_safety", "receipt_failure_state"),
+            "completed",
+        ),
+        (
+            "resolved-interpreter-equivalence",
+            (
+                "launch_contract",
+                "launcher_safety",
+                "interpreter_identity",
+                "executable",
+            ),
+            "resolved_equivalent_python_allowed",
+        ),
+        (
+            "prefix-mismatch-allowed",
+            (
+                "launch_contract",
+                "launcher_safety",
+                "interpreter_identity",
+                "prefix_mismatch",
+            ),
+            "accepted",
         ),
         (
             "post-token-prelaunch-label",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -185,8 +185,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
     assert correction["old_guard"] == "sys.argv[1:] == LAUNCH_COMMAND[1:]"
     assert correction["corrected_guard"] == "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]"
     assert correction["corrected_candidate_artifacts"] == {
-        "benchmark_sha256": "c922b59fbb79df6f8bd1aee35abf03b057859627a60f7fa7028d2d8f90f9bf32",
-        "lifecycle_test_sha256": "5e9cb0144887cb34bd123ed03a2e83724e70100c71b7512e57dc2a286e34349e",
+        "benchmark_sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
+        "lifecycle_test_sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
     }
     assert correction["old_candidate_artifacts"]["reuse"] == "forbidden"
     assert correction["non_launching_subprocess_test"]["required"] is True
@@ -215,8 +215,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
 def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> None:
     authority = _authority()
     candidate = authority["selected_candidate"]
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v9"
-    assert authority["authority_version"] == 9
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v10"
+    assert authority["authority_version"] == 10
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_no_run"
     assert authority["shared_preparation_binding"] == {
@@ -247,7 +247,7 @@ def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> 
         "role": "source",
     }
     assert candidate["binding"] == (
-        "only the byte-exact 66c015de/c922b59f/5e9cb014 cohort may enter "
+        "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter "
         "worker_prequalification after this authority merges and exact-main verifies"
     )
     assert authority["run_token"]["status"] == "unspent_unavailable"
@@ -533,7 +533,8 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
         ),
         "parent_signal_handling": (
             "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
-            "and_restored_after_wait"
+            "held_through_bounded_reap_evidence_receipt_and_terminal_ledger_"
+            "persistence_then_restored"
         ),
         "wait_interruption_cleanup": (
             "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_"
@@ -598,7 +599,7 @@ def test_process_exclusion_launch_token_and_evidence_capture_are_required() -> N
         "refund": False,
         "prior_identities_reused": False,
         "concurrent_processes_allowed": False,
-        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/c922b59f/5e9cb014 candidate cohort, and all gates pass",
+        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass",
         "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
         "old_candidate_reuse": "forbidden",
     }
@@ -713,6 +714,11 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
             "parent-signals-not-installed",
             ("launch_contract", "launcher_safety", "parent_signal_handling"),
             "not_installed",
+        ),
+        (
+            "parent-signals-restored-before-finalization",
+            ("launch_contract", "launcher_safety", "parent_signal_handling"),
+            "restored_after_wait",
         ),
         (
             "wait-error-without-reap",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -47,6 +47,17 @@ def test_run_invocation_authority_validates_and_is_strict() -> None:
     assert schema["additionalProperties"] is False
 
 
+def test_preserved_authority_path_bytes_are_exact() -> None:
+    for record in _authority()["preserved_authorities"].values():
+        for path_key, digest_key in (
+            ("path", "sha256"),
+            ("schema_path", "schema_sha256"),
+        ):
+            path = _ROOT / record[path_key]
+            assert path.is_file()
+            assert hashlib.sha256(path.read_bytes()).hexdigest() == record[digest_key]
+
+
 def test_command_cwd_interpreter_environment_and_output_are_exact() -> None:
     launch = _authority()["launch_contract"]
     assert launch["repository_relative_command"] == [

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -174,8 +174,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
     assert correction["old_guard"] == "sys.argv[1:] == LAUNCH_COMMAND[1:]"
     assert correction["corrected_guard"] == "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]"
     assert correction["corrected_candidate_artifacts"] == {
-        "benchmark_sha256": "98aac35d01c0e4ec6cd18b296807d1b67864db38353874d372efec3e470ec9bc",
-        "lifecycle_test_sha256": "7914d993286249e449b46c4f5ba0f344aeab9dc0e9eee0f5d3aeb4e917cb730f",
+        "benchmark_sha256": "2125d127fc2f7978f12b9655ac678fbd05f5db8b4fec2c478ca693e5779f1b97",
+        "lifecycle_test_sha256": "a4163ffbc121d101a40c6e304d9593e10ff0857beaf542df8f82236bb1f861c6",
     }
     assert correction["old_candidate_artifacts"]["reuse"] == "forbidden"
     assert correction["non_launching_subprocess_test"]["required"] is True
@@ -204,8 +204,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
 def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> None:
     authority = _authority()
     candidate = authority["selected_candidate"]
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v7"
-    assert authority["authority_version"] == 7
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v8"
+    assert authority["authority_version"] == 8
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_no_run"
     assert authority["shared_preparation_binding"] == {
@@ -236,7 +236,7 @@ def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> 
         "role": "source",
     }
     assert candidate["binding"] == (
-        "only the byte-exact 66c015de/98aac35d/7914d993 cohort may enter "
+        "only the byte-exact 66c015de/2125d127/a4163ffb cohort may enter "
         "worker_prequalification after this authority merges and exact-main verifies"
     )
     assert authority["run_token"]["status"] == "unspent_unavailable"
@@ -504,6 +504,25 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
             "construction_validation_or_finalization_failure_is_failed_after_launch_"
             "never_completed"
         ),
+        "parent_signal_handling": (
+            "temporary_SIGINT_SIGTERM_handlers_installed_before_child_observation_"
+            "and_restored_after_wait"
+        ),
+        "wait_interruption_cleanup": (
+            "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_"
+            "SIGKILL_then_reap_before_terminal_failure"
+        ),
+        "signal_cleanup_mask": (
+            "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"
+        ),
+        "evidence_completion_ordering": (
+            "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_"
+            "first_durable_completed_finalization"
+        ),
+        "evidence_failure_state": (
+            "missing_read_hash_parse_validation_or_finalization_failure_is_failed_"
+            "after_launch_never_completed"
+        ),
         "interpreter_identity": {
             "executable": "lexical_repository_worktree_.venv/bin/python_required",
             "sys_prefix": "lexical_repository_worktree_.venv_required",
@@ -552,7 +571,7 @@ def test_process_exclusion_launch_token_and_evidence_capture_are_required() -> N
         "refund": False,
         "prior_identities_reused": False,
         "concurrent_processes_allowed": False,
-        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/98aac35d/7914d993 candidate cohort, and all gates pass",
+        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/2125d127/a4163ffb candidate cohort, and all gates pass",
         "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
         "old_candidate_reuse": "forbidden",
     }
@@ -637,6 +656,31 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
             "receipt-construction-false-completed",
             ("launch_contract", "launcher_safety", "receipt_failure_state"),
             "completed",
+        ),
+        (
+            "parent-signals-not-installed",
+            ("launch_contract", "launcher_safety", "parent_signal_handling"),
+            "not_installed",
+        ),
+        (
+            "wait-error-without-reap",
+            ("launch_contract", "launcher_safety", "wait_interruption_cleanup"),
+            "persist_without_reap",
+        ),
+        (
+            "cleanup-signals-actionable",
+            ("launch_contract", "launcher_safety", "signal_cleanup_mask"),
+            "signals_remain_actionable",
+        ),
+        (
+            "nullable-evidence-before-completed",
+            ("launch_contract", "launcher_safety", "evidence_completion_ordering"),
+            "nullable_hashes_allowed",
+        ),
+        (
+            "evidence-failure-nonterminal",
+            ("launch_contract", "launcher_safety", "evidence_failure_state"),
+            "launched_consumed",
         ),
         (
             "resolved-interpreter-equivalence",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -185,8 +185,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
     assert correction["old_guard"] == "sys.argv[1:] == LAUNCH_COMMAND[1:]"
     assert correction["corrected_guard"] == "(sys.argv[0], *sys.argv[1:]) == LAUNCH_COMMAND[1:]"
     assert correction["corrected_candidate_artifacts"] == {
-        "benchmark_sha256": "1c7e1ea7168e916d856ea2eaab5f97a3e06cf2dc6d16665dbd441f7bb3f84fe5",
-        "lifecycle_test_sha256": "a8de96673b55a8015b865f1b0f80f1cc1bad4148b4118b56590d2de6636bb94b",
+        "benchmark_sha256": "f108dbb45d7586a15eb370c94fc124268a249f2f6f1ee97e7b8b28a3874b737c",
+        "lifecycle_test_sha256": "4c51488988397e0ccaf40266a4f68bb1d6d342e4be1db36dd1cf36ab63aa335a",
     }
     assert correction["old_candidate_artifacts"]["reuse"] == "forbidden"
     assert correction["non_launching_subprocess_test"]["required"] is True
@@ -215,8 +215,8 @@ def test_argv_correction_preserves_first_failure_and_one_run_gate() -> None:
 def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> None:
     authority = _authority()
     candidate = authority["selected_candidate"]
-    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v10"
-    assert authority["authority_version"] == 10
+    assert authority["schema"] == "codex-usage-tracker.lifecycle-run-invocation-authority.v11"
+    assert authority["authority_version"] == 11
     assert authority["authority_base_sha"] == "6c08ecd92a2c5166c1585be426e1ed437309a910"
     assert authority["status"] == "blocked_no_run"
     assert authority["shared_preparation_binding"] == {
@@ -247,7 +247,7 @@ def test_selected_candidate_is_exact_ck07_cohort_and_runtime_stays_blocked() -> 
         "role": "source",
     }
     assert candidate["binding"] == (
-        "only the byte-exact 66c015de/1c7e1ea7/a8de9667 cohort may enter "
+        "only the byte-exact 66c015de/f108dbb4/4c514889 cohort may enter "
         "worker_prequalification after this authority merges and exact-main verifies"
     )
     assert authority["run_token"]["status"] == "unspent_unavailable"
@@ -543,6 +543,10 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
         "signal_cleanup_mask": (
             "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"
         ),
+        "terminal_fallback_signal_mask": (
+            "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_"
+            "then_prior_temporary_handlers_restored"
+        ),
         "evidence_completion_ordering": (
             "required_non_null_stdout_stderr_output_read_hash_parse_validate_before_"
             "first_durable_completed_finalization"
@@ -599,7 +603,7 @@ def test_process_exclusion_launch_token_and_evidence_capture_are_required() -> N
         "refund": False,
         "prior_identities_reused": False,
         "concurrent_processes_allowed": False,
-        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/1c7e1ea7/a8de9667 candidate cohort, and all gates pass",
+        "eligibility": "only after this authority merges and exact-main verifies, the stopped existing worker resumes only the preserved exact 66c015de/f108dbb4/4c514889 candidate cohort, and all gates pass",
         "first_successful_launch": "exactly one first successful child launch may consume the still-unspent token; this is not a retry, restart, or replacement of a launched process",
         "old_candidate_reuse": "forbidden",
     }
@@ -728,6 +732,11 @@ def test_no_retry_semantics_and_candidate_blocker_are_explicit() -> None:
         (
             "cleanup-signals-actionable",
             ("launch_contract", "launcher_safety", "signal_cleanup_mask"),
+            "signals_remain_actionable",
+        ),
+        (
+            "fallback-persistence-signals-actionable",
+            ("launch_contract", "launcher_safety", "terminal_fallback_signal_mask"),
             "signals_remain_actionable",
         ),
         (


### PR DESCRIPTION
## What changed

- adds the versioned CK-07R1 shared successor overlay while preserving accepted CK-08R1B, CK-08R1, and CK-QG1 authority bytes
- binds only the exact `66c015de…` / `f108dbb4…` / `4c514889…` candidate cohort as `worker_prequalification`
- enforces exact committed and all-or-none combined-preflight Git deltas
- binds bounded reap, evidence and receipt ordering, lexical interpreter identity, atomic ledger persistence, and signal masking during every terminal fallback persistence call
- keeps runtime acceptance unclaimed, launch blocked, and the one-run token unspent/unavailable

## Why

The retained CK-07R1 launcher correction closes the final reviewed fallback-persistence signal race. Shared consumers need a versioned, fail-closed authority bridge before that exact implementation cohort can be considered for worker prequalification.

## Validation

- authority consumers: 193 passed
- focused publication/contracts/storage/oracle: 408 passed
- privacy: 9 passed
- `just vp`, `just v`, and `just vc` passed using existing dependencies
- full Python 3.14.6 validation: 1544 passed, 1 skipped
- intercepted exact argv boundary: no real child, `matching_processes=[]`, output/ledger/stdout/stderr absent, token unspent
- exact Git delta/fold/postconditions, schemas, ruff, mypy, compileall, diff check, secret scan, and one bounded independent correction review passed

Python 3.10 remains reserved for hosted CI. This PR contains authority/schema/docs/scope/consumer-test paths only; it does not publish implementation bytes, authorize launch, mutate PR #394, consume the token, create run artifacts, or advance downstream packets.