### PR TITLE
docs: bind CK-07R1 terminal correction authority

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -177,6 +177,29 @@ remains `unspent_unavailable`. The recovery command uses only the non-colliding
 `lifecycle-requalification-v2` output, ledger, stdout, and stderr paths; the
 v1 invocation and ledger are terminal and can never be reused or overwritten.
 
+The sole v2 invocation is also terminal. Child PID `20482` was verified before
+the one-run token was consumed at `2026-08-19T19:44:55Z`; the child then exited
+70 and the launcher durably recorded `failed_after_launch`. The immutable v2
+ledger SHA-256 is
+`570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2`;
+stderr SHA-256 is
+`4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f`;
+stdout is the empty-file SHA-256
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+Output and receipt are absent. The first child failure proves that the frozen
+benchmark incorrectly required `APPEND_SAFE_SMALL`: the accepted planner
+correctly selected `APPEND_SAFE_LARGE` for 1,369 selected records against the
+unchanged 32-record small-tail ceiling. The additive versioned terminal-failure correction authority,
+[`lifecycle-terminal-failure-correction-authority-v1`](decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json)
+binds both terminal ledgers, the consumed non-refundable token, the exact
+planner reproduction, and the only permitted two-file benchmark/test
+correction. It authorizes no invocation, retry, restart, replacement, refund,
+receipt fabrication, `post_single_run`, `final_accepted`, or downstream
+readiness. A corrected implementation may be reviewed and prequalified only
+through deterministic synthetic non-consuming evidence; the existing
+receipt-required runtime acceptance gate remains unsatisfied and CK-07R1,
+CK-08R4, CK-08RG, and CK-09 remain blocked pending a separate roadmap decision.
+
 The V11 candidate must construct and validate the exact overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
@@ -1,0 +1,243 @@
+{
+  "schema": "codex-usage-tracker.ck07r1-lifecycle-terminal-failure-correction.v1",
+  "version": 1,
+  "task": "CK-07R1",
+  "status": "permitted_not_accepted",
+  "authority_base_sha": "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8",
+  "worker": {
+    "thread_id": "019fbfe2-8fe4-7de2-9264-d58572366727",
+    "ownership": "normative_coordinator_orchestration_binding",
+    "replacement_worker": "forbidden"
+  },
+  "decision": {
+    "root_cause": "benchmark_unconditionally_required_append_safe_small_for_planner_selected_large_work",
+    "production_planner": "correct_and_immutable",
+    "production_preparation": "unchanged_selected_successor",
+    "corrective_implementation": "two_file_benchmark_and_owned_test_only",
+    "corrective_state": "corrective_implementation_prequalified",
+    "runtime_acceptance": "not_claimed",
+    "post_single_run": "unavailable_without_complete_planner_valid_receipt",
+    "final_accepted": "unavailable",
+    "new_command_invocations_permitted": 0,
+    "launch_authorized": false,
+    "token_refund": false,
+    "retry": "none",
+    "restart": "none",
+    "replacement": "none",
+    "receipt_fabrication": "forbidden",
+    "downstream": "CK-08R4_CK-08RG_CK-09_blocked_pending_separate_roadmap_decision"
+  },
+  "run_token": {
+    "id": "ck07r1-all-profile-e2e-1",
+    "maximum_new_end_to_end_runs": 1,
+    "successful_launches_observed": 1,
+    "token_status": "consumed",
+    "token_consumed": true,
+    "token_consumed_at_utc": "2026-08-19T19:44:55Z",
+    "non_refundable": true,
+    "remaining_invocations": 0
+  },
+  "immutable_authorities": [
+    {
+      "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+      "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+      "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+      "sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json",
+      "sha256": "bb8541e4071453b2b5e97821060c2d87c17acbe8b5e800732db0d92836dd9809"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.schema.json",
+      "sha256": "e7231eefdb6268877303fd1bbfeb202f8baf8f68b6c648d60e5e2b185348cf21"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+      "sha256": "95c420350e2e820fb192526493501b10ea9bc0e64424c683a345aaa9f3e5d500"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+      "sha256": "8996b460d178ed6211caefe8ff8505c8ee75e49799555f7f8ad7204dceb6c1ef"
+    },
+    {
+      "path": "scripts/ck07r1_prelaunch_recovery.py",
+      "sha256": "a3f6376f9f1328b5ccce3d8b16486b87cefe4d2b6c783a4e2a706e71142b1fc4"
+    },
+    {
+      "path": "src/codex_usage_tracker/agent_kernel/publication/planner.py",
+      "sha256": "204790ad86b99eedd4fd72c51b1c50dd07e0fe19284db809f9b990d689299148"
+    },
+    {
+      "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
+    }
+  ],
+  "failed_candidate_cohort": [
+    {
+      "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "role": "preparation_source",
+      "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+    },
+    {
+      "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "role": "failed_benchmark",
+      "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e"
+    },
+    {
+      "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+      "role": "failed_benchmark_tests",
+      "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854"
+    }
+  ],
+  "corrected_candidate_cohort": [
+    {
+      "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "role": "unchanged_preparation_source",
+      "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+    },
+    {
+      "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "role": "corrected_planner_path_benchmark",
+      "sha256": "8f4900b1ecc841fe04f6cd1232c3741efef105e8b997c7fd15cc61b5d8d14cc1"
+    },
+    {
+      "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+      "role": "corrected_planner_path_tests",
+      "sha256": "8364c4387b8e588cb18f420805d47e48241da22d6fb793e838a522cc7fb29e33"
+    }
+  ],
+  "terminal_evidence": {
+    "v1_ledger": {
+      "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be"
+    },
+    "v2_ledger": {
+      "path": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+      "sha256": "570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2"
+    },
+    "v2_stderr": {
+      "path": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+      "sha256": "4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f"
+    },
+    "v2_stdout": {
+      "path": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    "required_absent_paths": [
+      "output/ck07r1/lifecycle-requalification-v2.json",
+      "output/ck07r1/lifecycle-requalification-v2.receipt.json"
+    ],
+    "terminal_state": "failed_after_launch",
+    "child_exit_code": 70,
+    "failure_stage": "evidence_collection",
+    "matching_processes": [],
+    "temporary_residue": []
+  },
+  "planner_reproduction": {
+    "tail_limits": {
+      "selected_bytes": 8388608,
+      "selected_records": 32,
+      "observations": 12000,
+      "occurrences": 12000,
+      "affected_sessions": 2000,
+      "affected_turns": 4000,
+      "affected_resources": 4000,
+      "affected_allowance_cycles": 512,
+      "dirty_keys": 16000,
+      "projection_rows": 16000,
+      "expected_wal_bytes": 16777216,
+      "planning_staleness_us": 5000000,
+      "model_call_tail_rows": 32000
+    },
+    "standard_30_day": {
+      "operation_class": "append_safe_large",
+      "reasons": [
+        "limit_exceeded:selected_records"
+      ],
+      "selected_records": 1369,
+      "expected_wal_bytes": 11214848,
+      "observations": 1369
+    },
+    "production_first_chunk": {
+      "operation_class": "append_safe_large",
+      "reasons": [
+        "limit_exceeded:selected_records",
+        "limit_exceeded:expected_wal_bytes"
+      ],
+      "selected_records": 8000,
+      "expected_wal_bytes": 65536000,
+      "observations": 8000
+    },
+    "boundary": {
+      "record_32": "append_safe_small",
+      "record_33": "append_safe_large_limit_exceeded_selected_records"
+    },
+    "method": "unit_level_synthetic_plan_refresh_only_no_qualification_command"
+  },
+  "corrective_contract": {
+    "small_path": "exact_planner_object_to_pointer_coordinated_short_writer",
+    "large_path": "exact_planner_object_to_isolated_artifact_build_validation_durable_promotion_recovery_and_rollback",
+    "plan_substitution": "forbidden",
+    "operation_downcast": "forbidden",
+    "tail_limit_change": "forbidden",
+    "planner_or_preparation_change": "forbidden",
+    "independent_truth": "lifecycle_fold_oracle_and_committed_database_postconditions",
+    "required_validation": [
+      "standard_1369_record_large_classification",
+      "production_selected_record_and_wal_large_classification",
+      "32_33_record_boundary",
+      "small_and_large_plan_identity_through_selected_writer_path",
+      "large_artifact_promotion_rollback_and_prior_readability",
+      "lifecycle_identity_and_fold_equivalence",
+      "focused_and_full_repository_gates",
+      "one_bounded_reviewer",
+      "hosted_console_python_3_10_python_3_14",
+      "fresh_exact_main_authority_verification"
+    ]
+  },
+  "scope": {
+    "authority_write_scope": [
+      "docs/INDEX.md",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+      "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+      "docs/roadmap/TASK_PACKETS.md",
+      "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+      "scripts/check_kernel_scope.py",
+      "scripts/ck07r1_terminal_failure_correction.py",
+      "scripts/qualify_ck08r1_answer_truth.py",
+      "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+      "tests/kernel/test_documentation_authority.py",
+      "tests/kernel/test_kernel_scope.py"
+    ],
+    "combined_candidate_scope": [
+      "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+      "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+      "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+      "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "tests/agent_kernel/publication/test_lifecycle_scale.py"
+    ],
+    "forbidden": [
+      "qualification_command_invocation",
+      "child_or_fork",
+      "token_or_run_artifact_mutation",
+      "retry_restart_replacement_or_refund",
+      "receipt_fabrication",
+      "production_planner_or_preparation_change",
+      "implementation_files_in_authority_pr",
+      "PR_394_mutation",
+      "live_or_real_data",
+      "downstream_dispatch",
+      "cleanup_or_witness_loss"
+    ]
+  }
+}

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
@@ -73,10 +73,6 @@
     {
       "path": "src/codex_usage_tracker/agent_kernel/publication/planner.py",
       "sha256": "204790ad86b99eedd4fd72c51b1c50dd07e0fe19284db809f9b990d689299148"
-    },
-    {
-      "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
-      "sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
     }
   ],
   "failed_candidate_cohort": [

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
@@ -87,12 +87,12 @@
     },
     {
       "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-      "role": "failed_benchmark",
+      "role": "corrected_launcher",
       "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e"
     },
     {
       "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-      "role": "failed_benchmark_tests",
+      "role": "corrected_launcher_tests",
       "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854"
     }
   ],

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json
@@ -210,8 +210,10 @@
       "scripts/ck07r1_terminal_failure_correction.py",
       "scripts/qualify_ck08r1_answer_truth.py",
       "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+      "tests/kernel/test_ck07r1_shared_successor_overlay.py",
       "tests/kernel/test_documentation_authority.py",
-      "tests/kernel/test_kernel_scope.py"
+      "tests/kernel/test_kernel_scope.py",
+      "tests/kernel/test_lifecycle_run_invocation_authority.py"
     ],
     "combined_candidate_scope": [
       "output/ck07r1/lifecycle-requalification-v1.launch-token.json",

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
@@ -1,0 +1,297 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://local.codex/schemas/ck07r1-lifecycle-terminal-failure-correction-v1.json",
+  "title": "CK-07R1 lifecycle terminal failure correction authority v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "task",
+    "status",
+    "authority_base_sha",
+    "worker",
+    "decision",
+    "run_token",
+    "immutable_authorities",
+    "failed_candidate_cohort",
+    "corrected_candidate_cohort",
+    "terminal_evidence",
+    "planner_reproduction",
+    "corrective_contract",
+    "scope"
+  ],
+  "properties": {
+    "schema": {
+      "const": "codex-usage-tracker.ck07r1-lifecycle-terminal-failure-correction.v1"
+    },
+    "version": {
+      "const": 1
+    },
+    "task": {
+      "const": "CK-07R1"
+    },
+    "status": {
+      "const": "permitted_not_accepted"
+    },
+    "authority_base_sha": {
+      "const": "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8"
+    },
+    "worker": {
+      "const": {
+        "thread_id": "019fbfe2-8fe4-7de2-9264-d58572366727",
+        "ownership": "normative_coordinator_orchestration_binding",
+        "replacement_worker": "forbidden"
+      }
+    },
+    "decision": {
+      "const": {
+        "root_cause": "benchmark_unconditionally_required_append_safe_small_for_planner_selected_large_work",
+        "production_planner": "correct_and_immutable",
+        "production_preparation": "unchanged_selected_successor",
+        "corrective_implementation": "two_file_benchmark_and_owned_test_only",
+        "corrective_state": "corrective_implementation_prequalified",
+        "runtime_acceptance": "not_claimed",
+        "post_single_run": "unavailable_without_complete_planner_valid_receipt",
+        "final_accepted": "unavailable",
+        "new_command_invocations_permitted": 0,
+        "launch_authorized": false,
+        "token_refund": false,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+        "receipt_fabrication": "forbidden",
+        "downstream": "CK-08R4_CK-08RG_CK-09_blocked_pending_separate_roadmap_decision"
+      }
+    },
+    "run_token": {
+      "const": {
+        "id": "ck07r1-all-profile-e2e-1",
+        "maximum_new_end_to_end_runs": 1,
+        "successful_launches_observed": 1,
+        "token_status": "consumed",
+        "token_consumed": true,
+        "token_consumed_at_utc": "2026-08-19T19:44:55Z",
+        "non_refundable": true,
+        "remaining_invocations": 0
+      }
+    },
+    "immutable_authorities": {
+      "const": [
+        {
+          "path": "docs/decisions/evidence/ck07/publication-refresh-recovery-evidence.json",
+          "sha256": "36eb76ca286b3448037857b701caab9371afc704a22bc479523149e70aca41eb"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json",
+          "sha256": "437b05c7dfa23ff8efb3038c19e6a0f2524ac45e2fa25f910af40023aad7b8cd"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.schema.json",
+          "sha256": "ba0d47358aba2f1d66c5b699e2ecd89b2378d082b7bbbfb777fc806329c7e7d4"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.json",
+          "sha256": "bb8541e4071453b2b5e97821060c2d87c17acbe8b5e800732db0d92836dd9809"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-consuming-boundary-authority-v1.schema.json",
+          "sha256": "e7231eefdb6268877303fd1bbfeb202f8baf8f68b6c648d60e5e2b185348cf21"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json",
+          "sha256": "95c420350e2e820fb192526493501b10ea9bc0e64424c683a345aaa9f3e5d500"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.schema.json",
+          "sha256": "8996b460d178ed6211caefe8ff8505c8ee75e49799555f7f8ad7204dceb6c1ef"
+        },
+        {
+          "path": "scripts/ck07r1_prelaunch_recovery.py",
+          "sha256": "a3f6376f9f1328b5ccce3d8b16486b87cefe4d2b6c783a4e2a706e71142b1fc4"
+        },
+        {
+          "path": "src/codex_usage_tracker/agent_kernel/publication/planner.py",
+          "sha256": "204790ad86b99eedd4fd72c51b1c50dd07e0fe19284db809f9b990d689299148"
+        },
+        {
+          "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+          "sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
+        }
+      ]
+    },
+    "failed_candidate_cohort": {
+      "const": [
+        {
+          "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+          "role": "preparation_source",
+          "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+        },
+        {
+          "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+          "role": "failed_benchmark",
+          "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e"
+        },
+        {
+          "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+          "role": "failed_benchmark_tests",
+          "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854"
+        }
+      ]
+    },
+    "corrected_candidate_cohort": {
+      "const": [
+        {
+          "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+          "role": "unchanged_preparation_source",
+          "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+        },
+        {
+          "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+          "role": "corrected_planner_path_benchmark",
+              "sha256": "8f4900b1ecc841fe04f6cd1232c3741efef105e8b997c7fd15cc61b5d8d14cc1"
+        },
+        {
+          "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+          "role": "corrected_planner_path_tests",
+              "sha256": "8364c4387b8e588cb18f420805d47e48241da22d6fb793e838a522cc7fb29e33"
+        }
+      ]
+    },
+    "terminal_evidence": {
+      "const": {
+        "v1_ledger": {
+          "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+          "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be"
+        },
+        "v2_ledger": {
+          "path": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+          "sha256": "570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2"
+        },
+        "v2_stderr": {
+          "path": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+          "sha256": "4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f"
+        },
+        "v2_stdout": {
+          "path": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        "required_absent_paths": [
+          "output/ck07r1/lifecycle-requalification-v2.json",
+          "output/ck07r1/lifecycle-requalification-v2.receipt.json"
+        ],
+        "terminal_state": "failed_after_launch",
+        "child_exit_code": 70,
+        "failure_stage": "evidence_collection",
+        "matching_processes": [],
+        "temporary_residue": []
+      }
+    },
+    "planner_reproduction": {
+      "const": {
+        "tail_limits": {
+          "selected_bytes": 8388608,
+          "selected_records": 32,
+          "observations": 12000,
+          "occurrences": 12000,
+          "affected_sessions": 2000,
+          "affected_turns": 4000,
+          "affected_resources": 4000,
+          "affected_allowance_cycles": 512,
+          "dirty_keys": 16000,
+          "projection_rows": 16000,
+          "expected_wal_bytes": 16777216,
+          "planning_staleness_us": 5000000,
+          "model_call_tail_rows": 32000
+        },
+        "standard_30_day": {
+          "operation_class": "append_safe_large",
+          "reasons": [
+            "limit_exceeded:selected_records"
+          ],
+          "selected_records": 1369,
+          "expected_wal_bytes": 11214848,
+          "observations": 1369
+        },
+        "production_first_chunk": {
+          "operation_class": "append_safe_large",
+          "reasons": [
+            "limit_exceeded:selected_records",
+            "limit_exceeded:expected_wal_bytes"
+          ],
+          "selected_records": 8000,
+          "expected_wal_bytes": 65536000,
+          "observations": 8000
+        },
+        "boundary": {
+          "record_32": "append_safe_small",
+          "record_33": "append_safe_large_limit_exceeded_selected_records"
+        },
+        "method": "unit_level_synthetic_plan_refresh_only_no_qualification_command"
+      }
+    },
+    "corrective_contract": {
+      "const": {
+        "small_path": "exact_planner_object_to_pointer_coordinated_short_writer",
+        "large_path": "exact_planner_object_to_isolated_artifact_build_validation_durable_promotion_recovery_and_rollback",
+        "plan_substitution": "forbidden",
+        "operation_downcast": "forbidden",
+        "tail_limit_change": "forbidden",
+        "planner_or_preparation_change": "forbidden",
+        "independent_truth": "lifecycle_fold_oracle_and_committed_database_postconditions",
+        "required_validation": [
+          "standard_1369_record_large_classification",
+          "production_selected_record_and_wal_large_classification",
+          "32_33_record_boundary",
+          "small_and_large_plan_identity_through_selected_writer_path",
+          "large_artifact_promotion_rollback_and_prior_readability",
+          "lifecycle_identity_and_fold_equivalence",
+          "focused_and_full_repository_gates",
+          "one_bounded_reviewer",
+          "hosted_console_python_3_10_python_3_14",
+          "fresh_exact_main_authority_verification"
+        ]
+      }
+    },
+    "scope": {
+      "const": {
+        "authority_write_scope": [
+          "docs/INDEX.md",
+          "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+          "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+          "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+          "docs/roadmap/TASK_PACKETS.md",
+          "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+          "scripts/check_kernel_scope.py",
+          "scripts/ck07r1_terminal_failure_correction.py",
+          "scripts/qualify_ck08r1_answer_truth.py",
+          "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+          "tests/kernel/test_documentation_authority.py",
+          "tests/kernel/test_kernel_scope.py"
+        ],
+        "combined_candidate_scope": [
+          "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+          "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+          "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+          "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+          "scripts/benchmark_ck07r1_lifecycle_scale.py",
+          "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+          "tests/agent_kernel/publication/test_lifecycle_scale.py"
+        ],
+        "forbidden": [
+          "qualification_command_invocation",
+          "child_or_fork",
+          "token_or_run_artifact_mutation",
+          "retry_restart_replacement_or_refund",
+          "receipt_fabrication",
+          "production_planner_or_preparation_change",
+          "implementation_files_in_authority_pr",
+          "PR_394_mutation",
+          "live_or_real_data",
+          "downstream_dispatch",
+          "cleanup_or_witness_loss"
+        ]
+      }
+    }
+  }
+}

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
@@ -129,12 +129,12 @@
         },
         {
           "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
-          "role": "failed_benchmark",
+              "role": "corrected_launcher",
           "sha256": "37cb7330494675b2211f31ab419b4105d23f5c71856a546f735304883f25ba8e"
         },
         {
           "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
-          "role": "failed_benchmark_tests",
+              "role": "corrected_launcher_tests",
           "sha256": "47659f999ae765d6f09472eb7db67814c60ec8bd0fccbd258fda1654e22e2854"
         }
       ]

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
@@ -110,15 +110,11 @@
           "path": "scripts/ck07r1_prelaunch_recovery.py",
           "sha256": "a3f6376f9f1328b5ccce3d8b16486b87cefe4d2b6c783a4e2a706e71142b1fc4"
         },
-        {
-          "path": "src/codex_usage_tracker/agent_kernel/publication/planner.py",
-          "sha256": "204790ad86b99eedd4fd72c51b1c50dd07e0fe19284db809f9b990d689299148"
-        },
-        {
-          "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
-          "sha256": "7d1831ff5229e8e2a9819f0bd155d116ad97c3c3579bfa0444f791fe81e81feb"
-        }
-      ]
+            {
+              "path": "src/codex_usage_tracker/agent_kernel/publication/planner.py",
+              "sha256": "204790ad86b99eedd4fd72c51b1c50dd07e0fe19284db809f9b990d689299148"
+            }
+          ]
     },
     "failed_candidate_cohort": {
       "const": [

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json
@@ -262,8 +262,10 @@
           "scripts/ck07r1_terminal_failure_correction.py",
           "scripts/qualify_ck08r1_answer_truth.py",
           "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+          "tests/kernel/test_ck07r1_shared_successor_overlay.py",
           "tests/kernel/test_documentation_authority.py",
-          "tests/kernel/test_kernel_scope.py"
+          "tests/kernel/test_kernel_scope.py",
+          "tests/kernel/test_lifecycle_run_invocation_authority.py"
         ],
         "combined_candidate_scope": [
           "output/ck07r1/lifecycle-requalification-v1.launch-token.json",

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -186,6 +186,27 @@ authority and evidence byte while selecting this recovery bridge only when
 its exact versioned authority exists; predecessor-only and exact complete
 successor states remain explicit, and mixed or partial states fail closed.
 
+The v2 recovery opportunity has now been consumed and is terminal. Exact child
+PID `20482` passed the handshake and consumed the non-refundable token at
+`2026-08-19T19:44:55Z`; the child exited 70 before producing output or a
+receipt. The immutable v2 ledger
+`570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2`
+records `failed_after_launch`, `token_consumed=true`, and no retry, restart, or
+replacement. Its stderr
+`4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f`
+shows that the reachable planner correctly selected `APPEND_SAFE_LARGE` for
+1,369 selected records while the benchmark incorrectly required
+`APPEND_SAFE_SMALL`; the accepted small-tail ceiling remains 32 records.
+The versioned [terminal-failure correction authority](../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json)
+permits the same worker to correct only the benchmark and its owned lifecycle
+test, with exact planner-selected small/large paths and deterministic
+synthetic non-consuming evidence. It does not reopen either command, refund
+the token, authorize any launch, fabricate a receipt, or make
+`post_single_run` or `final_accepted` reachable. CK-07R1 is blocked after the
+corrective implementation prequalification because the existing
+receipt-required runtime acceptance contract remains unsatisfied; CK-08R4,
+CK-08RG, and CK-09 remain blocked pending an explicit future roadmap decision.
+
 The exact V11 launcher contract constructs and validates the fully
 overlay/cohort-bound receipt and non-null stdout/stderr/output evidence before
 any first durable `completed` finalization. Evidence
@@ -301,11 +322,11 @@ conditions in the table and child files; they are not unconditional DAG edges.
  },
   "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
   "ready": [],
-  "conditional_ready": [{
-    "condition": "prelaunch-recovery authority preserves the exact terminal v1 ledger, binds the corrected cohort and non-colliding v2 paths, merges and exact-main verifies; coordinator resumes exact existing worker 019fbfe2-8fe4-7de2-9264-d58572366727; one corrected synthetic invocation may seek the first successful child launch under immediate preflight; no retry of a launched process, replacement, or downstream task",
+  "conditional_ready": [],
+  "blocked": [{
+    "condition": "the terminal CK-07R1 v2 failed_after_launch state consumed the sole token; deterministic corrective evidence cannot satisfy receipt-required runtime acceptance without a separate roadmap decision",
     "tasks": ["CK-07R1"]
   }],
-  "blocked": [],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},
     {"id": "CK-08R1A", "file": "tasks/ck-08r1a-freeze-answer-semantics.md", "dependencies": ["CK-08R0"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -15,8 +15,8 @@ parents are accounting umbrellas.
 - Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
 - Remaining delegable child tasks: **37**
 - Ready child tasks: **0**
-- Conditional-ready child tasks: **1 — CK-07R1 for one corrected synthetic v2 qualification command only after the prelaunch-recovery authority is squash-merged and exact-main verified**
-- Blocked child tasks: **36**
+- Conditional-ready child tasks: **0**
+- Blocked child tasks: **37 — CK-07R1 is terminal after its consumed v2 failure; CK-08R4/CK-08RG/CK-09 and downstream remain blocked**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -69,7 +69,7 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Conditional Ready for the bound existing worker's one corrected v2 synthetic qualification command only after the versioned [prelaunch-recovery authority](../decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json) preserves the terminal v1 ledger, merges, and exact-main verifies; the token remains unspent and PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked after the prelaunch-recovery-authorized sole v2 child handshake consumed the non-refundable token and terminated `failed_after_launch`; the versioned [terminal-failure correction authority](../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json) permits only deterministic non-consuming benchmark/test correction prequalification, never another run or receipt-based acceptance; PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
 - [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,8 +1,9 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** `blocked_hold` after the terminal v1 `prelaunch_failed` invocation;
-only the versioned prelaunch-recovery authority may restore `ready_one_shot`
-for the bound existing worker, while implementation/runtime remain unaccepted
+**Status:** `terminal_failed_no_rerun` after the sole v2 child launch consumed
+the non-refundable token and durably recorded `failed_after_launch`; only
+deterministic non-consuming corrective implementation prequalification remains,
+while runtime acceptance and downstream readiness are unavailable
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -19,7 +20,10 @@ exact-main verification. The first invocation then stopped before successful
 child observation. The additive
 [prelaunch-recovery authority](../../decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json)
 alone can authorize one corrected v2 invocation after preserving that terminal
-ledger and proving the token remains unspent.
+ledger and proving the token remains unspent. That invocation has now occurred
+and is terminal; the additive
+[terminal-failure correction authority](../../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json)
+authorizes no run and only binds a deterministic benchmark/test correction.
 
 **Central plan:** [REMAINING_EXECUTION_PLAN.md](../REMAINING_EXECUTION_PLAN.md)
 
@@ -77,6 +81,34 @@ opportunity to observe the token-funded first successful child. It must use
 the exact `lifecycle-requalification-v2` output, ledger, stdout, and stderr
 paths and the exact corrected cohort bound by the recovery authority.
 
+**Preserved terminal v2 failure:** The one permitted v2 invocation was made
+exactly once. Child PID `20482` passed the exact handshake and consumed the
+non-refundable token at `2026-08-19T19:44:55Z`, then exited 70. The immutable
+v2 ledger SHA-256
+`570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2`
+records `failed_after_launch` and `token_consumed=true`; stderr SHA-256
+`4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f`
+records the exact child assertion; stdout is empty with SHA-256
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`;
+output and receipt are absent. No retry, restart, replacement, refund, or
+second invocation exists or can be authorized.
+
+The deterministic root cause is a benchmark defect, not a production planner
+defect. The accepted `TailLimits.selected_records` ceiling is 32. The frozen
+standard workload yields 1,369 selected records and 11,214,848 expected WAL
+bytes, so the production planner must select `APPEND_SAFE_LARGE` with
+`limit_exceeded:selected_records`. Production chunks additionally exceed the
+WAL bound. The benchmark incorrectly asserted `APPEND_SAFE_SMALL` for every
+chunk and therefore never exercised the selected large-artifact path.
+
+The terminal-failure correction authority permits the same worker to correct
+only the benchmark and its lifecycle test. Every chunk must preserve the exact
+`plan_refresh` result: small plans use the pointer-coordinated short writer;
+large plans use the production-reachable isolated-artifact build, validation,
+durable promotion, recovery, rollback, and prior-readability path. Tail limits,
+production planner/preparation behavior, accepted authority bytes, both
+terminal ledgers, and all run artifacts remain immutable.
+
 **Parallelism:** Resume only existing worker
 `019fbfe2-8fe4-7de2-9264-d58572366727` after the consuming-boundary authority
 merges and exact-main verifies, using frozen cwd
@@ -108,7 +140,7 @@ standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
 the finite state transitions and real non-launching subprocess argv guard; no
 E2E or benchmark run in the authority reconciliation.
 
-**Acceptance:** Immediately before the one command, the worker must revalidate
+**Acceptance:** Historical v2 launch — immediately before the one command, the worker must revalidate
 the exact recovery authority bytes, the corrected three-path source cohort,
 the preserved v1 ledger as the sole fourth dirty path, lexical worktree
 `.venv/bin/python` plus matching `sys.prefix`, exact cwd/argv/environment,
@@ -133,6 +165,17 @@ successful child launch only after the authority merge/exact-main gate and all
 worker gates pass; this is not a retry, restart, or replacement of a launched
 process. Receipt absence before dispatch is required; receipt absence or
 invalidity at successor acceptance remains fail-closed.
+
+**Post-terminal corrective acceptance:** The corrected two-file cohort may
+enter only `corrective_implementation_prequalified` after exact unit-level
+planner reproduction, 32/33 boundary tests, large-artifact promotion and
+rollback/readability tests, independent lifecycle-fold equivalence, exact
+small/large plan preservation, focused and full repository gates, one bounded
+reviewer, hosted Console/Python 3.10/3.14, squash merge of the authority-only
+packet, and fresh exact-main verification. This state is not runtime
+qualification and cannot transition to `post_single_run` or `final_accepted`;
+the existing complete-receipt requirement remains unsatisfied. No command
+invocation or run artifact creation is part of this correction.
 
 The V11 candidate must construct and validate the fully overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
@@ -162,8 +205,12 @@ complete Console job at 20 minutes. A mirror stall therefore fails closed
 instead of hanging or bypassing Console evidence.
 
 **Failure/rollback:** Retain the profile and create one narrow follow-up for a
-new dominant blocker; never weaken the gate. The preserved v1 ledger is never
-deleted, moved, rewritten, or reclassified.
+new dominant blocker; never weaken the gate. The preserved v1 and v2 ledgers,
+v2 stdout/stderr, absent output/receipt state, child identity, token
+consumption, and terminal classifications are never deleted, moved, rewritten,
+or reclassified. A separate explicit roadmap decision is required to resolve
+the receipt-required acceptance dead end; no implementation or authority
+correction may infer another run.
 
 **Handoff:** Evidence digest, profiles, retained first hosted failure, PR #394
 CI, exact-main result, and CK-08R4 input.

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -875,6 +875,19 @@ CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS = frozenset(
     }
 )
 
+CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+        "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+        "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+        "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+        "scripts/ck07r1_terminal_failure_correction.py",
+        "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -953,6 +966,7 @@ INTEGRATION_ADDITIONS = (
     | CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS
     | CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS
     | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
+    | CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | {
         "config/agent-kernel/maintainability-baseline-v1.json",

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -884,7 +884,9 @@ CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS = frozenset(
         "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
         "scripts/ck07r1_terminal_failure_correction.py",
         "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/kernel/test_ck07r1_shared_successor_overlay.py",
         "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+        "tests/kernel/test_lifecycle_run_invocation_authority.py",
     }
 )
 

--- a/scripts/ck07r1_terminal_failure_correction.py
+++ b/scripts/ck07r1_terminal_failure_correction.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Verify the non-consuming CK-07R1 terminal-failure correction boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+AUTHORITY_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/"
+    "lifecycle-terminal-failure-correction-authority-v1.json"
+)
+SCHEMA_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/"
+    "lifecycle-terminal-failure-correction-authority-v1.schema.json"
+)
+
+
+class TerminalCorrectionError(RuntimeError):
+    """The exact terminal correction contract is not satisfied."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TerminalCorrectionError(f"cannot load exact JSON at {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise TerminalCorrectionError(f"exact JSON is not an object: {path}")
+    return value
+
+
+def load_authority(root: Path) -> dict[str, Any]:
+    authority = _load_json(root / AUTHORITY_PATH)
+    schema = _load_json(root / SCHEMA_PATH)
+    try:
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(authority)
+    except Exception as exc:
+        raise TerminalCorrectionError(
+            f"terminal correction authority/schema validation failed: {exc}"
+        ) from exc
+    return authority
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise TerminalCorrectionError(
+            f"git {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _status_paths(root: Path) -> set[str]:
+    result = subprocess.run(
+        ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise TerminalCorrectionError("cannot inspect exact Git delta")
+    paths: set[str] = set()
+    entries = result.stdout.split(b"\0")
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        decoded = entry.decode("utf-8", errors="strict")
+        if len(decoded) < 4:
+            raise TerminalCorrectionError("Git status entry is malformed")
+        status = decoded[:2]
+        path = decoded[3:]
+        if "R" in status or "C" in status:
+            if index >= len(entries) or not entries[index]:
+                raise TerminalCorrectionError("Git rename status is malformed")
+            path = entries[index].decode("utf-8", errors="strict")
+            index += 1
+        paths.add(path)
+    return paths
+
+
+def verify_exact_authority_delta(
+    authority: Mapping[str, Any],
+    root: Path,
+    *,
+    observed: set[str] | None = None,
+    allowed_worktree_delta: set[str] | None = None,
+) -> None:
+    expected = set(authority["scope"]["authority_write_scope"])
+    if observed is None:
+        base = str(authority["authority_base_sha"])
+        head = _git(root, "rev-parse", "HEAD")
+        worktree = _status_paths(root)
+        if head == base:
+            actual = worktree
+        else:
+            actual = {
+                line
+                for line in _git(root, "diff", "--name-only", f"{base}..{head}", "--").splitlines()
+                if line
+            }
+            permitted = allowed_worktree_delta or set()
+            if worktree != permitted:
+                raise TerminalCorrectionError(
+                    "authority worktree delta must be exact: "
+                    f"expected={sorted(permitted)} actual={sorted(worktree)}"
+                )
+    else:
+        actual = observed
+    if actual != expected:
+        raise TerminalCorrectionError(
+            "authority Git delta must be exact: "
+            f"expected={sorted(expected)} actual={sorted(actual)}"
+        )
+
+
+def verify_exact_candidate_delta(
+    authority: Mapping[str, Any],
+    root: Path,
+    *,
+    observed: set[str] | None = None,
+) -> None:
+    expected = set(authority["scope"]["combined_candidate_scope"])
+    actual = _status_paths(root) if observed is None else observed
+    if actual != expected:
+        raise TerminalCorrectionError(
+            "candidate Git delta must be exact and all-or-none: "
+            f"expected={sorted(expected)} actual={sorted(actual)}"
+        )
+
+
+def verify_immutable_authority_bytes(authority: Mapping[str, Any], root: Path) -> None:
+    for record in authority["immutable_authorities"]:
+        path = root / record["path"]
+        if not path.is_file() or _sha256(path) != record["sha256"]:
+            raise TerminalCorrectionError(
+                f"immutable authority byte identity mismatch: {record['path']}"
+            )
+
+
+def _verify_record(root: Path, record: Mapping[str, Any], label: str) -> Path:
+    path = root / str(record["path"])
+    if not path.is_file() or _sha256(path) != record["sha256"]:
+        raise TerminalCorrectionError(f"{label} byte identity mismatch: {record['path']}")
+    return path
+
+
+def verify_corrected_cohort(authority: Mapping[str, Any], root: Path) -> None:
+    cohort = authority["corrected_candidate_cohort"]
+    if len(cohort) != 3:
+        raise TerminalCorrectionError("corrected candidate cohort is incomplete")
+    for record in cohort:
+        _verify_record(root, record, "corrected candidate")
+
+
+def verify_terminal_evidence(
+    authority: Mapping[str, Any], root: Path
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    evidence = authority["terminal_evidence"]
+    v1_path = _verify_record(root, evidence["v1_ledger"], "v1 ledger")
+    v2_path = _verify_record(root, evidence["v2_ledger"], "v2 ledger")
+    stderr_path = _verify_record(root, evidence["v2_stderr"], "v2 stderr")
+    _verify_record(root, evidence["v2_stdout"], "v2 stdout")
+    v1 = _load_json(v1_path)
+    v2 = _load_json(v2_path)
+    if {
+        "state": v1.get("state"),
+        "token_consumed": v1.get("token_consumed"),
+        "token_status": v1.get("token_status"),
+    } != {
+        "state": "prelaunch_failed",
+        "token_consumed": False,
+        "token_status": "unspent_unavailable",
+    }:
+        raise TerminalCorrectionError("v1 terminal state was rewritten")
+    launch_v1 = v1.get("launch")
+    if not isinstance(launch_v1, Mapping) or launch_v1.get("matching_processes") != []:
+        raise TerminalCorrectionError("v1 process evidence was rewritten")
+    expected_v2 = {
+        "state": "failed_after_launch",
+        "token_consumed": True,
+        "token_status": "consumed",
+        "token_consumed_at_utc": "2026-08-19T19:44:55Z",
+        "retry_allowed": False,
+        "restart_allowed": False,
+        "replacement_allowed": False,
+    }
+    for field, value in expected_v2.items():
+        if v2.get(field) != value:
+            raise TerminalCorrectionError(f"v2 terminal field changed: {field}")
+    process = v2.get("process")
+    if not isinstance(process, Mapping) or {
+        "pid": process.get("pid"),
+        "parent_pid": process.get("parent_pid"),
+        "run_token_id": process.get("run_token_id"),
+    } != {
+        "pid": 20482,
+        "parent_pid": 20450,
+        "run_token_id": "ck07r1-all-profile-e2e-1",
+    }:
+        raise TerminalCorrectionError("v2 child identity changed")
+    launch_v2 = v2.get("launch")
+    if not isinstance(launch_v2, Mapping) or launch_v2.get("matching_processes") != []:
+        raise TerminalCorrectionError("v2 process collision evidence changed")
+    failed_cohort = launch_v2.get("prelaunch_recovery", {}).get("candidate_cohort")
+    if failed_cohort != authority["failed_candidate_cohort"]:
+        raise TerminalCorrectionError("v2 failed candidate cohort binding changed")
+    failure = v2.get("failure")
+    if not isinstance(failure, Mapping) or failure.get("stage") != "evidence_collection":
+        raise TerminalCorrectionError("v2 terminal failure classification changed")
+    stderr = _load_json(stderr_path)
+    reproduction = authority["planner_reproduction"]["standard_30_day"]
+    if {
+        "exception_type": stderr.get("exception_type"),
+        "failure": stderr.get("failure"),
+        "selected_fragment": (
+            f"selected_records={reproduction['selected_records']}"
+            in str(stderr.get("message"))
+        ),
+        "reason_fragment": (
+            "limit_exceeded:selected_records" in str(stderr.get("message"))
+        ),
+    } != {
+        "exception_type": "AssertionError",
+        "failure": "child_exception",
+        "selected_fragment": True,
+        "reason_fragment": True,
+    }:
+        raise TerminalCorrectionError("v2 stderr planner failure identity changed")
+    for relative in evidence["required_absent_paths"]:
+        if (root / relative).exists():
+            raise TerminalCorrectionError(f"forbidden terminal artifact exists: {relative}")
+    return v1, v2
+
+
+def verify_planner_reproduction(authority: Mapping[str, Any], root: Path) -> None:
+    code = r"""
+import json
+from codex_usage_tracker.agent_kernel.publication.planner import RefreshIntent, plan_refresh
+from scripts import benchmark_ck07r1_lifecycle_scale as b
+rows = {}
+for profile_name, days in (("standard", 30), ("production", None)):
+    scale = b._scale_observations(profile_name, b._profile(profile_name), days)
+    chunk = scale[: b.PUBLICATION_CHUNK_OBSERVATIONS]
+    plan = plan_refresh(
+        b._changes(chunk),
+        RefreshIntent(
+            parent_publication_id="publication:seed",
+            parent_observed_at_us=1_800_000_000_000_000,
+            planned_at_us=1_800_000_000_000_001,
+            history_preset="all_time",
+            current_history_preset="all_time",
+        ),
+        limits=b._tail_limits(),
+        dirty_keys=0,
+        projection_rows=0,
+        expected_wal_bytes=None,
+    )
+    rows[profile_name] = {
+        "operation_class": plan.operation_class.value,
+        "reasons": list(plan.reasons),
+        "selected_records": plan.estimate.selected_records,
+        "expected_wal_bytes": plan.estimate.expected_wal_bytes,
+        "observations": plan.estimate.observations,
+    }
+print(json.dumps(rows, sort_keys=True, separators=(",", ":")))
+"""
+    result = subprocess.run(
+        (str(root / ".venv/bin/python"), "-c", code),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "LC_ALL": "C.UTF-8",
+            "PYTHONHASHSEED": "0",
+            "PYTHONUNBUFFERED": "1",
+            "TZ": "UTC",
+        },
+    )
+    if result.returncode != 0:
+        raise TerminalCorrectionError(
+            f"non-consuming planner reproduction failed: {result.stderr.strip()}"
+        )
+    try:
+        observed = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise TerminalCorrectionError("planner reproduction output is invalid") from exc
+    expected = {
+        "standard": authority["planner_reproduction"]["standard_30_day"],
+        "production": authority["planner_reproduction"]["production_first_chunk"],
+    }
+    if observed != expected:
+        raise TerminalCorrectionError(
+            f"planner reproduction drifted: expected={expected} actual={observed}"
+        )
+
+
+def verify_combined(authority: Mapping[str, Any], root: Path) -> dict[str, Any]:
+    verify_exact_candidate_delta(authority, root)
+    verify_corrected_cohort(authority, root)
+    verify_terminal_evidence(authority, root)
+    verify_planner_reproduction(authority, root)
+    return {
+        "candidate_paths": len(authority["scope"]["combined_candidate_scope"]),
+        "new_run_permitted": False,
+        "runtime_acceptance": "not_claimed",
+        "token_consumed": True,
+    }
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("authority", "combined"))
+    parser.add_argument("--authority-root", type=Path, default=Path.cwd())
+    parser.add_argument("--candidate-root", type=Path)
+    args = parser.parse_args(argv)
+    authority_root = args.authority_root.absolute()
+    authority = load_authority(authority_root)
+    verify_immutable_authority_bytes(authority, authority_root)
+    verify_exact_authority_delta(authority, authority_root)
+    result: dict[str, Any] = {
+        "authority_paths": len(authority["scope"]["authority_write_scope"]),
+        "authority_schema": authority["schema"],
+        "status": authority["status"],
+        "verification": "passed",
+    }
+    if args.command == "combined":
+        if args.candidate_root is None:
+            parser.error("--candidate-root is required for combined")
+        result.update(verify_combined(authority, args.candidate_root.absolute()))
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/ck07r1_terminal_failure_correction.py
+++ b/scripts/ck07r1_terminal_failure_correction.py
@@ -14,8 +14,7 @@ from typing import Any
 from jsonschema import Draft202012Validator
 
 AUTHORITY_PATH = Path(
-    "docs/decisions/evidence/ck07r1a0/"
-    "lifecycle-terminal-failure-correction-authority-v1.json"
+    "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json"
 )
 SCHEMA_PATH = Path(
     "docs/decisions/evidence/ck07r1a0/"
@@ -67,9 +66,7 @@ def _git(root: Path, *args: str) -> str:
         text=True,
     )
     if result.returncode != 0:
-        raise TerminalCorrectionError(
-            f"git {' '.join(args)} failed: {result.stderr.strip()}"
-        )
+        raise TerminalCorrectionError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
     return result.stdout.strip()
 
 
@@ -110,10 +107,22 @@ def verify_exact_authority_delta(
     *,
     observed: set[str] | None = None,
     allowed_worktree_delta: set[str] | None = None,
+    base_is_ancestor: bool | None = None,
 ) -> None:
     expected = set(authority["scope"]["authority_write_scope"])
+    base = str(authority["authority_base_sha"])
+    if base_is_ancestor is None:
+        ancestor = subprocess.run(
+            ("git", "merge-base", "--is-ancestor", base, "HEAD"),
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        base_is_ancestor = ancestor.returncode == 0
+    if not base_is_ancestor:
+        raise TerminalCorrectionError("authority base is not an ancestor of HEAD")
     if observed is None:
-        base = str(authority["authority_base_sha"])
         head = _git(root, "rev-parse", "HEAD")
         worktree = _status_paths(root)
         if head == base:
@@ -239,12 +248,9 @@ def verify_terminal_evidence(
         "exception_type": stderr.get("exception_type"),
         "failure": stderr.get("failure"),
         "selected_fragment": (
-            f"selected_records={reproduction['selected_records']}"
-            in str(stderr.get("message"))
+            f"selected_records={reproduction['selected_records']}" in str(stderr.get("message"))
         ),
-        "reason_fragment": (
-            "limit_exceeded:selected_records" in str(stderr.get("message"))
-        ),
+        "reason_fragment": ("limit_exceeded:selected_records" in str(stderr.get("message"))),
     } != {
         "exception_type": "AssertionError",
         "failure": "child_exception",
@@ -322,6 +328,13 @@ print(json.dumps(rows, sort_keys=True, separators=(",", ":")))
 
 
 def verify_combined(authority: Mapping[str, Any], root: Path) -> dict[str, Any]:
+    candidate_delta = set(authority["scope"]["combined_candidate_scope"])
+    verify_immutable_authority_bytes(authority, root)
+    verify_exact_authority_delta(
+        authority,
+        root,
+        allowed_worktree_delta=candidate_delta,
+    )
     verify_exact_candidate_delta(authority, root)
     verify_corrected_cohort(authority, root)
     verify_terminal_evidence(authority, root)

--- a/scripts/qualify_ck08r1_answer_truth.py
+++ b/scripts/qualify_ck08r1_answer_truth.py
@@ -62,6 +62,21 @@ from scripts.ck07r1_shared_successor_overlay import (  # noqa: E402
 from scripts.ck07r1_shared_successor_overlay import (  # noqa: E402
     verify_shared_successor_overlay,
 )
+from scripts.ck07r1_terminal_failure_correction import (  # noqa: E402
+    AUTHORITY_PATH as CK07R1_TERMINAL_AUTHORITY_PATH,
+)
+from scripts.ck07r1_terminal_failure_correction import (  # noqa: E402
+    load_authority as load_ck07r1_terminal_authority,
+)
+from scripts.ck07r1_terminal_failure_correction import (  # noqa: E402
+    verify_combined as verify_ck07r1_terminal_combined,
+)
+from scripts.ck07r1_terminal_failure_correction import (  # noqa: E402
+    verify_exact_authority_delta as verify_ck07r1_terminal_authority_delta,
+)
+from scripts.ck07r1_terminal_failure_correction import (  # noqa: E402
+    verify_immutable_authority_bytes as verify_ck07r1_terminal_authority_bytes,
+)
 from tests.agent_kernel.fixtures.independent import (  # noqa: E402
     semantic as independent_semantic,
 )
@@ -142,9 +157,39 @@ def _git_last_touch(relative: str) -> str:
 
 
 def current_ck07r1_overlay() -> tuple[dict[str, Any], str]:
-    """Select the immutable v1 overlay or its exact versioned recovery bridge."""
+    """Select the immutable v1 overlay through its latest exact versioned bridge."""
 
+    terminal_path = ROOT / CK07R1_TERMINAL_AUTHORITY_PATH
     recovery_path = ROOT / CK07R1_RECOVERY_AUTHORITY_PATH
+    if terminal_path.is_file():
+        terminal = load_ck07r1_terminal_authority(ROOT)
+        verify_ck07r1_terminal_authority_bytes(terminal, ROOT)
+        overlay = _json(
+            ROOT / "docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json"
+        )
+        predecessor = overlay["states"]["predecessor"]["artifacts"][0]["sha256"]
+        successor = next(
+            item["sha256"]
+            for item in terminal["corrected_candidate_cohort"]
+            if item["path"] == CK07R1_PREPARATION_PATH
+        )
+        observed = sha256_file(ROOT / CK07R1_PREPARATION_PATH)
+        if observed == predecessor:
+            verify_ck07r1_terminal_authority_delta(terminal, ROOT)
+            overlay["scope"]["authority_write_scope"] = sorted(
+                set(overlay["scope"]["authority_write_scope"])
+                | set(terminal["scope"]["authority_write_scope"])
+            )
+            return overlay, "authority_main"
+        if observed == successor:
+            verify_ck07r1_terminal_combined(terminal, ROOT)
+            overlay["scope"]["authority_write_scope"] = sorted(
+                set(overlay["scope"]["authority_write_scope"])
+                | set(terminal["scope"]["authority_write_scope"])
+                | set(terminal["scope"]["combined_candidate_scope"])
+            )
+            return overlay, "worker_prequalification"
+        raise QualificationError("CK-07R1 preparation state is outside terminal authority")
     if not recovery_path.is_file():
         return verify_shared_successor_overlay(ROOT)
 

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -34,6 +34,21 @@ from scripts.ck07r1_shared_successor_overlay import (
     verify_launcher_safety_contract,
     verify_shared_successor_overlay,
 )
+from scripts.ck07r1_terminal_failure_correction import (
+    AUTHORITY_PATH as TERMINAL_AUTHORITY_PATH,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    load_authority as load_terminal_authority,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    verify_combined as verify_terminal_combined,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    verify_exact_authority_delta as verify_terminal_authority_delta,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    verify_immutable_authority_bytes as verify_terminal_authority_bytes,
+)
 
 
 def _state_observed(
@@ -51,6 +66,26 @@ def test_overlay_is_exact_and_live_state_is_authorized() -> None:
     try:
         authority, state = verify_shared_successor_overlay()
     except SharedSuccessorOverlayError:
+        if (ROOT / TERMINAL_AUTHORITY_PATH).is_file():
+            terminal_authority = load_terminal_authority(ROOT)
+            corrected_preparation = terminal_authority["corrected_candidate_cohort"][0]
+            if sha256_path(ROOT / corrected_preparation["path"]) == corrected_preparation["sha256"]:
+                terminal = verify_terminal_combined(terminal_authority, ROOT)
+                assert terminal == {
+                    "candidate_paths": 7,
+                    "new_run_permitted": False,
+                    "runtime_acceptance": "not_claimed",
+                    "token_consumed": True,
+                }
+            else:
+                verify_terminal_authority_bytes(terminal_authority, ROOT)
+                verify_terminal_authority_delta(terminal_authority, ROOT)
+                overlay = load_overlay(ROOT)
+                assert (
+                    sha256_path(ROOT / corrected_preparation["path"])
+                    == (overlay["states"]["predecessor"]["artifacts"][0]["sha256"])
+                )
+            return
         if not (ROOT / RECOVERY_AUTHORITY_PATH).is_file():
             raise
         recovery_ledger = ROOT / "output/ck07r1/lifecycle-requalification-v1.launch-token.json"

--- a/tests/kernel/test_ck07r1_shared_successor_overlay.py
+++ b/tests/kernel/test_ck07r1_shared_successor_overlay.py
@@ -69,7 +69,7 @@ def test_overlay_is_exact_and_live_state_is_authorized() -> None:
         if (ROOT / TERMINAL_AUTHORITY_PATH).is_file():
             terminal_authority = load_terminal_authority(ROOT)
             corrected_preparation = terminal_authority["corrected_candidate_cohort"][0]
-            if sha256_path(ROOT / corrected_preparation["path"]) == corrected_preparation["sha256"]:
+            if sha256_path(ROOT, corrected_preparation["path"]) == corrected_preparation["sha256"]:
                 terminal = verify_terminal_combined(terminal_authority, ROOT)
                 assert terminal == {
                     "candidate_paths": 7,
@@ -82,7 +82,7 @@ def test_overlay_is_exact_and_live_state_is_authorized() -> None:
                 verify_terminal_authority_delta(terminal_authority, ROOT)
                 overlay = load_overlay(ROOT)
                 assert (
-                    sha256_path(ROOT / corrected_preparation["path"])
+                    sha256_path(ROOT, corrected_preparation["path"])
                     == (overlay["states"]["predecessor"]["artifacts"][0]["sha256"])
                 )
             return

--- a/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
+++ b/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.ck07r1_terminal_failure_correction import (
+    AUTHORITY_PATH,
+    SCHEMA_PATH,
+    TerminalCorrectionError,
+    load_authority,
+    verify_corrected_cohort,
+    verify_exact_authority_delta,
+    verify_exact_candidate_delta,
+    verify_immutable_authority_bytes,
+    verify_terminal_evidence,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _authority() -> dict[str, Any]:
+    return load_authority(ROOT)
+
+
+def _write(path: Path, value: bytes) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(value)
+    return hashlib.sha256(value).hexdigest()
+
+
+def _synthetic_candidate(authority: dict[str, Any], root: Path) -> None:
+    for index, record in enumerate(authority["corrected_candidate_cohort"]):
+        payload = f"corrected candidate {index}\n".encode()
+        record["sha256"] = _write(root / record["path"], payload)
+    v1 = {
+        "state": "prelaunch_failed",
+        "token_consumed": False,
+        "token_status": "unspent_unavailable",
+        "launch": {"matching_processes": []},
+    }
+    v2 = {
+        "state": "failed_after_launch",
+        "token_consumed": True,
+        "token_status": "consumed",
+        "token_consumed_at_utc": "2026-08-19T19:44:55Z",
+        "retry_allowed": False,
+        "restart_allowed": False,
+        "replacement_allowed": False,
+        "process": {
+            "pid": 20482,
+            "parent_pid": 20450,
+            "run_token_id": "ck07r1-all-profile-e2e-1",
+        },
+        "launch": {
+            "matching_processes": [],
+            "prelaunch_recovery": {
+                "candidate_cohort": authority["failed_candidate_cohort"]
+            },
+        },
+        "failure": {"stage": "evidence_collection"},
+    }
+    stderr = {
+        "exception_type": "AssertionError",
+        "failure": "child_exception",
+        "message": (
+            "reachable planner did not select APPEND_SAFE_SMALL: "
+            "APPEND_SAFE_LARGE selected_records=1369 "
+            "reason limit_exceeded:selected_records"
+        ),
+    }
+    evidence = authority["terminal_evidence"]
+    evidence["v1_ledger"]["sha256"] = _write(
+        root / evidence["v1_ledger"]["path"],
+        (json.dumps(v1) + "\n").encode(),
+    )
+    evidence["v2_ledger"]["sha256"] = _write(
+        root / evidence["v2_ledger"]["path"],
+        (json.dumps(v2) + "\n").encode(),
+    )
+    evidence["v2_stderr"]["sha256"] = _write(
+        root / evidence["v2_stderr"]["path"],
+        (json.dumps(stderr) + "\n").encode(),
+    )
+    evidence["v2_stdout"]["sha256"] = _write(
+        root / evidence["v2_stdout"]["path"],
+        b"",
+    )
+
+
+def test_terminal_correction_schema_is_versioned_strict_and_exact() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(authority)
+    assert authority["schema"].endswith(".v1")
+    assert authority["authority_base_sha"] == (
+        "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8"
+    )
+    assert authority["status"] == "permitted_not_accepted"
+
+
+def test_terminal_correction_preserves_accepted_authority_bytes() -> None:
+    verify_immutable_authority_bytes(_authority(), ROOT)
+
+
+def test_terminal_evidence_and_corrected_cohort_are_exact(tmp_path: Path) -> None:
+    authority = deepcopy(_authority())
+    _synthetic_candidate(authority, tmp_path)
+    verify_corrected_cohort(authority, tmp_path)
+    v1, v2 = verify_terminal_evidence(authority, tmp_path)
+    assert v1["token_consumed"] is False
+    assert v2["token_consumed"] is True
+    assert v2["state"] == "failed_after_launch"
+
+
+@pytest.mark.parametrize(
+    ("record_name", "replacement"),
+    [
+        ("v1_ledger", b"rewritten v1\n"),
+        ("v2_ledger", b"rewritten v2\n"),
+        ("v2_stderr", b"rewritten stderr\n"),
+        ("v2_stdout", b"not empty\n"),
+    ],
+)
+def test_terminal_evidence_rewrite_fails_closed(
+    tmp_path: Path, record_name: str, replacement: bytes
+) -> None:
+    authority = deepcopy(_authority())
+    _synthetic_candidate(authority, tmp_path)
+    record = authority["terminal_evidence"][record_name]
+    (tmp_path / record["path"]).write_bytes(replacement)
+    with pytest.raises(TerminalCorrectionError, match="byte identity mismatch"):
+        verify_terminal_evidence(authority, tmp_path)
+
+
+def test_terminal_output_or_receipt_fabrication_fails_closed(tmp_path: Path) -> None:
+    authority = deepcopy(_authority())
+    _synthetic_candidate(authority, tmp_path)
+    forbidden = (
+        tmp_path / authority["terminal_evidence"]["required_absent_paths"][0]
+    )
+    forbidden.write_text("fabricated\n", encoding="utf-8")
+    with pytest.raises(TerminalCorrectionError, match="forbidden terminal artifact"):
+        verify_terminal_evidence(authority, tmp_path)
+
+
+def test_corrected_candidate_digest_and_atomic_delta_fail_closed(
+    tmp_path: Path,
+) -> None:
+    authority = deepcopy(_authority())
+    _synthetic_candidate(authority, tmp_path)
+    path = tmp_path / authority["corrected_candidate_cohort"][1]["path"]
+    path.write_bytes(b"other benchmark\n")
+    with pytest.raises(TerminalCorrectionError, match="candidate byte identity"):
+        verify_corrected_cohort(authority, tmp_path)
+    expected = set(authority["scope"]["combined_candidate_scope"])
+    verify_exact_candidate_delta(authority, ROOT, observed=expected)
+    for changed in (
+        expected - {next(iter(expected))},
+        expected | {"output/ck07r1/lifecycle-requalification-v2.json"},
+    ):
+        with pytest.raises(TerminalCorrectionError, match="candidate Git delta"):
+            verify_exact_candidate_delta(authority, ROOT, observed=changed)
+
+
+def test_authority_delta_is_exact_and_excludes_implementation() -> None:
+    authority = _authority()
+    expected = set(authority["scope"]["authority_write_scope"])
+    verify_exact_authority_delta(authority, ROOT, observed=expected)
+    assert "scripts/benchmark_ck07r1_lifecycle_scale.py" not in expected
+    assert "src/codex_usage_tracker/agent_kernel/publication/preparation.py" not in expected
+    with pytest.raises(TerminalCorrectionError, match="authority Git delta"):
+        verify_exact_authority_delta(
+            authority,
+            ROOT,
+            observed=expected | {"scripts/benchmark_ck07r1_lifecycle_scale.py"},
+        )
+
+
+def test_planner_reproduction_binds_correct_large_classification_and_boundary() -> None:
+    reproduction = _authority()["planner_reproduction"]
+    assert reproduction["tail_limits"]["selected_records"] == 32
+    assert reproduction["standard_30_day"] == {
+        "operation_class": "append_safe_large",
+        "reasons": ["limit_exceeded:selected_records"],
+        "selected_records": 1369,
+        "expected_wal_bytes": 11214848,
+        "observations": 1369,
+    }
+    assert reproduction["production_first_chunk"]["reasons"] == [
+        "limit_exceeded:selected_records",
+        "limit_exceeded:expected_wal_bytes",
+    ]
+    assert reproduction["boundary"] == {
+        "record_32": "append_safe_small",
+        "record_33": "append_safe_large_limit_exceeded_selected_records",
+    }
+
+
+def test_terminal_state_never_authorizes_another_run_or_acceptance() -> None:
+    authority = _authority()
+    decision = authority["decision"]
+    token = authority["run_token"]
+    assert decision["new_command_invocations_permitted"] == 0
+    assert decision["launch_authorized"] is False
+    assert decision["token_refund"] is False
+    assert decision["retry"] == decision["restart"] == decision["replacement"] == "none"
+    assert decision["post_single_run"].startswith("unavailable")
+    assert decision["final_accepted"] == "unavailable"
+    assert decision["runtime_acceptance"] == "not_claimed"
+    assert token["token_consumed"] is True
+    assert token["remaining_invocations"] == 0
+    assert token["successful_launches_observed"] == 1
+
+
+def test_schema_rejects_token_scope_planner_and_acceptance_weakening() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    mutations = [
+        lambda value: value["decision"].__setitem__("launch_authorized", True),
+        lambda value: value["decision"].__setitem__(
+            "new_command_invocations_permitted", 1
+        ),
+        lambda value: value["decision"].__setitem__("final_accepted", "available"),
+        lambda value: value["run_token"].__setitem__("token_consumed", False),
+        lambda value: value["run_token"].__setitem__("non_refundable", False),
+        lambda value: value["planner_reproduction"]["tail_limits"].__setitem__(
+            "selected_records", 1369
+        ),
+        lambda value: value["corrected_candidate_cohort"].pop(),
+        lambda value: value["scope"]["authority_write_scope"].append(
+            "scripts/benchmark_ck07r1_lifecycle_scale.py"
+        ),
+    ]
+    for mutate in mutations:
+        changed = deepcopy(authority)
+        mutate(changed)
+        assert list(Draft202012Validator(schema).iter_errors(changed))
+
+
+def test_authority_file_name_is_versioned() -> None:
+    assert Path(AUTHORITY_PATH).name.endswith("-v1.json")

--- a/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
+++ b/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+import scripts.ck07r1_terminal_failure_correction as terminal_module
 from scripts.ck07r1_terminal_failure_correction import (
     AUTHORITY_PATH,
     SCHEMA_PATH,
@@ -59,9 +60,7 @@ def _synthetic_candidate(authority: dict[str, Any], root: Path) -> None:
         },
         "launch": {
             "matching_processes": [],
-            "prelaunch_recovery": {
-                "candidate_cohort": authority["failed_candidate_cohort"]
-            },
+            "prelaunch_recovery": {"candidate_cohort": authority["failed_candidate_cohort"]},
         },
         "failure": {"stage": "evidence_collection"},
     }
@@ -99,9 +98,7 @@ def test_terminal_correction_schema_is_versioned_strict_and_exact() -> None:
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(authority)
     assert authority["schema"].endswith(".v1")
-    assert authority["authority_base_sha"] == (
-        "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8"
-    )
+    assert authority["authority_base_sha"] == ("77cb03cb3dd6bcf5608249056cb3470bc7fee3d8")
     assert authority["status"] == "permitted_not_accepted"
 
 
@@ -142,9 +139,7 @@ def test_terminal_evidence_rewrite_fails_closed(
 def test_terminal_output_or_receipt_fabrication_fails_closed(tmp_path: Path) -> None:
     authority = deepcopy(_authority())
     _synthetic_candidate(authority, tmp_path)
-    forbidden = (
-        tmp_path / authority["terminal_evidence"]["required_absent_paths"][0]
-    )
+    forbidden = tmp_path / authority["terminal_evidence"]["required_absent_paths"][0]
     forbidden.write_text("fabricated\n", encoding="utf-8")
     with pytest.raises(TerminalCorrectionError, match="forbidden terminal artifact"):
         verify_terminal_evidence(authority, tmp_path)
@@ -181,6 +176,72 @@ def test_authority_delta_is_exact_and_excludes_implementation() -> None:
             ROOT,
             observed=expected | {"scripts/benchmark_ck07r1_lifecycle_scale.py"},
         )
+    with pytest.raises(TerminalCorrectionError, match="not an ancestor"):
+        verify_exact_authority_delta(
+            authority,
+            ROOT,
+            observed=expected,
+            base_is_ancestor=False,
+        )
+
+
+def test_combined_verifies_authority_binding_before_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authority = _authority()
+    expected_delta = set(authority["scope"]["combined_candidate_scope"])
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_immutable_authority_bytes",
+        lambda _authority, _root: calls.append(("immutable", None)),
+    )
+
+    def _authority_delta(
+        _authority: dict[str, Any],
+        _root: Path,
+        *,
+        observed: set[str] | None = None,
+        allowed_worktree_delta: set[str] | None = None,
+        base_is_ancestor: bool | None = None,
+    ) -> None:
+        assert observed is None
+        assert base_is_ancestor is None
+        calls.append(("authority_delta", allowed_worktree_delta))
+
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_exact_authority_delta",
+        _authority_delta,
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_exact_candidate_delta",
+        lambda _authority, _root: calls.append(("candidate_delta", None)),
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_corrected_cohort",
+        lambda _authority, _root: calls.append(("cohort", None)),
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_terminal_evidence",
+        lambda _authority, _root: calls.append(("evidence", None)),
+    )
+    monkeypatch.setattr(
+        terminal_module,
+        "verify_planner_reproduction",
+        lambda _authority, _root: calls.append(("planner", None)),
+    )
+
+    terminal_module.verify_combined(authority, ROOT)
+    assert calls[:3] == [
+        ("immutable", None),
+        ("authority_delta", expected_delta),
+        ("candidate_delta", None),
+    ]
 
 
 def test_planner_reproduction_binds_correct_large_classification_and_boundary() -> None:
@@ -224,9 +285,7 @@ def test_schema_rejects_token_scope_planner_and_acceptance_weakening() -> None:
     schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
     mutations = [
         lambda value: value["decision"].__setitem__("launch_authorized", True),
-        lambda value: value["decision"].__setitem__(
-            "new_command_invocations_permitted", 1
-        ),
+        lambda value: value["decision"].__setitem__("new_command_invocations_permitted", 1),
         lambda value: value["decision"].__setitem__("final_accepted", "available"),
         lambda value: value["run_token"].__setitem__("token_consumed", False),
         lambda value: value["run_token"].__setitem__("non_refundable", False),

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -10,6 +10,12 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from scripts.ck07r1_prelaunch_recovery import verify_combined_preflight
+from scripts.ck07r1_terminal_failure_correction import (
+    load_authority as load_terminal_correction_authority,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    verify_combined as verify_terminal_correction_combined,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOCS = _REPO_ROOT / "docs"
@@ -111,6 +117,7 @@ def _assert_ck07_selected_or_recovery_cohort(
         for item in recovery["candidate_cohort"]
     }
     if actual == recovery_expected:
+        verify_combined_preflight(_REPO_ROOT, _REPO_ROOT)
         return
 
     terminal = _json(
@@ -122,7 +129,10 @@ def _assert_ck07_selected_or_recovery_cohort(
         for item in terminal["corrected_candidate_cohort"]
     }
     assert actual == terminal_expected
-    verify_combined_preflight(_REPO_ROOT, _REPO_ROOT)
+    verify_terminal_correction_combined(
+        load_terminal_correction_authority(_REPO_ROOT),
+        _REPO_ROOT,
+    )
 
 
 def _portable_selected_support_hashes() -> dict[str, str]:

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -234,8 +234,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
         "blocked_policy": "spawn_none_and_report_to_orchestrator",
     }
-    conditional_ready = {"CK-07R1"}
-    blocked: set[str] = set()
+    conditional_ready: set[str] = set()
+    blocked = {"CK-07R1"}
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R1A",
@@ -261,20 +261,17 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     )
     ready: set[str] = set()
     assert manifest["ready"] == []
-    assert manifest["conditional_ready"] == [
+    assert manifest["conditional_ready"] == []
+    assert manifest["blocked"] == [
         {
             "condition": (
-                "prelaunch-recovery authority preserves the exact terminal v1 ledger, binds "
-                "the corrected cohort and non-colliding v2 paths, merges and exact-main "
-                "verifies; coordinator resumes exact existing worker "
-                "019fbfe2-8fe4-7de2-9264-d58572366727; one corrected synthetic invocation "
-                "may seek the first successful child launch under immediate preflight; no "
-                "retry of a launched process, replacement, or downstream task"
+                "the terminal CK-07R1 v2 failed_after_launch state consumed the sole "
+                "token; deterministic corrective evidence cannot satisfy receipt-required "
+                "runtime acceptance without a separate roadmap decision"
             ),
             "tasks": ["CK-07R1"],
-        },
+        }
     ]
-    assert manifest["blocked"] == []
     parent_section = ledger.split("## Parent packets", 1)[1].split(
         "## Remaining delegated child tasks", 1
     )[0]
@@ -291,7 +288,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     remaining_delegable = len(manifest["tasks"]) - len(manifest["completed"])
     assert remaining_delegable == 37
     assert f"Remaining delegable child tasks: **{remaining_delegable}**" in ledger
-    assert "Blocked child tasks: **36" in ledger
+    assert "Blocked child tasks: **37" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -413,7 +410,10 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         elif packet_id in ready:
             assert "**Status:** Ready" in body
         elif packet_id in blocked:
-            assert "**Status:** Blocked" in body
+            if packet_id == "CK-07R1":
+                assert "**Status:** `terminal_failed_no_rerun`" in body
+            else:
+                assert "**Status:** Blocked" in body
         elif packet_id in {
             "CK-08R0",
             "CK-08R1A",
@@ -902,7 +902,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
         "**Status:** Completed on merge — PR #392 hosted-green, squash-merged at\n"
         "`68050b93`, and exact-main verified"
     ) in ckqg1
-    assert "**Status:** `blocked_hold`" in ck07r1
+    assert "**Status:** `terminal_failed_no_rerun`" in ck07r1
     assert "720-second wrapper timeout" in ck07r1a0
     assert "revoked, never authoritative, and never used" in ck07r1a0
 
@@ -1274,7 +1274,8 @@ def test_ck07r1_consuming_boundary_is_documented_without_downstream_readiness() 
         ]["downstream"]
     )
     assert "Ready child tasks: **0**" in accounting
-    assert "Conditional-ready child tasks: **1 — CK-07R1" in accounting
+    assert "Conditional-ready child tasks: **0**" in accounting
+    assert "Blocked child tasks: **37 — CK-07R1 is terminal" in accounting
     assert "## Standing Repository Authorization" in agents
     assert "No additional user approval is required" in agents
     assert "normative coordinator/orchestration binding" in agents
@@ -1305,3 +1306,26 @@ def test_ck07r1_prelaunch_recovery_is_documented_fail_closed() -> None:
     assert authority["run_token"]["successful_launches_observed"] == 0
     assert authority["decision"]["new_invocation_is_launched_process_retry"] is False
     assert authority["decision"]["launch_authorized_in_authority_task"] is False
+
+
+def test_ck07r1_terminal_failure_correction_is_documented_no_rerun() -> None:
+    index = _read("docs/INDEX.md")
+    central = _read("docs/roadmap/REMAINING_EXECUTION_PLAN.md")
+    accounting = _read("docs/roadmap/TASK_PACKETS.md")
+    packet = _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
+    authority = _json(
+        "docs/decisions/evidence/ck07r1a0/"
+        "lifecycle-terminal-failure-correction-authority-v1.json"
+    )
+    for body in (index, central, accounting, packet):
+        assert "terminal-failure correction authority" in body
+        assert "failed_after_launch" in body
+    for body in (index, central, packet):
+        assert "570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2" in body
+        assert "APPEND_SAFE_LARGE" in body
+        assert "1,369" in body
+        assert "32" in body
+    assert authority["run_token"]["token_consumed"] is True
+    assert authority["run_token"]["remaining_invocations"] == 0
+    assert authority["decision"]["launch_authorized"] is False
+    assert authority["decision"]["final_accepted"] == "unavailable"

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -110,7 +110,18 @@ def _assert_ck07_selected_or_recovery_cohort(
         item["path"]: item["sha256"]
         for item in recovery["candidate_cohort"]
     }
-    assert actual == recovery_expected
+    if actual == recovery_expected:
+        return
+
+    terminal = _json(
+        "docs/decisions/evidence/ck07r1a0/"
+        "lifecycle-terminal-failure-correction-authority-v1.json"
+    )
+    terminal_expected = {
+        item["path"]: item["sha256"]
+        for item in terminal["corrected_candidate_cohort"]
+    }
+    assert actual == terminal_expected
     verify_combined_preflight(_REPO_ROOT, _REPO_ROOT)
 
 

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -23,6 +23,7 @@ from scripts.check_kernel_scope import (
     CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS,
     CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS,
     CK07R1_SHARED_OVERLAY_AUTHORITY_ADDITIONS,
+    CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS,
     CK07R1A0_AUTHORITY_ADDITIONS,
     CK08_PREREQUISITE_BLOCKER_ADDITIONS,
     CK08_QUERY_EVIDENCE_ADDITIONS,
@@ -703,6 +704,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS
         | CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS
         | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
+        | CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | {
             "config/agent-kernel/maintainability-baseline-v1.json",
@@ -822,6 +824,19 @@ def test_ck07r1_prelaunch_recovery_additions_are_explicit_and_bounded() -> None:
         "tests/agent_kernel/test_ck08r1_answer_requalification.py",
         "tests/kernel/test_ck07r1_prelaunch_recovery_authority.py",
     } == CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
+
+
+def test_ck07r1_terminal_failure_correction_additions_are_explicit_and_bounded() -> None:
+    assert {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+        "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+        "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+        "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+        "scripts/ck07r1_terminal_failure_correction.py",
+        "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+    } == CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
 
 
 def test_kernel_skeleton_imports_without_legacy_runtime() -> None:

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -835,7 +835,9 @@ def test_ck07r1_terminal_failure_correction_additions_are_explicit_and_bounded()
         "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
         "scripts/ck07r1_terminal_failure_correction.py",
         "scripts/qualify_ck08r1_answer_truth.py",
+        "tests/kernel/test_ck07r1_shared_successor_overlay.py",
         "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+        "tests/kernel/test_lifecycle_run_invocation_authority.py",
     } == CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
 
 

--- a/tests/kernel/test_lifecycle_run_invocation_authority.py
+++ b/tests/kernel/test_lifecycle_run_invocation_authority.py
@@ -13,6 +13,15 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from scripts.check_kernel_scope import CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS
+from scripts.ck07r1_terminal_failure_correction import (
+    AUTHORITY_PATH as TERMINAL_CORRECTION_AUTHORITY_PATH,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    load_authority as load_terminal_correction_authority,
+)
+from scripts.ck07r1_terminal_failure_correction import (
+    verify_combined as verify_terminal_correction_combined,
+)
 
 _ROOT = Path(__file__).resolve().parents[2]
 _AUTHORITY_PATH = _ROOT / "docs/decisions/evidence/ck07r1a0/lifecycle-run-invocation-authority.json"
@@ -111,6 +120,22 @@ def test_corrected_argv_guard_accepts_exact_candidate_in_real_non_launching_subp
         pytest.skip("the retained candidate is unavailable until the worker reapplies it")
     candidate_sha256 = hashlib.sha256(candidate.read_bytes()).hexdigest()
     expected_v1_sha256 = authority["selected_candidate"]["artifacts"][1]["sha256"]
+    terminal_path = _ROOT / TERMINAL_CORRECTION_AUTHORITY_PATH
+    if terminal_path.is_file():
+        terminal = load_terminal_correction_authority(_ROOT)
+        expected_terminal_sha256 = next(
+            item["sha256"]
+            for item in terminal["corrected_candidate_cohort"]
+            if item["path"] == str(relative_candidate)
+        )
+        if candidate_sha256 == expected_terminal_sha256:
+            assert verify_terminal_correction_combined(terminal, _ROOT) == {
+                "candidate_paths": 7,
+                "new_run_permitted": False,
+                "runtime_acceptance": "not_claimed",
+                "token_consumed": True,
+            }
+            return
     recovery_path = (
         _ROOT / "docs/decisions/evidence/ck07r1a0/lifecycle-prelaunch-recovery-authority-v1.json"
     )


### PR DESCRIPTION
## Summary
- bind the immutable CK-07R1 v1 prelaunch failure and v2 consumed terminal failure as historical evidence
- classify the corrected planner cohort only as permitted-not-accepted corrective implementation evidence
- require exact authority ancestry, immutable bytes, exact 14-path authority delta, and exact seven-path combined candidate/evidence delta
- preserve zero launch authorization, consumed non-refundable token, no retry/restart/replacement, no receipt/runtime acceptance, and downstream holds

## Validation
- exact combined verifier and focused authority consumers: 152 passed
- complete kernel suite: 643 passed
- `just vp`
- `just v`: 1,581 passed, 1 skipped; 13 performance invariants; pyright/release checks green
- sole reviewer: one P1 accepted and corrected; correction pass has no remaining findings
- Python 3.14.6 locally; hosted Python 3.10/3.14 and Focused Evidence Console required

## Safety
Authority/docs/schema/scope/tests only. No implementation candidate files or runtime artifacts are included. No CK-07 launch, token mutation, artifact mutation, PR #394 change, cleanup, or downstream dispatch.