### PR TITLE
Authorize CK-07R1 prelaunch failure recovery

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -159,6 +159,24 @@ worker to continue through this repository workflow without repeated user
 approval while every exact fail-closed gate remains binding. The central authority is
 [REMAINING_EXECUTION_PLAN.md](roadmap/REMAINING_EXECUTION_PLAN.md).
 
+The first v1 consuming-boundary command invocation terminated at
+`child_start_handshake` before token persistence or child release. Its sole
+durable artifact is the immutable
+`output/ck07r1/lifecycle-requalification-v1.launch-token.json` ledger with
+SHA-256 `5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be`,
+state `prelaunch_failed`, and `token_consumed=false`; no verified child,
+runtime output, stdout, stderr, or receipt exists. The versioned
+[`lifecycle-prelaunch-recovery-authority-v1`](decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json)
+is the only corrective path. It preserves the v1 ledger byte-for-byte and
+permits the same worker to make one new command invocation only after the
+portable parent/child process-snapshot correction, exact corrected cohort,
+authority merge, exact-main verification, and immediate gates all pass. This
+is not a retry, restart, replacement, or refund of a launched process because
+zero successful child launches were observed and the original one-run token
+remains `unspent_unavailable`. The recovery command uses only the non-colliding
+`lifecycle-requalification-v2` output, ledger, stdout, and stderr paths; the
+v1 invocation and ledger are terminal and can never be reused or overwritten.
+
 The V11 candidate must construct and validate the exact overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
@@ -110,12 +110,12 @@
     },
     {
       "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-      "sha256": "e8de2aab10c065fc4e5b4667e3db7f4058f9261ca731af25aec06ffab7c20565",
+      "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e",
       "role": "corrected_launcher"
     },
     {
       "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-      "sha256": "d49e959bf65602472a5d60dc9b2239f840aab5c5050544fa1df545a2e5246d7e",
+      "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854",
       "role": "corrected_launcher_tests"
     }
   ],

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
@@ -1,0 +1,260 @@
+{
+  "schema": "codex-usage-tracker.ck07r1-lifecycle-prelaunch-recovery.v1",
+  "authority_version": 1,
+  "authority_base_sha": "213b5d280dac58d11d71511c21aac58f61227fd3",
+  "status": "permitted_not_accepted",
+  "decision": {
+    "policy": "one corrected v2 command invocation may seek the first successfully observed child launch only after this authority is merged, exact-main verified, and every immediate gate passes",
+    "prior_invocation_is_terminal": true,
+    "new_invocation_is_launched_process_retry": false,
+    "refund_claimed": false,
+    "launch_authorized_in_authority_task": false,
+    "implementation_acceptance": "not_claimed",
+    "runtime_acceptance": "not_claimed",
+    "pr394": "stale_read_only",
+    "downstream": "CK-08R4_CK-08RG_CK-09_blocked"
+  },
+  "worker": {
+    "thread_id": "019fbfe2-8fe4-7de2-9264-d58572366727",
+    "ownership": "coordinator_orchestration_binding_to_exact_existing_thread",
+    "frozen_cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+    "replacement_worker": "forbidden"
+  },
+  "immutable_authorities": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "b835817af3a0e12dbce7560a2d639e1e6d207dc75b0a85892804623280700e8b"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json",
+      "sha256": "bb8541e4071453b2b5e97821060c2d87c17acbe8b5e800732db0d92836dd9809"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.schema.json",
+      "sha256": "e7231eefdb6268877303fd1bbfeb202f8baf8f68b6c648d60e5e2b185348cf21"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+      "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+      "sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
+      "sha256": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
+      "sha256": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json",
+      "sha256": "73071209d42dbf65130fd307a69a0a3e76eceb65161e90baaf271321a6a81b8d"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json",
+      "sha256": "943117da4e3d82624ad2cd4656092d2a7aa86266d5d30f7bca2b07f15c9ed86b"
+    },
+    {
+      "path": "scripts/ck07r1_shared_successor_overlay.py",
+      "sha256": "f3745ec07bf47ee15f50969132f315aec61d407c745f6c63694e9910a88c5768"
+    }
+  ],
+  "preserved_v1_ledger": {
+    "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+    "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be",
+    "state": "prelaunch_failed",
+    "token_consumed": false,
+    "token_status": "unspent_unavailable",
+    "matching_processes": []
+  },
+  "preserved_failure_lineage": {
+    "ledger_path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+    "ledger_sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be",
+    "ledger_schema": "codex-usage-tracker.lifecycle-run-ledger.v1",
+    "state": "prelaunch_failed",
+    "failure_stage": "child_start_handshake",
+    "failure_message": "child-start handshake did not prove exact PID/argv/cwd/owner",
+    "elapsed_seconds": 6.518352,
+    "exit_code": 1,
+    "verified_child": false,
+    "child_released": false,
+    "successful_launches_observed": 0,
+    "terminal_immutable": true,
+    "exclusive_paths": {
+      "output": "output/ck07r1/lifecycle-requalification-v1.json",
+      "ledger": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "stdout": "output/ck07r1/lifecycle-requalification-v1.stdout.txt",
+      "stderr": "output/ck07r1/lifecycle-requalification-v1.stderr.txt"
+    }
+  },
+  "diagnostic_evidence": {
+    "method": "non_consuming_dummy_blocked_fork_child",
+    "qualification_command_invoked": false,
+    "dummy_pid": 79500,
+    "dummy_parent_pid": 79490,
+    "owner": "Monsky",
+    "cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+    "lexical_interpreter": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9/.venv/bin/python",
+    "resolved_interpreter": "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/bin/python3.14",
+    "observed_process_executable": "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python",
+    "finding": "macOS_process_argv0_representation_differs_from_lexical_venv_interpreter_for_fork_without_exec"
+  },
+  "candidate_cohort": [
+    {
+      "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea",
+      "role": "preparation_source"
+    },
+    {
+      "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "sha256": "e8de2aab10c065fc4e5b4667e3db7f4058f9261ca731af25aec06ffab7c20565",
+      "role": "corrected_launcher"
+    },
+    {
+      "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+      "sha256": "d49e959bf65602472a5d60dc9b2239f840aab5c5050544fa1df545a2e5246d7e",
+      "role": "corrected_launcher_tests"
+    }
+  ],
+  "recovery_transition": {
+    "from": "terminal_prelaunch_failed_v1",
+    "to": "ready_one_shot_v2_after_merge_exact_main_and_immediate_gates",
+    "old_shared_overlay": "immutable_historical_predecessor_evidence",
+    "live_corrected_cohort_authority": "this_versioned_recovery_authority_only",
+    "first_successful_child_launch_remaining": true,
+    "launched_process_retry": false,
+    "restart": false,
+    "replacement": false,
+    "refund": false
+  },
+  "handshake_contract": {
+    "pre_fork_parent_snapshot_required": true,
+    "child_process_creation": "fork_without_exec_before_release",
+    "required_child_fields": [
+      "pid",
+      "parent_pid",
+      "owner",
+      "cwd",
+      "platform_process_command_signature"
+    ],
+    "child_signature_rule": "exact_equality_to_the_verified_parent_platform_process_command_signature",
+    "argv_rule": "macos_python_app_bundle_or_lexical_venv_interpreter_representation_with_exact_script_and_flags_tail",
+    "lexical_interpreter_and_sys_prefix_gate": "unchanged_required",
+    "ambiguous_or_extra_match": "fail_closed",
+    "release_before_complete_proof": "forbidden"
+  },
+  "v2_paths": {
+    "output": "output/ck07r1/lifecycle-requalification-v2.json",
+    "ledger": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+    "stdout": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+    "stderr": "output/ck07r1/lifecycle-requalification-v2.stderr.txt"
+  },
+  "launch_contract": {
+    "cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+    "argv": [
+      ".venv/bin/python",
+      "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "--profile",
+      "all",
+      "--samples",
+      "5",
+      "--output",
+      "output/ck07r1/lifecycle-requalification-v2.json"
+    ],
+    "environment": {
+      "required": {
+        "LC_ALL": "C.UTF-8",
+        "PYTHONHASHSEED": "0",
+        "PYTHONUNBUFFERED": "1",
+        "TZ": "UTC"
+      },
+      "forbidden": [
+        "PYTHONPATH",
+        "CODEX_HOME"
+      ]
+    },
+    "exclusive_paths": {
+      "output": "output/ck07r1/lifecycle-requalification-v2.json",
+      "ledger": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+      "stdout": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+      "stderr": "output/ck07r1/lifecycle-requalification-v2.stderr.txt"
+    },
+    "synthetic_fixture_only": true,
+    "live_or_real_data": false
+  },
+  "run_token": {
+    "id": "ck07r1-all-profile-e2e-1",
+    "maximum_new_end_to_end_runs": 1,
+    "status": "unspent_unavailable",
+    "token_consumed": false,
+    "refund": false,
+    "retry": "none",
+    "restart": "none",
+    "replacement": "none",
+    "successful_launches_observed": 0,
+    "new_recovery_invocations_permitted": 1,
+    "consumption": "first_successfully_observed_exact_child_launch_and_handshake"
+  },
+  "immediate_gates": {
+    "authority_integrity": "exact",
+    "candidate_cohort": "exact_complete",
+    "candidate_delta": "exact_four_paths_including_preserved_v1_ledger",
+    "main": "head_equals_fetched_origin_main_equals_live_origin_main",
+    "cwd_argv_environment": "exact",
+    "interpreter": "lexical_worktree_venv_and_matching_sys_prefix",
+    "capacity_bytes_minimum": 10737418240,
+    "matching_processes": [],
+    "v2_paths": "all_absent",
+    "token": "unspent_unavailable_and_not_consumed",
+    "fixture": "synthetic_only",
+    "command_boundary": "real_non_consuming_preflight_required"
+  },
+  "failure_policy": {
+    "before_successful_child_handshake": "fail_closed_without_token_consumption_or_child_release",
+    "after_successful_child_handshake": "token_consumed_non_refundable_and_terminal_failed_after_launch_on_any_failure",
+    "retry": "none",
+    "restart": "none",
+    "replacement": "none",
+    "receipt_fabrication": "forbidden",
+    "v1_ledger_rewrite": "forbidden"
+  },
+  "scope": {
+    "authority_write_scope": [
+      "docs/INDEX.md",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+      "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+      "docs/roadmap/TASK_PACKETS.md",
+      "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+      "scripts/check_kernel_scope.py",
+      "scripts/ck07r1_prelaunch_recovery.py",
+      "scripts/qualify_ck08r1_answer_truth.py",
+      "tests/agent_kernel/test_ck08r1_answer_requalification.py",
+      "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
+      "tests/kernel/test_ck07r1_shared_successor_overlay.py",
+      "tests/kernel/test_documentation_authority.py",
+      "tests/kernel/test_kernel_scope.py",
+      "tests/kernel/test_lifecycle_run_invocation_authority.py"
+    ],
+    "combined_preflight_candidate_scope": [
+      "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "tests/agent_kernel/publication/test_lifecycle_scale.py"
+    ],
+    "forbidden": [
+      "candidate_implementation_files_in_authority_pr",
+      "generated_v2_runtime_artifacts",
+      "launch_or_child_in_authority_task",
+      "token_consumption_in_authority_task",
+      "v1_ledger_mutation",
+      "pr394_mutation",
+      "downstream_dispatch",
+      "live_or_real_data",
+      "cleanup"
+    ]
+  }
+}

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json
@@ -235,6 +235,8 @@
       "tests/agent_kernel/test_ck08r1_answer_requalification.py",
       "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
       "tests/kernel/test_ck07r1_shared_successor_overlay.py",
+      "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
+      "tests/kernel/test_ckqg1_maintainability_baseline_authority.py",
       "tests/kernel/test_documentation_authority.py",
       "tests/kernel/test_kernel_scope.py",
       "tests/kernel/test_lifecycle_run_invocation_authority.py"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
@@ -13,12 +13,12 @@
       {
         "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
         "role": "corrected_launcher",
-        "sha256": "e8de2aab10c065fc4e5b4667e3db7f4058f9261ca731af25aec06ffab7c20565"
+        "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e"
       },
       {
         "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
         "role": "corrected_launcher_tests",
-        "sha256": "d49e959bf65602472a5d60dc9b2239f840aab5c5050544fa1df545a2e5246d7e"
+        "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854"
       }
     ],
     "decision": {

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
@@ -225,6 +225,8 @@
         "tests/agent_kernel/test_ck08r1_answer_requalification.py",
         "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
         "tests/kernel/test_ck07r1_shared_successor_overlay.py",
+        "tests/kernel/test_ck08r1b_answer_semantics_join_authority.py",
+        "tests/kernel/test_ckqg1_maintainability_baseline_authority.py",
         "tests/kernel/test_documentation_authority.py",
         "tests/kernel/test_kernel_scope.py",
         "tests/kernel/test_lifecycle_run_invocation_authority.py"

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json
@@ -1,0 +1,266 @@
+{
+  "$id": "https://codex-usage-tracker.invalid/schemas/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "const": {
+    "authority_base_sha": "213b5d280dac58d11d71511c21aac58f61227fd3",
+    "authority_version": 1,
+    "candidate_cohort": [
+      {
+        "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+        "role": "preparation_source",
+        "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+      },
+      {
+        "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "role": "corrected_launcher",
+        "sha256": "e8de2aab10c065fc4e5b4667e3db7f4058f9261ca731af25aec06ffab7c20565"
+      },
+      {
+        "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+        "role": "corrected_launcher_tests",
+        "sha256": "d49e959bf65602472a5d60dc9b2239f840aab5c5050544fa1df545a2e5246d7e"
+      }
+    ],
+    "decision": {
+      "downstream": "CK-08R4_CK-08RG_CK-09_blocked",
+      "implementation_acceptance": "not_claimed",
+      "launch_authorized_in_authority_task": false,
+      "new_invocation_is_launched_process_retry": false,
+      "policy": "one corrected v2 command invocation may seek the first successfully observed child launch only after this authority is merged, exact-main verified, and every immediate gate passes",
+      "pr394": "stale_read_only",
+      "prior_invocation_is_terminal": true,
+      "refund_claimed": false,
+      "runtime_acceptance": "not_claimed"
+    },
+    "diagnostic_evidence": {
+      "cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+      "dummy_parent_pid": 79490,
+      "dummy_pid": 79500,
+      "finding": "macOS_process_argv0_representation_differs_from_lexical_venv_interpreter_for_fork_without_exec",
+      "lexical_interpreter": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9/.venv/bin/python",
+      "method": "non_consuming_dummy_blocked_fork_child",
+      "observed_process_executable": "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python",
+      "owner": "Monsky",
+      "qualification_command_invoked": false,
+      "resolved_interpreter": "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/bin/python3.14"
+    },
+    "failure_policy": {
+      "after_successful_child_handshake": "token_consumed_non_refundable_and_terminal_failed_after_launch_on_any_failure",
+      "before_successful_child_handshake": "fail_closed_without_token_consumption_or_child_release",
+      "receipt_fabrication": "forbidden",
+      "replacement": "none",
+      "restart": "none",
+      "retry": "none",
+      "v1_ledger_rewrite": "forbidden"
+    },
+    "handshake_contract": {
+      "ambiguous_or_extra_match": "fail_closed",
+      "argv_rule": "macos_python_app_bundle_or_lexical_venv_interpreter_representation_with_exact_script_and_flags_tail",
+      "child_process_creation": "fork_without_exec_before_release",
+      "child_signature_rule": "exact_equality_to_the_verified_parent_platform_process_command_signature",
+      "lexical_interpreter_and_sys_prefix_gate": "unchanged_required",
+      "pre_fork_parent_snapshot_required": true,
+      "release_before_complete_proof": "forbidden",
+      "required_child_fields": [
+        "pid",
+        "parent_pid",
+        "owner",
+        "cwd",
+        "platform_process_command_signature"
+      ]
+    },
+    "immediate_gates": {
+      "authority_integrity": "exact",
+      "candidate_cohort": "exact_complete",
+      "candidate_delta": "exact_four_paths_including_preserved_v1_ledger",
+      "capacity_bytes_minimum": 10737418240,
+      "command_boundary": "real_non_consuming_preflight_required",
+      "cwd_argv_environment": "exact",
+      "fixture": "synthetic_only",
+      "interpreter": "lexical_worktree_venv_and_matching_sys_prefix",
+      "main": "head_equals_fetched_origin_main_equals_live_origin_main",
+      "matching_processes": [],
+      "token": "unspent_unavailable_and_not_consumed",
+      "v2_paths": "all_absent"
+    },
+    "immutable_authorities": [
+      {
+        "path": "AGENTS.md",
+        "sha256": "b835817af3a0e12dbce7560a2d639e1e6d207dc75b0a85892804623280700e8b"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json",
+        "sha256": "bb8541e4071453b2b5e97821060c2d87c17acbe8b5e800732db0d92836dd9809"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.schema.json",
+        "sha256": "e7231eefdb6268877303fd1bbfeb202f8baf8f68b6c648d60e5e2b185348cf21"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+        "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+        "sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.json",
+        "sha256": "7cc998fb29cad3a7b87e95026df5fb2195684c064628885cab7cc0a781d0bb74"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/lifecycle-source-digest-authority.schema.json",
+        "sha256": "6bf00ce49082be581783c33ce7247a29eb9b63515d6a5af209dccd82d28d685b"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json",
+        "sha256": "73071209d42dbf65130fd307a69a0a3e76eceb65161e90baaf271321a6a81b8d"
+      },
+      {
+        "path": "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.schema.json",
+        "sha256": "943117da4e3d82624ad2cd4656092d2a7aa86266d5d30f7bca2b07f15c9ed86b"
+      },
+      {
+        "path": "scripts/ck07r1_shared_successor_overlay.py",
+        "sha256": "f3745ec07bf47ee15f50969132f315aec61d407c745f6c63694e9910a88c5768"
+      }
+    ],
+    "launch_contract": {
+      "argv": [
+        ".venv/bin/python",
+        "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "--profile",
+        "all",
+        "--samples",
+        "5",
+        "--output",
+        "output/ck07r1/lifecycle-requalification-v2.json"
+      ],
+      "cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+      "environment": {
+        "forbidden": [
+          "PYTHONPATH",
+          "CODEX_HOME"
+        ],
+        "required": {
+          "LC_ALL": "C.UTF-8",
+          "PYTHONHASHSEED": "0",
+          "PYTHONUNBUFFERED": "1",
+          "TZ": "UTC"
+        }
+      },
+      "exclusive_paths": {
+        "ledger": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+        "output": "output/ck07r1/lifecycle-requalification-v2.json",
+        "stderr": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+        "stdout": "output/ck07r1/lifecycle-requalification-v2.stdout.txt"
+      },
+      "live_or_real_data": false,
+      "synthetic_fixture_only": true
+    },
+    "preserved_failure_lineage": {
+      "child_released": false,
+      "elapsed_seconds": 6.518352,
+      "exclusive_paths": {
+        "ledger": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+        "output": "output/ck07r1/lifecycle-requalification-v1.json",
+        "stderr": "output/ck07r1/lifecycle-requalification-v1.stderr.txt",
+        "stdout": "output/ck07r1/lifecycle-requalification-v1.stdout.txt"
+      },
+      "exit_code": 1,
+      "failure_message": "child-start handshake did not prove exact PID/argv/cwd/owner",
+      "failure_stage": "child_start_handshake",
+      "ledger_path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "ledger_schema": "codex-usage-tracker.lifecycle-run-ledger.v1",
+      "ledger_sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be",
+      "state": "prelaunch_failed",
+      "successful_launches_observed": 0,
+      "terminal_immutable": true,
+      "verified_child": false
+    },
+    "preserved_v1_ledger": {
+      "matching_processes": [],
+      "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be",
+      "state": "prelaunch_failed",
+      "token_consumed": false,
+      "token_status": "unspent_unavailable"
+    },
+    "recovery_transition": {
+      "first_successful_child_launch_remaining": true,
+      "from": "terminal_prelaunch_failed_v1",
+      "launched_process_retry": false,
+      "live_corrected_cohort_authority": "this_versioned_recovery_authority_only",
+      "old_shared_overlay": "immutable_historical_predecessor_evidence",
+      "refund": false,
+      "replacement": false,
+      "restart": false,
+      "to": "ready_one_shot_v2_after_merge_exact_main_and_immediate_gates"
+    },
+    "run_token": {
+      "consumption": "first_successfully_observed_exact_child_launch_and_handshake",
+      "id": "ck07r1-all-profile-e2e-1",
+      "maximum_new_end_to_end_runs": 1,
+      "new_recovery_invocations_permitted": 1,
+      "refund": false,
+      "replacement": "none",
+      "restart": "none",
+      "retry": "none",
+      "status": "unspent_unavailable",
+      "successful_launches_observed": 0,
+      "token_consumed": false
+    },
+    "schema": "codex-usage-tracker.ck07r1-lifecycle-prelaunch-recovery.v1",
+    "scope": {
+      "authority_write_scope": [
+        "docs/INDEX.md",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+        "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+        "docs/roadmap/TASK_PACKETS.md",
+        "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+        "scripts/check_kernel_scope.py",
+        "scripts/ck07r1_prelaunch_recovery.py",
+        "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/agent_kernel/test_ck08r1_answer_requalification.py",
+        "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
+        "tests/kernel/test_ck07r1_shared_successor_overlay.py",
+        "tests/kernel/test_documentation_authority.py",
+        "tests/kernel/test_kernel_scope.py",
+        "tests/kernel/test_lifecycle_run_invocation_authority.py"
+      ],
+      "combined_preflight_candidate_scope": [
+        "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+        "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+        "tests/agent_kernel/publication/test_lifecycle_scale.py"
+      ],
+      "forbidden": [
+        "candidate_implementation_files_in_authority_pr",
+        "generated_v2_runtime_artifacts",
+        "launch_or_child_in_authority_task",
+        "token_consumption_in_authority_task",
+        "v1_ledger_mutation",
+        "pr394_mutation",
+        "downstream_dispatch",
+        "live_or_real_data",
+        "cleanup"
+      ]
+    },
+    "status": "permitted_not_accepted",
+    "v2_paths": {
+      "ledger": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+      "output": "output/ck07r1/lifecycle-requalification-v2.json",
+      "stderr": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+      "stdout": "output/ck07r1/lifecycle-requalification-v2.stdout.txt"
+    },
+    "worker": {
+      "frozen_cwd": "/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9",
+      "ownership": "coordinator_orchestration_binding_to_exact_existing_thread",
+      "replacement_worker": "forbidden",
+      "thread_id": "019fbfe2-8fe4-7de2-9264-d58572366727"
+    }
+  },
+  "description": "Exact versioned recovery decision preserving the terminal v1 prelaunch failure and admitting only one corrected v2 invocation for the first successful child launch.",
+  "title": "CK-07R1 lifecycle prelaunch recovery authority v1"
+}

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -160,6 +160,32 @@ authority supersedes earlier CK-07R1 wording that says to resume, refresh, or
 rerun PR #394; those retained references are historical provenance and do not
 authorize action.
 
+The exact-main v1 consuming invocation is now a second preserved prelaunch
+incident: after all immediate gates passed, macOS represented the forked
+Python process with the app-bundle executable rather than the lexical venv
+symlink target, so the exact child snapshot was not recognized. The command
+terminated after `6.518352` seconds at `child_start_handshake`, exit 1, with
+the sole durable v1 ledger SHA-256
+`5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be`.
+That ledger is terminal `prelaunch_failed`, `token_consumed=false`, and
+`unspent_unavailable`; no verified child, release, runtime output, stdout,
+stderr, or receipt exists. It is immutable and its command/path set cannot be
+reused. The additive
+[prelaunch-recovery authority](../decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json)
+may admit one corrected v2 invocation by the same worker only after it binds
+the exact corrected cohort, parent/child process-snapshot semantics, preserved
+ledger bytes, non-colliding v2 paths, authority merge, exact-main, and every
+immediate gate. Because no successful child launch occurred, this is the first
+remaining token-funded successful-launch opportunity, not a retry, restart,
+replacement, or refund of a launched process.
+The non-colliding files are the exact
+`output/ck07r1/lifecycle-requalification-v2` output, launch-token ledger,
+stdout, and stderr paths.
+Current CK-08R1 requalification consumers preserve every accepted CK-08
+authority and evidence byte while selecting this recovery bridge only when
+its exact versioned authority exists; predecessor-only and exact complete
+successor states remain explicit, and mixed or partial states fail closed.
+
 The exact V11 launcher contract constructs and validates the fully
 overlay/cohort-bound receipt and non-null stdout/stderr/output evidence before
 any first durable `completed` finalization. Evidence
@@ -276,7 +302,7 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
   "conditional_ready": [{
-    "condition": "v1 consuming-boundary authority merges and exact-main verifies; coordinator resumes exact existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with the atomic 66c015de/f108dbb4/4c514889 cohort; exactly one synthetic qualification launch may proceed under immediate preflight; no replacement or downstream task",
+    "condition": "prelaunch-recovery authority preserves the exact terminal v1 ledger, binds the corrected cohort and non-colliding v2 paths, merges and exact-main verifies; coordinator resumes exact existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; one corrected synthetic invocation may seek the first successful child launch under immediate preflight; no retry of a launched process, replacement, or downstream task",
     "tasks": ["CK-07R1"]
   }],
   "blocked": [],

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,7 +15,7 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 for exactly one synthetic qualification command only after the v1 consuming-boundary authority is squash-merged and exact-main verified**
+- Conditional-ready child tasks: **1 — CK-07R1 for one corrected synthetic v2 qualification command only after the prelaunch-recovery authority is squash-merged and exact-main verified**
 - Blocked child tasks: **36**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready for the bound existing worker's exactly one synthetic qualification command only after the versioned [consuming-boundary authority](../decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json) merges and exact-main verifies; PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready for the bound existing worker's one corrected v2 synthetic qualification command only after the versioned [prelaunch-recovery authority](../decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json) preserves the terminal v1 ledger, merges, and exact-main verifies; the token remains unspent and PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,8 +1,8 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** `blocked_hold` until the v1 consuming-boundary authority
-squash-merges and exact-main verifies; then `ready_one_shot` for the bound
-existing worker only, while implementation/runtime remain unaccepted
+**Status:** `blocked_hold` after the terminal v1 `prelaunch_failed` invocation;
+only the versioned prelaunch-recovery authority may restore `ready_one_shot`
+for the bound existing worker, while implementation/runtime remain unaccepted
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -15,7 +15,11 @@ preserves the one-shot launch contract. The versioned
 [consuming-boundary authority](../../decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json)
 alone permits the bound existing worker to cross from exact
 `worker_prequalification` to `launch_authorized_once` after authority merge and
-exact-main verification.
+exact-main verification. The first invocation then stopped before successful
+child observation. The additive
+[prelaunch-recovery authority](../../decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json)
+alone can authorize one corrected v2 invocation after preserving that terminal
+ledger and proving the token remains unspent.
 
 **Central plan:** [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md)
 
@@ -61,6 +65,18 @@ database postconditions.
 
 **Consumer seam:** Preparation to `PublicationWriter` to read-only publication.
 
+**Preserved prelaunch failure:** The exact v1 ledger at
+`output/ck07r1/lifecycle-requalification-v1.launch-token.json` has SHA-256
+`5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be`,
+state `prelaunch_failed`, stage `child_start_handshake`, and
+`token_consumed=false`. No child was successfully observed or released and no
+runtime output, stdout, stderr, or receipt exists. The v1 invocation and path
+set are terminal and immutable. A corrected invocation is not a launched
+process retry, restart, replacement, or refund; it is the one remaining
+opportunity to observe the token-funded first successful child. It must use
+the exact `lifecycle-requalification-v2` output, ledger, stdout, and stderr
+paths and the exact corrected cohort bound by the recovery authority.
+
 **Parallelism:** Resume only existing worker
 `019fbfe2-8fe4-7de2-9264-d58572366727` after the consuming-boundary authority
 merges and exact-main verifies, using frozen cwd
@@ -93,9 +109,10 @@ the finite state transitions and real non-launching subprocess argv guard; no
 E2E or benchmark run in the authority reconciliation.
 
 **Acceptance:** Immediately before the one command, the worker must revalidate
-the exact authority bytes and three-path Git delta, lexical worktree
+the exact recovery authority bytes, the corrected three-path source cohort,
+the preserved v1 ledger as the sole fourth dirty path, lexical worktree
 `.venv/bin/python` plus matching `sys.prefix`, exact cwd/argv/environment,
-capacity at or above 10 GiB, `matching_processes=[]`, all four frozen artifact
+capacity at or above 10 GiB, `matching_processes=[]`, all four new v2 artifact
 paths absent, the unconsumed token, and synthetic fixture identity. Any miss
 fails closed without launch or artifact creation. If every gate passes, exactly
 one successfully observed child PID/argv/cwd/owner/handshake consumes the
@@ -145,7 +162,8 @@ complete Console job at 20 minutes. A mirror stall therefore fails closed
 instead of hanging or bypassing Console evidence.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
-new dominant blocker; never weaken the gate.
+new dominant blocker; never weaken the gate. The preserved v1 ledger is never
+deleted, moved, rewritten, or reclassified.
 
 **Handoff:** Evidence digest, profiles, retained first hosted failure, PR #394
 CI, exact-main result, and CK-08R4 input.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -863,6 +863,17 @@ CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS = frozenset(
     }
 )
 
+CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+        "scripts/ck07r1_prelaunch_recovery.py",
+        "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/agent_kernel/test_ck08r1_answer_requalification.py",
+        "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -940,6 +951,7 @@ INTEGRATION_ADDITIONS = (
     | CK07R1_LIFECYCLE_SCOPE_ADDITIONS
     | CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS
     | CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS
+    | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | {
         "config/agent-kernel/maintainability-baseline-v1.json",
@@ -979,9 +991,7 @@ def active_paths(repo_root: Path) -> set[str]:
     }
 
 
-def authority_changed_path_failures(
-    changed_paths: set[str], allowed_paths: set[str]
-) -> list[str]:
+def authority_changed_path_failures(changed_paths: set[str], allowed_paths: set[str]) -> list[str]:
     """Reject any changed path outside a machine-bound authority scope."""
 
     return [

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -869,6 +869,7 @@ CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS = frozenset(
         "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
         "scripts/ck07r1_prelaunch_recovery.py",
         "scripts/qualify_ck08r1_answer_truth.py",
+        "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
         "tests/agent_kernel/test_ck08r1_answer_requalification.py",
         "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
     }

--- a/scripts/ck07r1_prelaunch_recovery.py
+++ b/scripts/ck07r1_prelaunch_recovery.py
@@ -275,6 +275,28 @@ def verify_new_paths_absent(authority: Mapping[str, Any], candidate_root: Path) 
         raise PrelaunchRecoveryError(f"recovery launch path already exists: {sorted(present)}")
 
 
+def verify_combined_preflight(
+    authority_root: Path,
+    candidate_root: Path,
+) -> dict[str, Any]:
+    authority = load_authority(authority_root)
+    same_root = authority_root.absolute() == candidate_root.absolute()
+    candidate_delta = set(
+        authority["scope"]["combined_preflight_candidate_scope"]
+    )
+    verify_bound_authority_bytes(authority, authority_root)
+    verify_exact_authority_delta(
+        authority,
+        authority_root,
+        allowed_worktree_delta=candidate_delta if same_root else None,
+    )
+    verify_candidate_cohort(authority, candidate_root)
+    verify_exact_candidate_delta(authority, candidate_root)
+    verify_preserved_failure_ledger(authority, candidate_root)
+    verify_new_paths_absent(authority, candidate_root)
+    return authority
+
+
 def verify_current_exact_main(root: Path) -> str:
     head = _git(root, "rev-parse", "HEAD")
     tracking = _git(root, "rev-parse", "refs/remotes/origin/main")
@@ -313,6 +335,13 @@ def verify_pre_side_effect_recovery(root: Path) -> dict[str, Any]:
     verify_frozen_candidate_root(authority, root)
     verify_bound_authority_bytes(authority, root)
     verify_current_exact_main(root)
+    verify_exact_authority_delta(
+        authority,
+        root,
+        allowed_worktree_delta=set(
+            authority["scope"]["combined_preflight_candidate_scope"]
+        ),
+    )
     available = verify_minimum_capacity(root)
     verify_candidate_cohort(authority, root)
     verify_exact_candidate_delta(authority, root)

--- a/scripts/ck07r1_prelaunch_recovery.py
+++ b/scripts/ck07r1_prelaunch_recovery.py
@@ -146,26 +146,33 @@ def verify_exact_authority_delta(
     authority_root: Path,
     *,
     observed: set[str] | None = None,
+    allowed_worktree_delta: set[str] | None = None,
 ) -> None:
     expected = set(authority["scope"]["authority_write_scope"])
     if observed is None:
         base = str(authority["authority_base_sha"])
-        tracked = {
-            line
-            for line in _git(authority_root, "diff", "--name-only", base, "--").splitlines()
-            if line
-        }
-        untracked = {
-            line
-            for line in _git(
-                authority_root,
-                "ls-files",
-                "--others",
-                "--exclude-standard",
-            ).splitlines()
-            if line
-        }
-        actual = tracked | untracked
+        head = _git(authority_root, "rev-parse", "HEAD")
+        worktree = _status_paths(authority_root)
+        if head == base:
+            actual = worktree
+        else:
+            actual = {
+                line
+                for line in _git(
+                    authority_root,
+                    "diff",
+                    "--name-only",
+                    f"{base}..{head}",
+                    "--",
+                ).splitlines()
+                if line
+            }
+            permitted = allowed_worktree_delta or set()
+            if worktree != permitted:
+                raise PrelaunchRecoveryError(
+                    "authority worktree delta must be exact: "
+                    f"expected={sorted(permitted)} actual={sorted(worktree)}"
+                )
     else:
         actual = observed
     if actual != expected:
@@ -415,8 +422,22 @@ def _main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     authority_root = args.authority_root.absolute()
     authority = load_authority(authority_root)
+    candidate_root = (
+        args.candidate_root.absolute()
+        if args.candidate_root is not None
+        else None
+    )
+    allowed_worktree_delta = None
+    if args.command == "combined" and candidate_root == authority_root:
+        allowed_worktree_delta = set(
+            authority["scope"]["combined_preflight_candidate_scope"]
+        )
     verify_bound_authority_bytes(authority, authority_root)
-    verify_exact_authority_delta(authority, authority_root)
+    verify_exact_authority_delta(
+        authority,
+        authority_root,
+        allowed_worktree_delta=allowed_worktree_delta,
+    )
     result: dict[str, Any] = {
         "authority_schema": authority["schema"],
         "authority_status": authority["status"],
@@ -425,9 +446,8 @@ def _main(argv: Sequence[str] | None = None) -> int:
         "verification": "passed",
     }
     if args.command == "combined":
-        if args.candidate_root is None:
+        if candidate_root is None:
             parser.error("--candidate-root is required for combined")
-        candidate_root = args.candidate_root.absolute()
         verify_candidate_cohort(authority, candidate_root)
         verify_exact_candidate_delta(authority, candidate_root)
         verify_preserved_failure_ledger(authority, candidate_root)

--- a/scripts/ck07r1_prelaunch_recovery.py
+++ b/scripts/ck07r1_prelaunch_recovery.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Fail-closed CK-07R1 prelaunch-failure recovery verifier.
+
+This module never launches the qualification child.  It binds the preserved
+terminal v1 ledger, the exact corrected candidate cohort, the non-colliding v2
+paths, and the still-unspent one-run token before a corrected launcher may
+create any new durable state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+AUTHORITY_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json"
+)
+SCHEMA_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json"
+)
+MINIMUM_CAPACITY_BYTES = 10 * 1024**3
+
+
+class PrelaunchRecoveryError(RuntimeError):
+    """The exact recovery contract is not satisfied."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PrelaunchRecoveryError(f"cannot load exact JSON at {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PrelaunchRecoveryError(f"exact JSON is not an object: {path}")
+    return value
+
+
+def load_authority(root: Path) -> dict[str, Any]:
+    authority_path = root / AUTHORITY_PATH
+    schema_path = root / SCHEMA_PATH
+    authority = _load_json(authority_path)
+    schema = _load_json(schema_path)
+    try:
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(authority)
+    except Exception as exc:
+        raise PrelaunchRecoveryError(
+            f"prelaunch recovery authority/schema validation failed: {exc}"
+        ) from exc
+    return authority
+
+
+def verify_bound_authority_bytes(authority: Mapping[str, Any], root: Path) -> None:
+    records = authority.get("immutable_authorities")
+    if not isinstance(records, list) or not records:
+        raise PrelaunchRecoveryError("immutable authority set is missing")
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise PrelaunchRecoveryError("immutable authority record is malformed")
+        relative = record.get("path")
+        expected = record.get("sha256")
+        if not isinstance(relative, str) or not isinstance(expected, str):
+            raise PrelaunchRecoveryError("immutable authority identity is malformed")
+        path = root / relative
+        if not path.is_file() or _sha256(path) != expected:
+            raise PrelaunchRecoveryError(f"immutable authority byte identity mismatch: {relative}")
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PrelaunchRecoveryError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _status_paths(root: Path) -> set[str]:
+    result = subprocess.run(
+        ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise PrelaunchRecoveryError("cannot inspect candidate Git delta")
+    paths: set[str] = set()
+    entries = result.stdout.split(b"\0")
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        decoded = entry.decode("utf-8", errors="strict")
+        if len(decoded) < 4:
+            raise PrelaunchRecoveryError("candidate Git status entry is malformed")
+        status = decoded[:2]
+        path = decoded[3:]
+        if "R" in status or "C" in status:
+            if index >= len(entries) or not entries[index]:
+                raise PrelaunchRecoveryError("candidate rename status is malformed")
+            path = entries[index].decode("utf-8", errors="strict")
+            index += 1
+        paths.add(path)
+    return paths
+
+
+def verify_exact_candidate_delta(
+    authority: Mapping[str, Any],
+    candidate_root: Path,
+    *,
+    observed: set[str] | None = None,
+) -> None:
+    expected = set(authority["scope"]["combined_preflight_candidate_scope"])
+    actual = _status_paths(candidate_root) if observed is None else observed
+    if actual != expected:
+        raise PrelaunchRecoveryError(
+            "candidate Git delta must be exact and all-or-none: "
+            f"expected={sorted(expected)} actual={sorted(actual)}"
+        )
+
+
+def verify_exact_authority_delta(
+    authority: Mapping[str, Any],
+    authority_root: Path,
+    *,
+    observed: set[str] | None = None,
+) -> None:
+    expected = set(authority["scope"]["authority_write_scope"])
+    if observed is None:
+        base = str(authority["authority_base_sha"])
+        tracked = {
+            line
+            for line in _git(authority_root, "diff", "--name-only", base, "--").splitlines()
+            if line
+        }
+        untracked = {
+            line
+            for line in _git(
+                authority_root,
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+            ).splitlines()
+            if line
+        }
+        actual = tracked | untracked
+    else:
+        actual = observed
+    if actual != expected:
+        raise PrelaunchRecoveryError(
+            "authority Git delta must be exact: "
+            f"expected={sorted(expected)} actual={sorted(actual)}"
+        )
+
+
+def verify_candidate_cohort(authority: Mapping[str, Any], candidate_root: Path) -> None:
+    records = authority.get("candidate_cohort")
+    if not isinstance(records, list) or len(records) != 3:
+        raise PrelaunchRecoveryError("corrected candidate cohort is malformed")
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise PrelaunchRecoveryError("corrected candidate record is malformed")
+        relative = record.get("path")
+        expected = record.get("sha256")
+        if not isinstance(relative, str) or not isinstance(expected, str):
+            raise PrelaunchRecoveryError("corrected candidate identity is malformed")
+        path = candidate_root / relative
+        if not path.is_file() or _sha256(path) != expected:
+            raise PrelaunchRecoveryError(f"corrected candidate identity mismatch: {relative}")
+
+
+def verify_preserved_failure_ledger(
+    authority: Mapping[str, Any], candidate_root: Path
+) -> dict[str, Any]:
+    lineage = authority["preserved_failure_lineage"]
+    preserved = authority["preserved_v1_ledger"]
+    relative = str(preserved["path"])
+    ledger_path = candidate_root / relative
+    if not ledger_path.is_file():
+        raise PrelaunchRecoveryError("preserved terminal v1 ledger is missing")
+    if _sha256(ledger_path) != preserved["sha256"]:
+        raise PrelaunchRecoveryError("preserved terminal v1 ledger bytes changed")
+    ledger = _load_json(ledger_path)
+    expected = {
+        "schema": lineage["ledger_schema"],
+        "state": "prelaunch_failed",
+        "run_token_id": authority["run_token"]["id"],
+        "maximum_new_end_to_end_runs": 1,
+        "token_status": "unspent_unavailable",
+        "token_consumed": False,
+        "retry_allowed": False,
+        "restart_allowed": False,
+        "replacement_allowed": False,
+        "first_result_retained": True,
+    }
+    for field, value in expected.items():
+        if ledger.get(field) != value:
+            raise PrelaunchRecoveryError(f"preserved terminal v1 ledger field changed: {field}")
+    failure = ledger.get("failure")
+    if not isinstance(failure, Mapping) or {
+        "stage": failure.get("stage"),
+        "exception_type": failure.get("exception_type"),
+        "message": failure.get("message"),
+    } != {
+        "stage": "child_start_handshake",
+        "exception_type": "RuntimeError",
+        "message": "child-start handshake did not prove exact PID/argv/cwd/owner",
+    }:
+        raise PrelaunchRecoveryError("preserved terminal v1 failure identity changed")
+    forbidden = {
+        "process",
+        "receipt",
+        "evidence",
+        "completed_at_utc",
+        "token_consumed_at_utc",
+    }
+    if forbidden.intersection(ledger):
+        raise PrelaunchRecoveryError(
+            "preserved terminal v1 ledger fabricates launched/runtime evidence"
+        )
+    launch = ledger.get("launch")
+    if not isinstance(launch, Mapping) or launch.get("matching_processes") != []:
+        raise PrelaunchRecoveryError("preserved terminal v1 process evidence changed")
+    if {
+        "path": relative,
+        "sha256": _sha256(ledger_path),
+        "state": ledger["state"],
+        "token_consumed": ledger["token_consumed"],
+        "token_status": ledger["token_status"],
+        "matching_processes": launch["matching_processes"],
+    } != preserved:
+        raise PrelaunchRecoveryError("preserved terminal v1 authority binding drifted")
+    old_paths = authority["preserved_failure_lineage"]["exclusive_paths"]
+    for name in ("output", "stdout", "stderr"):
+        if (candidate_root / old_paths[name]).exists():
+            raise PrelaunchRecoveryError(
+                f"unexpected v1 runtime artifact exists: {old_paths[name]}"
+            )
+    return ledger
+
+
+def verify_new_paths_absent(authority: Mapping[str, Any], candidate_root: Path) -> None:
+    paths = authority["launch_contract"]["exclusive_paths"]
+    present = [relative for relative in paths.values() if (candidate_root / str(relative)).exists()]
+    if present:
+        raise PrelaunchRecoveryError(f"recovery launch path already exists: {sorted(present)}")
+
+
+def verify_current_exact_main(root: Path) -> str:
+    head = _git(root, "rev-parse", "HEAD")
+    tracking = _git(root, "rev-parse", "refs/remotes/origin/main")
+    remote_line = _git(root, "ls-remote", "origin", "refs/heads/main")
+    remote = remote_line.split()[0] if remote_line else ""
+    if not head or head != tracking or head != remote:
+        raise PrelaunchRecoveryError(
+            "recovery activation requires HEAD == fetched origin/main == live origin/main"
+        )
+    return head
+
+
+def verify_minimum_capacity(root: Path, *, observed_bytes: int | None = None) -> int:
+    available = shutil.disk_usage(root).free if observed_bytes is None else observed_bytes
+    if available < MINIMUM_CAPACITY_BYTES:
+        raise PrelaunchRecoveryError("recovery activation requires at least 10 GiB free")
+    return available
+
+
+def verify_frozen_candidate_root(
+    authority: Mapping[str, Any], root: Path
+) -> None:
+    expected = Path(str(authority["launch_contract"]["cwd"])).absolute()
+    actual = root.absolute()
+    if actual != expected:
+        raise PrelaunchRecoveryError(
+            "recovery activation requires the exact frozen lexical cwd: "
+            f"expected={expected} actual={actual}"
+        )
+
+
+def verify_pre_side_effect_recovery(root: Path) -> dict[str, Any]:
+    """Verify every static recovery gate from the exact candidate root."""
+
+    authority = load_authority(root)
+    verify_frozen_candidate_root(authority, root)
+    verify_bound_authority_bytes(authority, root)
+    verify_current_exact_main(root)
+    available = verify_minimum_capacity(root)
+    verify_candidate_cohort(authority, root)
+    verify_exact_candidate_delta(authority, root)
+    verify_preserved_failure_ledger(authority, root)
+    verify_new_paths_absent(authority, root)
+    return {
+        "schema": authority["schema"],
+        "authority_version": authority["authority_version"],
+        "authority_base_sha": authority["authority_base_sha"],
+        "verification": "passed",
+        "preserved_v1_ledger": authority["preserved_v1_ledger"],
+        "candidate_cohort": authority["candidate_cohort"],
+        "v2_paths": authority["v2_paths"],
+        "run_token_id": authority["run_token"]["id"],
+        "token_status": authority["run_token"]["status"],
+        "token_consumed": authority["run_token"]["token_consumed"],
+        "disk_available_bytes": available,
+        "retry": authority["run_token"]["retry"],
+        "restart": authority["run_token"]["restart"],
+        "replacement": authority["run_token"]["replacement"],
+    }
+
+
+def verify_prelaunch_recovery(root: Path) -> tuple[dict[str, Any], str]:
+    """Return the exact launcher-facing recovery authority and verified state."""
+
+    verify_pre_side_effect_recovery(root)
+    return load_authority(root), "prelaunch_recovery_verified"
+
+
+def evaluate_recovery_prelaunch(
+    authority: Mapping[str, Any], observation: Mapping[str, Any]
+) -> dict[str, Any]:
+    contract = authority["launch_contract"]
+    worker = authority["worker"]
+    token = authority["run_token"]
+    required_environment = contract["environment"]["required"]
+    exact = {
+        "worker_thread_id": worker["thread_id"],
+        "cwd": contract["cwd"],
+        "argv": contract["argv"],
+        "environment": required_environment,
+        "interpreter": contract["cwd"] + "/.venv/bin/python",
+        "venv_prefix": contract["cwd"] + "/.venv",
+        "authority_integrity": "passed",
+        "candidate_cohort": "passed",
+        "candidate_delta": "passed",
+        "preserved_ledger": "passed",
+        "new_paths_present": [],
+        "matching_processes": [],
+        "token_status": "unspent_unavailable",
+        "token_consumed": False,
+        "prior_invocation_state": "prelaunch_failed",
+        "prior_successful_child": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+        "synthetic_fixture": True,
+        "live_or_real_data": False,
+    }
+    for field, expected in exact.items():
+        if observation.get(field) != expected:
+            raise PrelaunchRecoveryError(f"recovery prelaunch gate failed: {field}")
+    present = observation.get("environment_present")
+    if not isinstance(present, Mapping):
+        raise PrelaunchRecoveryError("recovery prelaunch gate failed: environment_present")
+    for name in contract["environment"]["forbidden"]:
+        if name in present:
+            raise PrelaunchRecoveryError(
+                f"recovery prelaunch gate failed: forbidden environment {name}"
+            )
+    capacity = observation.get("disk_available_bytes")
+    if not isinstance(capacity, int) or capacity < MINIMUM_CAPACITY_BYTES:
+        raise PrelaunchRecoveryError("recovery prelaunch gate failed: disk_available_bytes")
+    if token != {
+        "id": "ck07r1-all-profile-e2e-1",
+        "maximum_new_end_to_end_runs": 1,
+        "status": "unspent_unavailable",
+        "token_consumed": False,
+        "refund": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+        "successful_launches_observed": 0,
+        "new_recovery_invocations_permitted": 1,
+        "consumption": "first_successfully_observed_exact_child_launch_and_handshake",
+    }:
+        raise PrelaunchRecoveryError("recovery run-token contract drifted")
+    return {
+        "decision": "recovery_launch_authorized_once",
+        "run_token_id": token["id"],
+        "new_command_invocations_permitted": 1,
+        "consume_only_after_successful_child_handshake": True,
+        "prior_prelaunch_failure_is_not_a_launched_process_retry": True,
+        "refund": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+    }
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("authority", "combined"))
+    parser.add_argument("--authority-root", type=Path, default=Path.cwd())
+    parser.add_argument("--candidate-root", type=Path)
+    args = parser.parse_args(argv)
+    authority_root = args.authority_root.absolute()
+    authority = load_authority(authority_root)
+    verify_bound_authority_bytes(authority, authority_root)
+    verify_exact_authority_delta(authority, authority_root)
+    result: dict[str, Any] = {
+        "authority_schema": authority["schema"],
+        "authority_status": authority["status"],
+        "authority_paths": len(authority["scope"]["authority_write_scope"]),
+        "token_consumed": authority["run_token"]["token_consumed"],
+        "verification": "passed",
+    }
+    if args.command == "combined":
+        if args.candidate_root is None:
+            parser.error("--candidate-root is required for combined")
+        candidate_root = args.candidate_root.absolute()
+        verify_candidate_cohort(authority, candidate_root)
+        verify_exact_candidate_delta(authority, candidate_root)
+        verify_preserved_failure_ledger(authority, candidate_root)
+        verify_new_paths_absent(authority, candidate_root)
+        result["candidate_paths"] = len(authority["scope"]["combined_preflight_candidate_scope"])
+        result["preserved_ledger_sha256"] = authority["preserved_v1_ledger"]["sha256"]
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/qualify_ck08r1_answer_truth.py
+++ b/scripts/qualify_ck08r1_answer_truth.py
@@ -41,6 +41,21 @@ from codex_usage_tracker.agent_kernel.query.service import (  # noqa: E402
     QueryService,
     QueryServiceError,
 )
+from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
+    AUTHORITY_PATH as CK07R1_RECOVERY_AUTHORITY_PATH,
+)
+from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
+    load_authority as load_ck07r1_recovery_authority,
+)
+from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
+    verify_bound_authority_bytes as verify_ck07r1_recovery_authority_bytes,
+)
+from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
+    verify_exact_authority_delta as verify_ck07r1_recovery_authority_delta,
+)
+from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
+    verify_prelaunch_recovery,
+)
 from scripts.ck07r1_shared_successor_overlay import (  # noqa: E402
     PREPARATION_PATH as CK07R1_PREPARATION_PATH,
 )
@@ -126,10 +141,40 @@ def _git_last_touch(relative: str) -> str:
     return result
 
 
+def _current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
+    """Select the immutable v1 overlay or its exact versioned recovery bridge."""
+
+    recovery_path = ROOT / CK07R1_RECOVERY_AUTHORITY_PATH
+    if not recovery_path.is_file():
+        return verify_shared_successor_overlay(ROOT)
+
+    recovery = load_ck07r1_recovery_authority(ROOT)
+    verify_ck07r1_recovery_authority_bytes(recovery, ROOT)
+    verify_ck07r1_recovery_authority_delta(recovery, ROOT)
+    overlay = _json(
+        ROOT / "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json"
+    )
+    predecessor = overlay["states"]["predecessor"]["artifacts"][0]["sha256"]
+    successor = next(
+        item["sha256"]
+        for item in recovery["candidate_cohort"]
+        if item["path"] == CK07R1_PREPARATION_PATH
+    )
+    observed = sha256_file(ROOT / CK07R1_PREPARATION_PATH)
+    if observed == predecessor:
+        return overlay, "authority_main"
+    if observed == successor:
+        _, state = verify_prelaunch_recovery(ROOT)
+        if state != "prelaunch_recovery_verified":
+            raise QualificationError("CK-07R1 recovery state is not verified")
+        return overlay, "worker_prequalification"
+    raise QualificationError("CK-07R1 preparation state is outside the recovery authority")
+
+
 def recompute_authority_identities() -> dict[str, Any]:
     """Recompute all R1A/B/C identities from committed authority paths."""
 
-    overlay, overlay_state = verify_shared_successor_overlay(ROOT)
+    overlay, overlay_state = _current_ck07r1_overlay()
     overlay_predecessor = overlay["states"]["predecessor"]["artifacts"][0]["sha256"]
     overlay_successor = overlay["states"]["successor"]["artifacts"][0]["sha256"]
     authority = _json(JOIN_AUTHORITY)

--- a/scripts/qualify_ck08r1_answer_truth.py
+++ b/scripts/qualify_ck08r1_answer_truth.py
@@ -51,10 +51,10 @@ from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
     verify_bound_authority_bytes as verify_ck07r1_recovery_authority_bytes,
 )
 from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
-    verify_exact_authority_delta as verify_ck07r1_recovery_authority_delta,
+    verify_combined_preflight as verify_ck07r1_recovery_combined_preflight,
 )
 from scripts.ck07r1_prelaunch_recovery import (  # noqa: E402
-    verify_prelaunch_recovery,
+    verify_exact_authority_delta as verify_ck07r1_recovery_authority_delta,
 )
 from scripts.ck07r1_shared_successor_overlay import (  # noqa: E402
     PREPARATION_PATH as CK07R1_PREPARATION_PATH,
@@ -150,7 +150,6 @@ def _current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
 
     recovery = load_ck07r1_recovery_authority(ROOT)
     verify_ck07r1_recovery_authority_bytes(recovery, ROOT)
-    verify_ck07r1_recovery_authority_delta(recovery, ROOT)
     overlay = _json(
         ROOT / "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json"
     )
@@ -162,11 +161,10 @@ def _current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
     )
     observed = sha256_file(ROOT / CK07R1_PREPARATION_PATH)
     if observed == predecessor:
+        verify_ck07r1_recovery_authority_delta(recovery, ROOT)
         return overlay, "authority_main"
     if observed == successor:
-        _, state = verify_prelaunch_recovery(ROOT)
-        if state != "prelaunch_recovery_verified":
-            raise QualificationError("CK-07R1 recovery state is not verified")
+        verify_ck07r1_recovery_combined_preflight(ROOT, ROOT)
         return overlay, "worker_prequalification"
     raise QualificationError("CK-07R1 preparation state is outside the recovery authority")
 

--- a/scripts/qualify_ck08r1_answer_truth.py
+++ b/scripts/qualify_ck08r1_answer_truth.py
@@ -141,7 +141,7 @@ def _git_last_touch(relative: str) -> str:
     return result
 
 
-def _current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
+def current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
     """Select the immutable v1 overlay or its exact versioned recovery bridge."""
 
     recovery_path = ROOT / CK07R1_RECOVERY_AUTHORITY_PATH
@@ -172,7 +172,7 @@ def _current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
 def recompute_authority_identities() -> dict[str, Any]:
     """Recompute all R1A/B/C identities from committed authority paths."""
 
-    overlay, overlay_state = _current_ck07r1_overlay()
+    overlay, overlay_state = current_ck07r1_overlay()
     overlay_predecessor = overlay["states"]["predecessor"]["artifacts"][0]["sha256"]
     overlay_successor = overlay["states"]["successor"]["artifacts"][0]["sha256"]
     authority = _json(JOIN_AUTHORITY)

--- a/tests/agent_kernel/test_ck08r1_answer_requalification.py
+++ b/tests/agent_kernel/test_ck08r1_answer_requalification.py
@@ -78,6 +78,10 @@ def test_authority_identities_and_both_lane_closures_are_recomputed(
     assert identities["dependency_shas"] == collected["dependency_shas"]
     assert identities["authority_digests"] == collected["authority_digests"]
     assert identities["r1b_selected_paths"] == 23
+    assert identities["ck07r1_overlay_state"] in {
+        "authority_main",
+        "worker_prequalification",
+    }
 
     lanes = collected["lanes"]
     assert isinstance(lanes, list)

--- a/tests/kernel/test_ck07r1_prelaunch_recovery_authority.py
+++ b/tests/kernel/test_ck07r1_prelaunch_recovery_authority.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+import scripts.ck07r1_prelaunch_recovery as recovery
 from scripts.ck07r1_prelaunch_recovery import (
     AUTHORITY_PATH,
     MINIMUM_CAPACITY_BYTES,
@@ -186,6 +187,50 @@ def test_recovery_authority_delta_is_exact() -> None:
     ):
         with pytest.raises(PrelaunchRecoveryError, match="authority Git delta"):
             verify_exact_authority_delta(authority, ROOT, observed=changed)
+
+
+def test_committed_authority_allows_only_exact_combined_worktree_delta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = _authority()
+    expected_authority = set(authority["scope"]["authority_write_scope"])
+    expected_candidate = set(
+        authority["scope"]["combined_preflight_candidate_scope"]
+    )
+    head = "a" * 40
+    base = authority["authority_base_sha"]
+
+    def fake_git(root: Path, *args: str) -> str:
+        assert root == ROOT
+        if args == ("rev-parse", "HEAD"):
+            return head
+        if args == ("diff", "--name-only", f"{base}..{head}", "--"):
+            return "\n".join(sorted(expected_authority))
+        raise AssertionError(args)
+
+    monkeypatch.setattr(recovery, "_git", fake_git)
+    monkeypatch.setattr(
+        recovery,
+        "_status_paths",
+        lambda root: expected_candidate if root == ROOT else set(),
+    )
+    verify_exact_authority_delta(
+        authority,
+        ROOT,
+        allowed_worktree_delta=expected_candidate,
+    )
+
+    with pytest.raises(
+        PrelaunchRecoveryError,
+        match="authority worktree delta must be exact",
+    ):
+        verify_exact_authority_delta(
+            authority,
+            ROOT,
+            allowed_worktree_delta=expected_candidate - {
+                "scripts/benchmark_ck07r1_lifecycle_scale.py"
+            },
+        )
 
 
 def test_recovery_uses_new_noncolliding_paths_and_same_token() -> None:

--- a/tests/kernel/test_ck07r1_prelaunch_recovery_authority.py
+++ b/tests/kernel/test_ck07r1_prelaunch_recovery_authority.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.ck07r1_prelaunch_recovery import (
+    AUTHORITY_PATH,
+    MINIMUM_CAPACITY_BYTES,
+    SCHEMA_PATH,
+    PrelaunchRecoveryError,
+    evaluate_recovery_prelaunch,
+    load_authority,
+    verify_bound_authority_bytes,
+    verify_candidate_cohort,
+    verify_exact_authority_delta,
+    verify_exact_candidate_delta,
+    verify_frozen_candidate_root,
+    verify_minimum_capacity,
+    verify_new_paths_absent,
+    verify_preserved_failure_ledger,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _authority() -> dict[str, Any]:
+    return load_authority(ROOT)
+
+
+def _ledger(authority: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": "codex-usage-tracker.lifecycle-run-ledger.v1",
+        "run_token_id": authority["run_token"]["id"],
+        "maximum_new_end_to_end_runs": 1,
+        "token_status": "unspent_unavailable",
+        "token_consumed": False,
+        "state": "prelaunch_failed",
+        "retry_allowed": False,
+        "restart_allowed": False,
+        "replacement_allowed": False,
+        "first_result_retained": True,
+        "launch": {"synthetic": True, "matching_processes": []},
+        "failure": {
+            "stage": "child_start_handshake",
+            "exception_type": "RuntimeError",
+            "message": ("child-start handshake did not prove exact PID/argv/cwd/owner"),
+        },
+        "process_states": [
+            {"state": "prelaunch_verified", "at_utc": "2026-08-19T17:16:44Z"},
+            {
+                "state": "prelaunch_failed",
+                "at_utc": "2026-08-19T17:16:49Z",
+                "stage": "child_start_handshake",
+            },
+        ],
+    }
+
+
+def _write_synthetic_candidate(authority: dict[str, Any], root: Path) -> dict[str, Any]:
+    for index, record in enumerate(authority["candidate_cohort"]):
+        path = root / record["path"]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"synthetic candidate {index}\n".encode())
+        record["sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
+    ledger = _ledger(authority)
+    ledger_path = root / authority["preserved_failure_lineage"]["ledger_path"]
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_path.write_text(
+        json.dumps(ledger, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    authority["preserved_v1_ledger"]["sha256"] = hashlib.sha256(
+        ledger_path.read_bytes()
+    ).hexdigest()
+    authority["preserved_v1_ledger"]["matching_processes"] = []
+    return ledger
+
+
+def _valid_observation(authority: dict[str, Any]) -> dict[str, Any]:
+    contract = authority["launch_contract"]
+    cwd = contract["cwd"]
+    required = contract["environment"]["required"]
+    return {
+        "worker_thread_id": authority["worker"]["thread_id"],
+        "cwd": cwd,
+        "argv": contract["argv"],
+        "environment": required,
+        "environment_present": required,
+        "interpreter": cwd + "/.venv/bin/python",
+        "venv_prefix": cwd + "/.venv",
+        "authority_integrity": "passed",
+        "candidate_cohort": "passed",
+        "candidate_delta": "passed",
+        "preserved_ledger": "passed",
+        "new_paths_present": [],
+        "matching_processes": [],
+        "token_status": "unspent_unavailable",
+        "token_consumed": False,
+        "prior_invocation_state": "prelaunch_failed",
+        "prior_successful_child": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+        "synthetic_fixture": True,
+        "live_or_real_data": False,
+        "disk_available_bytes": MINIMUM_CAPACITY_BYTES,
+    }
+
+
+def test_recovery_authority_schema_is_strict_and_exact() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(authority)
+    assert authority["schema"].endswith(".v1")
+    assert authority["authority_base_sha"] == ("213b5d280dac58d11d71511c21aac58f61227fd3")
+    assert authority["status"] == "permitted_not_accepted"
+    assert authority["decision"]["launch_authorized_in_authority_task"] is False
+    assert authority["decision"]["new_invocation_is_launched_process_retry"] is False
+
+
+def test_recovery_authority_preserves_every_predecessor_byte() -> None:
+    verify_bound_authority_bytes(_authority(), ROOT)
+
+
+def test_recovery_authority_binds_exact_candidate_and_terminal_ledger(
+    tmp_path: Path,
+) -> None:
+    authority = deepcopy(_authority())
+    _write_synthetic_candidate(authority, tmp_path)
+    verify_candidate_cohort(authority, tmp_path)
+    ledger = verify_preserved_failure_ledger(authority, tmp_path)
+    verify_new_paths_absent(authority, tmp_path)
+    assert ledger["state"] == "prelaunch_failed"
+    assert ledger["token_consumed"] is False
+    assert "process" not in ledger
+    assert "receipt" not in ledger
+
+
+def test_recovery_rejects_any_terminal_ledger_rewrite(tmp_path: Path) -> None:
+    authority = deepcopy(_authority())
+    _write_synthetic_candidate(authority, tmp_path)
+    path = tmp_path / authority["preserved_failure_lineage"]["ledger_path"]
+    ledger = json.loads(path.read_text(encoding="utf-8"))
+    ledger["token_consumed"] = True
+    path.write_text(json.dumps(ledger), encoding="utf-8")
+    with pytest.raises(PrelaunchRecoveryError, match="terminal v1 ledger bytes changed"):
+        verify_preserved_failure_ledger(authority, tmp_path)
+
+
+def test_recovery_rejects_other_candidate_digest(tmp_path: Path) -> None:
+    authority = deepcopy(_authority())
+    _write_synthetic_candidate(authority, tmp_path)
+    path = tmp_path / authority["candidate_cohort"][1]["path"]
+    path.write_bytes(b"other candidate\n")
+    with pytest.raises(PrelaunchRecoveryError, match="candidate identity mismatch"):
+        verify_candidate_cohort(authority, tmp_path)
+
+
+def test_recovery_candidate_delta_is_exact_and_includes_old_ledger() -> None:
+    authority = _authority()
+    expected = set(authority["scope"]["combined_preflight_candidate_scope"])
+    verify_exact_candidate_delta(authority, ROOT, observed=expected)
+    assert authority["preserved_v1_ledger"]["path"] in expected
+    for changed in (
+        expected - {authority["preserved_v1_ledger"]["path"]},
+        expected | {"output/ck07r1/lifecycle-requalification-v2.json"},
+    ):
+        with pytest.raises(PrelaunchRecoveryError, match="candidate Git delta"):
+            verify_exact_candidate_delta(authority, ROOT, observed=changed)
+
+
+def test_recovery_authority_delta_is_exact() -> None:
+    authority = _authority()
+    expected = set(authority["scope"]["authority_write_scope"])
+    verify_exact_authority_delta(authority, ROOT, observed=expected)
+    for changed in (
+        expected - {next(iter(expected))},
+        expected | {"scripts/benchmark_ck07r1_lifecycle_scale.py"},
+    ):
+        with pytest.raises(PrelaunchRecoveryError, match="authority Git delta"):
+            verify_exact_authority_delta(authority, ROOT, observed=changed)
+
+
+def test_recovery_uses_new_noncolliding_paths_and_same_token() -> None:
+    authority = _authority()
+    paths = authority["launch_contract"]["exclusive_paths"]
+    assert set(paths.values()) == {
+        "output/ck07r1/lifecycle-requalification-v2.json",
+        "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+        "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+        "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+    }
+    assert authority["run_token"]["id"] == "ck07r1-all-profile-e2e-1"
+    assert authority["run_token"]["successful_launches_observed"] == 0
+    assert authority["run_token"]["new_recovery_invocations_permitted"] == 1
+
+
+def test_recovery_handshake_binds_verified_parent_snapshot_without_weakening() -> None:
+    contract = _authority()["handshake_contract"]
+    assert contract["pre_fork_parent_snapshot_required"] is True
+    assert contract["child_process_creation"] == "fork_without_exec_before_release"
+    assert contract["required_child_fields"] == [
+        "pid",
+        "parent_pid",
+        "owner",
+        "cwd",
+        "platform_process_command_signature",
+    ]
+    assert contract["child_signature_rule"] == (
+        "exact_equality_to_the_verified_parent_platform_process_command_signature"
+    )
+    assert contract["lexical_interpreter_and_sys_prefix_gate"] == "unchanged_required"
+    assert contract["ambiguous_or_extra_match"] == "fail_closed"
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("worker_thread_id", "replacement-worker"),
+        ("cwd", "/wrong"),
+        ("argv", [".venv/bin/python", "wrong.py"]),
+        ("environment", {"LC_ALL": "C"}),
+        ("interpreter", "/usr/bin/python3"),
+        ("venv_prefix", "/wrong/.venv"),
+        ("authority_integrity", "failed"),
+        ("candidate_cohort", "partial"),
+        ("candidate_delta", "extra"),
+        ("preserved_ledger", "rewritten"),
+        ("new_paths_present", ["output/ck07r1/lifecycle-requalification-v2.json"]),
+        ("matching_processes", [{"pid": 1}]),
+        ("token_status", "consumed"),
+        ("token_consumed", True),
+        ("prior_invocation_state", "completed"),
+        ("prior_successful_child", True),
+        ("retry", "allowed"),
+        ("restart", "allowed"),
+        ("replacement", "allowed"),
+        ("synthetic_fixture", False),
+        ("live_or_real_data", True),
+        ("disk_available_bytes", MINIMUM_CAPACITY_BYTES - 1),
+    ],
+)
+def test_recovery_prelaunch_negative_mutations_fail_closed(field: str, replacement: Any) -> None:
+    authority = _authority()
+    observation = _valid_observation(authority)
+    observation[field] = replacement
+    with pytest.raises(PrelaunchRecoveryError, match="recovery prelaunch gate"):
+        evaluate_recovery_prelaunch(authority, observation)
+
+
+def test_recovery_forbidden_environment_fails_closed() -> None:
+    authority = _authority()
+    observation = _valid_observation(authority)
+    observation["environment_present"] = {
+        **observation["environment_present"],
+        "CODEX_HOME": "/synthetic/forbidden",
+    }
+    with pytest.raises(PrelaunchRecoveryError, match="forbidden environment"):
+        evaluate_recovery_prelaunch(authority, observation)
+
+
+def test_recovery_capacity_gate_is_fail_closed() -> None:
+    assert (
+        verify_minimum_capacity(ROOT, observed_bytes=MINIMUM_CAPACITY_BYTES)
+        == MINIMUM_CAPACITY_BYTES
+    )
+    with pytest.raises(PrelaunchRecoveryError, match="at least 10 GiB"):
+        verify_minimum_capacity(ROOT, observed_bytes=MINIMUM_CAPACITY_BYTES - 1)
+
+
+def test_recovery_requires_exact_frozen_lexical_candidate_root() -> None:
+    authority = _authority()
+    frozen = Path(authority["launch_contract"]["cwd"])
+    verify_frozen_candidate_root(authority, frozen)
+
+    with pytest.raises(
+        PrelaunchRecoveryError,
+        match="exact frozen lexical cwd",
+    ):
+        verify_frozen_candidate_root(authority, frozen.parent / "wrong-worktree")
+
+
+def test_recovery_decision_is_first_successful_launch_not_retry_or_refund() -> None:
+    authority = _authority()
+    assert evaluate_recovery_prelaunch(authority, _valid_observation(authority)) == {
+        "decision": "recovery_launch_authorized_once",
+        "run_token_id": "ck07r1-all-profile-e2e-1",
+        "new_command_invocations_permitted": 1,
+        "consume_only_after_successful_child_handshake": True,
+        "prior_prelaunch_failure_is_not_a_launched_process_retry": True,
+        "refund": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+    }
+
+
+def test_schema_rejects_policy_scope_token_and_lineage_weakening() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    mutations = [
+        lambda value: value["decision"].__setitem__("launch_authorized_in_authority_task", True),
+        lambda value: value["decision"].__setitem__(
+            "new_invocation_is_launched_process_retry", True
+        ),
+        lambda value: value["run_token"].__setitem__("maximum_new_end_to_end_runs", 2),
+        lambda value: value["run_token"].__setitem__("refund", True),
+        lambda value: value["run_token"].__setitem__("token_consumed", True),
+        lambda value: value["preserved_v1_ledger"].__setitem__("sha256", "0" * 64),
+        lambda value: value["candidate_cohort"].pop(),
+        lambda value: value["launch_contract"]["exclusive_paths"].__setitem__(
+            "ledger",
+            "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+        ),
+        lambda value: value["handshake_contract"].__setitem__(
+            "lexical_interpreter_and_sys_prefix_gate", "waived"
+        ),
+        lambda value: value["scope"]["authority_write_scope"].append(
+            "scripts/benchmark_ck07r1_lifecycle_scale.py"
+        ),
+    ]
+    for mutate in mutations:
+        changed = deepcopy(authority)
+        mutate(changed)
+        assert list(Draft202012Validator(schema).iter_errors(changed))
+
+
+def test_authority_task_remains_non_consuming() -> None:
+    authority = _authority()
+    assert authority["run_token"]["token_consumed"] is False
+    assert authority["decision"]["runtime_acceptance"] == "not_claimed"
+    assert authority["decision"]["implementation_acceptance"] == "not_claimed"
+    assert "launch_or_child_in_authority_task" in authority["scope"]["forbidden"]
+    assert Path(AUTHORITY_PATH).name.endswith("-v1.json")

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -8,6 +8,12 @@ import pytest
 from jsonschema import Draft202012Validator
 
 import scripts.ck07r1_shared_successor_overlay as overlay_module
+from scripts.ck07r1_prelaunch_recovery import (
+    AUTHORITY_PATH as RECOVERY_AUTHORITY_PATH,
+)
+from scripts.ck07r1_prelaunch_recovery import (
+    verify_prelaunch_recovery,
+)
 from scripts.ck07r1_shared_successor_overlay import (
     CONSUMING_AUTHORITY_PATH,
     ROOT,
@@ -42,7 +48,27 @@ def _state_observed(
 
 
 def test_overlay_is_exact_and_live_state_is_authorized() -> None:
-    authority, state = verify_shared_successor_overlay()
+    try:
+        authority, state = verify_shared_successor_overlay()
+    except SharedSuccessorOverlayError:
+        if not (ROOT / RECOVERY_AUTHORITY_PATH).is_file():
+            raise
+        recovery_ledger = ROOT / "output/ck07r1/lifecycle-requalification-v1.launch-token.json"
+        if recovery_ledger.is_file():
+            recovery, recovery_state = verify_prelaunch_recovery(ROOT)
+            assert recovery_state == "prelaunch_recovery_verified"
+            assert recovery["recovery_transition"]["old_shared_overlay"] == (
+                "immutable_historical_predecessor_evidence"
+            )
+            assert recovery["recovery_transition"]["live_corrected_cohort_authority"] == (
+                "this_versioned_recovery_authority_only"
+            )
+            assert recovery["status"] == "permitted_not_accepted"
+            assert recovery["decision"]["runtime_acceptance"] == "not_claimed"
+            assert recovery["decision"]["launch_authorized_in_authority_task"] is False
+            return
+        authority = load_overlay()
+        state = classify_observed_state(authority, observed_candidate_artifacts(authority))
 
     assert state in {"authority_main", "worker_prequalification"}
     assert authority["status"] == "permitted_not_accepted"
@@ -70,9 +96,7 @@ def test_overlay_is_exact_and_live_state_is_authorized() -> None:
         "data_policy": "synthetic_only",
     }
     state_key = "predecessor" if state == "authority_main" else "successor"
-    assert observed_candidate_artifacts(authority) == _state_observed(
-        authority, state_key
-    )
+    assert observed_candidate_artifacts(authority) == _state_observed(authority, state_key)
 
 
 def test_complete_consuming_boundary_is_the_only_additive_authority_delta() -> None:
@@ -82,9 +106,7 @@ def test_complete_consuming_boundary_is_the_only_additive_authority_delta() -> N
     scope = set(consuming["scope"]["authority_write_scope"])
     predecessor_scope = set(overlay["scope"]["authority_write_scope"])
 
-    verify_exact_worktree_delta(
-        overlay, "authority_main", observed=scope
-    )
+    verify_exact_worktree_delta(overlay, "authority_main", observed=scope)
     verify_exact_committed_delta(
         overlay,
         observed=predecessor_scope | scope,
@@ -95,9 +117,7 @@ def test_complete_consuming_boundary_is_the_only_additive_authority_delta() -> N
         scope | {"src/codex_usage_tracker/agent_kernel/publication/writer.py"},
     ):
         with pytest.raises(SharedSuccessorOverlayError, match="Git delta mismatch"):
-            verify_exact_worktree_delta(
-                overlay, "authority_main", observed=changed
-            )
+            verify_exact_worktree_delta(overlay, "authority_main", observed=changed)
 
 
 def test_partial_consuming_boundary_pair_fails_closed(tmp_path: Path) -> None:
@@ -188,29 +208,17 @@ def test_worker_state_reaches_consuming_activation_before_verifier_returns(
     assert consuming is not None
     calls: list[str] = []
     monkeypatch.setattr(overlay_module, "load_overlay", lambda root: overlay)
-    monkeypatch.setattr(
-        overlay_module, "verify_bound_authority_bytes", lambda *_: None
-    )
-    monkeypatch.setattr(
-        overlay_module, "verify_launcher_safety_contract", lambda *_: None
-    )
-    monkeypatch.setattr(
-        overlay_module, "verify_exact_committed_delta", lambda *_: None
-    )
-    monkeypatch.setattr(
-        overlay_module, "observed_candidate_artifacts", lambda *_: {}
-    )
+    monkeypatch.setattr(overlay_module, "verify_bound_authority_bytes", lambda *_: None)
+    monkeypatch.setattr(overlay_module, "verify_launcher_safety_contract", lambda *_: None)
+    monkeypatch.setattr(overlay_module, "verify_exact_committed_delta", lambda *_: None)
+    monkeypatch.setattr(overlay_module, "observed_candidate_artifacts", lambda *_: {})
     monkeypatch.setattr(
         overlay_module,
         "classify_observed_state",
         lambda *_: "worker_prequalification",
     )
-    monkeypatch.setattr(
-        overlay_module, "verify_exact_worktree_delta", lambda *_: None
-    )
-    monkeypatch.setattr(
-        overlay_module, "load_consuming_boundary", lambda *_: consuming
-    )
+    monkeypatch.setattr(overlay_module, "verify_exact_worktree_delta", lambda *_: None)
+    monkeypatch.setattr(overlay_module, "load_consuming_boundary", lambda *_: consuming)
     monkeypatch.setattr(
         overlay_module,
         "verify_consuming_boundary_activation",
@@ -226,18 +234,17 @@ def test_frozen_launcher_imports_verifier_before_any_side_effect() -> None:
     consuming = load_consuming_boundary()
     assert consuming is not None
     launcher_path = (
-        Path(consuming["worker"]["frozen_cwd"])
-        / "scripts/benchmark_ck07r1_lifecycle_scale.py"
+        Path(consuming["worker"]["frozen_cwd"]) / "scripts/benchmark_ck07r1_lifecycle_scale.py"
     )
     if not launcher_path.is_file():
         pytest.skip("retained frozen candidate witness is unavailable")
     launcher = launcher_path.read_text(encoding="utf-8")
-    launch = launcher[
-        launcher.index("def _launch_exact()") : launcher.index("\ndef main()")
-    ]
-    assert "verifier.verify_shared_successor_overlay(root)" in launcher
-    assert launch.index("_verify_overlay_cohort()") < launch.index("os.pipe()")
-    assert launch.index("_verify_overlay_cohort()") < launch.index("os.fork()")
+    launch = launcher[launcher.index("def _launch_exact()") : launcher.index("\ndef main()")]
+    assert "verifier.verify_prelaunch_recovery(root)" in launcher
+    assert "_verify_historical_shared_overlay_binding" in launcher
+    assert "_verify_overlay_cohort()" not in launch
+    assert launch.index("_verify_prelaunch_recovery()") < launch.index("os.pipe()")
+    assert launch.index("_verify_prelaunch_recovery()") < launch.index("os.fork()")
 
 
 def test_overlay_admits_only_the_complete_exact_successor() -> None:
@@ -294,9 +301,7 @@ def test_overlay_schema_rejects_status_token_launch_scope_and_safety_weakening()
         lambda value: value["launcher_safety"].__setitem__(
             "receipt_completion_ordering", "durable_completed_before_validation"
         ),
-        lambda value: value["launcher_safety"].__setitem__(
-            "receipt_failure_state", "completed"
-        ),
+        lambda value: value["launcher_safety"].__setitem__("receipt_failure_state", "completed"),
         lambda value: value["launcher_safety"].__setitem__(
             "child_pre_release_failure", "exception_returns_to_parent_path"
         ),
@@ -432,8 +437,7 @@ def test_overlay_requires_exact_committed_authority_delta() -> None:
     with pytest.raises(SharedSuccessorOverlayError, match="extra="):
         verify_exact_committed_delta(
             authority,
-            observed=expected
-            | {"src/codex_usage_tracker/agent_kernel/publication/writer.py"},
+            observed=expected | {"src/codex_usage_tracker/agent_kernel/publication/writer.py"},
             base_is_ancestor=True,
         )
 
@@ -455,8 +459,8 @@ def test_overlay_scope_and_launcher_contract_are_exact() -> None:
         verify_launcher_safety_contract(weakened)
 
     weakened = deepcopy(authority)
-    weakened["launcher_safety"]["interpreter_identity"][
-        "symlink_or_resolved_equivalence"
-    ] = "accepted"
+    weakened["launcher_safety"]["interpreter_identity"]["symlink_or_resolved_equivalence"] = (
+        "accepted"
+    )
     with pytest.raises(SharedSuccessorOverlayError, match="safety"):
         verify_launcher_safety_contract(weakened)

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -12,7 +12,7 @@ from scripts.ck07r1_prelaunch_recovery import (
     AUTHORITY_PATH as RECOVERY_AUTHORITY_PATH,
 )
 from scripts.ck07r1_prelaunch_recovery import (
-    verify_prelaunch_recovery,
+    verify_combined_preflight,
 )
 from scripts.ck07r1_shared_successor_overlay import (
     CONSUMING_AUTHORITY_PATH,
@@ -55,8 +55,7 @@ def test_overlay_is_exact_and_live_state_is_authorized() -> None:
             raise
         recovery_ledger = ROOT / "output/ck07r1/lifecycle-requalification-v1.launch-token.json"
         if recovery_ledger.is_file():
-            recovery, recovery_state = verify_prelaunch_recovery(ROOT)
-            assert recovery_state == "prelaunch_recovery_verified"
+            recovery = verify_combined_preflight(ROOT, ROOT)
             assert recovery["recovery_transition"]["old_shared_overlay"] == (
                 "immutable_historical_predecessor_evidence"
             )

--- a/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
+++ b/tests/kernel/test_ck08r1b_answer_semantics_join_authority.py
@@ -10,8 +10,8 @@ from jsonschema import Draft202012Validator
 
 from scripts.ck07r1_shared_successor_overlay import (
     PREPARATION_PATH,
-    verify_shared_successor_overlay,
 )
+from scripts.qualify_ck08r1_answer_truth import current_ck07r1_overlay
 
 ROOT = Path(__file__).resolve().parents[2]
 AUTHORITY_PATH = (
@@ -272,7 +272,7 @@ def test_successor_cohort_is_all_or_none_and_rejects_unbound_bytes() -> None:
     files = authority["selected_successor_cohort"]["files"]
     assert isinstance(files, list)
     observed = {item["path"]: _sha256(item["path"]) for item in files}
-    overlay, overlay_state = verify_shared_successor_overlay(ROOT)
+    overlay, overlay_state = current_ck07r1_overlay()
     bound_observed = dict(observed)
     if overlay_state == "worker_prequalification":
         preparation = next(item for item in files if item["path"] == PREPARATION_PATH)

--- a/tests/kernel/test_ckqg1_maintainability_baseline_authority.py
+++ b/tests/kernel/test_ckqg1_maintainability_baseline_authority.py
@@ -11,8 +11,8 @@ from jsonschema import Draft202012Validator
 from scripts.check_kernel_scope import authority_changed_path_failures
 from scripts.ck07r1_shared_successor_overlay import (
     overlay_changed_path_allowance,
-    verify_shared_successor_overlay,
 )
+from scripts.qualify_ck08r1_answer_truth import current_ck07r1_overlay
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _AUTHORITY_PATH = "docs/decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json"
@@ -166,7 +166,7 @@ def test_ckqg1_authority_is_exact_and_binds_the_selected_successor() -> None:
     ]
     changed_paths = _changed_paths(authority["authority_base_sha"])
     allowed_paths = set(scope["authority_write_scope"])
-    overlay, overlay_state = verify_shared_successor_overlay(_REPO_ROOT)
+    overlay, overlay_state = current_ck07r1_overlay()
     overlay_paths = overlay_changed_path_allowance(overlay, overlay_state)
     ckqg1_changed_paths = changed_paths - overlay_paths
     assert ckqg1_changed_paths <= allowed_paths

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.ck07r1_prelaunch_recovery import verify_combined_preflight
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOCS = _REPO_ROOT / "docs"
 _AUTHORITY_PATHS = (
@@ -84,6 +86,32 @@ def _read(path: str) -> str:
 
 def _json(path: str):
     return json.loads(_read(path))
+
+
+def _assert_ck07_selected_or_recovery_cohort(
+    selected_successor: dict,
+) -> None:
+    expected = {
+        item["path"]: item["sha256"]
+        for item in selected_successor["artifacts"]
+    }
+    actual = {
+        path: hashlib.sha256((_REPO_ROOT / path).read_bytes()).hexdigest()
+        for path in expected
+    }
+    if actual == expected:
+        return
+
+    recovery = _json(
+        "docs/decisions/evidence/ck07r1a0/"
+        "lifecycle-prelaunch-recovery-authority-v1.json"
+    )
+    recovery_expected = {
+        item["path"]: item["sha256"]
+        for item in recovery["candidate_cohort"]
+    }
+    assert actual == recovery_expected
+    verify_combined_preflight(_REPO_ROOT, _REPO_ROOT)
 
 
 def _portable_selected_support_hashes() -> dict[str, str]:
@@ -503,12 +531,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
                         expected.add(_ck08r1b_selected_hashes()[required["path"]])
                     assert hashlib.sha256(required_path.read_bytes()).hexdigest() in expected
             elif actual == ck07_selected["sha256"]:
-                for required in ck07_selected["artifacts"]:
-                    required_path = _REPO_ROOT / required["path"]
-                    assert required_path.is_file()
-                    assert (
-                        hashlib.sha256(required_path.read_bytes()).hexdigest() == required["sha256"]
-                    )
+                _assert_ck07_selected_or_recovery_cohort(ck07_selected)
         elif artifact["path"] in {
             "config/agent-kernel/formula-contract-v1.json",
             "config/agent-kernel/plan-operand-contract-v1.json",
@@ -1109,10 +1132,9 @@ def test_ck07r1a0_source_digest_authority_is_exact_and_fail_closed() -> None:
         authority["selected_successor"]["sha256"],
     }
     if actual_source == authority["selected_successor"]["sha256"]:
-        for required in authority["selected_successor"]["artifacts"]:
-            required_path = _REPO_ROOT / required["path"]
-            assert required_path.is_file()
-            assert hashlib.sha256(required_path.read_bytes()).hexdigest() == required["sha256"]
+        _assert_ck07_selected_or_recovery_cohort(
+            authority["selected_successor"]
+        )
 
     mutations = [
         ("selected_successor", "sha256", "0" * 64),

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -96,12 +96,9 @@ def _portable_selected_support_hashes() -> dict[str, str]:
 
 
 def _ck08r1b_selected_hashes() -> dict[str, str]:
-    authority = _json(
-        "docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json"
-    )
+    authority = _json("docs/decisions/evidence/ck08r1b/answer-semantics-join-authority.json")
     return {
-        item["path"]: item["sha256"]
-        for item in authority["selected_successor_cohort"]["files"]
+        item["path"]: item["sha256"] for item in authority["selected_successor_cohort"]["files"]
     }
 
 
@@ -239,11 +236,12 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert manifest["conditional_ready"] == [
         {
             "condition": (
-                "v1 consuming-boundary authority merges and exact-main verifies; coordinator "
-                "resumes exact existing worker 019fbfe2-8fe4-7de2-9264-d58572366727 with "
-                "the atomic 66c015de/f108dbb4/4c514889 cohort; exactly one synthetic "
-                "qualification launch may proceed under immediate preflight; no replacement "
-                "or downstream task"
+                "prelaunch-recovery authority preserves the exact terminal v1 ledger, binds "
+                "the corrected cohort and non-colliding v2 paths, merges and exact-main "
+                "verifies; coordinator resumes exact existing worker "
+                "019fbfe2-8fe4-7de2-9264-d58572366727; one corrected synthetic invocation "
+                "may seek the first successful child launch under immediate preflight; no "
+                "retry of a launched process, replacement, or downstream task"
             ),
             "tasks": ["CK-07R1"],
         },
@@ -253,9 +251,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "## Remaining delegated child tasks", 1
     )[0]
     parent_rows = [
-        line
-        for line in parent_section.splitlines()
-        if line.startswith("- [") and "**CK-" in line
+        line for line in parent_section.splitlines() if line.startswith("- [") and "**CK-" in line
     ]
     parent_completed = sum(line.startswith("- [x]") for line in parent_rows)
     assert len(parent_rows) == 22
@@ -510,7 +506,9 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
                 for required in ck07_selected["artifacts"]:
                     required_path = _REPO_ROOT / required["path"]
                     assert required_path.is_file()
-                    assert hashlib.sha256(required_path.read_bytes()).hexdigest() == required["sha256"]
+                    assert (
+                        hashlib.sha256(required_path.read_bytes()).hexdigest() == required["sha256"]
+                    )
         elif artifact["path"] in {
             "config/agent-kernel/formula-contract-v1.json",
             "config/agent-kernel/plan-operand-contract-v1.json",
@@ -1228,27 +1226,31 @@ def test_obsolete_planning_framework_is_absent_from_active_authority() -> None:
         not any(marker in path.read_text(encoding="utf-8") for marker in resolved_pull_request_refs)
         for path in active_paths
     )
+
+
 def test_ck07r1_consuming_boundary_is_documented_without_downstream_readiness() -> None:
     agents = _read("AGENTS.md")
     index = _read("docs/INDEX.md")
     central = _read("docs/roadmap/REMAINING_EXECUTION_PLAN.md")
     accounting = _read("docs/roadmap/TASK_PACKETS.md")
-    packet = _read(
-        "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md"
-    )
+    packet = _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
 
-    for body in (index, central, accounting, packet):
+    for body in (index, central, packet):
         assert "lifecycle-consuming-boundary-authority-v1" in body or (
             "consuming-boundary authority" in body
         )
+    for body in (index, central, accounting, packet):
+        assert "prelaunch-recovery" in body
     assert "019fbfe2-8fe4-7de2-9264-d58572366727" in central
     assert "019fbfe2-8fe4-7de2-9264-d58572366727" in packet
     assert "launch_authorized_once" in central
     assert "launch_authorized_once" in packet
-    assert "CK-08R4_CK-08RG_CK-09_blocked" in _json(
-        "docs/decisions/evidence/ck07r1a0/"
-        "lifecycle-consuming-boundary-authority-v1.json"
-    )["approval"]["downstream"]
+    assert (
+        "CK-08R4_CK-08RG_CK-09_blocked"
+        in _json("docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json")[
+            "approval"
+        ]["downstream"]
+    )
     assert "Ready child tasks: **0**" in accounting
     assert "Conditional-ready child tasks: **1 — CK-07R1" in accounting
     assert "## Standing Repository Authorization" in agents
@@ -1261,3 +1263,23 @@ def test_ck07r1_consuming_boundary_is_documented_without_downstream_readiness() 
         assert "cryptographic" in body
         assert "fast-forward" in body
         assert "67bb1a" in body
+
+
+def test_ck07r1_prelaunch_recovery_is_documented_fail_closed() -> None:
+    index = _read("docs/INDEX.md")
+    central = _read("docs/roadmap/REMAINING_EXECUTION_PLAN.md")
+    accounting = _read("docs/roadmap/TASK_PACKETS.md")
+    packet = _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
+    authority = _json(
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json"
+    )
+    for body in (index, central, accounting, packet):
+        assert "prelaunch-recovery" in body
+    for body in (index, central, packet):
+        assert "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be" in body
+        assert "prelaunch_failed" in body
+        assert "lifecycle-requalification-v2" in body
+    assert authority["run_token"]["token_consumed"] is False
+    assert authority["run_token"]["successful_launches_observed"] == 0
+    assert authority["decision"]["new_invocation_is_launched_process_retry"] is False
+    assert authority["decision"]["launch_authorized_in_authority_task"] is False

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -20,6 +20,7 @@ from scripts.check_kernel_scope import (
     CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS,
     CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS,
     CK07R1_LIFECYCLE_SCOPE_ADDITIONS,
+    CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS,
     CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS,
     CK07R1_SHARED_OVERLAY_AUTHORITY_ADDITIONS,
     CK07R1A0_AUTHORITY_ADDITIONS,
@@ -701,6 +702,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK07R1_LIFECYCLE_SCOPE_ADDITIONS
         | CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS
         | CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS
+        | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | {
             "config/agent-kernel/maintainability-baseline-v1.json",
@@ -808,6 +810,17 @@ def test_ck07r1_consuming_boundary_additions_are_explicit_and_bounded() -> None:
         "scripts/ck07r1_consuming_boundary.py",
         "tests/kernel/test_ck07r1_consuming_boundary_authority.py",
     } == CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS
+
+
+def test_ck07r1_prelaunch_recovery_additions_are_explicit_and_bounded() -> None:
+    assert {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+        "scripts/ck07r1_prelaunch_recovery.py",
+        "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/agent_kernel/test_ck08r1_answer_requalification.py",
+        "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
+    } == CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
 
 
 def test_kernel_skeleton_imports_without_legacy_runtime() -> None:

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -816,6 +816,7 @@ def test_ck07r1_prelaunch_recovery_additions_are_explicit_and_bounded() -> None:
     assert {
         "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
         "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+        "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
         "scripts/ck07r1_prelaunch_recovery.py",
         "scripts/qualify_ck08r1_answer_truth.py",
         "tests/agent_kernel/test_ck08r1_answer_requalification.py",

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -109,28 +109,41 @@ def test_corrected_argv_guard_accepts_exact_candidate_in_real_non_launching_subp
     )
     if candidate is None:
         pytest.skip("the retained candidate is unavailable until the worker reapplies it")
-    assert (
-        hashlib.sha256(candidate.read_bytes()).hexdigest()
-        == authority["selected_candidate"]["artifacts"][1]["sha256"]
+    candidate_sha256 = hashlib.sha256(candidate.read_bytes()).hexdigest()
+    expected_v1_sha256 = authority["selected_candidate"]["artifacts"][1]["sha256"]
+    recovery_path = (
+        _ROOT / "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json"
     )
+    if candidate_sha256 == expected_v1_sha256:
+        frozen_args = [
+            "--profile",
+            "all",
+            "--samples",
+            "5",
+            "--output",
+            "output/ck07r1/lifecycle-requalification-v1.json",
+        ]
+        exact_paths = [
+            _ROOT / "output/ck07r1/lifecycle-requalification-v1.json",
+            _ROOT / "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+            _ROOT / "output/ck07r1/lifecycle-requalification-v1.stdout.txt",
+            _ROOT / "output/ck07r1/lifecycle-requalification-v1.stderr.txt",
+        ]
+    else:
+        recovery = json.loads(recovery_path.read_text(encoding="utf-8"))
+        expected_recovery_sha256 = next(
+            item["sha256"]
+            for item in recovery["candidate_cohort"]
+            if item["path"] == str(relative_candidate)
+        )
+        assert candidate_sha256 == expected_recovery_sha256
+        frozen_args = recovery["launch_contract"]["argv"][2:]
+        exact_paths = [
+            _ROOT / relative for relative in recovery["launch_contract"]["exclusive_paths"].values()
+        ]
     candidate_copy = tmp_path / relative_candidate
     candidate_copy.parent.mkdir(parents=True)
     candidate_copy.write_bytes(candidate.read_bytes())
-
-    frozen_args = [
-        "--profile",
-        "all",
-        "--samples",
-        "5",
-        "--output",
-        "output/ck07r1/lifecycle-requalification-v1.json",
-    ]
-    exact_paths = [
-        _ROOT / "output/ck07r1/lifecycle-requalification-v1.json",
-        _ROOT / "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
-        _ROOT / "output/ck07r1/lifecycle-requalification-v1.stdout.txt",
-        _ROOT / "output/ck07r1/lifecycle-requalification-v1.stderr.txt",
-    ]
     assert all(not path.exists() for path in exact_paths)
 
     wrapper = """
@@ -512,15 +525,10 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
             "completed_finalization"
         ),
         "receipt_failure_state": (
-            "construction_validation_or_finalization_failure_is_failed_after_launch_"
-            "never_completed"
+            "construction_validation_or_finalization_failure_is_failed_after_launch_never_completed"
         ),
-        "child_pre_release_failure": (
-            "every_pre_release_child_failure_routes_to_os._exit_71"
-        ),
-        "child_wait_signal_handling": (
-            "SIGINT_SIGTERM_ignored_while_waiting_for_parent_release"
-        ),
+        "child_pre_release_failure": ("every_pre_release_child_failure_routes_to_os._exit_71"),
+        "child_wait_signal_handling": ("SIGINT_SIGTERM_ignored_while_waiting_for_parent_release"),
         "parent_cleanup_pid_guard": (
             "reject_pid_less_than_or_equal_to_zero_before_kill_wait_or_reap"
         ),
@@ -540,9 +548,7 @@ def test_corrected_launcher_safety_contract_is_exact() -> None:
             "every_wait_exception_or_parent_signal_requires_bounded_SIGTERM_then_"
             "SIGKILL_then_reap_before_terminal_failure"
         ),
-        "signal_cleanup_mask": (
-            "SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"
-        ),
+        "signal_cleanup_mask": ("SIGINT_SIGTERM_ignored_during_bounded_child_cleanup"),
         "terminal_fallback_signal_mask": (
             "SIGINT_SIGTERM_ignored_during_every_terminal_fallback_persistence_"
             "then_prior_temporary_handlers_restored"


### PR DESCRIPTION
## Summary
- add versioned CK-07R1 prelaunch-failure recovery authority, schema, verifier, and roadmap bindings
- preserve the terminal v1 prelaunch-failed ledger while authorizing only a first successful child launch through new v2 paths
- reconcile historical CK-08 consumers with the exact corrected recovery cohort without changing accepted authority bytes
- enforce exact committed authority and all-or-none combined candidate deltas

## Exact recovery cohort
- preparation: 66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea
- benchmark: 37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e
- lifecycle test: 47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854
- preserved v1 ledger: 5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be

## Validation
- authority consumers: 175 passed
- exact combined authority/candidate suite: 458 passed
- just vp, just v, just vc: green; 1481 passed, 1 skipped
- worker focused/broader/privacy: 92 / 290 / 12 passed
- sole reviewer correction pass: clean
- Python 3.14 local; Python 3.10 delegated to hosted CI

No CK-07 qualification launch, token consumption, v2 output/ledger/stdout/stderr/receipt creation, live data use, or downstream dispatch occurred.