### PR TITLE
Complete CK-07R1 post-terminal roadmap dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ corrective proof. CK-08R0 froze `corrective-gates-v1`; CK-08R2 is complete and
 CK-09 remains blocked. CK-08R1A froze corrected answer meaning and recursive
 closure; R1C is accepted at exact main `fb0c578`, and R1B is accepted at exact
 main `9e9332b3`. Final R1 requalification passed hosted CI in PR #439,
-squash-merged, and was exact-main verified at `0832b854`; no packet is Ready
-while CK-07R1 remains conditional.
+squash-merged, and was exact-main verified at `0832b854`. CK-07R1's separate
+post-terminal roadmap completion makes CK-08R4 the sole Ready packet while
+CK-08RG and CK-09 remain blocked.
 CK-QG1A removed the two R2 page-executor complexity findings without changing
 behavior or the frozen baseline and is accepted at exact main `30983d4`;
 QG1 PR #392 passed hosted CI, squash-merged, and was exact-main verified at
@@ -47,27 +48,19 @@ The versioned
 [`shared-successor-overlay-authority-v1`](docs/decisions/evidence/ck07r1a0/shared-successor-overlay-authority-v1.json)
 preserves accepted CK-08R1B, CK-08R1, and CK-QG1 bytes while admitting only
 that complete cohort as CK-07 `worker_prequalification`.
-The existing CK-07R1 worker remains stopped until that authority transition is
-merged and exact-main verified; no launch or token use is authorized. The
-candidate must construct and validate its exact overlay-bound receipt and
-non-null stdout/stderr/output evidence before the first durable `completed`
-finalization; any evidence read/hash/parse/validation/finalization failure is
-terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM handlers must
-route every wait interruption/error through bounded TERM/KILL/reap before
-terminal failure persistence and remain installed through evidence, receipt,
-and terminal ledger finalization; originals restore only after the terminal
-state attempt. Every terminal fallback persistence call masks SIGINT/SIGTERM
-with the existing ignore guard and restores the prior temporary handlers
-afterward; the outer final restoration of original handlers remains last. The
-fork child ignores SIGINT/SIGTERM while
-waiting for parent release and routes every pre-release failure to
-`os._exit(71)`; parent cleanup rejects nonpositive PIDs. Ledger updates use a
-unique same-directory `mkstemp`, close and unlink every failed or interrupted
-path, and persist durable consumed/no-retry `failed_after_launch` evidence
-without temporary residue. Its interpreter must be the lexical
-repository-worktree `.venv/bin/python` with matching lexical venv `sys.prefix`;
-base interpreters, resolved/symlink equivalence, wrong-worktree venvs, and prefix
-mismatch fail closed. PR #394 remains stale failed read-only.
+The sole CK-07R1 v2 launch is terminal `failed_after_launch`; its token is
+consumed and non-refundable, no planner-valid receipt or output exists, and no
+retry, restart, replacement, or further invocation is permitted. PR #448
+merged the exact deterministic planner-selected small/large correction and
+immutable v1/v2 terminal evidence at exact main `1d0466b1`. The additive
+[`lifecycle-post-terminal-completion-authority-v1`](docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json)
+accepts that merged deterministic evidence only for CK-07R1 roadmap dependency
+completion. It permanently records `runtime_acceptance=not_claimed`,
+planner-valid receipt absent, `post_single_run` unavailable, and
+`final_accepted` unavailable. It neither reclassifies the failed run nor
+changes production semantics. CK-08R4 must independently measure current
+merged publication behavior and must not claim the missing CK-07R1 runtime
+acceptance. PR #394 remains stale failed read-only.
 Retained R3 evidence proved the EvidenceService outer query
 physically unbounded; CK-08R3A owns that isolated fix and R3 awaits its
 accepted, merged, exact-main-verified result.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,7 +30,8 @@ CK-08R1's schema-valid
 records 80/80 rows, grades, order, evidence, provenance, null semantics,
 closure, grading isolation, and mutation proof. PR #439 passed hosted CI,
 squash-merged, and was exact-main verified at `0832b854`; CK-08R1 is complete.
-CK-08R4 remains blocked on CK-07R1. Independent
+CK-08R4 is Ready through CK-07R1's post-terminal roadmap dependency
+completion. Independent
 truth now consumes [`answer-semantics.v1`](../config/agent-kernel/answer-semantics-v1.json);
 The linked [CK-08R3A schema/publication requalification authority](decisions/evidence/ck08r3a/schema-publication-requalification-authority.json)
 binds the resulting 57-index schema digest, synthetic publication fixture
@@ -224,7 +225,23 @@ missing, extra, partial, wrong-workflow, wrong-lineage, and wrong-candidate
 states fail closed. It adds no network install, qualification invocation,
 launch, refund, retry, receipt, runtime acceptance, or downstream authority.
 
-The V11 candidate must construct and validate the exact overlay/cohort-bound
+PR #448 subsequently passed hosted Console and Python 3.10/3.14, squash-merged
+the exact seven-path correction/evidence cohort, and was fresh exact-main
+verified at `1d0466b1b2992b48c5272dc4598606eeaea4dae2`. The additive
+[`lifecycle-post-terminal-completion-authority-v1`](decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json)
+is the separate roadmap decision reserved by the terminal-failure authority.
+It accepts the merged deterministic small/large planner, publication,
+recovery, full/package, review, hosted, and exact-main evidence only as
+CK-07R1 dependency completion. The immutable v2 run remains
+`failed_after_launch`, the token remains consumed/non-refundable,
+`runtime_acceptance=not_claimed`, planner-valid receipt/output remain absent,
+and `post_single_run` and `final_accepted` remain unavailable. No command,
+artifact mutation, receipt fabrication, refund, retry, restart, replacement,
+or production-semantic change is authorized. After this authority transition
+is hosted-green, squash-merged, and fresh exact-main verified, CK-08R4 is the
+sole Ready successor; CK-08RG and CK-09 remain blocked.
+
+The historical V11 launcher contract required construction and validation of the exact overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failures are terminal `failed_after_launch`. Temporary parent SIGINT/SIGTERM
@@ -242,15 +259,15 @@ write/fsync/replace/post-replace paths and retain durable consumed/no-retry
 `failed_after_launch` evidence without temporary residue. Interpreter identity
 is the lexical repository-worktree `.venv/bin/python` plus the matching lexical venv
 `sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
-venvs, and prefix mismatch are rejected.
+venvs, and prefix mismatch are rejected. That contract cannot authorize
+another invocation after the consumed terminal v2 run.
 
-The finite source/runtime state machine is currently `authority_main`: the live
-predecessor may remain on authority main, while only the exact selected
-successor may enter worker prequalification. `post_single_run` is unavailable
-without a complete planner-valid receipt bound to its exact dynamic receipt and
-evidence identity, and `final_accepted` additionally requires the worker PR to
-be squash-merged and exact-main verified. No state transition claims runtime
-qualification in this authority.
+The finite source/runtime state machine remains terminal at
+`failed_after_launch`: `post_single_run` is unavailable without a complete
+planner-valid receipt bound to its exact dynamic evidence identity, and
+`final_accepted` remains unavailable. The separate roadmap dependency state is
+`completed_post_terminal_deterministic_evidence`; it does not claim or imply
+runtime qualification.
 
 ## Authority set
 

--- a/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
+++ b/docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md
@@ -115,8 +115,11 @@ consumer is accepted at exact main
 [R1B join authority](../decisions/evidence/ck08r1b/answer-semantics-join-authority.json)
 bound the shared query/evidence/grading seams accepted through PR #430 and
 exact-main `9e9332b3`. Final R1 replayed both accepted consumers, passed hosted
-CI in PR #439, squash-merged, and was exact-main verified at `0832b854`; no
-packet is Ready while CK-07R1 remains conditional. Cursor serialization still
+CI in PR #439, squash-merged, and was exact-main verified at `0832b854`.
+CK-07R1's post-terminal deterministic-evidence roadmap completion makes
+CK-08R4 the sole Ready packet; CK-08R4 must preserve
+`runtime_acceptance=not_claimed` and independently measure current merged
+publication behavior. Cursor serialization still
 binds its version, request digest,
 plan, publication, and order; malformed, tampered, stale, replacement, and
 mismatched bindings fail closed.

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json
@@ -1,0 +1,294 @@
+{
+  "schema": "codex-usage-tracker.ck07r1-lifecycle-post-terminal-completion.v1",
+  "version": 1,
+  "task": "CK-07R1",
+  "status": "roadmap_transition_authorized",
+  "authority_base_sha": "1d0466b1b2992b48c5272dc4598606eeaea4dae2",
+  "authority_base_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+  "source_authorities": [
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+      "sha256": "7752565abd5c5f27a852b8a8814ea1b7afde03d967de46419856eae85583f97b"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+      "sha256": "f4affab070de6aa1ed54cfc648051b7b6398bd57011fed8d942309894714744e"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.json",
+      "sha256": "badda5361f66944eb4972c061103435d55c6d59c2797ce7db8f34c70662d1e02"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.schema.json",
+      "sha256": "0819f90addbacccc2d45a467cce134a4a8112bd836cbfe2cbe9702b163ace03b"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.json",
+      "sha256": "e0cb34fdd2c45216f34ec9f5d6f55aa04b67d9811243ef1a1e032ac5b01f709c"
+    },
+    {
+      "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.schema.json",
+      "sha256": "7b29d882fe57bcbfe35035d84a33d1a116c5f564b994219dbb9380f28dc6fd15"
+    }
+  ],
+  "historical_successor_bindings": [
+    {
+      "path": "AGENTS.md",
+      "predecessor_sha256": "b835817af3a0e12dbce7560a2d639e1e6d207dc75b0a85892804623280700e8b",
+      "successor_sha256": "302e3f9c9d3fa281a3b8f070dd6970cd2571e8cce044396e7414288929bfd8d6"
+    }
+  ],
+  "integrated_cohort": {
+    "exact_main_sha": "1d0466b1b2992b48c5272dc4598606eeaea4dae2",
+    "exact_main_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+    "paths": [
+      {
+        "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+        "role": "corrected_preparation",
+        "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+      },
+      {
+        "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+        "role": "planner_selected_small_large_benchmark",
+        "sha256": "8f4900b1ecc841fe04f6cd1232c3741efef105e8b997c7fd15cc61b5d8d14cc1"
+      },
+      {
+        "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+        "role": "planner_selected_small_large_tests",
+        "sha256": "8364c4387b8e588cb18f420805d47e48241da22d6fb793e838a522cc7fb29e33"
+      },
+      {
+        "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+        "role": "immutable_v1_prelaunch_failed_ledger",
+        "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be"
+      },
+      {
+        "path": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+        "role": "immutable_v2_failed_after_launch_ledger",
+        "sha256": "570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2"
+      },
+      {
+        "path": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+        "role": "immutable_v2_empty_stdout",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      {
+        "path": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+        "role": "immutable_v2_failure_stderr",
+        "sha256": "4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f"
+      }
+    ]
+  },
+  "terminal_history": {
+    "v1": {
+      "state": "prelaunch_failed",
+      "token_consumed": false,
+      "token_status": "unspent_unavailable",
+      "successful_launches_observed": 0
+    },
+    "v2": {
+      "state": "failed_after_launch",
+      "token_consumed": true,
+      "token_status": "consumed",
+      "token_consumed_at_utc": "2026-08-19T19:44:55Z",
+      "successful_launches_observed": 1,
+      "child_pid": 20482,
+      "child_exit_code": 70,
+      "failure_stage": "evidence_collection"
+    },
+    "required_absent_paths": [
+      "output/ck07r1/lifecycle-requalification-v1.json",
+      "output/ck07r1/lifecycle-requalification-v1.receipt.json",
+      "output/ck07r1/lifecycle-requalification-v1.stdout.txt",
+      "output/ck07r1/lifecycle-requalification-v1.stderr.txt",
+      "output/ck07r1/lifecycle-requalification-v2.json",
+      "output/ck07r1/lifecycle-requalification-v2.receipt.json"
+    ],
+    "maximum_new_end_to_end_runs": 1,
+    "remaining_invocations": 0,
+    "token_refund": false,
+    "retry": "none",
+    "restart": "none",
+    "replacement": "none"
+  },
+  "publication_evidence": {
+    "terminal_correction_authority": {
+      "pull_request": 447,
+      "base_sha": "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8",
+      "head_sha": "4e43c941ba6dc1aaebe7ca6fa45a1a4b01e1f2dd",
+      "head_tree_sha": "cc148aa820962c084655017e404cce54430313bd",
+      "merge_sha": "652f2166b58b9ee0d719348a769901577d11e6fd",
+      "merge_tree_sha": "cc148aa820962c084655017e404cce54430313bd",
+      "ci_run": 32302049140,
+      "required_jobs": [
+        "Focused Evidence Console",
+        "Kernel phase and package isolation (3.10)",
+        "Kernel phase and package isolation (3.14)"
+      ],
+      "conclusion": "success"
+    },
+    "clean_commit_authority": {
+      "pull_request": 450,
+      "base_sha": "487e0b7138d638d7cfb1d91627e5a6ebda743699",
+      "head_sha": "b9f2b5d44c9f0fae89d36b9d73f9d155bc5179df",
+      "head_tree_sha": "df23bca16785de590ad809646acd6e169ea14a13",
+      "merge_sha": "0897ecc85977deb078abaf1729e2771a7573af58",
+      "merge_tree_sha": "df23bca16785de590ad809646acd6e169ea14a13",
+      "ci_run": 32401646264,
+      "required_jobs": [
+        "Focused Evidence Console",
+        "Kernel phase and package isolation (3.10)",
+        "Kernel phase and package isolation (3.14)"
+      ],
+      "conclusion": "success"
+    },
+    "corrected_implementation": {
+      "pull_request": 448,
+      "base_sha": "0897ecc85977deb078abaf1729e2771a7573af58",
+      "head_sha": "0fb5e6edbfb891970fe452e981148784b2f1b4c4",
+      "head_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+      "merge_sha": "1d0466b1b2992b48c5272dc4598606eeaea4dae2",
+      "merge_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+      "ci_run": 32402374087,
+      "required_jobs": [
+        "Focused Evidence Console",
+        "Kernel phase and package isolation (3.10)",
+        "Kernel phase and package isolation (3.14)"
+      ],
+      "conclusion": "success"
+    }
+  },
+  "deterministic_acceptance_evidence": {
+    "planner_result": {
+      "standard_selected_records": 1369,
+      "standard_expected_wal_bytes": 11214848,
+      "standard_operation_class": "append_safe_large",
+      "standard_reasons": [
+        "limit_exceeded:selected_records"
+      ],
+      "small_tail_ceiling_records": 32,
+      "record_32_operation_class": "append_safe_small",
+      "record_33_operation_class": "append_safe_large"
+    },
+    "path_proof": [
+      "exact_plan_refresh_result_preserved",
+      "small_pointer_writer_validated",
+      "large_isolated_artifact_build_validated",
+      "large_artifact_durable_promotion_validated",
+      "large_artifact_recovery_and_rollback_validated",
+      "prior_publication_readability_validated",
+      "independent_lifecycle_fold_equivalence_validated"
+    ],
+    "local_validation": {
+      "authority_consumers_passed": 99,
+      "focused_passed": 204,
+      "broader_passed": 312,
+      "full_passed": 1581,
+      "full_skipped": 1,
+      "performance_invariants_passed": 13,
+      "just_vc": "passed",
+      "sdist_bytes": 916639,
+      "wheel_bytes": 388537
+    },
+    "implementation_review": {
+      "reviewers": 1,
+      "accepted_findings": 0,
+      "result": "clean"
+    }
+  },
+  "decision": {
+    "completion_basis": "deterministic_post_terminal_merged_evidence",
+    "corrective_implementation_state": "accepted_for_CK-07R1_roadmap_dependency",
+    "roadmap_dependency_completion": "authorized_on_authority_PR_merge_and_fresh_exact_main_verification",
+    "runtime_acceptance": "not_claimed",
+    "planner_valid_receipt": "absent",
+    "receipt_fabrication": "forbidden",
+    "post_single_run": "unavailable",
+    "final_accepted": "unavailable",
+    "failed_after_launch_reclassified": false,
+    "new_command_invocations_permitted": 0,
+    "launch_authorized": false,
+    "token_consumed": true,
+    "token_refund": false,
+    "retry": "none",
+    "restart": "none",
+    "replacement": "none",
+    "production_semantics_changed_by_authority": false
+  },
+  "roadmap_transition": {
+    "from": "terminal_failed_no_rerun_corrective_implementation_prequalified",
+    "to": "completed_post_terminal_deterministic_evidence",
+    "activation": "authority_PR_hosted_green_squash_merged_and_fresh_exact_main_verified",
+    "completed": [
+      "CK-07R1"
+    ],
+    "new_ready": [
+      "CK-08R4"
+    ],
+    "still_blocked": [
+      "CK-08RG",
+      "CK-09"
+    ]
+  },
+  "residual_risks": [
+    "no_planner_valid_end_to_end_receipt_exists_for_the_corrected_implementation",
+    "the_failed_v2_run_proved_launch_and_initial_planner_reachability_but_not_successful_end_to_end_completion",
+    "CK-08R4_must_measure_current_merged_publication_behavior_and_must_not_claim_CK-07R1_runtime_acceptance"
+  ],
+  "required_transition_gates": [
+    "exact_authority_schema_and_source_bytes",
+    "exact_integrated_seven_path_cohort",
+    "immutable_v1_v2_terminal_evidence_and_required_absence",
+    "focused_authority_and_roadmap_consumers",
+    "full_and_package_validation",
+    "privacy_secret_and_diff_checks",
+    "one_bounded_independent_reviewer",
+    "hosted_console_python_3_10_python_3_14",
+    "squash_merge",
+    "fresh_exact_main_verification"
+  ],
+  "scope": {
+    "authority_write_scope": [
+      "AGENTS.md",
+      "docs/INDEX.md",
+      "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json",
+      "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json",
+      "docs/quality/QUALIFICATION_PLAN.md",
+      "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+      "docs/roadmap/TASK_PACKETS.md",
+      "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+      "docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md",
+      "scripts/check_kernel_scope.py",
+      "scripts/ck07r1_post_terminal_completion.py",
+      "scripts/ck07r1_terminal_failure_correction.py",
+      "tests/kernel/test_ck07r1_post_terminal_completion_authority.py",
+      "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+      "tests/kernel/test_documentation_authority.py",
+      "tests/kernel/test_kernel_scope.py"
+    ],
+    "immutable_integrated_scope": [
+      "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+      "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+      "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+      "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+      "scripts/benchmark_ck07r1_lifecycle_scale.py",
+      "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+      "tests/agent_kernel/publication/test_lifecycle_scale.py"
+    ],
+    "forbidden": [
+      "qualification_command_invocation",
+      "child_or_fork",
+      "token_or_terminal_artifact_mutation",
+      "retry_restart_replacement_or_refund",
+      "failed_after_launch_reclassification",
+      "receipt_or_output_fabrication",
+      "runtime_acceptance_claim",
+      "production_implementation_change",
+      "PR_394_mutation",
+      "CK-08RG_or_CK-09_readiness",
+      "live_or_real_data",
+      "cleanup_or_witness_loss"
+    ]
+  }
+}

--- a/docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json
+++ b/docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json
@@ -1,0 +1,747 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://douglasmonsky.github.io/codex-usage-tracker/schemas/ck07r1-lifecycle-post-terminal-completion-v1.schema.json",
+  "title": "CK-07R1 lifecycle post-terminal roadmap completion authority v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "task",
+    "status",
+    "authority_base_sha",
+    "authority_base_tree_sha",
+    "source_authorities",
+    "historical_successor_bindings",
+    "integrated_cohort",
+    "terminal_history",
+    "publication_evidence",
+    "deterministic_acceptance_evidence",
+    "decision",
+    "roadmap_transition",
+    "residual_risks",
+    "required_transition_gates",
+    "scope"
+  ],
+  "properties": {
+    "schema": {
+      "const": "codex-usage-tracker.ck07r1-lifecycle-post-terminal-completion.v1"
+    },
+    "version": {
+      "const": 1
+    },
+    "task": {
+      "const": "CK-07R1"
+    },
+    "status": {
+      "const": "roadmap_transition_authorized"
+    },
+    "authority_base_sha": {
+      "const": "1d0466b1b2992b48c5272dc4598606eeaea4dae2"
+    },
+    "authority_base_tree_sha": {
+      "const": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f"
+    },
+    "source_authorities": {
+      "const": [
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json",
+          "sha256": "7752565abd5c5f27a852b8a8814ea1b7afde03d967de46419856eae85583f97b"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.schema.json",
+          "sha256": "f4affab070de6aa1ed54cfc648051b7b6398bd57011fed8d942309894714744e"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.json",
+          "sha256": "badda5361f66944eb4972c061103435d55c6d59c2797ce7db8f34c70662d1e02"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.schema.json",
+          "sha256": "0819f90addbacccc2d45a467cce134a4a8112bd836cbfe2cbe9702b163ace03b"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.json",
+          "sha256": "e0cb34fdd2c45216f34ec9f5d6f55aa04b67d9811243ef1a1e032ac5b01f709c"
+        },
+        {
+          "path": "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.schema.json",
+          "sha256": "7b29d882fe57bcbfe35035d84a33d1a116c5f564b994219dbb9380f28dc6fd15"
+        }
+      ],
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/pathDigest"
+      }
+    },
+    "historical_successor_bindings": {
+      "const": [
+        {
+          "path": "AGENTS.md",
+          "predecessor_sha256": "b835817af3a0e12dbce7560a2d639e1e6d207dc75b0a85892804623280700e8b",
+          "successor_sha256": "302e3f9c9d3fa281a3b8f070dd6970cd2571e8cce044396e7414288929bfd8d6"
+        }
+      ]
+    },
+    "integrated_cohort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact_main_sha",
+        "exact_main_tree_sha",
+        "paths"
+      ],
+      "properties": {
+        "exact_main_sha": {
+          "const": "1d0466b1b2992b48c5272dc4598606eeaea4dae2"
+        },
+        "exact_main_tree_sha": {
+          "const": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f"
+        },
+        "paths": {
+          "const": [
+            {
+              "path": "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+              "role": "corrected_preparation",
+              "sha256": "66c015de949a6c380bd49964cb6c48c30dee64ecb14074b480837c44024328ea"
+            },
+            {
+              "path": "scripts/benchmark_ck07r1_lifecycle_scale.py",
+              "role": "planner_selected_small_large_benchmark",
+              "sha256": "8f4900b1ecc841fe04f6cd1232c3741efef105e8b997c7fd15cc61b5d8d14cc1"
+            },
+            {
+              "path": "tests/agent_kernel/publication/test_lifecycle_scale.py",
+              "role": "planner_selected_small_large_tests",
+              "sha256": "8364c4387b8e588cb18f420805d47e48241da22d6fb793e838a522cc7fb29e33"
+            },
+            {
+              "path": "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+              "role": "immutable_v1_prelaunch_failed_ledger",
+              "sha256": "5c2b42eca6a3e54cf4163226bc55f3c75aa35112c4ed0342c11f4e39cb9922be"
+            },
+            {
+              "path": "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+              "role": "immutable_v2_failed_after_launch_ledger",
+              "sha256": "570e27824ee04a51aa4012adb461bd4aebb00b61541f2477fd9e1665854325a2"
+            },
+            {
+              "path": "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+              "role": "immutable_v2_empty_stdout",
+              "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            },
+            {
+              "path": "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+              "role": "immutable_v2_failure_stderr",
+              "sha256": "4cf4b10fd04f20a190e4ac41898d25b9295b3dc9d7addead8a81edd27b3aca2f"
+            }
+          ],
+          "type": "array",
+          "minItems": 7,
+          "maxItems": 7,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/rolePathDigest"
+          }
+        }
+      }
+    },
+    "terminal_history": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "v1",
+        "v2",
+        "required_absent_paths",
+        "maximum_new_end_to_end_runs",
+        "remaining_invocations",
+        "token_refund",
+        "retry",
+        "restart",
+        "replacement"
+      ],
+      "properties": {
+        "v1": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "state",
+            "token_consumed",
+            "token_status",
+            "successful_launches_observed"
+          ],
+          "properties": {
+            "state": {
+              "const": "prelaunch_failed"
+            },
+            "token_consumed": {
+              "const": false
+            },
+            "token_status": {
+              "const": "unspent_unavailable"
+            },
+            "successful_launches_observed": {
+              "const": 0
+            }
+          }
+        },
+        "v2": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "state",
+            "token_consumed",
+            "token_status",
+            "token_consumed_at_utc",
+            "successful_launches_observed",
+            "child_pid",
+            "child_exit_code",
+            "failure_stage"
+          ],
+          "properties": {
+            "state": {
+              "const": "failed_after_launch"
+            },
+            "token_consumed": {
+              "const": true
+            },
+            "token_status": {
+              "const": "consumed"
+            },
+            "token_consumed_at_utc": {
+              "const": "2026-08-19T19:44:55Z"
+            },
+            "successful_launches_observed": {
+              "const": 1
+            },
+            "child_pid": {
+              "const": 20482
+            },
+            "child_exit_code": {
+              "const": 70
+            },
+            "failure_stage": {
+              "const": "evidence_collection"
+            }
+          }
+        },
+        "required_absent_paths": {
+          "const": [
+            "output/ck07r1/lifecycle-requalification-v1.json",
+            "output/ck07r1/lifecycle-requalification-v1.receipt.json",
+            "output/ck07r1/lifecycle-requalification-v1.stdout.txt",
+            "output/ck07r1/lifecycle-requalification-v1.stderr.txt",
+            "output/ck07r1/lifecycle-requalification-v2.json",
+            "output/ck07r1/lifecycle-requalification-v2.receipt.json"
+          ]
+        },
+        "maximum_new_end_to_end_runs": {
+          "const": 1
+        },
+        "remaining_invocations": {
+          "const": 0
+        },
+        "token_refund": {
+          "const": false
+        },
+        "retry": {
+          "const": "none"
+        },
+        "restart": {
+          "const": "none"
+        },
+        "replacement": {
+          "const": "none"
+        }
+      }
+    },
+    "publication_evidence": {
+      "const": {
+        "terminal_correction_authority": {
+          "pull_request": 447,
+          "base_sha": "77cb03cb3dd6bcf5608249056cb3470bc7fee3d8",
+          "head_sha": "4e43c941ba6dc1aaebe7ca6fa45a1a4b01e1f2dd",
+          "head_tree_sha": "cc148aa820962c084655017e404cce54430313bd",
+          "merge_sha": "652f2166b58b9ee0d719348a769901577d11e6fd",
+          "merge_tree_sha": "cc148aa820962c084655017e404cce54430313bd",
+          "ci_run": 32302049140,
+          "required_jobs": [
+            "Focused Evidence Console",
+            "Kernel phase and package isolation (3.10)",
+            "Kernel phase and package isolation (3.14)"
+          ],
+          "conclusion": "success"
+        },
+        "clean_commit_authority": {
+          "pull_request": 450,
+          "base_sha": "487e0b7138d638d7cfb1d91627e5a6ebda743699",
+          "head_sha": "b9f2b5d44c9f0fae89d36b9d73f9d155bc5179df",
+          "head_tree_sha": "df23bca16785de590ad809646acd6e169ea14a13",
+          "merge_sha": "0897ecc85977deb078abaf1729e2771a7573af58",
+          "merge_tree_sha": "df23bca16785de590ad809646acd6e169ea14a13",
+          "ci_run": 32401646264,
+          "required_jobs": [
+            "Focused Evidence Console",
+            "Kernel phase and package isolation (3.10)",
+            "Kernel phase and package isolation (3.14)"
+          ],
+          "conclusion": "success"
+        },
+        "corrected_implementation": {
+          "pull_request": 448,
+          "base_sha": "0897ecc85977deb078abaf1729e2771a7573af58",
+          "head_sha": "0fb5e6edbfb891970fe452e981148784b2f1b4c4",
+          "head_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+          "merge_sha": "1d0466b1b2992b48c5272dc4598606eeaea4dae2",
+          "merge_tree_sha": "d1b06f0927ae660f9e09d642bb1ef79a04413b5f",
+          "ci_run": 32402374087,
+          "required_jobs": [
+            "Focused Evidence Console",
+            "Kernel phase and package isolation (3.10)",
+            "Kernel phase and package isolation (3.14)"
+          ],
+          "conclusion": "success"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "terminal_correction_authority",
+        "clean_commit_authority",
+        "corrected_implementation"
+      ],
+      "properties": {
+        "terminal_correction_authority": {
+          "$ref": "#/$defs/publicationRecord"
+        },
+        "clean_commit_authority": {
+          "$ref": "#/$defs/publicationRecord"
+        },
+        "corrected_implementation": {
+          "$ref": "#/$defs/publicationRecord"
+        }
+      }
+    },
+    "deterministic_acceptance_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planner_result",
+        "path_proof",
+        "local_validation",
+        "implementation_review"
+      ],
+      "properties": {
+        "planner_result": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "standard_selected_records",
+            "standard_expected_wal_bytes",
+            "standard_operation_class",
+            "standard_reasons",
+            "small_tail_ceiling_records",
+            "record_32_operation_class",
+            "record_33_operation_class"
+          ],
+          "properties": {
+            "standard_selected_records": {
+              "const": 1369
+            },
+            "standard_expected_wal_bytes": {
+              "const": 11214848
+            },
+            "standard_operation_class": {
+              "const": "append_safe_large"
+            },
+            "standard_reasons": {
+              "const": [
+                "limit_exceeded:selected_records"
+              ]
+            },
+            "small_tail_ceiling_records": {
+              "const": 32
+            },
+            "record_32_operation_class": {
+              "const": "append_safe_small"
+            },
+            "record_33_operation_class": {
+              "const": "append_safe_large"
+            }
+          }
+        },
+        "path_proof": {
+          "const": [
+            "exact_plan_refresh_result_preserved",
+            "small_pointer_writer_validated",
+            "large_isolated_artifact_build_validated",
+            "large_artifact_durable_promotion_validated",
+            "large_artifact_recovery_and_rollback_validated",
+            "prior_publication_readability_validated",
+            "independent_lifecycle_fold_equivalence_validated"
+          ]
+        },
+        "local_validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "authority_consumers_passed",
+            "focused_passed",
+            "broader_passed",
+            "full_passed",
+            "full_skipped",
+            "performance_invariants_passed",
+            "just_vc",
+            "sdist_bytes",
+            "wheel_bytes"
+          ],
+          "properties": {
+            "authority_consumers_passed": {
+              "const": 99
+            },
+            "focused_passed": {
+              "const": 204
+            },
+            "broader_passed": {
+              "const": 312
+            },
+            "full_passed": {
+              "const": 1581
+            },
+            "full_skipped": {
+              "const": 1
+            },
+            "performance_invariants_passed": {
+              "const": 13
+            },
+            "just_vc": {
+              "const": "passed"
+            },
+            "sdist_bytes": {
+              "const": 916639
+            },
+            "wheel_bytes": {
+              "const": 388537
+            }
+          }
+        },
+        "implementation_review": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "reviewers",
+            "accepted_findings",
+            "result"
+          ],
+          "properties": {
+            "reviewers": {
+              "const": 1
+            },
+            "accepted_findings": {
+              "const": 0
+            },
+            "result": {
+              "const": "clean"
+            }
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completion_basis",
+        "corrective_implementation_state",
+        "roadmap_dependency_completion",
+        "runtime_acceptance",
+        "planner_valid_receipt",
+        "receipt_fabrication",
+        "post_single_run",
+        "final_accepted",
+        "failed_after_launch_reclassified",
+        "new_command_invocations_permitted",
+        "launch_authorized",
+        "token_consumed",
+        "token_refund",
+        "retry",
+        "restart",
+        "replacement",
+        "production_semantics_changed_by_authority"
+      ],
+      "properties": {
+        "completion_basis": {
+          "const": "deterministic_post_terminal_merged_evidence"
+        },
+        "corrective_implementation_state": {
+          "const": "accepted_for_CK-07R1_roadmap_dependency"
+        },
+        "roadmap_dependency_completion": {
+          "const": "authorized_on_authority_PR_merge_and_fresh_exact_main_verification"
+        },
+        "runtime_acceptance": {
+          "const": "not_claimed"
+        },
+        "planner_valid_receipt": {
+          "const": "absent"
+        },
+        "receipt_fabrication": {
+          "const": "forbidden"
+        },
+        "post_single_run": {
+          "const": "unavailable"
+        },
+        "final_accepted": {
+          "const": "unavailable"
+        },
+        "failed_after_launch_reclassified": {
+          "const": false
+        },
+        "new_command_invocations_permitted": {
+          "const": 0
+        },
+        "launch_authorized": {
+          "const": false
+        },
+        "token_consumed": {
+          "const": true
+        },
+        "token_refund": {
+          "const": false
+        },
+        "retry": {
+          "const": "none"
+        },
+        "restart": {
+          "const": "none"
+        },
+        "replacement": {
+          "const": "none"
+        },
+        "production_semantics_changed_by_authority": {
+          "const": false
+        }
+      }
+    },
+    "roadmap_transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "from",
+        "to",
+        "activation",
+        "completed",
+        "new_ready",
+        "still_blocked"
+      ],
+      "properties": {
+        "from": {
+          "const": "terminal_failed_no_rerun_corrective_implementation_prequalified"
+        },
+        "to": {
+          "const": "completed_post_terminal_deterministic_evidence"
+        },
+        "activation": {
+          "const": "authority_PR_hosted_green_squash_merged_and_fresh_exact_main_verified"
+        },
+        "completed": {
+          "const": [
+            "CK-07R1"
+          ]
+        },
+        "new_ready": {
+          "const": [
+            "CK-08R4"
+          ]
+        },
+        "still_blocked": {
+          "const": [
+            "CK-08RG",
+            "CK-09"
+          ]
+        }
+      }
+    },
+    "residual_risks": {
+      "const": [
+        "no_planner_valid_end_to_end_receipt_exists_for_the_corrected_implementation",
+        "the_failed_v2_run_proved_launch_and_initial_planner_reachability_but_not_successful_end_to_end_completion",
+        "CK-08R4_must_measure_current_merged_publication_behavior_and_must_not_claim_CK-07R1_runtime_acceptance"
+      ]
+    },
+    "required_transition_gates": {
+      "const": [
+        "exact_authority_schema_and_source_bytes",
+        "exact_integrated_seven_path_cohort",
+        "immutable_v1_v2_terminal_evidence_and_required_absence",
+        "focused_authority_and_roadmap_consumers",
+        "full_and_package_validation",
+        "privacy_secret_and_diff_checks",
+        "one_bounded_independent_reviewer",
+        "hosted_console_python_3_10_python_3_14",
+        "squash_merge",
+        "fresh_exact_main_verification"
+      ]
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_write_scope",
+        "immutable_integrated_scope",
+        "forbidden"
+      ],
+      "properties": {
+        "authority_write_scope": {
+          "const": [
+            "AGENTS.md",
+            "docs/INDEX.md",
+            "docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md",
+            "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json",
+            "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json",
+            "docs/quality/QUALIFICATION_PLAN.md",
+            "docs/roadmap/REMAINING_EXECUTION_PLAN.md",
+            "docs/roadmap/TASK_PACKETS.md",
+            "docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md",
+            "docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md",
+            "scripts/check_kernel_scope.py",
+            "scripts/ck07r1_post_terminal_completion.py",
+            "scripts/ck07r1_terminal_failure_correction.py",
+            "tests/kernel/test_ck07r1_post_terminal_completion_authority.py",
+            "tests/kernel/test_ck07r1_terminal_failure_correction_authority.py",
+            "tests/kernel/test_documentation_authority.py",
+            "tests/kernel/test_kernel_scope.py"
+          ]
+        },
+        "immutable_integrated_scope": {
+          "const": [
+            "output/ck07r1/lifecycle-requalification-v1.launch-token.json",
+            "output/ck07r1/lifecycle-requalification-v2.launch-token.json",
+            "output/ck07r1/lifecycle-requalification-v2.stderr.txt",
+            "output/ck07r1/lifecycle-requalification-v2.stdout.txt",
+            "scripts/benchmark_ck07r1_lifecycle_scale.py",
+            "src/codex_usage_tracker/agent_kernel/publication/preparation.py",
+            "tests/agent_kernel/publication/test_lifecycle_scale.py"
+          ]
+        },
+        "forbidden": {
+          "const": [
+            "qualification_command_invocation",
+            "child_or_fork",
+            "token_or_terminal_artifact_mutation",
+            "retry_restart_replacement_or_refund",
+            "failed_after_launch_reclassification",
+            "receipt_or_output_fabrication",
+            "runtime_acceptance_claim",
+            "production_implementation_change",
+            "PR_394_mutation",
+            "CK-08RG_or_CK-09_readiness",
+            "live_or_real_data",
+            "cleanup_or_witness_loss"
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "pathDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "rolePathDigest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "role",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "publicationRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pull_request",
+        "base_sha",
+        "head_sha",
+        "head_tree_sha",
+        "merge_sha",
+        "merge_tree_sha",
+        "ci_run",
+        "required_jobs",
+        "conclusion"
+      ],
+      "properties": {
+        "pull_request": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "base_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "head_tree_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "merge_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "merge_tree_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "ci_run": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "required_jobs": {
+          "const": [
+            "Focused Evidence Console",
+            "Kernel phase and package isolation (3.10)",
+            "Kernel phase and package isolation (3.14)"
+          ]
+        },
+        "conclusion": {
+          "const": "success"
+        }
+      }
+    }
+  }
+}

--- a/docs/quality/QUALIFICATION_PLAN.md
+++ b/docs/quality/QUALIFICATION_PLAN.md
@@ -52,7 +52,10 @@ schema-valid 80/80 two-lane replay with exact closure membership/digests,
 grading isolation, and sentinel mutations in
 `docs/decisions/evidence/ck08r1/answer-truth-requalification-v2.json`; PR #439
 passed hosted CI, squash-merged, and was exact-main verified at `0832b854`.
-R1 is complete and no packet is Ready while CK-07R1 remains conditional.
+R1 is complete. CK-07R1's post-terminal deterministic-evidence roadmap
+completion makes CK-08R4 the sole Ready packet while preserving
+`runtime_acceptance=not_claimed`, absent planner-valid receipt/output, and the
+consumed no-rerun terminal state.
 R3 scale awaits merged/exact-main R3A.
 CK-QG1A removed only R2's two rank-D findings against its unchanged baseline and is accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`; CK-QG1 PR #392 then passed the exact authorized normalized baseline ratchet, hosted CI, squash merge, and fresh exact-main verification at `68050b93`. CK-07R1A preserves the first hosted Python
 3.14 `ordinary.2000_call_tail` failure and

--- a/docs/roadmap/REMAINING_EXECUTION_PLAN.md
+++ b/docs/roadmap/REMAINING_EXECUTION_PLAN.md
@@ -28,7 +28,8 @@ all 196 selector/view/direction outcomes per profile, typed seven-part truth,
 late-event, truncation, cursor, and query-only contracts. PR #425 passed hosted
 Python 3.10/3.14 and Console, squash-merged at
 `0fad272b3205614fb254398c9c9dc0a56d5ba7cd`, and was exact-main verified.
-CK-08R3 and CK-08R1 are complete; CK-08R4 remains blocked on CK-07R1.
+CK-08R3 and CK-08R1 are complete. CK-07R1 is complete through its separate
+post-terminal deterministic-evidence roadmap transition, so CK-08R4 is Ready.
 Retained CK-08R1 work reached
 80/80 parity by copying unsupported Q-REV-03/Q-WF-02 semantics; R1A now freezes
 their meaning and closure. R1C is accepted at exact main
@@ -67,8 +68,8 @@ provenance equality for equal-coordinate idempotency, and resolves
 current-batch relations by the six-part authority order before logical
 identity with one emitted winner. PR #430 passed hosted CI, squash-merged, and
 was exact-main verified at `9e9332b3ae2be78cedb581ff8f76149ad76f4440`.
-R1B and R1 are complete. No successor becomes Ready while CK-07R1 remains
-conditional.
+R1B and R1 are complete. CK-08R4 is the sole Ready successor after CK-07R1's
+post-terminal roadmap dependency completion.
 CK-QG1A removed R2's two page-executor C/B/B violations
 without changing behavior or the frozen maintainability baseline and is
 accepted at exact main `30983d4b5005e7e2a507757c76a3c05ab56281e6`.
@@ -82,8 +83,8 @@ binds current main `dd771073` writer `13da341f…` to reviewed PR #430 writer
 `d163e6c5…` with the unchanged `fda777e2…` baseline and identical normalized
 findings. CK-08R1B is accepted at `9e9332b3`; CK-08R1's serialized
 production-versus-independent answer-truth requalification is accepted through
-PR #439 and exact-main `0832b854`. CK-08R4 remains blocked on CK-07R1, and
-CK-08RG remains blocked on CK-08R4.
+PR #439 and exact-main `0832b854`. CK-08R4 is Ready; CK-08RG remains blocked
+on CK-08R4.
 CK-07R1A is accepted, merged, and exact-main verified at
 `4d8074952f679877f2b4fbb3e89c51015e96a197`; CK-07R1A0 was accepted at
 `519b503aa3b23019033b6481687c08b23fc6c31e`; its linked
@@ -202,10 +203,9 @@ permits the same worker to correct only the benchmark and its owned lifecycle
 test, with exact planner-selected small/large paths and deterministic
 synthetic non-consuming evidence. It does not reopen either command, refund
 the token, authorize any launch, fabricate a receipt, or make
-`post_single_run` or `final_accepted` reachable. CK-07R1 is blocked after the
-corrective implementation prequalification because the existing
-receipt-required runtime acceptance contract remains unsatisfied; CK-08R4,
-CK-08RG, and CK-09 remain blocked pending an explicit future roadmap decision.
+`post_single_run` or `final_accepted` reachable. It left CK-07R1 blocked after
+corrective implementation prequalification pending the separate roadmap
+decision now recorded below.
 The linked
 [clean-committed transition authority](../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.json)
 keeps the v1 authority immutable while binding PR #448 base `652f2166…`,
@@ -222,6 +222,24 @@ exact 18-path follow-up authority delta and exact 18-plus-seven integrated
 PR #448 state. This deterministic environment correction does not authorize a
 qualification command, another child, token action, retry, receipt,
 implementation acceptance, or downstream readiness.
+
+PR #448 then passed hosted Console and Python 3.10/3.14, squash-merged its
+exact seven-path correction/evidence cohort, and was fresh exact-main verified
+at `1d0466b1b2992b48c5272dc4598606eeaea4dae2`. The additive
+[post-terminal completion authority](../decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json)
+is the explicit roadmap decision reserved by the terminal-failure authority.
+It accepts exact merged deterministic planner reproduction, small/large
+writer-path validation, promotion/recovery/rollback/readability proof,
+independent fold equivalence, full/package checks, one clean implementation
+review, hosted CI, and exact-main identity only for CK-07R1 dependency
+completion. The v2 run remains `failed_after_launch`; the token remains
+consumed and non-refundable; planner-valid receipt and output remain absent;
+`runtime_acceptance=not_claimed`; and `post_single_run` and `final_accepted`
+remain unavailable. No launch, retry, restart, replacement, refund, artifact
+mutation, receipt fabrication, failed-run reclassification, or production
+semantic change is authorized. CK-08R4 is the sole Ready packet and must
+independently measure current merged publication behavior without claiming
+the missing CK-07R1 runtime acceptance. CK-08RG and CK-09 remain blocked.
 
 The exact V11 launcher contract constructs and validates the fully
 overlay/cohort-bound receipt and non-null stdout/stderr/output evidence before
@@ -336,13 +354,10 @@ conditions in the table and child files; they are not unconditional DAG edges.
   "recovery_exit_policy": "return_to_convergence_after_integrity_restored",
   "blocked_policy": "spawn_none_and_report_to_orchestrator"
  },
-  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0"],
-  "ready": [],
+  "completed": ["CK-08R0", "CK-08R1A", "CK-08R1B", "CK-08R1C", "CK-08R1", "CK-08R2", "CK-08R3A", "CK-08R3", "CK-QG1A0", "CK-QG1A", "CK-QG1", "CK-07R1A", "CK-07R1A0", "CK-07R1"],
+  "ready": ["CK-08R4"],
   "conditional_ready": [],
-  "blocked": [{
-    "condition": "the terminal CK-07R1 v2 failed_after_launch state consumed the sole token; deterministic corrective evidence cannot satisfy receipt-required runtime acceptance without a separate roadmap decision",
-    "tasks": ["CK-07R1"]
-  }],
+  "blocked": [],
   "tasks": [
     {"id": "CK-08R0", "file": "tasks/ck-08r0-freeze-corrective-contracts.md", "dependencies": []},
     {"id": "CK-08R1A", "file": "tasks/ck-08r1a-freeze-answer-semantics.md", "dependencies": ["CK-08R0"]},

--- a/docs/roadmap/TASK_PACKETS.md
+++ b/docs/roadmap/TASK_PACKETS.md
@@ -12,11 +12,11 @@ parents are accounting umbrellas.
 - Not started: **8**
 - Critical-path completion: **14 / 21**
 - Optional packets: **CK-15**
-- Completed corrective child tasks: **13 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0**
-- Remaining delegable child tasks: **37**
-- Ready child tasks: **0**
+- Completed corrective child tasks: **14 — CK-08R0, CK-08R1A, CK-08R1B, CK-08R1C, CK-08R1, CK-08R2, CK-08R3A, CK-08R3, CK-QG1A0, CK-QG1A, CK-QG1, CK-07R1A, CK-07R1A0, CK-07R1**
+- Remaining delegable child tasks: **36**
+- Ready child tasks: **1 — CK-08R4**
 - Conditional-ready child tasks: **0**
-- Blocked child tasks: **37 — CK-07R1 is terminal after its consumed v2 failure; CK-08R4/CK-08RG/CK-09 and downstream remain blocked**
+- Blocked child tasks: **35 — CK-08RG/CK-09 and downstream remain blocked; CK-08R4 is the sole Ready packet**
 - Orchestration mode: **convergence — one coordinator, one existing task per active packet, at most one shared-authority task**
 - Continuation policy: **reuse the active packet task for ordinary corrections; create a task only for a newly Ready distinct packet or a genuinely new authority decision**
 - Handoff policy: **tasks proactively message the parent; no polling or wait-only tasks**
@@ -52,9 +52,9 @@ parents are accounting umbrellas.
 Readiness is controlled by
 [the machine DAG](REMAINING_EXECUTION_PLAN.md). R1C and R1B are accepted after
 R1A; R1 is complete on merge with a schema-valid 80/80 two-lane
-requalification artifact. No successor is Ready while CK-07R1 remains
-conditional. CK-QG1 is accepted and exact-main verified; other corrective
-locks are unchanged.
+requalification artifact. CK-07R1's post-terminal deterministic-evidence
+roadmap completion makes CK-08R4 the sole Ready successor. CK-QG1 is accepted
+and exact-main verified; other corrective locks are unchanged.
 
 ### Corrective gates
 
@@ -69,10 +69,10 @@ locks are unchanged.
 - [x] **CK-08R3 — Qualify evidence service scale** · PR #425 hosted-green and squash-merged at `0fad272b`; both frozen synthetic profiles accepted and exact-main verified · [packet](tasks/ck-08r3-qualify-evidence-scale.md)
 - [x] **CK-07R1A — Correct hosted lifecycle tail** · Accepted/merged at `4d807495`; exact-main verified · [packet](tasks/ck-07r1a-correct-hosted-lifecycle-tail.md)
 - [x] **CK-07R1A0 — Freeze lifecycle planner/recovery path authority** · Path, finite source/runtime, run-invocation authority, and argv-correction authority merged through `479cbdb`; retained witnesses remain read-only · [packet](tasks/ck-07r1a0-freeze-lifecycle-path-authority.md)
-- [ ] **CK-07R1 — Correct lifecycle preparation scale** · Blocked after the prelaunch-recovery-authorized sole v2 child handshake consumed the non-refundable token and terminated `failed_after_launch`; the versioned [terminal-failure correction authority](../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-correction-authority-v1.json) permits only deterministic non-consuming benchmark/test correction prequalification, while its [clean-committed transition bridge](../decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v1.json) binds exact PR #448 dirty and clean representations without authorizing another run or receipt-based acceptance; PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
+- [x] **CK-07R1 — Correct lifecycle preparation scale** · Completed for roadmap dependency through the versioned [post-terminal completion authority](../decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json), exact merged deterministic planner/publication evidence, and immutable consumed-token failure history; `runtime_acceptance=not_claimed`, planner-valid receipt absent, `post_single_run`/`final_accepted` unavailable, no rerun, and PR #394 remains read-only · [packet](tasks/ck-07r1-correct-lifecycle-preparation-scale.md)
 - [x] **CK-QG1A — Correct page-executor complexity** · PR #408 merged/exact-main `30983d4`; authorized successor `9e80c867…` accepted without behavior or baseline change · [packet](tasks/ck-qg1a-correct-page-executor-complexity.md)
 - [x] **CK-QG1 — Enforce replacement-kernel maintainability** · PR #392 hosted-green, squash-merged at `68050b93`, exact-main verified, and its [v2 writer transition authority](../decisions/evidence/ckqg1/maintainability-baseline-transition-authority.json) is linked for the reviewed PR #430 successor · [packet](tasks/ck-qg1-enforce-agent-kernel-maintainability.md)
-- [ ] **CK-08R4 — Reclassify physical named plans** · Blocked on CK-07R1; CK-08R1/R2/R3 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
+- [ ] **CK-08R4 — Reclassify physical named plans** · Ready; CK-08R1/R2/R3 and CK-07R1 are complete · [packet](tasks/ck-08r4-reclassify-physical-plans.md)
 - [ ] **CK-08RG — Authorize CK-09 resumption** · Blocked on CK-08R4; CK-QG1 is complete · [packet](tasks/ck-08rg-authorize-ck09-resumption.md)
 
 ### CK-09 children
@@ -130,6 +130,27 @@ The [clean-committed CI authority v2](../decisions/evidence/ck07r1a0/lifecycle-t
 binds the exact repository-local hosted `.venv` seam for PR #448 without
 reopening the consumed run, authorizing a retry, or changing receipt-based
 acceptance and downstream holds.
+
+### CK-07R1 post-terminal roadmap completion
+
+The [post-terminal completion authority](../decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json)
+binds exact PR #447/#450/#448 lineage, hosted CI, merged exact-main tree, the
+seven immutable implementation/evidence paths, deterministic planner and
+small/large publication-path validation, full/package evidence, and the clean
+implementation review. It completes only the CK-07R1 roadmap dependency while
+permanently preserving `failed_after_launch`, token consumed/non-refundable,
+`runtime_acceptance=not_claimed`, absent planner-valid receipt/output, and
+unavailable `post_single_run`/`final_accepted`. It authorizes no command or
+artifact mutation. CK-08R4 is the sole Ready successor; CK-08RG and CK-09
+remain blocked.
+
+Historical lineage remains explicit: the prelaunch-recovery authority
+preserves v1 `prelaunch_failed`; the terminal-failure correction authority
+binds the v2 `failed_after_launch` root cause and no-rerun correction; and the
+clean-committed transition plus
+`lifecycle-terminal-failure-clean-commit-authority-v2` bind PR #448's clean
+publication representations. None of those historical transitions is
+rewritten or reactivated.
 
 ## Critical path
 

--- a/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
+++ b/docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md
@@ -1,9 +1,10 @@
 # CK-07R1 — Correct lifecycle preparation scale
 
-**Status:** `terminal_failed_no_rerun` after the sole v2 child launch consumed
-the non-refundable token and durably recorded `failed_after_launch`; only
-deterministic non-consuming corrective implementation prequalification remains,
-while runtime acceptance and downstream readiness are unavailable
+**Status:** `completed_post_terminal_deterministic_evidence` for roadmap
+dependency only; the sole v2 child launch remains immutable
+`failed_after_launch`, its token remains consumed/non-refundable,
+`runtime_acceptance=not_claimed`, planner-valid receipt/output remain absent,
+and `post_single_run`/`final_accepted` remain unavailable
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -125,24 +126,30 @@ follow-up authority scope or exact follow-up-plus-seven integrated state. It
 does not reopen the consumed token or authorize a command, launch, retry,
 replacement, refund, receipt, runtime acceptance, or downstream work.
 
-**Parallelism:** Resume only existing worker
-`019fbfe2-8fe4-7de2-9264-d58572366727` after the consuming-boundary authority
-merges and exact-main verifies, using frozen cwd
-`/Users/Monsky/Developer/Codex/2026-08-11/codex-usage-tracker-ck07r1-corrected-shared-overlay-exact-main-6c08ecd9`
-and only the complete selected cohort. Historical
-`d192c858…` cannot be reapplied directly.
-Worker ownership is a normative coordinator/orchestration binding to that
-exact existing Codex task plus recomputed repository evidence. It is not a
-runtime-authenticated identity; the launcher must not accept or claim a
-cryptographic or self-asserted per-task credential.
-Never rebase, stash, reset, clean, delete, overwrite, or mutate the historical
-V9/V10 witnesses. After the authority merge only, the separate frozen launch
-lane must fetch and fast-forward only from prequalification base `67bb1a…` to
-the exact merged main while preserving and recomputing the exact three dirty
-candidate bytes. Any non-fast-forward transition or byte drift fails closed.
-Do not create a replacement worker task. The planner-valid receipt is produced by that worker
-and is required for acceptance, not for authority completion; other corrective
-locks stay disjoint and no downstream packet becomes Ready here.
+The additive
+[post-terminal completion authority](../../decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json)
+is the separate roadmap decision reserved by this terminal state. It binds
+exact PR #447/#450/#448 lineage, hosted Console/Python 3.10/3.14, exact merged
+main `1d0466b1b2992b48c5272dc4598606eeaea4dae2`, the exact seven-path
+implementation/evidence cohort, deterministic planner reproduction,
+small/large publication-path validation, promotion/recovery/rollback and
+prior-readability proof, independent fold equivalence, full/package checks,
+and the clean implementation review. That evidence accepts the corrected
+implementation only for CK-07R1 roadmap dependency completion. It does not
+claim runtime acceptance, satisfy or fabricate the missing receipt, reclassify
+the failed run, or change production semantics. CK-08R4 is the sole Ready
+successor and must independently measure current merged publication behavior;
+CK-08RG and CK-09 remain blocked.
+
+**Parallelism:** CK-07R1 is closed. Do not resume the worker, command, or
+historical launch lane. Preserve existing worker
+`019fbfe2-8fe4-7de2-9264-d58572366727`, frozen cwd, V9/V10 witnesses, v1/v2
+terminal evidence, PR #394, and exact repository history read-only. No
+replacement task, retry, restart, refund, or further invocation is permitted.
+Historical worker ownership remains the normative coordinator/orchestration
+binding; it was never cryptographic runtime authentication. The prior
+fast-forward-only launch lineage from `67bb1a…` is retained as historical
+evidence and cannot be reactivated.
 
 **Non-goals:** Writer/pointer/schema redesign, facts, projections, or budget
 waivers.
@@ -156,44 +163,29 @@ standard/production fixtures, five unprofiled samples, 30-day/all-time gates,
 the finite state transitions and real non-launching subprocess argv guard; no
 E2E or benchmark run in the authority reconciliation.
 
-**Acceptance:** Historical v2 launch — immediately before the one command, the worker must revalidate
-the exact recovery authority bytes, the corrected three-path source cohort,
-the preserved v1 ledger as the sole fourth dirty path, lexical worktree
-`.venv/bin/python` plus matching `sys.prefix`, exact cwd/argv/environment,
-capacity at or above 10 GiB, `matching_processes=[]`, all four new v2 artifact
-paths absent, the unconsumed token, and synthetic fixture identity. Any miss
-fails closed without launch or artifact creation. If every gate passes, exactly
-one successfully observed child PID/argv/cwd/owner/handshake consumes the
-non-refundable token. No retry, restart, replacement, live/real data, or
-fabricated receipt is permitted. The launcher-imported shared verifier enforces
-the consuming authority before ledger/fork and requires candidate
-`HEAD == refs/remotes/origin/main == live ls-remote origin/main`; the authority
-feature branch and the stale `67bb1a…` HEAD cannot satisfy that activation.
-The prequalification base must remain an ancestor of exact merged main. Work is linear in observations
-plus prior transitions and all
-publication-valid scale gates pass through the CK-07R1A0 reachable path and
-the frozen CK-07R1A0 run-invocation contract. The existing worker must
-revalidate the exact predecessor-to-successor digest
-transition, bind every frozen path and prior identity, produce the
-planner-valid receipt, and consume at most one new end-to-end run. The still-
-unspent `maximum_new_end_to_end_runs=1` token can fund exactly one first
-successful child launch only after the authority merge/exact-main gate and all
-worker gates pass; this is not a retry, restart, or replacement of a launched
-process. Receipt absence before dispatch is required; receipt absence or
-invalidity at successor acceptance remains fail-closed.
+**Acceptance:** Historical consuming acceptance required exact recovery
+authority bytes, cohort, preserved v1 ledger, lexical worktree interpreter and
+`sys.prefix`, cwd/argv/environment, capacity, process/output absence, token,
+and synthetic fixture identity before one child handshake could consume the
+non-refundable token. That handshake occurred and the token was consumed. The
+child then terminated `failed_after_launch`; therefore every launch condition
+is historical-only and can never authorize another command.
 
-**Post-terminal corrective acceptance:** The corrected two-file cohort may
-enter only `corrective_implementation_prequalified` after exact unit-level
+**Post-terminal corrective acceptance:** The corrected two-file cohort entered
+`corrective_implementation_prequalified` after exact unit-level
 planner reproduction, 32/33 boundary tests, large-artifact promotion and
 rollback/readability tests, independent lifecycle-fold equivalence, exact
 small/large plan preservation, focused and full repository gates, one bounded
 reviewer, hosted Console/Python 3.10/3.14, squash merge of the authority-only
-packet, and fresh exact-main verification. This state is not runtime
-qualification and cannot transition to `post_single_run` or `final_accepted`;
-the existing complete-receipt requirement remains unsatisfied. No command
-invocation or run artifact creation is part of this correction.
+packet, and fresh exact-main verification. PR #448 then merged the exact
+implementation/evidence cohort and passed the same hosted matrix. The separate
+post-terminal authority accepts that deterministic evidence as
+`completed_post_terminal_deterministic_evidence` for dependency accounting,
+not as runtime qualification. `post_single_run` and `final_accepted` remain
+unavailable and the complete-receipt requirement remains unsatisfied. No
+command invocation or run artifact creation is part of this completion.
 
-The V11 candidate must construct and validate the fully overlay/cohort-bound
+The historical V11 launcher contract required construction and validation of the fully overlay/cohort-bound
 receipt and non-null stdout/stderr/output evidence before its first durable
 `completed` finalization. Evidence read/hash/parse/validation/finalization
 failure is terminal `failed_after_launch`, never false `completed`. Temporary
@@ -212,7 +204,8 @@ consumed/no-retry `failed_after_launch` evidence without temporary residue.
 Interpreter identity requires the lexical repository-worktree
 `.venv/bin/python` plus matching lexical venv
 `sys.prefix`; base interpreters, symlink/resolved equivalence, wrong-worktree
-venvs, and prefix mismatch are rejected before side effects.
+venvs, and prefix mismatch were rejected before side effects. No part of that
+contract can authorize a new invocation after the consumed terminal run.
 
 The hosted Console gate retains Chromium dependency and browser coverage. It
 pins the canonical HTTPS Ubuntu archive before Playwright installs system
@@ -224,9 +217,9 @@ instead of hanging or bypassing Console evidence.
 new dominant blocker; never weaken the gate. The preserved v1 and v2 ledgers,
 v2 stdout/stderr, absent output/receipt state, child identity, token
 consumption, and terminal classifications are never deleted, moved, rewritten,
-or reclassified. A separate explicit roadmap decision is required to resolve
-the receipt-required acceptance dead end; no implementation or authority
-correction may infer another run.
+or reclassified. The separate roadmap decision resolves dependency accounting
+only; no implementation or authority correction may infer another run or
+runtime acceptance.
 
 **Handoff:** Evidence digest, profiles, retained first hosted failure, PR #394
 CI, exact-main result, and CK-08R4 input.

--- a/docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md
+++ b/docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md
@@ -1,6 +1,6 @@
 # CK-08R4 — Reclassify physical named plans
 
-**Status:** Blocked on CK-08R1 and CK-07R1; CK-08R2 and CK-08R3 are complete
+**Status:** Ready; CK-08R1/R2/R3 and CK-07R1 are complete
 
 **Parent:** Corrective prerequisite for CK-09
 
@@ -20,7 +20,10 @@ write-amplifying projections.
 
 **Controls:** CK-08R0 benchmark-v2 schema and all completed corrective evidence.
 
-**Dependencies:** CK-08R1/R2/R3 and CK-07R1 merged and exact-main verified.
+**Dependencies:** CK-08R1/R2/R3 are merged and exact-main verified. CK-07R1
+is complete for roadmap dependency through its versioned post-terminal
+deterministic-evidence authority. Its v2 run remains `failed_after_launch`,
+`runtime_acceptance=not_claimed`, and planner-valid receipt absent.
 
 **Owned files/interfaces:** Benchmark/collector v2, scale evidence v2,
 projection-admission record, affected packet claims; no projections.
@@ -47,7 +50,10 @@ stage-separated p95, direct/evidence/projection classes, admission rules,
 
 **Acceptance:** Every plan is measured and classified as direct-page,
 evidence-page, or projection-required; every proposed projection satisfies all
-admission rules.
+admission rules. Measurements must use current merged publication behavior and
+must preserve the CK-07R1 residual risk rather than claiming runtime acceptance
+or a receipt. CK-08RG and CK-09 remain blocked until this packet is
+hosted-green, squash-merged, and fresh exact-main verified.
 
 **Failure/rollback:** Any unmeasured/unbounded plan keeps CK-09 blocked.
 

--- a/scripts/check_kernel_scope.py
+++ b/scripts/check_kernel_scope.py
@@ -899,6 +899,15 @@ CK07R1_TERMINAL_CLEAN_COMMIT_AUTHORITY_ADDITIONS = frozenset(
     }
 )
 
+CK07R1_POST_TERMINAL_COMPLETION_AUTHORITY_ADDITIONS = frozenset(
+    {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json",
+        "scripts/ck07r1_post_terminal_completion.py",
+        "tests/kernel/test_ck07r1_post_terminal_completion_authority.py",
+    }
+)
+
 CK08_PREREQUISITE_BLOCKER_ADDITIONS = frozenset(
     {
         "docs/decisions/evidence/ck08/fact-backed-oracle-prerequisite-gap.json",
@@ -979,6 +988,7 @@ INTEGRATION_ADDITIONS = (
     | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
     | CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
     | CK07R1_TERMINAL_CLEAN_COMMIT_AUTHORITY_ADDITIONS
+    | CK07R1_POST_TERMINAL_COMPLETION_AUTHORITY_ADDITIONS
     | CK08_PREREQUISITE_BLOCKER_ADDITIONS
     | {
         "config/agent-kernel/maintainability-baseline-v1.json",

--- a/scripts/ck07r1_post_terminal_completion.py
+++ b/scripts/ck07r1_post_terminal_completion.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Verify the non-consuming CK-07R1 post-terminal roadmap transition."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+AUTHORITY_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json"
+)
+SCHEMA_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json"
+)
+REMAINING_PLAN_PATH = Path("docs/roadmap/REMAINING_EXECUTION_PLAN.md")
+TASK_PACKETS_PATH = Path("docs/roadmap/TASK_PACKETS.md")
+CK07R1_PACKET_PATH = Path("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md")
+CK08R4_PACKET_PATH = Path("docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md")
+
+
+class PostTerminalCompletionError(RuntimeError):
+    """The exact post-terminal roadmap completion contract is not satisfied."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PostTerminalCompletionError(f"cannot load exact JSON at {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PostTerminalCompletionError(f"exact JSON is not an object: {path}")
+    return value
+
+
+def load_authority(root: Path) -> dict[str, Any]:
+    authority = _load_json(root / AUTHORITY_PATH)
+    schema = _load_json(root / SCHEMA_PATH)
+    try:
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(authority)
+    except Exception as exc:
+        raise PostTerminalCompletionError(
+            f"post-terminal authority/schema validation failed: {exc}"
+        ) from exc
+    return authority
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PostTerminalCompletionError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _is_ancestor(root: Path, ancestor: str, descendant: str = "HEAD") -> bool:
+    result = subprocess.run(
+        ("git", "merge-base", "--is-ancestor", ancestor, descendant),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _status_paths(root: Path) -> set[str]:
+    result = subprocess.run(
+        ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise PostTerminalCompletionError("cannot inspect exact Git worktree delta")
+    paths: set[str] = set()
+    entries = result.stdout.split(b"\0")
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        decoded = entry.decode("utf-8", errors="strict")
+        if len(decoded) < 4:
+            raise PostTerminalCompletionError("Git status entry is malformed")
+        status = decoded[:2]
+        relative = decoded[3:]
+        if "R" in status or "C" in status:
+            if index >= len(entries) or not entries[index]:
+                raise PostTerminalCompletionError("Git rename status is malformed")
+            relative = entries[index].decode("utf-8", errors="strict")
+            index += 1
+        paths.add(relative)
+    return paths
+
+
+def _diff_paths(root: Path, base: str, head: str = "HEAD") -> set[str]:
+    output = _git(root, "diff", "--name-only", "--no-renames", base, head)
+    return {line for line in output.splitlines() if line}
+
+
+def _git_blob_sha256(root: Path, revision: str, relative: str) -> str:
+    result = subprocess.run(
+        ("git", "show", f"{revision}:{relative}"),
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise PostTerminalCompletionError(
+            f"cannot read exact Git blob {revision}:{relative}"
+        )
+    return hashlib.sha256(result.stdout).hexdigest()
+
+
+def verify_source_authorities(authority: Mapping[str, Any], root: Path) -> None:
+    for record in authority["source_authorities"]:
+        path = root / str(record["path"])
+        if not path.is_file() or _sha256(path) != record["sha256"]:
+            raise PostTerminalCompletionError(
+                f"source authority byte identity mismatch: {record['path']}"
+            )
+
+
+def verify_historical_successor_bindings(
+    authority: Mapping[str, Any], root: Path
+) -> None:
+    base = str(authority["authority_base_sha"])
+    scope = set(authority["scope"]["authority_write_scope"])
+    for record in authority["historical_successor_bindings"]:
+        relative = str(record["path"])
+        path = root / relative
+        if relative not in scope:
+            raise PostTerminalCompletionError(
+                f"historical successor binding escapes authority scope: {relative}"
+            )
+        if _git_blob_sha256(root, base, relative) != record["predecessor_sha256"]:
+            raise PostTerminalCompletionError(
+                f"historical predecessor byte identity mismatch: {relative}"
+            )
+        if not path.is_file() or _sha256(path) != record["successor_sha256"]:
+            raise PostTerminalCompletionError(
+                f"historical successor byte identity mismatch: {relative}"
+            )
+
+
+def verify_integrated_cohort(authority: Mapping[str, Any], root: Path) -> None:
+    cohort = authority["integrated_cohort"]
+    for record in cohort["paths"]:
+        path = root / str(record["path"])
+        if not path.is_file() or _sha256(path) != record["sha256"]:
+            raise PostTerminalCompletionError(
+                f"integrated cohort byte identity mismatch: {record['path']}"
+            )
+    expected_paths = {str(record["path"]) for record in cohort["paths"]}
+    if expected_paths != set(authority["scope"]["immutable_integrated_scope"]):
+        raise PostTerminalCompletionError(
+            "integrated cohort and immutable scope are not the same exact set"
+        )
+
+
+def verify_terminal_history(authority: Mapping[str, Any], root: Path) -> None:
+    records = {str(record["role"]): record for record in authority["integrated_cohort"]["paths"]}
+    v1 = _load_json(root / records["immutable_v1_prelaunch_failed_ledger"]["path"])
+    v2 = _load_json(root / records["immutable_v2_failed_after_launch_ledger"]["path"])
+    expected_v1 = authority["terminal_history"]["v1"]
+    expected_v2 = authority["terminal_history"]["v2"]
+    if (
+        v1.get("state") != expected_v1["state"]
+        or v1.get("token_consumed") is not expected_v1["token_consumed"]
+        or v1.get("token_status") != expected_v1["token_status"]
+        or v1.get("retry_allowed") is not False
+        or v1.get("restart_allowed") is not False
+        or v1.get("replacement_allowed") is not False
+    ):
+        raise PostTerminalCompletionError("immutable v1 terminal state drifted")
+    process = v2.get("process")
+    failure = v2.get("failure")
+    if not isinstance(process, dict) or not isinstance(failure, dict):
+        raise PostTerminalCompletionError("immutable v2 process/failure evidence is absent")
+    if (
+        v2.get("state") != expected_v2["state"]
+        or v2.get("token_consumed") is not expected_v2["token_consumed"]
+        or v2.get("token_status") != expected_v2["token_status"]
+        or v2.get("token_consumed_at_utc") != expected_v2["token_consumed_at_utc"]
+        or process.get("pid") != expected_v2["child_pid"]
+        or failure.get("stage") != expected_v2["failure_stage"]
+        or v2.get("retry_allowed") is not False
+        or v2.get("restart_allowed") is not False
+        or v2.get("replacement_allowed") is not False
+    ):
+        raise PostTerminalCompletionError("immutable v2 terminal state drifted")
+    for relative in authority["terminal_history"]["required_absent_paths"]:
+        if (root / str(relative)).exists():
+            raise PostTerminalCompletionError(f"forbidden runtime artifact exists: {relative}")
+
+
+def verify_publication_evidence(authority: Mapping[str, Any], root: Path) -> None:
+    for label, record in authority["publication_evidence"].items():
+        head_tree = _git(root, "rev-parse", f"{record['head_sha']}^{{tree}}")
+        merge_tree = _git(root, "rev-parse", f"{record['merge_sha']}^{{tree}}")
+        if head_tree != record["head_tree_sha"] or merge_tree != record["merge_tree_sha"]:
+            raise PostTerminalCompletionError(f"bound publication tree identity drifted: {label}")
+        parents = _git(root, "rev-list", "--parents", "-n", "1", record["merge_sha"])
+        parent_values = parents.split()[1:]
+        if parent_values != [record["base_sha"]]:
+            raise PostTerminalCompletionError(f"bound squash lineage drifted: {label}")
+
+
+def _delegation_manifest(root: Path) -> dict[str, Any]:
+    text = (root / REMAINING_PLAN_PATH).read_text(encoding="utf-8")
+    match = re.search(
+        r"<!-- delegated-task-dag:start -->\s*```json\s*(.*?)\s*```"
+        r"\s*<!-- delegated-task-dag:end -->",
+        text,
+        re.DOTALL,
+    )
+    if match is None:
+        raise PostTerminalCompletionError("machine delegation DAG is absent")
+    value = json.loads(match.group(1))
+    if not isinstance(value, dict):
+        raise PostTerminalCompletionError("machine delegation DAG is not an object")
+    return value
+
+
+def verify_roadmap_transition(authority: Mapping[str, Any], root: Path) -> None:
+    manifest = _delegation_manifest(root)
+    transition = authority["roadmap_transition"]
+    completed = set(manifest.get("completed", []))
+    ready = manifest.get("ready")
+    if not set(transition["completed"]).issubset(completed):
+        raise PostTerminalCompletionError("CK-07R1 is not machine-completed")
+    if ready != transition["new_ready"]:
+        raise PostTerminalCompletionError(
+            "machine Ready set is not the exact post-terminal successor set"
+        )
+    if manifest.get("conditional_ready") != [] or manifest.get("blocked") != []:
+        raise PostTerminalCompletionError("machine policy retains an unexpected explicit hold")
+    accounting = (root / TASK_PACKETS_PATH).read_text(encoding="utf-8")
+    ck07r1 = (root / CK07R1_PACKET_PATH).read_text(encoding="utf-8")
+    ck08r4 = (root / CK08R4_PACKET_PATH).read_text(encoding="utf-8")
+    required_accounting = (
+        "Completed corrective child tasks: **14",
+        "Remaining delegable child tasks: **36**",
+        "Ready child tasks: **1 — CK-08R4**",
+        "Blocked child tasks: **35",
+        "[x] **CK-07R1",
+        "[ ] **CK-08R4",
+    )
+    if any(claim not in accounting for claim in required_accounting):
+        raise PostTerminalCompletionError("task accounting did not transition atomically")
+    if (
+        "**Status:** `completed_post_terminal_deterministic_evidence`" not in ck07r1
+        or "**Status:** Ready" not in ck08r4
+        or "runtime_acceptance=not_claimed" not in ck07r1
+        or "CK-08RG and CK-09 remain blocked" not in ck08r4
+    ):
+        raise PostTerminalCompletionError("packet readiness wording drifted")
+
+
+def verify_decision(authority: Mapping[str, Any]) -> None:
+    decision = authority["decision"]
+    if decision != {
+        "completion_basis": "deterministic_post_terminal_merged_evidence",
+        "corrective_implementation_state": ("accepted_for_CK-07R1_roadmap_dependency"),
+        "roadmap_dependency_completion": (
+            "authorized_on_authority_PR_merge_and_fresh_exact_main_verification"
+        ),
+        "runtime_acceptance": "not_claimed",
+        "planner_valid_receipt": "absent",
+        "receipt_fabrication": "forbidden",
+        "post_single_run": "unavailable",
+        "final_accepted": "unavailable",
+        "failed_after_launch_reclassified": False,
+        "new_command_invocations_permitted": 0,
+        "launch_authorized": False,
+        "token_consumed": True,
+        "token_refund": False,
+        "retry": "none",
+        "restart": "none",
+        "replacement": "none",
+        "production_semantics_changed_by_authority": False,
+    }:
+        raise PostTerminalCompletionError("post-terminal decision weakened or drifted")
+
+
+def verify_authority_delta(
+    authority: Mapping[str, Any],
+    root: Path,
+    *,
+    observed_head: str | None = None,
+    observed_worktree: set[str] | None = None,
+    observed_committed: set[str] | None = None,
+    base_is_ancestor: bool | None = None,
+) -> str:
+    base = str(authority["authority_base_sha"])
+    expected = set(authority["scope"]["authority_write_scope"])
+    if _git(root, "rev-parse", f"{base}^{{tree}}") != authority["authority_base_tree_sha"]:
+        raise PostTerminalCompletionError("authority base tree identity drifted")
+    head = observed_head if observed_head is not None else _git(root, "rev-parse", "HEAD")
+    worktree = observed_worktree if observed_worktree is not None else _status_paths(root)
+    if head == base:
+        if worktree != expected:
+            raise PostTerminalCompletionError("prepublication authority Git delta is not exact")
+        return "dirty_prepublication"
+    ancestor = base_is_ancestor if base_is_ancestor is not None else _is_ancestor(root, base, head)
+    if not ancestor:
+        raise PostTerminalCompletionError("authority base is not an ancestor")
+    committed = (
+        observed_committed if observed_committed is not None else _diff_paths(root, base, head)
+    )
+    if worktree or committed != expected:
+        raise PostTerminalCompletionError("committed authority Git delta is not exact")
+    return "clean_committed"
+
+
+def verify_all(authority: Mapping[str, Any], root: Path) -> dict[str, Any]:
+    verify_source_authorities(authority, root)
+    verify_historical_successor_bindings(authority, root)
+    verify_integrated_cohort(authority, root)
+    verify_terminal_history(authority, root)
+    verify_publication_evidence(authority, root)
+    verify_decision(authority)
+    verify_roadmap_transition(authority, root)
+    representation = verify_authority_delta(authority, root)
+    return {
+        "authority_schema": authority["schema"],
+        "representation": representation,
+        "runtime_acceptance": "not_claimed",
+        "planner_valid_receipt": "absent",
+        "token_consumed": True,
+        "new_command_invocations_permitted": 0,
+        "completed": ["CK-07R1"],
+        "ready": ["CK-08R4"],
+        "verification": "passed",
+    }
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("authority",))
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    root = args.root.absolute()
+    authority = load_authority(root)
+    print(json.dumps(verify_all(authority, root), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/ck07r1_terminal_failure_correction.py
+++ b/scripts/ck07r1_terminal_failure_correction.py
@@ -36,6 +36,9 @@ CLEAN_COMMIT_CI_SCHEMA_PATH = Path(
     "docs/decisions/evidence/ck07r1a0/"
     "lifecycle-terminal-failure-clean-commit-authority-v2.schema.json"
 )
+POST_TERMINAL_AUTHORITY_PATH = Path(
+    "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json"
+)
 
 
 class TerminalCorrectionError(RuntimeError):
@@ -231,16 +234,43 @@ def bound_authority_digest_matches(
     actual = _sha256(path)
     if actual == expected:
         return True
-    if not (root / CLEAN_COMMIT_CI_AUTHORITY_PATH).is_file():
-        return False
-    authority = load_clean_commit_ci_authority(root)
-    verify_clean_commit_ci_authority_bytes(authority, root)
-    return any(
-        record["path"] == relative
-        and record["before_sha256"] == expected
-        and record["sha256"] == actual
-        for record in authority["superseded_immutable_paths"]
-    )
+    if (root / POST_TERMINAL_AUTHORITY_PATH).is_file():
+        from scripts.ck07r1_post_terminal_completion import (
+            load_authority as load_post_terminal_authority,
+        )
+        from scripts.ck07r1_post_terminal_completion import (
+            verify_all as verify_post_terminal,
+        )
+
+        post_terminal = load_post_terminal_authority(root)
+        verify_post_terminal(post_terminal, root)
+        bindings = {
+            str(record["path"]): record
+            for record in post_terminal["historical_successor_bindings"]
+        }
+        binding = bindings.get(relative)
+        if binding is not None:
+            return bool(
+                binding["predecessor_sha256"] == expected
+                and binding["successor_sha256"] == actual
+                and _git_blob_sha256(
+                    root,
+                    str(post_terminal["authority_base_sha"]),
+                    relative,
+                )
+                == expected
+            )
+    if (root / CLEAN_COMMIT_CI_AUTHORITY_PATH).is_file():
+        authority = load_clean_commit_ci_authority(root)
+        verify_clean_commit_ci_authority_bytes(authority, root)
+        if any(
+            record["path"] == relative
+            and record["before_sha256"] == expected
+            and record["sha256"] == actual
+            for record in authority["superseded_immutable_paths"]
+        ):
+            return True
+    return False
 
 
 def verify_clean_commit_ci_authority_delta(
@@ -495,6 +525,20 @@ def verify_exact_authority_delta(
     allowed_worktree_delta: set[str] | None = None,
     base_is_ancestor: bool | None = None,
 ) -> None:
+    if (
+        observed is None
+        and allowed_worktree_delta is None
+        and (root / POST_TERMINAL_AUTHORITY_PATH).is_file()
+    ):
+        from scripts.ck07r1_post_terminal_completion import (
+            load_authority as load_post_terminal_authority,
+        )
+        from scripts.ck07r1_post_terminal_completion import (
+            verify_all as verify_post_terminal,
+        )
+
+        verify_post_terminal(load_post_terminal_authority(root), root)
+        return
     if (
         observed is None
         and allowed_worktree_delta is None
@@ -757,6 +801,24 @@ def verify_combined(
     *,
     authority_root: Path | None = None,
 ) -> dict[str, Any]:
+    if (root / POST_TERMINAL_AUTHORITY_PATH).is_file():
+        from scripts.ck07r1_post_terminal_completion import (
+            load_authority as load_post_terminal_authority,
+        )
+        from scripts.ck07r1_post_terminal_completion import (
+            verify_all as verify_post_terminal,
+        )
+
+        verify_post_terminal(load_post_terminal_authority(root), root)
+        verify_corrected_cohort(authority, root)
+        verify_terminal_evidence(authority, root)
+        verify_planner_reproduction(authority, root)
+        return {
+            "candidate_paths": len(authority["scope"]["combined_candidate_scope"]),
+            "new_run_permitted": False,
+            "runtime_acceptance": "not_claimed",
+            "token_consumed": True,
+        }
     clean_commit_root = authority_root or root
     clean_commit_path = clean_commit_root / CLEAN_COMMIT_AUTHORITY_PATH
     clean_commit_ci_path = clean_commit_root / CLEAN_COMMIT_CI_AUTHORITY_PATH

--- a/tests/kernel/test_ck07r1_post_terminal_completion_authority.py
+++ b/tests/kernel/test_ck07r1_post_terminal_completion_authority.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.ck07r1_post_terminal_completion import (
+    AUTHORITY_PATH,
+    SCHEMA_PATH,
+    PostTerminalCompletionError,
+    load_authority,
+    verify_authority_delta,
+    verify_decision,
+    verify_historical_successor_bindings,
+    verify_integrated_cohort,
+    verify_publication_evidence,
+    verify_roadmap_transition,
+    verify_source_authorities,
+    verify_terminal_history,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _authority() -> dict[str, object]:
+    return load_authority(ROOT)
+
+
+def test_post_terminal_authority_is_versioned_strict_and_exact() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(authority)
+    assert authority["schema"].endswith(".v1")
+    assert authority["status"] == "roadmap_transition_authorized"
+    assert authority["authority_base_sha"] == ("1d0466b1b2992b48c5272dc4598606eeaea4dae2")
+    assert authority["authority_base_tree_sha"] == ("d1b06f0927ae660f9e09d642bb1ef79a04413b5f")
+
+
+def test_source_authorities_and_integrated_seven_path_cohort_are_exact() -> None:
+    authority = _authority()
+    verify_source_authorities(authority, ROOT)
+    verify_historical_successor_bindings(authority, ROOT)
+    verify_integrated_cohort(authority, ROOT)
+    assert len(authority["source_authorities"]) == 6
+    assert len(authority["integrated_cohort"]["paths"]) == 7
+    assert {record["path"] for record in authority["integrated_cohort"]["paths"]} == set(
+        authority["scope"]["immutable_integrated_scope"]
+    )
+
+
+def test_terminal_history_remains_consumed_failed_and_receipt_absent() -> None:
+    authority = _authority()
+    verify_terminal_history(authority, ROOT)
+    history = authority["terminal_history"]
+    assert history["v1"]["state"] == "prelaunch_failed"
+    assert history["v1"]["token_consumed"] is False
+    assert history["v2"]["state"] == "failed_after_launch"
+    assert history["v2"]["token_consumed"] is True
+    assert history["remaining_invocations"] == 0
+    assert history["token_refund"] is False
+    assert history["retry"] == history["restart"] == history["replacement"] == "none"
+    assert all(not (ROOT / path).exists() for path in history["required_absent_paths"])
+
+
+def test_publication_and_hosted_evidence_bind_exact_lineage() -> None:
+    authority = _authority()
+    verify_publication_evidence(authority, ROOT)
+    publications = authority["publication_evidence"]
+    assert [
+        publications[name]["pull_request"]
+        for name in (
+            "terminal_correction_authority",
+            "clean_commit_authority",
+            "corrected_implementation",
+        )
+    ] == [447, 450, 448]
+    assert [
+        publications[name]["ci_run"]
+        for name in (
+            "terminal_correction_authority",
+            "clean_commit_authority",
+            "corrected_implementation",
+        )
+    ] == [32302049140, 32401646264, 32402374087]
+    assert publications["corrected_implementation"]["merge_sha"] == (
+        "1d0466b1b2992b48c5272dc4598606eeaea4dae2"
+    )
+
+
+def test_decision_completes_dependency_without_runtime_acceptance() -> None:
+    authority = _authority()
+    verify_decision(authority)
+    decision = authority["decision"]
+    transition = authority["roadmap_transition"]
+    assert decision["corrective_implementation_state"] == (
+        "accepted_for_CK-07R1_roadmap_dependency"
+    )
+    assert decision["runtime_acceptance"] == "not_claimed"
+    assert decision["planner_valid_receipt"] == "absent"
+    assert decision["post_single_run"] == "unavailable"
+    assert decision["final_accepted"] == "unavailable"
+    assert decision["failed_after_launch_reclassified"] is False
+    assert decision["new_command_invocations_permitted"] == 0
+    assert decision["launch_authorized"] is False
+    assert decision["token_consumed"] is True
+    assert transition["completed"] == ["CK-07R1"]
+    assert transition["new_ready"] == ["CK-08R4"]
+    assert transition["still_blocked"] == ["CK-08RG", "CK-09"]
+
+
+def test_authority_delta_accepts_only_exact_dirty_or_committed_transition() -> None:
+    authority = _authority()
+    expected = set(authority["scope"]["authority_write_scope"])
+    base = authority["authority_base_sha"]
+    assert (
+        verify_authority_delta(
+            authority,
+            ROOT,
+            observed_head=base,
+            observed_worktree=expected,
+        )
+        == "dirty_prepublication"
+    )
+    assert (
+        verify_authority_delta(
+            authority,
+            ROOT,
+            observed_head="f" * 40,
+            observed_worktree=set(),
+            observed_committed=expected,
+            base_is_ancestor=True,
+        )
+        == "clean_committed"
+    )
+    for worktree, committed in (
+        (expected - {next(iter(expected))}, None),
+        (expected | {"extra.txt"}, None),
+        (set(), expected - {next(iter(expected))}),
+        ({"extra.txt"}, expected),
+    ):
+        with pytest.raises(PostTerminalCompletionError):
+            verify_authority_delta(
+                authority,
+                ROOT,
+                observed_head=base if committed is None else "f" * 40,
+                observed_worktree=worktree,
+                observed_committed=committed,
+                base_is_ancestor=True,
+            )
+    with pytest.raises(PostTerminalCompletionError, match="not an ancestor"):
+        verify_authority_delta(
+            authority,
+            ROOT,
+            observed_head="f" * 40,
+            observed_worktree=set(),
+            observed_committed=expected,
+            base_is_ancestor=False,
+        )
+
+
+def test_roadmap_transition_exposes_only_ck08r4() -> None:
+    verify_roadmap_transition(_authority(), ROOT)
+
+
+def test_schema_rejects_acceptance_run_scope_and_readiness_weakening() -> None:
+    authority = _authority()
+    schema = json.loads((ROOT / SCHEMA_PATH).read_text(encoding="utf-8"))
+    mutations = (
+        lambda value: value["decision"].__setitem__("runtime_acceptance", "claimed"),
+        lambda value: value["decision"].__setitem__("final_accepted", "available"),
+        lambda value: value["decision"].__setitem__("failed_after_launch_reclassified", True),
+        lambda value: value["decision"].__setitem__("new_command_invocations_permitted", 1),
+        lambda value: value["decision"].__setitem__("launch_authorized", True),
+        lambda value: value["decision"].__setitem__("token_consumed", False),
+        lambda value: value["terminal_history"].__setitem__("remaining_invocations", 1),
+        lambda value: value["terminal_history"].__setitem__("token_refund", True),
+        lambda value: value["integrated_cohort"]["paths"].pop(),
+        lambda value: value["source_authorities"].pop(),
+        lambda value: value["source_authorities"][0].__setitem__("path", "AGENTS.md"),
+        lambda value: value["integrated_cohort"]["paths"][0].__setitem__(
+            "path", "src/codex_usage_tracker/agent_kernel/publication/planner.py"
+        ),
+        lambda value: value["historical_successor_bindings"][0].__setitem__(
+            "successor_sha256", "0" * 64
+        ),
+        lambda value: value["terminal_history"]["required_absent_paths"].__setitem__(
+            0, "output/ck07r1/fabricated.json"
+        ),
+        lambda value: value["publication_evidence"]["corrected_implementation"].__setitem__(
+            "ci_run", 1
+        ),
+        lambda value: value["deterministic_acceptance_evidence"]["path_proof"].__setitem__(
+            0, "weakened"
+        ),
+        lambda value: value["residual_risks"].__setitem__(0, "weakened"),
+        lambda value: value["required_transition_gates"].__setitem__(0, "weakened"),
+        lambda value: value["roadmap_transition"]["new_ready"].append("CK-08RG"),
+        lambda value: value["scope"]["authority_write_scope"].append(
+            "scripts/benchmark_ck07r1_lifecycle_scale.py"
+        ),
+        lambda value: value["scope"]["authority_write_scope"].__setitem__(
+            0, "src/codex_usage_tracker/agent_kernel/publication/planner.py"
+        ),
+        lambda value: value["scope"]["immutable_integrated_scope"].__setitem__(
+            0, "output/ck07r1/fabricated.json"
+        ),
+        lambda value: value["scope"]["forbidden"].__setitem__(0, "weakened"),
+    )
+    for mutate in mutations:
+        changed = deepcopy(authority)
+        mutate(changed)
+        assert list(Draft202012Validator(schema).iter_errors(changed))
+
+
+def test_authority_file_name_is_versioned() -> None:
+    assert Path(AUTHORITY_PATH).name.endswith("-v1.json")

--- a/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
+++ b/tests/kernel/test_ck07r1_terminal_failure_correction_authority.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+import scripts.ck07r1_post_terminal_completion as post_terminal_module
 import scripts.ck07r1_terminal_failure_correction as terminal_module
 from scripts.ck07r1_terminal_failure_correction import (
     AUTHORITY_PATH,
@@ -203,11 +204,43 @@ def test_exact_authority_delta_admits_only_exact_clean_integrated_candidate(
             ("authority_delta", kwargs["include_candidate"])
         ),
     )
+    monkeypatch.setattr(
+        post_terminal_module,
+        "load_authority",
+        lambda _root: calls.append(("post_authority", None)) or {},
+    )
+    monkeypatch.setattr(
+        post_terminal_module,
+        "verify_all",
+        lambda _authority, _root: calls.append(("post_verification", None)),
+    )
     terminal_module.verify_exact_authority_delta(authority, ROOT)
     assert calls == [
-        ("authority_bytes", None),
-        ("authority_delta", True),
+        ("post_authority", None),
+        ("post_verification", None),
     ]
+
+
+def test_post_terminal_historical_successor_rejects_current_byte_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = post_terminal_module.load_authority(ROOT)["historical_successor_bindings"][0]
+    assert terminal_module.bound_authority_digest_matches(
+        ROOT,
+        binding["path"],
+        binding["predecessor_sha256"],
+    )
+    sha256 = terminal_module._sha256
+    monkeypatch.setattr(
+        terminal_module,
+        "_sha256",
+        lambda path: "f" * 64 if path == ROOT / binding["path"] else sha256(path),
+    )
+    assert not terminal_module.bound_authority_digest_matches(
+        ROOT,
+        binding["path"],
+        binding["predecessor_sha256"],
+    )
 
 
 def test_candidate_representation_accepts_exact_dirty_and_clean_states() -> None:
@@ -431,6 +464,16 @@ def test_combined_verifies_authority_binding_before_candidate(
         "verify_planner_reproduction",
         lambda _authority, _root: calls.append("planner"),
     )
+    monkeypatch.setattr(
+        post_terminal_module,
+        "load_authority",
+        lambda _root: calls.append("post_authority") or {},
+    )
+    monkeypatch.setattr(
+        post_terminal_module,
+        "verify_all",
+        lambda _authority, _root: calls.append("post_verification"),
+    )
     monkeypatch.setattr(terminal_module, "_sha256", lambda _path: next(
         record["sha256"]
         for record in clean_commit["implementation_transition"]["paths"]
@@ -440,9 +483,9 @@ def test_combined_verifies_authority_binding_before_candidate(
 
     terminal_module.verify_combined(authority, ROOT)
     assert calls[:3] == [
-        "authority_bytes",
-        "candidate_transition",
-        "authority_delta",
+        "post_authority",
+        "post_verification",
+        "cohort",
     ]
 
 

--- a/tests/kernel/test_documentation_authority.py
+++ b/tests/kernel/test_documentation_authority.py
@@ -9,6 +9,10 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.ck07r1_post_terminal_completion import (
+    load_authority as load_post_terminal_authority,
+)
+from scripts.ck07r1_post_terminal_completion import verify_all as verify_post_terminal
 from scripts.ck07r1_prelaunch_recovery import verify_combined_preflight
 from scripts.ck07r1_terminal_failure_correction import (
     load_authority as load_terminal_correction_authority,
@@ -129,6 +133,13 @@ def _assert_ck07_selected_or_recovery_cohort(
         for item in terminal["corrected_candidate_cohort"]
     }
     assert actual == terminal_expected
+    post_terminal_path = (
+        _REPO_ROOT / "docs/decisions/evidence/ck07r1a0/"
+        "lifecycle-post-terminal-completion-authority-v1.json"
+    )
+    if post_terminal_path.is_file():
+        verify_post_terminal(load_post_terminal_authority(_REPO_ROOT), _REPO_ROOT)
+        return
     verify_terminal_correction_combined(
         load_terminal_correction_authority(_REPO_ROOT),
         _REPO_ROOT,
@@ -256,7 +267,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "blocked_policy": "spawn_none_and_report_to_orchestrator",
     }
     conditional_ready: set[str] = set()
-    blocked = {"CK-07R1"}
+    blocked: set[str] = set()
     assert manifest["completed"] == [
         "CK-08R0",
         "CK-08R1A",
@@ -271,6 +282,7 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         "CK-QG1",
         "CK-07R1A",
         "CK-07R1A0",
+        "CK-07R1",
     ]
     qg1a_authority = _json(
         "docs/decisions/evidence/ckqg1a0/page-executor-source-supersession-authority.json"
@@ -280,19 +292,10 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
         hashlib.sha256(qg1a_source.read_bytes()).hexdigest()
         == (qg1a_authority["selected_successor"]["sha256"])
     )
-    ready: set[str] = set()
-    assert manifest["ready"] == []
+    ready = {"CK-08R4"}
+    assert manifest["ready"] == ["CK-08R4"]
     assert manifest["conditional_ready"] == []
-    assert manifest["blocked"] == [
-        {
-            "condition": (
-                "the terminal CK-07R1 v2 failed_after_launch state consumed the sole "
-                "token; deterministic corrective evidence cannot satisfy receipt-required "
-                "runtime acceptance without a separate roadmap decision"
-            ),
-            "tasks": ["CK-07R1"],
-        }
-    ]
+    assert manifest["blocked"] == []
     parent_section = ledger.split("## Parent packets", 1)[1].split(
         "## Remaining delegated child tasks", 1
     )[0]
@@ -305,11 +308,11 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
     assert f"Completed packets: **{parent_completed} / {len(parent_rows)}**" in ledger
     assert f"Not started: **{len(parent_rows) - parent_completed}**" in ledger
     assert f"Critical-path completion: **{parent_completed} / 21**" in ledger
-    assert "Completed corrective child tasks: **13" in ledger
+    assert "Completed corrective child tasks: **14" in ledger
     remaining_delegable = len(manifest["tasks"]) - len(manifest["completed"])
-    assert remaining_delegable == 37
+    assert remaining_delegable == 36
     assert f"Remaining delegable child tasks: **{remaining_delegable}**" in ledger
-    assert "Blocked child tasks: **37" in ledger
+    assert "Blocked child tasks: **35" in ledger
     assert f"Ready child tasks: **{len(manifest['ready'])}" in ledger
     assert (
         f"Conditional-ready child tasks: **{sum(len(item['tasks']) for item in manifest['conditional_ready'])}"
@@ -435,6 +438,8 @@ def test_remaining_execution_plan_is_complete_acyclic_and_fail_closed() -> None:
                 assert "**Status:** `terminal_failed_no_rerun`" in body
             else:
                 assert "**Status:** Blocked" in body
+        elif packet_id == "CK-07R1":
+            assert "**Status:** `completed_post_terminal_deterministic_evidence`" in body
         elif packet_id in {
             "CK-08R0",
             "CK-08R1A",
@@ -923,7 +928,7 @@ def test_corrective_seam_packet_is_critical_path_authority() -> None:
         "**Status:** Completed on merge — PR #392 hosted-green, squash-merged at\n"
         "`68050b93`, and exact-main verified"
     ) in ckqg1
-    assert "**Status:** `terminal_failed_no_rerun`" in ck07r1
+    assert "**Status:** `completed_post_terminal_deterministic_evidence`" in ck07r1
     assert "720-second wrapper timeout" in ck07r1a0
     assert "revoked, never authoritative, and never used" in ck07r1a0
 
@@ -1294,9 +1299,9 @@ def test_ck07r1_consuming_boundary_is_documented_without_downstream_readiness() 
             "approval"
         ]["downstream"]
     )
-    assert "Ready child tasks: **0**" in accounting
+    assert "Ready child tasks: **1 — CK-08R4**" in accounting
     assert "Conditional-ready child tasks: **0**" in accounting
-    assert "Blocked child tasks: **37 — CK-07R1 is terminal" in accounting
+    assert "Blocked child tasks: **35 — CK-08RG/CK-09" in accounting
     assert "## Standing Repository Authorization" in agents
     assert "No additional user approval is required" in agents
     assert "normative coordinator/orchestration binding" in agents
@@ -1394,3 +1399,36 @@ def test_ck07r1_terminal_clean_commit_ci_v2_is_documented_fail_closed() -> None:
     assert authority["decision"]["new_command_invocations_permitted"] == 0
     assert authority["decision"]["launch_authorized"] is False
     assert authority["decision"]["token_consumed"] is True
+
+
+def test_ck07r1_post_terminal_completion_is_documented_without_runtime_claim() -> None:
+    bodies = (
+        _read("AGENTS.md"),
+        _read("docs/INDEX.md"),
+        _read("docs/architecture/QUERY_EVIDENCE_PROJECTION_CONTRACTS.md"),
+        _read("docs/quality/QUALIFICATION_PLAN.md"),
+        _read("docs/roadmap/REMAINING_EXECUTION_PLAN.md"),
+        _read("docs/roadmap/TASK_PACKETS.md"),
+        _read("docs/roadmap/tasks/ck-07r1-correct-lifecycle-preparation-scale.md"),
+        _read("docs/roadmap/tasks/ck-08r4-reclassify-physical-plans.md"),
+    )
+    authority = _json(
+        "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json"
+    )
+    for body in bodies:
+        assert "CK-08R4" in body
+    for body in bodies[:7]:
+        assert "runtime_acceptance=not_claimed" in body
+    for body in bodies[:2] + bodies[4:7]:
+        assert "post-terminal" in body
+    decision = authority["decision"]
+    transition = authority["roadmap_transition"]
+    assert decision["runtime_acceptance"] == "not_claimed"
+    assert decision["planner_valid_receipt"] == "absent"
+    assert decision["final_accepted"] == "unavailable"
+    assert decision["new_command_invocations_permitted"] == 0
+    assert decision["launch_authorized"] is False
+    assert decision["token_consumed"] is True
+    assert transition["completed"] == ["CK-07R1"]
+    assert transition["new_ready"] == ["CK-08R4"]
+    assert transition["still_blocked"] == ["CK-08RG", "CK-09"]

--- a/tests/kernel/test_kernel_scope.py
+++ b/tests/kernel/test_kernel_scope.py
@@ -20,6 +20,7 @@ from scripts.check_kernel_scope import (
     CK07E_INDEPENDENT_FACT_ADAPTER_ADDITIONS,
     CK07R1_CONSUMING_BOUNDARY_AUTHORITY_ADDITIONS,
     CK07R1_LIFECYCLE_SCOPE_ADDITIONS,
+    CK07R1_POST_TERMINAL_COMPLETION_AUTHORITY_ADDITIONS,
     CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS,
     CK07R1_RUN_INVOCATION_AUTHORITY_ADDITIONS,
     CK07R1_SHARED_OVERLAY_AUTHORITY_ADDITIONS,
@@ -707,6 +708,7 @@ def test_k6_additions_are_explicit_and_bounded() -> None:
         | CK07R1_PRELAUNCH_RECOVERY_AUTHORITY_ADDITIONS
         | CK07R1_TERMINAL_FAILURE_CORRECTION_AUTHORITY_ADDITIONS
         | CK07R1_TERMINAL_CLEAN_COMMIT_AUTHORITY_ADDITIONS
+        | CK07R1_POST_TERMINAL_COMPLETION_AUTHORITY_ADDITIONS
         | CK08_PREREQUISITE_BLOCKER_ADDITIONS
         | {
             "config/agent-kernel/maintainability-baseline-v1.json",
@@ -850,6 +852,15 @@ def test_ck07r1_terminal_clean_commit_additions_are_explicit_and_bounded() -> No
         "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.json",
         "docs/decisions/evidence/ck07r1a0/lifecycle-terminal-failure-clean-commit-authority-v2.schema.json",
     } == CK07R1_TERMINAL_CLEAN_COMMIT_AUTHORITY_ADDITIONS
+
+
+def test_ck07r1_post_terminal_completion_additions_are_explicit_and_bounded() -> None:
+    assert {
+        "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.json",
+        "docs/decisions/evidence/ck07r1a0/lifecycle-post-terminal-completion-authority-v1.schema.json",
+        "scripts/ck07r1_post_terminal_completion.py",
+        "tests/kernel/test_ck07r1_post_terminal_completion_authority.py",
+    } == CK07R1_POST_TERMINAL_COMPLETION_AUTHORITY_ADDITIONS
 
 
 def test_kernel_skeleton_imports_without_legacy_runtime() -> None:


### PR DESCRIPTION
## Summary
- add a versioned CK-07R1 post-terminal roadmap completion authority bound to exact merged PR #447/#450/#448 lineage, seven-path implementation/evidence identities, immutable v1/v2 terminal evidence, and deterministic validation
- preserve `failed_after_launch`, consumed/non-refundable token, `runtime_acceptance=not_claimed`, absent planner-valid receipt/output, and zero further invocations
- atomically mark CK-07R1 dependency-complete and make only CK-08R4 Ready; CK-08RG and CK-09 remain blocked
- reconcile historical authority consumers through exact predecessor/successor bindings and exact dirty/clean 17-path authority delta

## Validation
- exact authority verifier: dirty and clean-committed representations passed
- focused CK-07R1 authority/docs/scope consumers: 171 passed
- `just vp` passed
- `just v`: 1,586 passed, 1 skipped; 13 performance invariants passed; release safety passed
- `just vc` passed, including clean package/distribution checks
- privacy tests: 9 passed
- Ruff, mypy, Pyright, console build/lint/type/tests, diff and secret scans passed
- one bounded independent reviewer: two fail-closed findings corrected; same-reviewer correction pass CLEAN

No qualification command, launch, token or runtime-artifact mutation, receipt fabrication, PR #394 mutation, cleanup, or downstream dispatch occurred.